### PR TITLE
Prepare v0.2.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4505,7 +4505,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -4542,7 +4542,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -4562,7 +4562,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-compiler"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -4583,7 +4583,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-server"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "axum",
  "cedar-policy",

--- a/crates/omnigraph-cli/Cargo.toml
+++ b/crates/omnigraph-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-cli"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "CLI for the Omnigraph graph database."
 license = "MIT"
@@ -10,9 +10,9 @@ name = "omnigraph"
 path = "src/main.rs"
 
 [dependencies]
-omnigraph = { path = "../omnigraph", version = "0.2.0" }
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.2.0" }
-omnigraph-server = { path = "../omnigraph-server", version = "0.2.0" }
+omnigraph = { path = "../omnigraph", version = "0.2.1" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.2.1" }
+omnigraph-server = { path = "../omnigraph-server", version = "0.2.1" }
 clap = { workspace = true }
 color-eyre = { workspace = true }
 serde = { workspace = true }

--- a/crates/omnigraph-compiler/Cargo.toml
+++ b/crates/omnigraph-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-compiler"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "Schema/query compiler for Omnigraph. Zero Lance dependency."
 license = "MIT"

--- a/crates/omnigraph-server/Cargo.toml
+++ b/crates/omnigraph-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-server"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "HTTP server for the Omnigraph graph database."
 license = "MIT"
@@ -10,8 +10,8 @@ name = "omnigraph-server"
 path = "src/main.rs"
 
 [dependencies]
-omnigraph = { path = "../omnigraph", version = "0.2.0" }
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.2.0" }
+omnigraph = { path = "../omnigraph", version = "0.2.1" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.2.1" }
 axum = { workspace = true }
 clap = { workspace = true }
 color-eyre = { workspace = true }

--- a/crates/omnigraph/Cargo.toml
+++ b/crates/omnigraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "Lance-native graph database with git-style branching."
 license = "MIT"
@@ -10,7 +10,7 @@ default = []
 failpoints = ["dep:fail", "fail/failpoints"]
 
 [dependencies]
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.2.0" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.2.1" }
 lance = { workspace = true }
 lance-datafusion = { workspace = true }
 lance-file = { workspace = true }
@@ -41,7 +41,7 @@ async-trait = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.2.0" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.2.1" }
 tokio = { workspace = true }
 lance-namespace-impls = { workspace = true }
 serial_test = "3"

--- a/docs/releases/v0.2.1.md
+++ b/docs/releases/v0.2.1.md
@@ -1,0 +1,59 @@
+# Omnigraph v0.2.1
+
+Omnigraph v0.2.1 is a focused follow-up release on top of v0.2.0. It adds query linting, improves query execution correctness, hardens the local RustFS bootstrap flow, and cleans up project config naming.
+
+## Highlights
+
+### Query lint and check
+
+The CLI now ships a first-class query validation surface:
+
+- `omnigraph query lint`
+- `omnigraph query check`
+
+These commands validate `.gq` files against either an explicit schema file or a local/S3-backed repo schema, emit structured results, and support both human-readable and JSON output.
+
+### Query execution fixes and aggregate support
+
+This release includes several improvements in the query engine:
+
+- aggregate execution support for read queries
+- nullable query parameters now accept omission and explicit null for nullable params
+- traversal planning and join alignment are more robust for traversal-introduced bindings
+
+Together, these changes make complex read queries more dependable and easier to author.
+
+### Better local RustFS startup
+
+The local RustFS bootstrap is more resilient:
+
+- detects dirty/stale repo prefixes before blindly reinitializing
+- makes bootstrap recovery clearer for persisted local RustFS state
+- ships a more generic demo fixture instead of user-specific seed content
+
+This reduces the most common failure mode in local-first setup.
+
+### Config terminology cleanup
+
+`omnigraph.yaml` now uses graph-oriented naming:
+
+- `graphs:` instead of `targets:`
+- `cli.graph` / `server.graph` instead of `target`
+
+This removes one of the more confusing overloaded terms in the CLI/server config model.
+
+## Included Changes
+
+- PR #15: query lint and query check commands
+- PR #6: aggregate execution support
+- PR #3: nullable query parameter fixes
+- PR #16: traversal planning and join-alignment fixes
+- PR #13: local RustFS bootstrap recovery hardening
+- PR #14: generic bootstrap fixture
+- PR #17: config rename from targets to graphs
+
+## Upgrade Notes
+
+- If you maintain `.gq` files in-repo, add `omnigraph query lint` to your local validation workflow
+- Existing configs must use `graphs:` / `graph:` after this release
+- Local RustFS users should prefer the current bootstrap script from `main` or this release rather than older cached copies


### PR DESCRIPTION
# Omnigraph v0.2.1

Omnigraph v0.2.1 is a focused follow-up release on top of v0.2.0. It adds query linting, improves query execution correctness, hardens the local RustFS bootstrap flow, and cleans up project config naming.

## Highlights

### Query lint and check

The CLI now ships a first-class query validation surface:

- `omnigraph query lint`
- `omnigraph query check`

These commands validate `.gq` files against either an explicit schema file or a local/S3-backed repo schema, emit structured results, and support both human-readable and JSON output.

### Query execution fixes and aggregate support

This release includes several improvements in the query engine:

- aggregate execution support for read queries
- nullable query parameters now accept omission and explicit null for nullable params
- traversal planning and join alignment are more robust for traversal-introduced bindings

Together, these changes make complex read queries more dependable and easier to author.

### Better local RustFS startup

The local RustFS bootstrap is more resilient:

- detects dirty/stale repo prefixes before blindly reinitializing
- makes bootstrap recovery clearer for persisted local RustFS state
- ships a more generic demo fixture instead of user-specific seed content

This reduces the most common failure mode in local-first setup.

### Config terminology cleanup

`omnigraph.yaml` now uses graph-oriented naming:

- `graphs:` instead of `targets:`
- `cli.graph` / `server.graph` instead of `target`

This removes one of the more confusing overloaded terms in the CLI/server config model.

## Included Changes

- PR #15: query lint and query check commands
- PR #6: aggregate execution support
- PR #3: nullable query parameter fixes
- PR #16: traversal planning and join-alignment fixes
- PR #13: local RustFS bootstrap recovery hardening
- PR #14: generic bootstrap fixture
- PR #17: config rename from targets to graphs

## Upgrade Notes

- If you maintain `.gq` files in-repo, add `omnigraph query lint` to your local validation workflow
- Existing configs must use `graphs:` / `graph:` after this release
- Local RustFS users should prefer the current bootstrap script from `main` or this release rather than older cached copies
