### PR TITLE
Update example config to graphs / cli.graph (finishes MR-603)

### DIFF
--- a/omnigraph.example.yaml
+++ b/omnigraph.example.yaml
@@ -1,4 +1,4 @@
-targets:
+graphs:
   local:
     uri: ./repo.omni
   dev:
@@ -6,7 +6,7 @@ targets:
     bearer_token_env: OMNIGRAPH_BEARER_TOKEN
 
 cli:
-  target: local
+  graph: local
   branch: main
 
 query:


### PR DESCRIPTION
Final loose end from MR-603 (target → graph rename).

The core rename shipped in #17 but \`omnigraph.example.yaml\` was left on the old form, which doesn't deserialize against current code (serde \`rename = \"graphs\"\` has no \`targets\` alias).

## Change

\`\`\`diff
-targets:
+graphs:
   local:
     uri: ./repo.omni
...
 cli:
-  target: local
+  graph: local
\`\`\`

## Test plan

- [x] Ruby YAML load confirms new structure.
- [x] \`cargo test -p omnigraph-server --lib config\` — 6 passed.

Closes MR-603.