### PR TITLE
package workflow: read AWS config from secrets, not variables

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -5,8 +5,10 @@ name: Package
 # main pushes today.
 #
 # Prerequisites:
-#   - Repo vars AWS_REGION, AWS_ROLE_TO_ASSUME, AWS_CODEBUILD_PACKAGE_PROJECT,
-#     AWS_ARTIFACT_BUCKET are set.
+#   - Repo secrets AWS_REGION, AWS_ROLE_TO_ASSUME, AWS_CODEBUILD_PACKAGE_PROJECT,
+#     AWS_ARTIFACT_BUCKET are set. Stored as secrets (not variables) so the
+#     AWS account ID embedded in the role ARN and bucket name stays masked in
+#     public workflow logs.
 #   - The shared workflow at ModernRelay/.github supports the `features` and
 #     `image_tag_suffix` inputs (ModernRelay/.github PR #2 or later).
 #
@@ -34,10 +36,10 @@ jobs:
     with:
       repository: ${{ github.repository }}
       source_ref: ${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}
-      aws_region: ${{ vars.AWS_REGION }}
-      aws_role_to_assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
-      aws_codebuild_package_project: ${{ vars.AWS_CODEBUILD_PACKAGE_PROJECT }}
-      aws_artifact_bucket: ${{ vars.AWS_ARTIFACT_BUCKET }}
+      aws_region: ${{ secrets.AWS_REGION }}
+      aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+      aws_codebuild_package_project: ${{ secrets.AWS_CODEBUILD_PACKAGE_PROJECT }}
+      aws_artifact_bucket: ${{ secrets.AWS_ARTIFACT_BUCKET }}
 
   package_aws:
     name: Package aws-feature build
@@ -49,9 +51,9 @@ jobs:
     with:
       repository: ${{ github.repository }}
       source_ref: ${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}
-      aws_region: ${{ vars.AWS_REGION }}
-      aws_role_to_assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
-      aws_codebuild_package_project: ${{ vars.AWS_CODEBUILD_PACKAGE_PROJECT }}
-      aws_artifact_bucket: ${{ vars.AWS_ARTIFACT_BUCKET }}
+      aws_region: ${{ secrets.AWS_REGION }}
+      aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+      aws_codebuild_package_project: ${{ secrets.AWS_CODEBUILD_PACKAGE_PROJECT }}
+      aws_artifact_bucket: ${{ secrets.AWS_ARTIFACT_BUCKET }}
       features: aws
       image_tag_suffix: "-aws"


### PR DESCRIPTION
Follow-up to #33. On a public repo, Actions variables are not masked in workflow logs. Values that embed the AWS account ID (role ARN, artifact bucket) appearing in public run logs isn't catastrophic but isn't the norm-preserving choice either.

All four values (region, role, project, bucket) now flow through \`\${{ secrets.* }}\` instead of \`\${{ vars.* }}\`. When secrets are passed via \`with:\` to a reusable workflow, the value stays in the masked set — GitHub's masking is value-based, not context-based, and applies across the whole run once the secret reference resolves.

The four repo-level secrets are already set. Variables have been deleted.

## Test plan

- [x] YAML parses.
- [ ] Manual dispatch on \`main\` once merged — workflow successfully assumes the role, CodeBuild kicks off. Log inspection: ARN + bucket render as \`***\`.