### PR TITLE
Dockerfile: switch base from Docker Hub to ECR Public

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM debian:bookworm-slim
+# Pulled from ECR Public (the Debian team mirrors official images there)
+# instead of Docker Hub to avoid anonymous-pull rate limits from AWS
+# CodeBuild, which shares an outbound IP pool with many other accounts.
+FROM public.ecr.aws/debian/debian:bookworm-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl \


### PR DESCRIPTION
Avoids anonymous Docker Hub pull rate-limits (100/6h/IP) from AWS CodeBuild. Package workflow run [24642508475](https://github.com/ModernRelay/omnigraph/actions/runs/24642508475) hit 429 on `debian:bookworm-slim`. Same upstream image via `public.ecr.aws/debian/debian:bookworm-slim`, no rate limit.