### PR TITLE
Rename config targets to graphs

### DIFF
--- a/crates/omnigraph-cli/src/main.rs
+++ b/crates/omnigraph-cli/src/main.rs
@@ -697,8 +697,8 @@ fn policy_repo_id(config: &OmnigraphConfig) -> String {
         return name.clone();
     }
     config
-        .resolve_target_uri(None, None, config.server_target_name())
-        .or_else(|_| config.resolve_target_uri(None, None, config.cli_target_name()))
+        .resolve_target_uri(None, None, config.server_graph_name())
+        .or_else(|_| config.resolve_target_uri(None, None, config.cli_graph_name()))
         .unwrap_or_else(|_| "default".to_string())
 }
 
@@ -708,7 +708,7 @@ fn resolve_remote_bearer_token(
     explicit_target: Option<&str>,
 ) -> Result<Option<String>> {
     let scoped_env =
-        config.target_bearer_token_env(explicit_uri, explicit_target, config.cli_target_name());
+        config.graph_bearer_token_env(explicit_uri, explicit_target, config.cli_graph_name());
     let mut env_names = Vec::new();
     if let Some(name) = scoped_env {
         env_names.push(name.to_string());
@@ -780,7 +780,7 @@ fn resolve_uri(
     cli_uri: Option<String>,
     cli_target: Option<&str>,
 ) -> Result<String> {
-    config.resolve_target_uri(cli_uri, cli_target, config.cli_target_name())
+    config.resolve_target_uri(cli_uri, cli_target, config.cli_graph_name())
 }
 
 fn resolve_local_uri(
@@ -1301,17 +1301,17 @@ fn scaffold_config_if_missing(uri: &str) -> Result<()> {
 project:
   name: Omnigraph Project
 
-targets:
+graphs:
   local:
     uri: {}
     # bearer_token_env: OMNIGRAPH_BEARER_TOKEN
 
 server:
-  target: local
+  graph: local
   bind: 127.0.0.1:8080
 
 cli:
-  target: local
+  graph: local
   branch: main
   output_format: table
   table_max_column_width: 80
@@ -1328,7 +1328,7 @@ aliases:
   #   query: context.gq
   #   name: decision_owner
   #   args: [slug]
-  #   target: local
+  #   graph: local
   #   branch: main
   #   format: kv
   #
@@ -1337,7 +1337,7 @@ aliases:
   #   query: mutations.gq
   #   name: attach_trace
   #   args: [decision_slug, trace_slug]
-  #   target: local
+  #   graph: local
   #   branch: main
 
 # auth:
@@ -1443,7 +1443,7 @@ async fn execute_query_lint(
     }
 
     let has_repo_target =
-        cli_uri.is_some() || cli_target.is_some() || config.cli_target_name().is_some();
+        cli_uri.is_some() || cli_target.is_some() || config.cli_graph_name().is_some();
     if !has_repo_target {
         bail!("query lint requires --schema <schema.pg> or a resolvable repo target");
     }
@@ -2241,15 +2241,15 @@ async fn main() -> Result<()> {
             let alias_config = alias.as_ref().map(|(_, alias)| *alias);
             let target_available = target.is_some()
                 || alias_config
-                    .and_then(|alias| alias.target.as_deref())
+                    .and_then(|alias| alias.graph.as_deref())
                     .is_some()
-                || config.cli_target_name().is_some();
+                || config.cli_graph_name().is_some();
             let (legacy_uri, alias_args) =
                 normalize_legacy_alias_uri(legacy_uri, target_available, alias_name, alias_args);
             let uri = uri.or(legacy_uri);
             let target_name = target
                 .as_deref()
-                .or_else(|| alias_config.and_then(|alias| alias.target.as_deref()));
+                .or_else(|| alias_config.and_then(|alias| alias.graph.as_deref()));
             let bearer_token = resolve_remote_bearer_token(&config, uri.as_deref(), target_name)?;
             let uri = resolve_uri(&config, uri, target_name)?;
             let query_source = resolve_query_source(
@@ -2324,15 +2324,15 @@ async fn main() -> Result<()> {
             let alias_config = alias.as_ref().map(|(_, alias)| *alias);
             let target_available = target.is_some()
                 || alias_config
-                    .and_then(|alias| alias.target.as_deref())
+                    .and_then(|alias| alias.graph.as_deref())
                     .is_some()
-                || config.cli_target_name().is_some();
+                || config.cli_graph_name().is_some();
             let (legacy_uri, alias_args) =
                 normalize_legacy_alias_uri(legacy_uri, target_available, alias_name, alias_args);
             let uri = uri.or(legacy_uri);
             let target_name = target
                 .as_deref()
-                .or_else(|| alias_config.and_then(|alias| alias.target.as_deref()));
+                .or_else(|| alias_config.and_then(|alias| alias.graph.as_deref()));
             let bearer_token = resolve_remote_bearer_token(&config, uri.as_deref(), target_name)?;
             let uri = resolve_uri(&config, uri, target_name)?;
             let query_source = resolve_query_source(
@@ -2555,14 +2555,14 @@ mod tests {
         fs::write(
             temp.path().join("omnigraph.yaml"),
             r#"
-targets:
+graphs:
   demo:
     uri: https://example.com
     bearer_token_env: DEMO_TOKEN
 auth:
   env_file: .env.omni
 cli:
-  target: demo
+  graph: demo
 "#,
         )
         .unwrap();
@@ -2610,7 +2610,7 @@ cli:
             r#"
 auth:
   env_file: .env.omni
-targets:
+graphs:
   demo:
     uri: s3://bucket/prefix
 "#,

--- a/crates/omnigraph-cli/tests/cli.rs
+++ b/crates/omnigraph-cli/tests/cli.rs
@@ -1195,7 +1195,7 @@ fn read_alias_uses_alias_target_without_cli_default_and_accepts_url_like_arg() {
     write_config(
         &config,
         &format!(
-            "targets:\n  local:\n    uri: '{}'\nquery:\n  roots:\n    - .\npolicy: {{}}\naliases:\n  owner:\n    command: read\n    query: aliases.gq\n    name: get_person\n    args: [name]\n    target: local\n    format: kv\n",
+            "graphs:\n  local:\n    uri: '{}'\nquery:\n  roots:\n    - .\npolicy: {{}}\naliases:\n  owner:\n    command: read\n    query: aliases.gq\n    name: get_person\n    args: [name]\n    graph: local\n    format: kv\n",
             repo.to_string_lossy()
         ),
     );

--- a/crates/omnigraph-cli/tests/support/mod.rs
+++ b/crates/omnigraph-cli/tests/support/mod.rs
@@ -121,11 +121,11 @@ fn yaml_string(value: &str) -> String {
 pub fn local_yaml_config(repo: &Path) -> String {
     format!(
         "\
-targets:
+graphs:
   local:
     uri: {}
 cli:
-  target: local
+  graph: local
   branch: main
 query:
   roots:
@@ -139,11 +139,11 @@ policy: {{}}
 pub fn remote_yaml_config(url: &str) -> String {
     format!(
         "\
-targets:
+graphs:
   dev:
     uri: {}
 cli:
-  target: dev
+  graph: dev
   branch: main
 query:
   roots:

--- a/crates/omnigraph-cli/tests/system_local.rs
+++ b/crates/omnigraph-cli/tests/system_local.rs
@@ -61,11 +61,11 @@ fn local_policy_config(repo: &SystemRepo) -> String {
         "\
 project:
   name: policy-e2e-local
-targets:
+graphs:
   local:
     uri: {}
 cli:
-  target: local
+  graph: local
   branch: main
 query:
   roots:
@@ -548,11 +548,11 @@ fn local_cli_s3_end_to_end_init_load_read_flow() {
         &config,
         &format!(
             "\
-targets:
+graphs:
   rustfs:
     uri: '{}'
 cli:
-  target: rustfs
+  graph: rustfs
   branch: main
 query:
   roots:
@@ -707,11 +707,11 @@ fn local_cli_resolves_relative_query_against_config_base_dir() {
         &config,
         &format!(
             "\
-targets:
+graphs:
   local:
     uri: '{}'
 cli:
-  target: local
+  graph: local
   branch: main
 query:
   roots:

--- a/crates/omnigraph-cli/tests/system_remote.rs
+++ b/crates/omnigraph-cli/tests/system_remote.rs
@@ -46,11 +46,11 @@ fn remote_policy_server_config(repo: &SystemRepo) -> String {
         "\
 project:
   name: remote-policy-e2e
-targets:
+graphs:
   local:
     uri: {}
 server:
-  target: local
+  graph: local
 policy:
   file: ./policy.yaml
 ",
@@ -61,12 +61,12 @@ policy:
 fn remote_policy_client_config(url: &str) -> String {
     format!(
         "\
-targets:
+graphs:
   dev:
     uri: {}
     bearer_token_env: POLICY_TEST_TOKEN
 cli:
-  target: dev
+  graph: dev
   branch: main
 query:
   roots:

--- a/crates/omnigraph-server/src/config.rs
+++ b/crates/omnigraph-server/src/config.rs
@@ -40,7 +40,8 @@ pub enum TableCellLayout {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CliDefaults {
-    pub target: Option<String>,
+    #[serde(rename = "graph")]
+    pub graph: Option<String>,
     pub branch: Option<String>,
     pub output_format: Option<ReadOutputFormat>,
     pub table_max_column_width: Option<usize>,
@@ -49,7 +50,8 @@ pub struct CliDefaults {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ServerDefaults {
-    pub target: Option<String>,
+    #[serde(rename = "graph")]
+    pub graph: Option<String>,
     pub bind: Option<String>,
 }
 
@@ -83,7 +85,8 @@ pub struct AliasConfig {
     pub name: Option<String>,
     #[serde(default)]
     pub args: Vec<String>,
-    pub target: Option<String>,
+    #[serde(rename = "graph")]
+    pub graph: Option<String>,
     pub branch: Option<String>,
     pub format: Option<ReadOutputFormat>,
 }
@@ -92,8 +95,8 @@ pub struct AliasConfig {
 pub struct OmnigraphConfig {
     #[serde(default)]
     pub project: ProjectConfig,
-    #[serde(default)]
-    pub targets: BTreeMap<String, TargetConfig>,
+    #[serde(default, rename = "graphs")]
+    pub graphs: BTreeMap<String, TargetConfig>,
     #[serde(default)]
     pub server: ServerDefaults,
     #[serde(default)]
@@ -114,7 +117,7 @@ impl Default for OmnigraphConfig {
     fn default() -> Self {
         Self {
             project: ProjectConfig::default(),
-            targets: BTreeMap::new(),
+            graphs: BTreeMap::new(),
             server: ServerDefaults::default(),
             auth: AuthDefaults::default(),
             cli: CliDefaults::default(),
@@ -147,12 +150,12 @@ impl OmnigraphConfig {
         self.cli.table_cell_layout.unwrap_or_default()
     }
 
-    pub fn cli_target_name(&self) -> Option<&str> {
-        self.cli.target.as_deref()
+    pub fn cli_graph_name(&self) -> Option<&str> {
+        self.cli.graph.as_deref()
     }
 
-    pub fn server_target_name(&self) -> Option<&str> {
-        self.server.target.as_deref()
+    pub fn server_graph_name(&self) -> Option<&str> {
+        self.server.graph.as_deref()
     }
 
     pub fn server_bind(&self) -> &str {
@@ -174,7 +177,7 @@ impl OmnigraphConfig {
         })
     }
 
-    pub fn target_bearer_token_env(
+    pub fn graph_bearer_token_env(
         &self,
         explicit_uri: Option<&str>,
         explicit_target: Option<&str>,
@@ -182,7 +185,7 @@ impl OmnigraphConfig {
     ) -> Option<&str> {
         let target_name =
             self.resolve_target_name(explicit_uri, explicit_target, default_target)?;
-        self.targets
+        self.graphs
             .get(target_name)
             .and_then(|target| target.bearer_token_env.as_deref())
     }
@@ -231,9 +234,9 @@ impl OmnigraphConfig {
         let target_name = explicit_target.or(default_target).ok_or_else(|| {
             color_eyre::eyre::eyre!("URI must be provided via <URI>, --target, or config")
         })?;
-        let target = self.targets.get(target_name).ok_or_else(|| {
+        let target = self.graphs.get(target_name).ok_or_else(|| {
             color_eyre::eyre::eyre!(
-                "target '{}' not found in {}",
+                "graph '{}' not found in {}",
                 target_name,
                 DEFAULT_CONFIG_FILE
             )
@@ -332,14 +335,14 @@ mod tests {
         fs::write(
             temp.path().join("omnigraph.yaml"),
             r#"
-targets:
+graphs:
   local:
     uri: ./demo.omni
     bearer_token_env: DEMO_TOKEN
 auth:
   env_file: .env.omni
 cli:
-  target: local
+  graph: local
   branch: main
   output_format: kv
   table_max_column_width: 40
@@ -350,13 +353,13 @@ policy: {}
         .unwrap();
 
         let config = load_config_in(temp.path(), None).unwrap();
-        assert_eq!(config.cli_target_name(), Some("local"));
+        assert_eq!(config.cli_graph_name(), Some("local"));
         assert_eq!(config.cli_branch(), "main");
         assert_eq!(config.cli_output_format(), ReadOutputFormat::Kv);
         assert_eq!(config.table_max_column_width(), 40);
         assert_eq!(config.table_cell_layout(), TableCellLayout::Wrap);
         assert_eq!(
-            config.target_bearer_token_env(None, None, config.cli_target_name()),
+            config.graph_bearer_token_env(None, None, config.cli_graph_name()),
             Some("DEMO_TOKEN")
         );
         assert_eq!(
@@ -366,7 +369,7 @@ policy: {}
         assert_eq!(
             PathBuf::from(
                 config
-                    .resolve_target_uri(None, None, config.cli_target_name())
+                    .resolve_target_uri(None, None, config.cli_graph_name())
                     .unwrap()
             ),
             temp.path().join("./demo.omni")
@@ -380,12 +383,12 @@ policy: {}
         fs::create_dir_all(&child).unwrap();
         fs::write(
             temp.path().join("omnigraph.yaml"),
-            "targets:\n  local:\n    uri: ./demo.omni\n",
+            "graphs:\n  local:\n    uri: ./demo.omni\n",
         )
         .unwrap();
 
         let config = load_config_in(&child, None).unwrap();
-        assert!(config.targets.is_empty());
+        assert!(config.graphs.is_empty());
     }
 
     #[test]
@@ -448,30 +451,30 @@ policy: {}
         fs::write(
             temp.path().join("omnigraph.yaml"),
             r#"
-targets:
+graphs:
   demo:
     uri: https://example.com
     bearer_token_env: DEMO_TOKEN
 cli:
-  target: demo
+  graph: demo
 "#,
         )
         .unwrap();
 
         let config = load_config_in(temp.path(), None).unwrap();
         assert_eq!(
-            config.target_bearer_token_env(
+            config.graph_bearer_token_env(
                 Some("https://override.example.com"),
                 None,
-                config.cli_target_name()
+                config.cli_graph_name()
             ),
             None
         );
         assert_eq!(
-            config.target_bearer_token_env(
+            config.graph_bearer_token_env(
                 Some("https://override.example.com"),
                 Some("demo"),
-                config.cli_target_name()
+                config.cli_graph_name()
             ),
             Some("DEMO_TOKEN")
         );

--- a/crates/omnigraph-server/src/lib.rs
+++ b/crates/omnigraph-server/src/lib.rs
@@ -390,7 +390,7 @@ pub fn load_server_settings(
 ) -> Result<ServerConfig> {
     let config = load_config(config_path)?;
     let uri =
-        config.resolve_target_uri(cli_uri, cli_target.as_deref(), config.server_target_name())?;
+        config.resolve_target_uri(cli_uri, cli_target.as_deref(), config.server_graph_name())?;
     let bind = cli_bind.unwrap_or_else(|| config.server_bind().to_string());
     let policy_file = config.resolve_policy_file();
 
@@ -1458,11 +1458,11 @@ mod tests {
         fs::write(
             &config,
             r#"
-targets:
+graphs:
   local:
     uri: /tmp/demo.omni
 server:
-  target: local
+  graph: local
   bind: 0.0.0.0:9090
 "#,
         )
@@ -1480,11 +1480,11 @@ server:
         fs::write(
             &config,
             r#"
-targets:
+graphs:
   local:
     uri: /tmp/demo.omni
 server:
-  target: local
+  graph: local
   bind: 127.0.0.1:8080
 "#,
         )
@@ -1508,13 +1508,13 @@ server:
         fs::write(
             &config,
             r#"
-targets:
+graphs:
   local:
     uri: ./demo.omni
   dev:
     uri: http://127.0.0.1:8080
 server:
-  target: local
+  graph: local
   bind: 127.0.0.1:8080
 "#,
         )

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -68,11 +68,11 @@ also pass `--schema`.
 
 ## Config
 
-`omnigraph.yaml` lets the CLI and server share named targets, defaults, and
+`omnigraph.yaml` lets the CLI and server share named graphs, defaults, and
 query roots:
 
 ```yaml
-targets:
+graphs:
   local:
     uri: ./demo.omni
   dev:
@@ -80,7 +80,7 @@ targets:
     bearer_token_env: OMNIGRAPH_BEARER_TOKEN
 
 cli:
-  target: local
+  graph: local
   branch: main
 
 query:


### PR DESCRIPTION
## Summary
- rename `omnigraph.yaml` config terminology from `targets`/`target` to `graphs`/`graph`
- update generated configs, CLI/server examples, and config-backed test fixtures to use the new names
- remove the temporary backward-compat layer so config loading is graph-only

## Validation
- cargo test -p omnigraph-server config::tests:: -- --test-threads=1
- cargo test -p omnigraph-cli --test cli read_alias_ -- --test-threads=1
- cargo test -p omnigraph-cli --test cli change_alias_from_yaml_config_persists_changes -- --exact --test-threads=1