### PR TITLE
Extract TokenSource trait (prep for AWS backend)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4585,6 +4585,7 @@ dependencies = [
 name = "omnigraph-server"
 version = "0.2.2"
 dependencies = [
+ "async-trait",
  "axum",
  "cedar-policy",
  "clap",

--- a/crates/omnigraph-server/Cargo.toml
+++ b/crates/omnigraph-server/Cargo.toml
@@ -30,6 +30,7 @@ cedar-policy = { workspace = true }
 futures = { workspace = true }
 sha2 = { workspace = true }
 subtle = { workspace = true }
+async-trait = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/omnigraph-server/src/auth.rs
+++ b/crates/omnigraph-server/src/auth.rs
@@ -1,0 +1,106 @@
+//! Bearer token sources.
+//!
+//! A `TokenSource` loads `(actor_id, token)` pairs that the server uses to
+//! authenticate incoming bearer tokens. Plaintext tokens returned here are
+//! hashed immediately by `AppState` on ingest — see `hash_bearer_token` —
+//! and never persist past startup/refresh.
+//!
+//! The trait exists so that additional backends (AWS Secrets Manager,
+//! HashiCorp Vault, etc.) can plug in behind feature flags without
+//! touching the server wiring.
+
+use async_trait::async_trait;
+use color_eyre::eyre::Result;
+
+use crate::server_bearer_tokens_from_env;
+
+/// A source of bearer tokens, returned as `(actor_id, token)` pairs in
+/// plaintext. The caller is expected to hash tokens before storing them.
+#[async_trait]
+pub trait TokenSource: Send + Sync {
+    /// Fetch the current set of actor → token pairs.
+    ///
+    /// Called once at startup. Implementations that support rotation may
+    /// also be polled periodically.
+    async fn load(&self) -> Result<Vec<(String, String)>>;
+
+    /// Whether this source can be re-fetched for rotation without restart.
+    /// Default: false (one-shot sources).
+    fn supports_refresh(&self) -> bool {
+        false
+    }
+
+    /// Human-readable name for logs and error messages.
+    fn name(&self) -> &'static str;
+}
+
+/// Reads bearer tokens from environment variables and / or files, matching
+/// the long-standing server configuration:
+///
+/// - `OMNIGRAPH_SERVER_BEARER_TOKEN` — a single token assigned to the
+///   implicit actor `default`.
+/// - `OMNIGRAPH_SERVER_BEARER_TOKENS_JSON` — a JSON object of
+///   `{"actor_id": "token", …}`.
+/// - `OMNIGRAPH_SERVER_BEARER_TOKENS_FILE` — a path to a JSON file of the
+///   same shape.
+///
+/// Does not support refresh — reloading means restarting the process.
+#[derive(Debug, Default, Clone)]
+pub struct EnvOrFileTokenSource;
+
+#[async_trait]
+impl TokenSource for EnvOrFileTokenSource {
+    async fn load(&self) -> Result<Vec<(String, String)>> {
+        server_bearer_tokens_from_env()
+    }
+
+    fn name(&self) -> &'static str {
+        "env-or-file"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+    use serial_test::serial;
+
+    fn clear_env() {
+        unsafe {
+            env::remove_var("OMNIGRAPH_SERVER_BEARER_TOKEN");
+            env::remove_var("OMNIGRAPH_SERVER_BEARER_TOKENS_JSON");
+            env::remove_var("OMNIGRAPH_SERVER_BEARER_TOKENS_FILE");
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn env_or_file_source_returns_empty_when_nothing_configured() {
+        clear_env();
+        let source = EnvOrFileTokenSource;
+        let tokens = source.load().await.unwrap();
+        assert!(tokens.is_empty());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn env_or_file_source_reads_single_token_as_default_actor() {
+        clear_env();
+        unsafe {
+            env::set_var("OMNIGRAPH_SERVER_BEARER_TOKEN", "some-token");
+        }
+        let source = EnvOrFileTokenSource;
+        let tokens = source.load().await.unwrap();
+        unsafe {
+            env::remove_var("OMNIGRAPH_SERVER_BEARER_TOKEN");
+        }
+        assert_eq!(tokens, vec![("default".to_string(), "some-token".to_string())]);
+    }
+
+    #[tokio::test]
+    async fn env_or_file_source_does_not_support_refresh() {
+        let source = EnvOrFileTokenSource;
+        assert!(!source.supports_refresh());
+        assert_eq!(source.name(), "env-or-file");
+    }
+}

--- a/crates/omnigraph-server/src/lib.rs
+++ b/crates/omnigraph-server/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod auth;
 pub mod config;
 pub mod policy;
 
@@ -37,6 +38,7 @@ use omnigraph::error::{ManifestErrorKind, OmniError};
 use omnigraph_compiler::json_params_to_param_map;
 use omnigraph_compiler::query::parser::parse_query;
 use omnigraph_compiler::{JsonParamMode, ParamMap};
+pub use auth::{EnvOrFileTokenSource, TokenSource};
 pub use policy::{
     PolicyAction, PolicyCompiler, PolicyConfig, PolicyDecision, PolicyEngine, PolicyExpectation,
     PolicyRequest, PolicyTestConfig,
@@ -462,9 +464,10 @@ pub fn build_app(state: AppState) -> Router {
 }
 
 pub async fn serve(config: ServerConfig) -> Result<()> {
+    let token_source = EnvOrFileTokenSource;
     let state = AppState::open_with_bearer_tokens_and_policy(
         config.uri.clone(),
-        server_bearer_tokens_from_env()?,
+        token_source.load().await?,
         config.policy_file.as_ref(),
     )
     .await?;


### PR DESCRIPTION
Stacked on #28. Pure refactor in preparation for adding an AWS Secrets Manager backend behind a feature flag.

## Summary

Introduces a \`TokenSource\` trait so additional bearer-token backends can plug in without touching the server wiring. One implementation today — \`EnvOrFileTokenSource\` — matching current behavior exactly.

## What changed

- New module \`crates/omnigraph-server/src/auth.rs\` with \`TokenSource\` + \`EnvOrFileTokenSource\`.
- \`serve()\` constructs \`EnvOrFileTokenSource\` and calls \`.load().await\` instead of calling \`server_bearer_tokens_from_env()\` directly.
- \`TokenSource::supports_refresh()\` hook (default: false) for future implementations that rotate without restart.
- \`async-trait\` pulled in as a server dep (already in the workspace).

## Test plan

- [x] \`cargo test -p omnigraph-server --lib\` — 26 passed (23 existing + 3 new auth tests).
- [x] \`cargo test -p omnigraph-server --test server -- --test-threads=1\` — 41 passed.
- [x] \`cargo test -p omnigraph-server --test openapi\` — 64 passed.

## Base

Based on \`fix/bearer-auth-hardening\` (#28). Merge #28 first, then this rebases trivially onto main.

## Follow-up

Next PR: add \`aws\` Cargo feature with \`SecretsManagerTokenSource\` + background refresh loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)