### PR TITLE
claude/add-graph-schema-cli-ykEH3

### DIFF
--- a/crates/omnigraph-cli/src/main.rs
+++ b/crates/omnigraph-cli/src/main.rs
@@ -18,7 +18,7 @@ use omnigraph_server::api::{
     BranchCreateOutput, BranchCreateRequest, BranchDeleteOutput, BranchListOutput,
     BranchMergeOutput, BranchMergeRequest, ChangeOutput, ChangeRequest, CommitListOutput,
     CommitOutput, ErrorOutput, ExportRequest, IngestOutput, IngestRequest, ReadOutput, ReadRequest,
-    RunListOutput, RunOutput, SchemaApplyOutput, SchemaApplyRequest, SnapshotOutput,
+    RunListOutput, RunOutput, SchemaApplyOutput, SchemaApplyRequest, SchemaGetOutput, SnapshotOutput,
     SnapshotTableOutput, commit_output, ingest_output, read_output, run_output,
     schema_apply_output, snapshot_payload,
 };
@@ -300,6 +300,17 @@ enum SchemaCommand {
         config: Option<PathBuf>,
         #[arg(long)]
         schema: PathBuf,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Get the current accepted schema source
+    Get {
+        /// Repo URI
+        uri: Option<String>,
+        #[arg(long)]
+        target: Option<String>,
+        #[arg(long)]
+        config: Option<PathBuf>,
         #[arg(long)]
         json: bool,
     },
@@ -2001,6 +2012,37 @@ async fn main() -> Result<()> {
                     print_json(&output)?;
                 } else {
                     print_schema_apply_human(&output);
+                }
+            }
+            SchemaCommand::Get {
+                uri,
+                target,
+                config,
+                json,
+            } => {
+                let config = load_cli_config(config.as_ref())?;
+                let bearer_token =
+                    resolve_remote_bearer_token(&config, uri.as_deref(), target.as_deref())?;
+                let uri = resolve_uri(&config, uri, target.as_deref())?;
+                let output = if is_remote_uri(&uri) {
+                    remote_json::<SchemaGetOutput>(
+                        &http_client,
+                        Method::GET,
+                        remote_url(&uri, "/schema"),
+                        None,
+                        bearer_token.as_deref(),
+                    )
+                    .await?
+                } else {
+                    let db = Omnigraph::open(&uri).await?;
+                    SchemaGetOutput {
+                        source: db.schema_source().to_string(),
+                    }
+                };
+                if json {
+                    print_json(&output)?;
+                } else {
+                    print!("{}", output.source);
                 }
             }
         },

--- a/crates/omnigraph-server/src/api.rs
+++ b/crates/omnigraph-server/src/api.rs
@@ -281,6 +281,11 @@ pub struct SchemaApplyOutput {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct SchemaGetOutput {
+    pub source: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct IngestRequest {
     pub branch: Option<String>,
     pub from: Option<String>,

--- a/crates/omnigraph-server/src/lib.rs
+++ b/crates/omnigraph-server/src/lib.rs
@@ -14,7 +14,7 @@ use api::{
     BranchMergeOutput, BranchMergeRequest, ChangeOutput, ChangeRequest, CommitListOutput,
     CommitListQuery, ErrorCode, ErrorOutput, ExportRequest, HealthOutput, IngestOutput,
     IngestRequest, ReadOutput, ReadRequest, RunListOutput, SchemaApplyOutput, SchemaApplyRequest,
-    SnapshotQuery, ingest_output, schema_apply_output, snapshot_payload,
+    SchemaGetOutput, SnapshotQuery, ingest_output, schema_apply_output, snapshot_payload,
 };
 use axum::body::{Body, Bytes};
 use axum::extract::DefaultBodyLimit;
@@ -63,6 +63,7 @@ use utoipa::openapi::security::{Http, HttpAuthScheme, SecurityScheme};
         server_export,
         server_change,
         server_schema_apply,
+        server_schema_get,
         server_ingest,
         server_branch_list,
         server_branch_create,
@@ -407,6 +408,7 @@ pub fn build_app(state: AppState) -> Router {
         .route("/export", post(server_export))
         .route("/read", post(server_read))
         .route("/change", post(server_change))
+        .route("/schema", get(server_schema_get))
         .route("/schema/apply", post(server_schema_apply))
         .route(
             "/ingest",
@@ -794,6 +796,41 @@ async fn server_change(
         affected_edges: result.affected_edges,
         actor_id: actor_id.map(str::to_string),
     }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/schema",
+    tag = "schema",
+    responses(
+        (status = 200, description = "Current schema source", body = SchemaGetOutput),
+        (status = 401, description = "Unauthorized", body = ErrorOutput),
+        (status = 403, description = "Forbidden", body = ErrorOutput),
+    ),
+    security(("bearer_token" = [])),
+)]
+async fn server_schema_get(
+    State(state): State<AppState>,
+    actor: Option<Extension<AuthenticatedActor>>,
+) -> std::result::Result<Json<SchemaGetOutput>, ApiError> {
+    authorize_request(
+        &state,
+        actor.as_ref().map(|Extension(actor)| actor),
+        PolicyRequest {
+            actor_id: actor
+                .as_ref()
+                .map(|Extension(actor)| actor.as_str().to_string())
+                .unwrap_or_default(),
+            action: PolicyAction::Read,
+            branch: None,
+            target_branch: None,
+        },
+    )?;
+    let source = {
+        let db = Arc::clone(&state.db).read_owned().await;
+        db.schema_source().to_string()
+    };
+    Ok(Json(SchemaGetOutput { source }))
 }
 
 #[utoipa::path(

--- a/crates/omnigraph-server/tests/openapi.rs
+++ b/crates/omnigraph-server/tests/openapi.rs
@@ -161,6 +161,7 @@ const EXPECTED_PATHS: &[&str] = &[
     "/read",
     "/export",
     "/change",
+    "/schema",
     "/schema/apply",
     "/ingest",
     "/branches",


### PR DESCRIPTION
Exposes the existing schema_source() method via a new `omnigraph schema get`
CLI subcommand and a `GET /schema` API endpoint, allowing users to retrieve
the current accepted schema from any graph repository.

https://claude.ai/code/session_01UYybeBQks3fz3RJrTHtwQw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new read-only endpoint and CLI command without altering schema application or data mutation paths; primary risk is minor auth/policy misconfiguration on the new route.
> 
> **Overview**
> Adds a new read-only schema retrieval surface: `GET /schema` on the server (OpenAPI-documented and covered by path tests) plus a matching `omnigraph schema get` CLI subcommand.
> 
> The CLI resolves local vs remote targets; for remote it calls `GET /schema` with optional bearer auth, and for local it reads `schema_source()` directly, outputting either raw text or JSON (`SchemaGetOutput`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c4df674fa65b1e37f0c7db4905199bd6e18353d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->