### PR TITLE
Prepare v0.3.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4596,7 +4596,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-cli"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -4616,7 +4616,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-compiler"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -4637,7 +4637,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-engine"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -4674,7 +4674,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-server"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/crates/omnigraph-cli/Cargo.toml
+++ b/crates/omnigraph-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-cli"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2024"
 description = "CLI for the Omnigraph graph database."
 license = "MIT"
@@ -13,9 +13,9 @@ name = "omnigraph"
 path = "src/main.rs"
 
 [dependencies]
-omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.2.2" }
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.2.2" }
-omnigraph-server = { path = "../omnigraph-server", version = "0.2.2" }
+omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.3.0" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.3.0" }
+omnigraph-server = { path = "../omnigraph-server", version = "0.3.0" }
 clap = { workspace = true }
 color-eyre = { workspace = true }
 serde = { workspace = true }

--- a/crates/omnigraph-compiler/Cargo.toml
+++ b/crates/omnigraph-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-compiler"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2024"
 description = "Schema/query compiler for Omnigraph. Zero Lance dependency."
 license = "MIT"

--- a/crates/omnigraph-server/Cargo.toml
+++ b/crates/omnigraph-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-server"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2024"
 description = "HTTP server for the Omnigraph graph database."
 license = "MIT"
@@ -19,8 +19,8 @@ default = []
 aws = ["dep:aws-config", "dep:aws-sdk-secretsmanager"]
 
 [dependencies]
-omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.2.2" }
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.2.2" }
+omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.3.0" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.3.0" }
 axum = { workspace = true }
 clap = { workspace = true }
 color-eyre = { workspace = true }

--- a/crates/omnigraph/Cargo.toml
+++ b/crates/omnigraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-engine"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2024"
 description = "Runtime engine for the Omnigraph graph database."
 license = "MIT"
@@ -16,7 +16,7 @@ default = []
 failpoints = ["dep:fail", "fail/failpoints"]
 
 [dependencies]
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.2.2" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.3.0" }
 lance = { workspace = true }
 lance-datafusion = { workspace = true }
 lance-file = { workspace = true }
@@ -47,7 +47,7 @@ async-trait = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.2.2" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.3.0" }
 tokio = { workspace = true }
 lance-namespace-impls = { workspace = true }
 serial_test = "3"

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -1,0 +1,49 @@
+# Omnigraph v0.3.0
+
+Omnigraph v0.3.0 is a feature and security release. It adds an AWS deployment path for the server, hardens bearer-token authentication, introduces a schema inspection endpoint, and ships the CodeBuild-driven image packaging pipeline.
+
+## Highlights
+
+### AWS deployment path
+
+A new `aws` Cargo feature enables an AWS-native bearer-token backend. When compiled with `--features aws` and pointed at an AWS Secrets Manager secret ARN via `OMNIGRAPH_SERVER_BEARER_TOKENS_AWS_SECRET`, the server fetches and parses bearer tokens directly from Secrets Manager at startup. The token loading path is abstracted behind a `TokenSource` trait so additional backends are easy to add.
+
+A manually-dispatched Package workflow builds two variants of the server image (default and `--features aws`) via AWS CodeBuild, tags them by source SHA in ECR, and records the digests for downstream deploy automation.
+
+### Bearer auth hardening
+
+Bearer tokens are now hashed (SHA-256) at rest inside the server and compared using constant-time equality (`subtle::ConstantTimeEq`). The authenticated actor id is resolved server-side from the hash match — requests can no longer assert their own actor id by setting a header.
+
+### Schema inspection API
+
+A new `GET /schema` endpoint and matching CLI `schema get` command return the active graph schema as JSON. A static OpenAPI spec is published at `openapi.json` and kept in sync with the server via a CI job.
+
+### Stricter run-branch hygiene
+
+Internal `__run__…` branches, used for short-lived write staging, are now filtered out of user-visible branch listings and are deleted on every terminal state transition instead of accumulating over time (MR-670, MR-674).
+
+## Breaking changes
+
+### Schema state is now required
+
+The server refuses to open a repo that lacks persisted schema state (`_schema.pg`, `_schema.ir.json`, `__schema_state.json`) or that has non-main public branches left over from earlier versions. Existing repos created with 0.2.x need to be reinitialized (or have their schema state written explicitly) before they can be opened with 0.3.0.
+
+## Included Changes
+
+- Add `aws` feature + `SecretsManagerTokenSource` backend
+- Extract `TokenSource` trait for bearer token loading
+- Harden bearer auth: constant-time compare, SHA-256 hashed at rest, server-authoritative actor id
+- Add manually-dispatched Package workflow for CodeBuild image builds (default + aws variants)
+- Add `GET /schema` endpoint and `schema get` CLI command
+- Ship static `openapi.json` spec with CI auto-sync
+- Filter and delete ephemeral `__run__` branches (MR-670, MR-674)
+- Switch Dockerfile base to ECR Public (avoid Docker Hub rate limits)
+- Raise `LANCE_MEM_POOL_SIZE` default to 1 GB for stable parallel tests
+- Automate Homebrew tap updates on release tags
+- Documentation for the AWS build variant and bearer-token sources
+
+## Upgrade Notes
+
+- Repos created with 0.2.x must be reinitialized (or have their schema state generated) before they can be opened with 0.3.0
+- Deployments using AWS Secrets Manager for bearer tokens must build the server with `--features aws` and set `OMNIGRAPH_SERVER_BEARER_TOKENS_AWS_SECRET` to the secret ARN
+- The default token source (env var or JSON file) continues to work unchanged

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "0.2.2"
+    "version": "0.3.0"
   },
   "paths": {
     "/branches": {


### PR DESCRIPTION
## Summary
- Bump workspace crates from 0.2.2 → 0.3.0
- Add release notes at `docs/releases/v0.3.0.md`

## Highlights
- `--features aws` + `SecretsManagerTokenSource` backend for the server
- Bearer auth hardening (SHA-256 hashed at rest, constant-time compare, server-authoritative actor id)
- `GET /schema` endpoint + CLI `schema get` command; static `openapi.json` with CI auto-sync
- Package workflow for CodeBuild-driven default + aws image builds
- Ephemeral `__run__` branch hygiene (MR-670, MR-674)

## Breaking
Repos created with 0.2.x that lack persisted schema state (`_schema.pg`, `_schema.ir.json`, `__schema_state.json`) or that have non-main public branches must be reinitialized before they can be opened with 0.3.0.

## Test plan
- [ ] CI green
- [ ] Merging this tag (v0.3.0) triggers the release workflow and produces linux/macos artifacts + Homebrew tap update

🤖 Generated with [Claude Code](https://claude.com/claude-code)