### PR TITLE
Add X-Request-Id middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4700,6 +4700,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "ulid",
  "utoipa",
 ]
 

--- a/crates/omnigraph-server/Cargo.toml
+++ b/crates/omnigraph-server/Cargo.toml
@@ -31,6 +31,7 @@ serde_yaml = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tower-http = { workspace = true }
+ulid = { workspace = true }
 utoipa = { workspace = true }
 cedar-policy = { workspace = true }
 futures = { workspace = true }

--- a/crates/omnigraph-server/src/lib.rs
+++ b/crates/omnigraph-server/src/lib.rs
@@ -2,6 +2,7 @@ pub mod api;
 pub mod auth;
 pub mod config;
 pub mod policy;
+pub mod request_id;
 
 use std::collections::{HashMap, HashSet};
 use std::fs;
@@ -460,6 +461,7 @@ pub fn build_app(state: AppState) -> Router {
         .merge(protected)
         .layer(DefaultBodyLimit::max(DEFAULT_REQUEST_BODY_LIMIT_BYTES))
         .layer(TraceLayer::new_for_http())
+        .layer(middleware::from_fn(request_id::request_id_middleware))
         .with_state(state)
 }
 

--- a/crates/omnigraph-server/src/request_id.rs
+++ b/crates/omnigraph-server/src/request_id.rs
@@ -1,0 +1,59 @@
+//! `X-Request-Id` middleware.
+//!
+//! Mints a ULID per inbound request, or echoes a caller-supplied
+//! `X-Request-Id` header if it's well-formed. Stores the value in request
+//! extensions so handlers can include it in error bodies, log lines, or
+//! audit records, and surfaces it on the response header so SDK clients
+//! can correlate logs across the wire.
+
+use axum::{
+    body::Body,
+    extract::Request,
+    http::{HeaderName, HeaderValue, header},
+    middleware::Next,
+    response::Response,
+};
+use ulid::Ulid;
+
+pub const X_REQUEST_ID: HeaderName = HeaderName::from_static("x-request-id");
+
+/// Wraps a request id pulled out of (or minted into) request extensions.
+#[derive(Clone, Debug)]
+pub struct RequestId(pub String);
+
+impl RequestId {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Acceptable inbound `X-Request-Id` shape: 1..=128 ASCII printable chars.
+/// Rejecting wider input keeps the value safe to log and emit verbatim.
+fn is_valid_inbound(raw: &str) -> bool {
+    !raw.is_empty()
+        && raw.len() <= 128
+        && raw
+            .bytes()
+            .all(|b| b.is_ascii_graphic() || b == b' ' || b == b'-' || b == b'_')
+}
+
+pub async fn request_id_middleware(mut req: Request<Body>, next: Next) -> Response {
+    let inbound = req
+        .headers()
+        .get(header::HeaderName::from_static("x-request-id"))
+        .and_then(|v| v.to_str().ok())
+        .filter(|raw| is_valid_inbound(raw));
+
+    let id = match inbound {
+        Some(raw) => raw.to_owned(),
+        None => Ulid::new().to_string(),
+    };
+
+    req.extensions_mut().insert(RequestId(id.clone()));
+
+    let mut response = next.run(req).await;
+    if let Ok(value) = HeaderValue::from_str(&id) {
+        response.headers_mut().insert(X_REQUEST_ID, value);
+    }
+    response
+}

--- a/crates/omnigraph-server/src/request_id.rs
+++ b/crates/omnigraph-server/src/request_id.rs
@@ -9,7 +9,7 @@
 use axum::{
     body::Body,
     extract::Request,
-    http::{HeaderName, HeaderValue, header},
+    http::{HeaderName, HeaderValue},
     middleware::Next,
     response::Response,
 };
@@ -40,7 +40,7 @@ fn is_valid_inbound(raw: &str) -> bool {
 pub async fn request_id_middleware(mut req: Request<Body>, next: Next) -> Response {
     let inbound = req
         .headers()
-        .get(header::HeaderName::from_static("x-request-id"))
+        .get(&X_REQUEST_ID)
         .and_then(|v| v.to_str().ok())
         .filter(|raw| is_valid_inbound(raw));
 

--- a/crates/omnigraph-server/tests/server.rs
+++ b/crates/omnigraph-server/tests/server.rs
@@ -676,6 +676,85 @@ async fn healthz_succeeds_after_startup() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn request_id_minted_when_absent() {
+    let (_temp, app) = app_for_loaded_repo().await;
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/healthz")
+                .method(Method::GET)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let id = response
+        .headers()
+        .get("x-request-id")
+        .expect("X-Request-Id missing")
+        .to_str()
+        .unwrap()
+        .to_owned();
+    // ULIDs are 26 chars Crockford base32.
+    assert_eq!(id.len(), 26);
+    assert!(id.chars().all(|c| c.is_ascii_alphanumeric()));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn request_id_echoed_when_caller_supplies_valid_value() {
+    let (_temp, app) = app_for_loaded_repo().await;
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/healthz")
+                .method(Method::GET)
+                .header("X-Request-Id", "trace-abc123")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response
+            .headers()
+            .get("x-request-id")
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "trace-abc123"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn request_id_minted_when_caller_supplies_invalid_value() {
+    let (_temp, app) = app_for_loaded_repo().await;
+    // 200-char string is a valid HeaderValue but exceeds the inbound length cap.
+    let too_long = "a".repeat(200);
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/healthz")
+                .method(Method::GET)
+                .header("X-Request-Id", &too_long)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let id = response
+        .headers()
+        .get("x-request-id")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert_ne!(id, too_long);
+    assert_eq!(id.len(), 26);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn schema_drift_returns_conflict_for_snapshot_read_and_change() {
     let (temp, app) = app_for_loaded_repo().await;
     let repo = repo_path(temp.path());


### PR DESCRIPTION
## Summary

Mints a per-request ULID at the edge, exposes it in request extensions for handlers, and surfaces it on the response header. Caller-supplied `X-Request-Id` is echoed when well-formed (1..=128 ASCII printable characters); otherwise rejected and replaced with a fresh ULID so the value is always safe to log.

This is **Part A1** of the Stripe-style TypeScript SDK rollout (omnigraph-ts#2). The SDK already reads this header from response headers and surfaces it on every `OmnigraphError.requestId` for log correlation across the wire.

## Test plan

- [x] `cargo test -p omnigraph-server --test server request_id` — three new tests pass:
  - mint a ULID when no header is provided
  - echo a valid caller-supplied id
  - reject an overlong header (200 chars), mint a fresh ULID
- [x] `cargo test -p omnigraph-server --test server` — full server suite green (44 tests)
- [x] `cargo test -p omnigraph-server --test openapi` — no spec drift (the header is transport-layer, no schema change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new global Axum middleware on all routes that mints/echoes and returns `X-Request-Id`, which can affect every request/response path and header handling. Functional risk is limited to transport-layer behavior and is covered by new integration tests.
> 
> **Overview**
> Adds an `X-Request-Id` middleware to `omnigraph-server` that **generates a per-request ULID** when the header is absent/invalid, or **echoes a caller-supplied** `X-Request-Id` when it matches a constrained safe-to-log format.
> 
> The middleware stores the ID in request extensions for downstream handlers and always surfaces it back on the response header. The PR also introduces the `ulid` dependency and adds server tests covering mint/echo/reject behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e14b2032080d1fafedd46ff77b54cadda3fe675c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `X-Request-Id` middleware that mints a per-request ULID, stores it in request extensions, and sets the response header for cross-service log correlation; echoes a valid inbound id, otherwise replaces it. Reuses the `X_REQUEST_ID` constant for inbound header lookup to avoid drift.

- **New Features**
  - Mints a ULID when absent; echoes valid ids; rejects invalid/overlong (1–128 ASCII printable).
  - Stores id in request extensions and sets `X-Request-Id` on responses; added as an Axum middleware layer.
  - Enables the TypeScript SDK to surface `requestId` on errors for easier trace correlation.

- **Dependencies**
  - Added `ulid` for id generation.

<sup>Written for commit e14b2032080d1fafedd46ff77b54cadda3fe675c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

