### PR TITLE
Raise LANCE_MEM_POOL_SIZE to 1 GB in .cargo/config.toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,22 @@
+# Cargo config for the omnigraph workspace.
+#
+# `[env]` entries here apply to anything cargo launches in this repo —
+# `cargo build`, `cargo test`, `cargo run`. Shipped binaries are NOT
+# affected: the env var lives only in the cargo-launched process, not in
+# release artifacts or Docker images.
+
+[env]
+# Lance's DataFusion memory pool per `Omnigraph` instance. Lance defaults
+# to 100 MB (`lance-datafusion/src/exec.rs`), which is fine for a single
+# server process in production.
+#
+# Under `cargo test` it's a problem: the omnigraph-server integration
+# suite spins up many `Omnigraph` instances in parallel (one per test,
+# default `num_cpus` threads), each with concurrent BTree index builds
+# sharing that test's 100 MB pool — saturates quickly and surfaces as
+# `Not enough memory to continue external sort` / `0.0 B remain
+# available for the total pool`.
+#
+# 1 GB is comfortable headroom per-test pool; prod and CI-for-prod
+# builds set the variable themselves (or keep the 100 MB default).
+LANCE_MEM_POOL_SIZE = "1073741824"


### PR DESCRIPTION
## Problem

The omnigraph-server integration suite (`tests/server.rs`) is flaky under parallel `cargo test`. 10 of 41 tests OOM with:

```
Lance("create BTree index on node:Person(id): ... LanceError(IO):
Not enough memory to continue external sort. ... 0.0 B remain
available for the total pool")
```

Lance defaults to a 100 MB `FairSpillPool` per `Omnigraph` instance ([lance-datafusion/src/exec.rs:316](https://github.com/lancedb/lance/blob/main/rust/lance-datafusion/src/exec.rs)). Under `cargo test`, many `Omnigraph` instances run in parallel (one per test, `num_cpus` threads), each running concurrent BTree index builds during load — saturates the per-test pool.

## Fix

Set `LANCE_MEM_POOL_SIZE=1073741824` (1 GB) via `.cargo/config.toml`'s `[env]` section. Only applies to cargo-launched processes — shipped binaries (release tarballs, Docker images) are unaffected and inherit whatever the runtime env provides, defaulting to Lance's 100 MB.

## Verification

```
$ cargo test -p omnigraph-server --test server --locked
test result: ok. 41 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.95s
```

Previously: 10 failed on parallel, all passed with `--test-threads=1`. Now all 41 pass in parallel in ~3s.