### PR TITLE
Prepare v0.2.2 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
             --bucket "${OMNIGRAPH_S3_TEST_BUCKET}" >/dev/null 2>&1 || true
 
       - name: Run RustFS storage tests
-        run: cargo test --locked -p omnigraph --test s3_storage -- --nocapture
+        run: cargo test --locked -p omnigraph-engine --test s3_storage -- --nocapture
 
       - name: Run RustFS server smoke
         run: cargo test --locked -p omnigraph-server --test server server_opens_s3_repo_directly_and_serves_snapshot_and_read -- --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4504,8 +4504,49 @@ dependencies = [
 ]
 
 [[package]]
-name = "omnigraph"
-version = "0.2.1"
+name = "omnigraph-cli"
+version = "0.2.2"
+dependencies = [
+ "assert_cmd",
+ "clap",
+ "color-eyre",
+ "lance-index",
+ "omnigraph-compiler",
+ "omnigraph-engine",
+ "omnigraph-server",
+ "predicates",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
+name = "omnigraph-compiler"
+version = "0.2.2"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-cast",
+ "arrow-ipc",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "pest",
+ "pest_derive",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "omnigraph-engine"
+version = "0.2.2"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -4541,49 +4582,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "omnigraph-cli"
-version = "0.2.1"
-dependencies = [
- "assert_cmd",
- "clap",
- "color-eyre",
- "lance-index",
- "omnigraph",
- "omnigraph-compiler",
- "omnigraph-server",
- "predicates",
- "reqwest",
- "serde",
- "serde_json",
- "serde_yaml",
- "tempfile",
- "tokio",
-]
-
-[[package]]
-name = "omnigraph-compiler"
-version = "0.2.1"
-dependencies = [
- "ahash",
- "arrow-array",
- "arrow-cast",
- "arrow-ipc",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
- "pest",
- "pest_derive",
- "reqwest",
- "serde",
- "serde_json",
- "sha2",
- "thiserror",
- "tokio",
-]
-
-[[package]]
 name = "omnigraph-server"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "axum",
  "cedar-policy",
@@ -4591,8 +4591,8 @@ dependencies = [
  "color-eyre",
  "futures",
  "lance-index",
- "omnigraph",
  "omnigraph-compiler",
+ "omnigraph-engine",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/omnigraph-cli/Cargo.toml
+++ b/crates/omnigraph-cli/Cargo.toml
@@ -1,18 +1,21 @@
 [package]
 name = "omnigraph-cli"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 description = "CLI for the Omnigraph graph database."
 license = "MIT"
+repository = "https://github.com/ModernRelay/omnigraph"
+homepage = "https://github.com/ModernRelay/omnigraph"
+documentation = "https://docs.rs/omnigraph-cli"
 
 [[bin]]
 name = "omnigraph"
 path = "src/main.rs"
 
 [dependencies]
-omnigraph = { path = "../omnigraph", version = "0.2.1" }
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.2.1" }
-omnigraph-server = { path = "../omnigraph-server", version = "0.2.1" }
+omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.2.2" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.2.2" }
+omnigraph-server = { path = "../omnigraph-server", version = "0.2.2" }
 clap = { workspace = true }
 color-eyre = { workspace = true }
 serde = { workspace = true }

--- a/crates/omnigraph-compiler/Cargo.toml
+++ b/crates/omnigraph-compiler/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "omnigraph-compiler"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 description = "Schema/query compiler for Omnigraph. Zero Lance dependency."
 license = "MIT"
+repository = "https://github.com/ModernRelay/omnigraph"
+homepage = "https://github.com/ModernRelay/omnigraph"
+documentation = "https://docs.rs/omnigraph-compiler"
 
 [dependencies]
 arrow-array = { workspace = true }

--- a/crates/omnigraph-server/Cargo.toml
+++ b/crates/omnigraph-server/Cargo.toml
@@ -1,17 +1,20 @@
 [package]
 name = "omnigraph-server"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 description = "HTTP server for the Omnigraph graph database."
 license = "MIT"
+repository = "https://github.com/ModernRelay/omnigraph"
+homepage = "https://github.com/ModernRelay/omnigraph"
+documentation = "https://docs.rs/omnigraph-server"
 
 [[bin]]
 name = "omnigraph-server"
 path = "src/main.rs"
 
 [dependencies]
-omnigraph = { path = "../omnigraph", version = "0.2.1" }
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.2.1" }
+omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.2.2" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.2.2" }
 axum = { workspace = true }
 clap = { workspace = true }
 color-eyre = { workspace = true }

--- a/crates/omnigraph/Cargo.toml
+++ b/crates/omnigraph/Cargo.toml
@@ -1,16 +1,22 @@
 [package]
-name = "omnigraph"
-version = "0.2.1"
+name = "omnigraph-engine"
+version = "0.2.2"
 edition = "2024"
-description = "Lance-native graph database with git-style branching."
+description = "Runtime engine for the Omnigraph graph database."
 license = "MIT"
+repository = "https://github.com/ModernRelay/omnigraph"
+homepage = "https://github.com/ModernRelay/omnigraph"
+documentation = "https://docs.rs/omnigraph-engine"
+
+[lib]
+name = "omnigraph"
 
 [features]
 default = []
 failpoints = ["dep:fail", "fail/failpoints"]
 
 [dependencies]
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.2.1" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.2.2" }
 lance = { workspace = true }
 lance-datafusion = { workspace = true }
 lance-file = { workspace = true }
@@ -41,7 +47,7 @@ async-trait = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.2.1" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.2.2" }
 tokio = { workspace = true }
 lance-namespace-impls = { workspace = true }
 serial_test = "3"

--- a/docs/releases/v0.2.2.md
+++ b/docs/releases/v0.2.2.md
@@ -1,0 +1,29 @@
+# Omnigraph v0.2.2
+
+Omnigraph v0.2.2 is a packaging follow-up to v0.2.1. It keeps the CLI and server surface the same, but renames the published runtime crate from `omnigraph` to `omnigraph-engine` so the full crate set can be published cleanly to crates.io.
+
+## Highlights
+
+### Published runtime crate rename
+
+The runtime package is now published as:
+
+- `omnigraph-engine`
+
+The in-code Rust library name remains `omnigraph`, so internal imports and code paths stay stable. CLI users are unaffected.
+
+### Crates.io metadata cleanup
+
+All published crates now ship repository, homepage, and documentation metadata so the crates.io pages are complete and the release pipeline no longer emits missing-package-metadata warnings.
+
+## Included Changes
+
+- rename runtime package from `omnigraph` to `omnigraph-engine`
+- bump `omnigraph-engine`, `omnigraph-compiler`, `omnigraph-server`, and `omnigraph-cli` to `0.2.2`
+- update dependent manifests and CI package references to the new runtime package name
+
+## Upgrade Notes
+
+- Rust consumers should depend on `omnigraph-engine` on crates.io
+- Code that imports the library can continue using `omnigraph` as the crate name
+- The `omnigraph` CLI binary name is unchanged


### PR DESCRIPTION
# Omnigraph v0.2.2

Omnigraph v0.2.2 is a packaging follow-up to v0.2.1. It keeps the CLI and server surface the same, but renames the published runtime crate from `omnigraph` to `omnigraph-engine` so the full crate set can be published cleanly to crates.io.

## Highlights

### Published runtime crate rename

The runtime package is now published as:

- `omnigraph-engine`

The in-code Rust library name remains `omnigraph`, so internal imports and code paths stay stable. CLI users are unaffected.

### Crates.io metadata cleanup

All published crates now ship repository, homepage, and documentation metadata so the crates.io pages are complete and the release pipeline no longer emits missing-package-metadata warnings.

## Included Changes

- rename runtime package from `omnigraph` to `omnigraph-engine`
- bump `omnigraph-engine`, `omnigraph-compiler`, `omnigraph-server`, and `omnigraph-cli` to `0.2.2`
- update dependent manifests and CI package references to the new runtime package name

## Upgrade Notes

- Rust consumers should depend on `omnigraph-engine` on crates.io
- Code that imports the library can continue using `omnigraph` as the crate name
- The `omnigraph` CLI binary name is unchanged
