### PR TITLE
Rewrite README around context-layer positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,79 +5,164 @@
 [![Crates.io](https://img.shields.io/crates/v/omnigraph-cli.svg)](https://crates.io/crates/omnigraph-cli)
 [![CI](https://github.com/ModernRelay/omnigraph/actions/workflows/ci.yml/badge.svg)](https://github.com/ModernRelay/omnigraph/actions/workflows/ci.yml)
 
-Typed graph engine built for reasoning paths, not just storage.  
-Git-style workflows, schema-as-code graph modeling, S3-optimized.
+**The context graph that versions like git.**
 
-## Use Cases
+Your company's context lives in a dozen places: the CRM, Slack, Notion, Linear, a warehouse, meeting transcripts, SOPs, and a few people's heads. Omnigraph is where it comes together as one typed, versioned graph that your agents and your team read from and write back to.
 
-- On-prem & hybrid context graphs
-- Backbone for multi-agentic research
-- Enterprise knowledge systems
+Agents and humans both work on branches. A reviewer (human or agent) merges the good writes into main and discards the rest. The ontology is the typed contract, so every write is either valid or rejected at the door.
 
-## Quick Install
+Technically: a typed graph database with git-style branches, commits, and merges. You write a schema in `.pg`, write queries in `.gq`, and the compiler typechecks both. Graph traversal, text, BM25, vector, and fuzzy search run in one engine. Same binary on a laptop, on-prem, or on S3 in your VPC.
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/ModernRelay/omnigraph/main/scripts/install.sh | bash
-```
+## Good fit for
 
-This installs `omnigraph` and `omnigraph-server` into `~/.local/bin` from
-published release binaries. 
+- Building a company "brain" that unifies context across Slack, Notion, the CRM, a warehouse, meeting transcripts, and your agents.
+- Running multi-agent systems where multiple agents write to shared state and you need branch-based review before anything lands.
+- Building research, incident response, compliance, or intel tooling where relationships between entities and the history of changes are load-bearing.
+- Tired of gluing a graph DB, a vector store, and a search index together and keeping them in sync.
 
-Or install with Homebrew:
+## If you want something lighter
+
+- For a personal markdown wiki you maintain by hand: [LLM Wikid](https://github.com/shannhk/llm-wikid) or plain Obsidian.
+- For on-device markdown search with an MCP server: [qmd](https://github.com/tobi/qmd).
+- For transactional OLTP workloads: stay with Postgres.
+
+## Install
+
+Homebrew:
 
 ```bash
 brew tap ModernRelay/tap
 brew install ModernRelay/tap/omnigraph
 ```
 
-For starter graphs and agent skills to bootstrap and operate Omnigraph, see [`ModernRelay/omnigraph-starters`](https://github.com/ModernRelay/omnigraph-starters).
+Or via install script (release binaries into `~/.local/bin`):
 
-## One-Command Local RustFS Bootstrap
+```bash
+curl -fsSL https://raw.githubusercontent.com/ModernRelay/omnigraph/main/scripts/install.sh | bash
+```
+
+Read [scripts/install.sh](scripts/install.sh) before piping to bash.
+
+## Quick start
+
+The same URI works for local paths, `s3://…`, or `http://host:port`.
+
+```bash
+# 1. Create a repo from a typed schema
+omnigraph init --schema ./schema.pg ./repo.omni
+
+# 2. Load the initial data on main
+omnigraph load --data ./people.jsonl ./repo.omni
+
+# 3. Run a typed query
+omnigraph read --query ./queries.gq --name get_person \
+  --params '{"name":"Alice"}' ./repo.omni
+
+# 4. Let an agent ingest enrichments onto a reviewable branch
+omnigraph ingest --data ./agent-enrichment.jsonl \
+  --branch agent/run-2026-04-17 --from main ./repo.omni
+
+# 5. Review the branch (read queries support --branch)
+omnigraph read --query ./queries.gq --name recent_changes \
+  --branch agent/run-2026-04-17 ./repo.omni
+
+# 6. Merge the reviewed work back into main
+omnigraph branch merge agent/run-2026-04-17 --into main ./repo.omni
+```
+
+See [docs/cli.md](docs/cli.md) for schema plan/apply, snapshots, exports, runs, commit history, and policy commands.
+
+## Connecting your sources
+
+Ingestion today is JSONL via `omnigraph load` and `omnigraph ingest`, plus HTTP ingest through `omnigraph-server`. You shape the data and run the jobs. A connector pack for common sources (Notion, Slack, HubSpot, Granola, Linear, Gmail) is on the roadmap. Until then, the load/ingest interface is yours to build against.
+
+## One-command local bootstrap
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/ModernRelay/omnigraph/main/scripts/local-rustfs-bootstrap.sh | bash
 ```
 
-That bootstrap:
+Starts RustFS on `127.0.0.1:9000`, creates a bucket and S3-backed repo, loads a fixture, and launches `omnigraph-server` on `127.0.0.1:8080`. Docker required.
 
-- starts RustFS on `127.0.0.1:9000`
-- creates a bucket and S3-backed repo
-- loads the checked-in context fixture
-- launches `omnigraph-server` on `127.0.0.1:8080`
+If a previous run left a partial repo under the same prefix, rerun with `RESET_REPO=1` or set `PREFIX` to a new value.
 
-Docker must be installed and running first.
+## How it works
 
-The RustFS bootstrap prefers the rolling `edge` binaries and only falls back to
-source builds when release assets are unavailable.
+Three concepts cover almost everything.
 
-If a previous run left objects under the same repo prefix but did not finish
-initializing the repo, rerun with `RESET_REPO=1` or set `PREFIX` to a new
-value.
+- **Schema (`.pg` files).** Node types, edge types, fields, keys, vector dimensions, enums. `omnigraph schema plan` and `omnigraph schema apply` make schema changes explicit and reviewable.
+- **Queries (`.gq` files).** Typed read and change queries with named parameters. Compiled against the schema. `omnigraph query lint` catches drift in CI.
+- **Branches.** Every write happens on a branch. `main` is the default. `ingest` creates reviewable branches for bulk work. `branch merge` moves them back. Commits carry full history.
 
-## Omnigraph CORE
+Storage is Lance on disk or on any S3-compatible bucket. Reads are snapshot-pinned. Search (text, BM25, vector, fuzzy, RRF) runs in the same engine as traversal.
 
-- Typed schema, typed queries, and typed mutations
-- Schema-as-code, query validation and linting
-- Git-style graph workflows: branches, commits, merges, and transactional runs
-- Local, on-prem & cloud S3-native storage with snapshot-pinned reads
-- Graph traversal + text, fuzzy, BM25, vector, and RRF search in one runtime
-- Policy-as-code for server-side access control
-- Single CLI for multiple deployments
+## Multiplayer by design
 
-## Common Commands
+Three kinds of writers coexist on one graph:
 
-The same URI works for local paths, `s3://…`, or `http://host:port`.
+- **Systems** land facts on main: nightly ETL, webhook ingest, SaaS syncs.
+- **Agents** work on branches: enrichment, workflow runs, research tasks. They stay off main until a reviewer merges them.
+- **Humans** review the branch and merge what's good.
 
-```bash
-omnigraph init   --schema ./schema.pg ./repo.omni
-omnigraph load   --data   ./data.jsonl ./repo.omni
-omnigraph read   --query  ./queries.gq --name get_person --params '{"name":"Alice"}' ./repo.omni
-omnigraph change --query  ./queries.gq --name insert_person --params '{"name":"Mina"}' ./repo.omni
-omnigraph branch create --from main feature-x ./repo.omni
-omnigraph branch merge  feature-x --into main ./repo.omni
-```
+Branches are what makes this work at scale. Run 20 enrichment agents in parallel, each on its own copy-on-write branch. A reviewer (human or agent) merges the correct work. You get history, provenance, and rollback for free because they're git primitives applied to rows and edges.
 
-See [docs/cli.md](docs/cli.md) for schema apply, snapshots, ingest, runs, and policy commands.
+## Design choices
+
+- **Schema-as-code.** The typed contract is the source of truth for every reader and writer. Schema changes go through `omnigraph schema plan` and `omnigraph schema apply`, so migrations are explicit and reviewable.
+- **Compiled queries.** `.gq` files live in your repo and go through typechecking and linting. Queries get reviewed like code.
+- **Copy-on-write branches.** Every writer gets an isolated branch. Merges are explicit and can surface conflicts, same as git.
+- **One runtime for graph + search + vector.** Traversal and retrieval share an execution engine. Graph-shaped workloads fit naturally; OLTP-shaped workloads still belong in Postgres.
+- **Object storage native.** Lance on S3 is a first-class deployment target. At laptop scale, local disk is faster, and the binary and semantics are identical across both.
+
+## What Omnigraph gives your agents
+
+- A shared system of record for entities, relationships, and state.
+- Schema-as-code: agents know what to ask for and how to write back.
+- Graph queries and text/vector search in one runtime.
+- Branches for parallel work. Agents run in isolation, humans review before merge.
+- Graph diffs so agents can react to state transitions.
+- Full history of what changed and why.
+
+## Use cases
+
+- **Research agents.** Papers, notes, concepts, and claims in a typed graph. Agents trace citations, surface contradictions, synthesize across sources.
+- **Revenue operations.** Accounts, contacts, deals, signals, activities. Agents score risk and brief reps.
+- **Incident response.** Services, alerts, incidents, actions in a dependency graph. Agents calculate blast radius.
+- **Compliance.** Policies, controls, evidence, risks versioned in a graph. Agents flag gaps and trace decision chains.
+- **Enterprise knowledge.** Multi-tenant, policy-gated context. Per-team branches, Cedar at the query layer, full audit.
+- **Industry intel.** Companies, people, deals, filings, patents over time. Agents detect signals and brief analysts.
+- **Context graphs for agents.** On-prem memory that survives sessions. Typed schema per agent, branches for experiments.
+
+## Foundation
+
+Open source all the way down.
+
+- **Rust** for the runtime. Single binary, no GC, no JVM.
+- **Apache Arrow** for in-memory columnar execution (same family as Polars and DuckDB).
+- **Lance** for storage. Versioned columnar format with random access.
+- **DataFusion** compiles typed graph queries to optimized physical plans.
+- **RustFS** for Rust-native S3. Same graph on laptop, VPC, or cloud.
+- **Cedar** for deny-first, auditable access control.
+
+## Out of scope (bring your own)
+
+- OLTP primary database. Your transactional store stays where it is.
+- Agent orchestrator. Works alongside LangGraph, CrewAI, or your own loop.
+- Embedding pipeline. Omnigraph stores and searches vectors; you generate them.
+- Hosted SaaS. Self-hosted, open source, local-first.
+
+## Roadmap
+
+Rough direction.
+
+- **Connector pack.** First-party ingestion jobs for Notion, Slack, HubSpot, Granola, Linear, Gmail, and friends, with shelf-life-aware refresh.
+- **Triggers.** Schema-declared reactions to writes (enrich a Person when a new one lands, validate an edge against an external source). Agents subscribe and react without polling.
+- **Change feeds.** Durable streams of graph diffs for downstream consumers.
+- **Background jobs.** First-class runner for long-lived agent tasks on branches.
+- **Richer merge strategies.** Policy-driven conflict resolution, semantic three-way merges for graph data.
+- **Managed server features.** Multi-tenant isolation, quota, audit hooks.
+
+Ideas and feedback in [GitHub issues](https://github.com/ModernRelay/omnigraph/issues).
 
 ## Docs
 
@@ -85,7 +170,11 @@ See [docs/cli.md](docs/cli.md) for schema apply, snapshots, ingest, runs, and po
 - [CLI guide](docs/cli.md)
 - [Deployment guide](docs/deployment.md)
 
-## Build And Test
+## Starter graphs
+
+For starter schemas and agent skills, see [ModernRelay/omnigraph-starters](https://github.com/ModernRelay/omnigraph-starters).
+
+## Build and test
 
 ```bash
 cargo build --workspace
@@ -93,22 +182,15 @@ cargo check --workspace
 cargo test --workspace
 ```
 
-Notes:
+Rust stable, edition 2024. CI runs `cargo test --workspace --locked`. Some local flows need `protobuf-compiler`. S3 integration tests expect an S3-compatible endpoint (RustFS works).
 
-- Rust stable toolchain, edition 2024
-- CI runs `cargo test --workspace --locked`
-- Full CI and some local test flows require `protobuf-compiler`
-- S3 integration tests expect an S3-compatible endpoint such as RustFS
+## Workspace crates
 
-## Workspace Crates
-
-- `crates/omnigraph-compiler`: shared schema/query parser, typechecker, catalog, and IR lowering
-- `crates/omnigraph`: storage/runtime, branching, merge, change detection, and query execution
-- `crates/omnigraph-cli`: CLI for init/load/ingest/read/change/branch/snapshot/export/policy operations
-- `crates/omnigraph-server`: Axum HTTP server for remote reads, changes, ingest, export, branches, commits, and runs
+- `crates/omnigraph-compiler`: schema/query parser, typechecker, catalog, IR lowering.
+- `crates/omnigraph`: storage, runtime, branching, merge, change detection, query execution.
+- `crates/omnigraph-cli`: init, load, ingest, read, change, branch, snapshot, export, commit, policy.
+- `crates/omnigraph-server`: Axum HTTP server for remote reads, changes, ingest, export, branches, commits, runs.
 
 ## Contributing
 
-Please open an issue, spec, or design discussion before sending large code
-changes. Design feedback and concrete problem statements are the fastest way to
-collaborate on the roadmap.
+Open an issue or design discussion before large code changes. Concrete problem statements and spec feedback are the fastest way to move the roadmap.


### PR DESCRIPTION
## Summary

- Reframe Omnigraph as a shared, versioned context graph for agents and humans, with a layered opener that works for both technical and less-technical readers.
- Replace the fabricated enrichment demo with a real agent-review flow using `ingest`, `read --branch`, and `branch merge`.
- Add honest scope sections: `Good fit for`, `If you want something lighter`, `Connecting your sources`, `Design choices`, `Out of scope`, and a `Roadmap` that flags triggers and the connector pack as not-yet-shipped.

## Test plan

- [ ] Read top-to-bottom as a platform engineer evaluating whether to build on Omnigraph.
- [ ] Read top-to-bottom as a non-engineer trying to decide if this is for them.
- [ ] Verify every CLI command in Quick Start matches the actual CLI surface (`init`, `load`, `ingest`, `read --branch`, `branch merge`).
- [ ] Check external links render (LLM Wikid, qmd, docs pages, starters repo).
- [ ] Confirm the Foundation list (Rust/Arrow/Lance/DataFusion/RustFS/Cedar) is accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; risk is limited to potential confusion if any CLI commands or claims are inaccurate.
> 
> **Overview**
> Rewrites `README.md` to reposition Omnigraph as a shared, typed **context graph for agents + humans** with git-style branching/merging at the core.
> 
> Updates install/quick-start docs by adding Homebrew steps, tightening safety notes, and replacing the example workflow with a branch-based agent ingestion + review flow (`ingest` → `read --branch` → `branch merge`). Adds new scope/expectations sections (fit, lighter alternatives, source-connection status, design choices, out-of-scope, and roadmap) and refreshes the bootstrap and workspace-crate descriptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a590fa3fc3bde2312679c3731991af8c91aa790d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->