### PR TITLE
Add schema show command (supersedes #23)

### DIFF
--- a/crates/omnigraph-cli/src/main.rs
+++ b/crates/omnigraph-cli/src/main.rs
@@ -18,7 +18,7 @@ use omnigraph_server::api::{
     BranchCreateOutput, BranchCreateRequest, BranchDeleteOutput, BranchListOutput,
     BranchMergeOutput, BranchMergeRequest, ChangeOutput, ChangeRequest, CommitListOutput,
     CommitOutput, ErrorOutput, ExportRequest, IngestOutput, IngestRequest, ReadOutput, ReadRequest,
-    RunListOutput, RunOutput, SchemaApplyOutput, SchemaApplyRequest, SchemaGetOutput, SnapshotOutput,
+    RunListOutput, RunOutput, SchemaApplyOutput, SchemaApplyRequest, SchemaOutput, SnapshotOutput,
     SnapshotTableOutput, commit_output, ingest_output, read_output, run_output,
     schema_apply_output, snapshot_payload,
 };
@@ -303,8 +303,9 @@ enum SchemaCommand {
         #[arg(long)]
         json: bool,
     },
-    /// Get the current accepted schema source
-    Get {
+    /// Show the current accepted schema source
+    #[command(alias = "get")]
+    Show {
         /// Repo URI
         uri: Option<String>,
         #[arg(long)]
@@ -2014,7 +2015,7 @@ async fn main() -> Result<()> {
                     print_schema_apply_human(&output);
                 }
             }
-            SchemaCommand::Get {
+            SchemaCommand::Show {
                 uri,
                 target,
                 config,
@@ -2025,7 +2026,7 @@ async fn main() -> Result<()> {
                     resolve_remote_bearer_token(&config, uri.as_deref(), target.as_deref())?;
                 let uri = resolve_uri(&config, uri, target.as_deref())?;
                 let output = if is_remote_uri(&uri) {
-                    remote_json::<SchemaGetOutput>(
+                    remote_json::<SchemaOutput>(
                         &http_client,
                         Method::GET,
                         remote_url(&uri, "/schema"),
@@ -2035,14 +2036,14 @@ async fn main() -> Result<()> {
                     .await?
                 } else {
                     let db = Omnigraph::open(&uri).await?;
-                    SchemaGetOutput {
-                        source: db.schema_source().to_string(),
+                    SchemaOutput {
+                        schema_source: db.schema_source().to_string(),
                     }
                 };
                 if json {
                     print_json(&output)?;
                 } else {
-                    print!("{}", output.source);
+                    println!("{}", output.schema_source);
                 }
             }
         },

--- a/crates/omnigraph-cli/src/main.rs
+++ b/crates/omnigraph-cli/src/main.rs
@@ -18,7 +18,7 @@ use omnigraph_server::api::{
     BranchCreateOutput, BranchCreateRequest, BranchDeleteOutput, BranchListOutput,
     BranchMergeOutput, BranchMergeRequest, ChangeOutput, ChangeRequest, CommitListOutput,
     CommitOutput, ErrorOutput, ExportRequest, IngestOutput, IngestRequest, ReadOutput, ReadRequest,
-    RunListOutput, RunOutput, SchemaApplyOutput, SchemaApplyRequest, SnapshotOutput,
+    RunListOutput, RunOutput, SchemaApplyOutput, SchemaApplyRequest, SchemaGetOutput, SnapshotOutput,
     SnapshotTableOutput, commit_output, ingest_output, read_output, run_output,
     schema_apply_output, snapshot_payload,
 };
@@ -300,6 +300,17 @@ enum SchemaCommand {
         config: Option<PathBuf>,
         #[arg(long)]
         schema: PathBuf,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Get the current accepted schema source
+    Get {
+        /// Repo URI
+        uri: Option<String>,
+        #[arg(long)]
+        target: Option<String>,
+        #[arg(long)]
+        config: Option<PathBuf>,
         #[arg(long)]
         json: bool,
     },
@@ -2001,6 +2012,37 @@ async fn main() -> Result<()> {
                     print_json(&output)?;
                 } else {
                     print_schema_apply_human(&output);
+                }
+            }
+            SchemaCommand::Get {
+                uri,
+                target,
+                config,
+                json,
+            } => {
+                let config = load_cli_config(config.as_ref())?;
+                let bearer_token =
+                    resolve_remote_bearer_token(&config, uri.as_deref(), target.as_deref())?;
+                let uri = resolve_uri(&config, uri, target.as_deref())?;
+                let output = if is_remote_uri(&uri) {
+                    remote_json::<SchemaGetOutput>(
+                        &http_client,
+                        Method::GET,
+                        remote_url(&uri, "/schema"),
+                        None,
+                        bearer_token.as_deref(),
+                    )
+                    .await?
+                } else {
+                    let db = Omnigraph::open(&uri).await?;
+                    SchemaGetOutput {
+                        source: db.schema_source().to_string(),
+                    }
+                };
+                if json {
+                    print_json(&output)?;
+                } else {
+                    print!("{}", output.source);
                 }
             }
         },

--- a/crates/omnigraph-server/src/api.rs
+++ b/crates/omnigraph-server/src/api.rs
@@ -281,6 +281,11 @@ pub struct SchemaApplyOutput {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct SchemaGetOutput {
+    pub source: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct IngestRequest {
     pub branch: Option<String>,
     pub from: Option<String>,

--- a/crates/omnigraph-server/src/api.rs
+++ b/crates/omnigraph-server/src/api.rs
@@ -281,8 +281,8 @@ pub struct SchemaApplyOutput {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-pub struct SchemaGetOutput {
-    pub source: String,
+pub struct SchemaOutput {
+    pub schema_source: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/crates/omnigraph-server/src/lib.rs
+++ b/crates/omnigraph-server/src/lib.rs
@@ -14,7 +14,7 @@ use api::{
     BranchMergeOutput, BranchMergeRequest, ChangeOutput, ChangeRequest, CommitListOutput,
     CommitListQuery, ErrorCode, ErrorOutput, ExportRequest, HealthOutput, IngestOutput,
     IngestRequest, ReadOutput, ReadRequest, RunListOutput, SchemaApplyOutput, SchemaApplyRequest,
-    SnapshotQuery, ingest_output, schema_apply_output, snapshot_payload,
+    SchemaGetOutput, SnapshotQuery, ingest_output, schema_apply_output, snapshot_payload,
 };
 use axum::body::{Body, Bytes};
 use axum::extract::DefaultBodyLimit;
@@ -63,6 +63,7 @@ use utoipa::openapi::security::{Http, HttpAuthScheme, SecurityScheme};
         server_export,
         server_change,
         server_schema_apply,
+        server_schema_get,
         server_ingest,
         server_branch_list,
         server_branch_create,
@@ -407,6 +408,7 @@ pub fn build_app(state: AppState) -> Router {
         .route("/export", post(server_export))
         .route("/read", post(server_read))
         .route("/change", post(server_change))
+        .route("/schema", get(server_schema_get))
         .route("/schema/apply", post(server_schema_apply))
         .route(
             "/ingest",
@@ -794,6 +796,41 @@ async fn server_change(
         affected_edges: result.affected_edges,
         actor_id: actor_id.map(str::to_string),
     }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/schema",
+    tag = "schema",
+    responses(
+        (status = 200, description = "Current schema source", body = SchemaGetOutput),
+        (status = 401, description = "Unauthorized", body = ErrorOutput),
+        (status = 403, description = "Forbidden", body = ErrorOutput),
+    ),
+    security(("bearer_token" = [])),
+)]
+async fn server_schema_get(
+    State(state): State<AppState>,
+    actor: Option<Extension<AuthenticatedActor>>,
+) -> std::result::Result<Json<SchemaGetOutput>, ApiError> {
+    authorize_request(
+        &state,
+        actor.as_ref().map(|Extension(actor)| actor),
+        PolicyRequest {
+            actor_id: actor
+                .as_ref()
+                .map(|Extension(actor)| actor.as_str().to_string())
+                .unwrap_or_default(),
+            action: PolicyAction::Read,
+            branch: None,
+            target_branch: None,
+        },
+    )?;
+    let source = {
+        let db = Arc::clone(&state.db).read_owned().await;
+        db.schema_source().to_string()
+    };
+    Ok(Json(SchemaGetOutput { source }))
 }
 
 #[utoipa::path(

--- a/crates/omnigraph-server/src/lib.rs
+++ b/crates/omnigraph-server/src/lib.rs
@@ -14,7 +14,7 @@ use api::{
     BranchMergeOutput, BranchMergeRequest, ChangeOutput, ChangeRequest, CommitListOutput,
     CommitListQuery, ErrorCode, ErrorOutput, ExportRequest, HealthOutput, IngestOutput,
     IngestRequest, ReadOutput, ReadRequest, RunListOutput, SchemaApplyOutput, SchemaApplyRequest,
-    SchemaGetOutput, SnapshotQuery, ingest_output, schema_apply_output, snapshot_payload,
+    SchemaOutput, SnapshotQuery, ingest_output, schema_apply_output, snapshot_payload,
 };
 use axum::body::{Body, Bytes};
 use axum::extract::DefaultBodyLimit;
@@ -803,7 +803,7 @@ async fn server_change(
     path = "/schema",
     tag = "schema",
     responses(
-        (status = 200, description = "Current schema source", body = SchemaGetOutput),
+        (status = 200, description = "Current schema source", body = SchemaOutput),
         (status = 401, description = "Unauthorized", body = ErrorOutput),
         (status = 403, description = "Forbidden", body = ErrorOutput),
     ),
@@ -812,7 +812,7 @@ async fn server_change(
 async fn server_schema_get(
     State(state): State<AppState>,
     actor: Option<Extension<AuthenticatedActor>>,
-) -> std::result::Result<Json<SchemaGetOutput>, ApiError> {
+) -> std::result::Result<Json<SchemaOutput>, ApiError> {
     authorize_request(
         &state,
         actor.as_ref().map(|Extension(actor)| actor),
@@ -826,11 +826,11 @@ async fn server_schema_get(
             target_branch: None,
         },
     )?;
-    let source = {
+    let schema_source = {
         let db = Arc::clone(&state.db).read_owned().await;
         db.schema_source().to_string()
     };
-    Ok(Json(SchemaGetOutput { source }))
+    Ok(Json(SchemaOutput { schema_source }))
 }
 
 #[utoipa::path(

--- a/crates/omnigraph-server/tests/openapi.rs
+++ b/crates/omnigraph-server/tests/openapi.rs
@@ -161,6 +161,7 @@ const EXPECTED_PATHS: &[&str] = &[
     "/read",
     "/export",
     "/change",
+    "/schema",
     "/schema/apply",
     "/ingest",
     "/branches",

--- a/crates/omnigraph-server/tests/server.rs
+++ b/crates/omnigraph-server/tests/server.rs
@@ -10,7 +10,7 @@ use omnigraph::db::{Omnigraph, ReadTarget};
 use omnigraph::loader::{LoadMode, load_jsonl};
 use omnigraph_server::api::{
     BranchCreateRequest, BranchMergeRequest, ChangeRequest, ErrorOutput, ExportRequest,
-    IngestRequest, ReadRequest, SchemaApplyRequest,
+    IngestRequest, ReadRequest, SchemaApplyRequest, SchemaOutput,
 };
 use omnigraph_server::{AppState, build_app};
 use serde_json::{Value, json};
@@ -1040,6 +1040,93 @@ async fn snapshot_route_returns_manifest_dataset_version() {
         expected_manifest_version
     );
     assert!(snapshot_body["tables"].is_array());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn schema_route_returns_current_source() {
+    let (_temp, app) = app_for_loaded_repo().await;
+    let (status, body) = json_response(
+        &app,
+        Request::builder()
+            .uri("/schema")
+            .method(Method::GET)
+            .body(Body::empty())
+            .unwrap(),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let output: SchemaOutput = serde_json::from_value(body).unwrap();
+    assert!(output.schema_source.contains("node Person"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn schema_route_requires_bearer_token_when_auth_configured() {
+    let (_temp, app) = app_for_loaded_repo_with_auth("demo-token").await;
+
+    let (missing_status, missing_body) = json_response(
+        &app,
+        Request::builder()
+            .uri("/schema")
+            .method(Method::GET)
+            .body(Body::empty())
+            .unwrap(),
+    )
+    .await;
+    let missing_error: ErrorOutput = serde_json::from_value(missing_body).unwrap();
+    assert_eq!(missing_status, StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        missing_error.code,
+        Some(omnigraph_server::api::ErrorCode::Unauthorized)
+    );
+
+    let (ok_status, ok_body) = json_response(
+        &app,
+        Request::builder()
+            .uri("/schema")
+            .method(Method::GET)
+            .header("authorization", "Bearer demo-token")
+            .body(Body::empty())
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(ok_status, StatusCode::OK);
+    let output: SchemaOutput = serde_json::from_value(ok_body).unwrap();
+    assert!(!output.schema_source.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn schema_route_denied_when_actor_lacks_read_permission() {
+    let temp = init_loaded_repo().await;
+    let repo = repo_path(temp.path());
+    let policy_path = temp.path().join("policy.yaml");
+    // Policy grants branch_create only — no read action for act-bruno.
+    fs::write(&policy_path, INGEST_CREATE_ONLY_POLICY_YAML).unwrap();
+    let state = AppState::open_with_bearer_tokens_and_policy(
+        repo.to_string_lossy().to_string(),
+        vec![("act-bruno".to_string(), "team-token".to_string())],
+        Some(&policy_path),
+    )
+    .await
+    .unwrap();
+    let app = build_app(state);
+
+    let (status, body) = json_response(
+        &app,
+        Request::builder()
+            .uri("/schema")
+            .method(Method::GET)
+            .header("authorization", "Bearer team-token")
+            .body(Body::empty())
+            .unwrap(),
+    )
+    .await;
+    let error: ErrorOutput = serde_json::from_value(body).unwrap();
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(
+        error.code,
+        Some(omnigraph_server::api::ErrorCode::Forbidden)
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Supersedes #23. Preserves @ragnorc's original commit (`0c4df67`) and adds a polish commit on top with the review feedback from that PR applied.

## Summary

- Carries forward @ragnorc's `GET /schema` endpoint + `omnigraph schema` CLI subcommand from #23.
- Renames the CLI verb from `get` to `show` to match the existing `run show` / `commit show` convention. A `#[command(alias = "get")]` preserves muscle memory for anyone who already typed `get`.
- Renames `SchemaGetOutput` → `SchemaOutput` and its field `source` → `schema_source`, so the get response and the apply request use the same field name for the same concept.
- `print!` → `println!` so the shell prompt doesn't collide with the last line of schema output.
- Adds three integration tests on `/schema`: happy path, 401 when bearer is required but missing, 403 when the policy grants `branch_create` but not `read`.

## Deferred for a follow-up PR

- `schema_ir_hash` and `schema_identity_version` in the response payload so clients can do drift detection without SHA-ing the source themselves. Needs new fields on `Omnigraph` populated at open/init/apply time.
- Server-side `ETag` / `If-None-Match` → 304 once the hash is in the payload.
- Fast-path local read that skips `Omnigraph::open()` when only the schema source is needed.

## Test plan

- [x] `cargo test -p omnigraph-server --test server -- --test-threads=1` — 40 passed, 0 failed (full parallel run hits Lance's external-sort memory pool on this machine — pre-existing flake, unrelated).
- [x] `cargo test -p omnigraph-server --test openapi` — 64 passed.
- [x] `cargo check -p omnigraph-cli` — clean.
- [x] New tests: `schema_route_returns_current_source`, `schema_route_requires_bearer_token_when_auth_configured`, `schema_route_denied_when_actor_lacks_read_permission`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)