### PR TITLE
Tag transient errors with HTTP 503 + Retry-After

### DIFF
--- a/crates/omnigraph-server/src/lib.rs
+++ b/crates/omnigraph-server/src/lib.rs
@@ -159,6 +159,32 @@ pub struct ApiError {
     code: ErrorCode,
     message: String,
     merge_conflicts: Vec<api::MergeConflictOutput>,
+    retry_after_seconds: Option<u64>,
+}
+
+/// Default `Retry-After` for transient backend failures (S3 throttles,
+/// object-store 503s). Conservative — clients respect the server's hint.
+const DEFAULT_RETRY_AFTER_SECONDS: u64 = 5;
+
+/// Substrings in `OmniError::Lance(...)` messages that indicate the failure
+/// is transient and worth retrying. Heuristic — Lance flattens its error
+/// types to `String`, so we pattern-match on shapes object_store and AWS
+/// SDK errors emit when S3 throttles or returns 503.
+const LANCE_TRANSIENT_PATTERNS: &[&str] = &[
+    "throttl",          // "ThrottlingException", "throttled"
+    "slowdown",         // S3 SlowDown (no space)
+    "slow down",        // human-readable variant
+    "503 service",      // "503 Service Unavailable"
+    "service unavailable",
+    "rate limit",
+    "request timeout",
+];
+
+fn lance_message_is_transient(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    LANCE_TRANSIENT_PATTERNS
+        .iter()
+        .any(|pat| lower.contains(pat))
 }
 
 impl AppState {
@@ -280,6 +306,7 @@ impl ApiError {
             code: ErrorCode::Unauthorized,
             message: message.into(),
             merge_conflicts: Vec::new(),
+            retry_after_seconds: None,
         }
     }
 
@@ -289,6 +316,7 @@ impl ApiError {
             code: ErrorCode::Forbidden,
             message: message.into(),
             merge_conflicts: Vec::new(),
+            retry_after_seconds: None,
         }
     }
 
@@ -298,6 +326,7 @@ impl ApiError {
             code: ErrorCode::BadRequest,
             message: message.into(),
             merge_conflicts: Vec::new(),
+            retry_after_seconds: None,
         }
     }
 
@@ -307,6 +336,7 @@ impl ApiError {
             code: ErrorCode::NotFound,
             message: message.into(),
             merge_conflicts: Vec::new(),
+            retry_after_seconds: None,
         }
     }
 
@@ -316,6 +346,7 @@ impl ApiError {
             code: ErrorCode::Conflict,
             message: message.into(),
             merge_conflicts: Vec::new(),
+            retry_after_seconds: None,
         }
     }
 
@@ -325,6 +356,19 @@ impl ApiError {
             code: ErrorCode::Internal,
             message: message.into(),
             merge_conflicts: Vec::new(),
+            retry_after_seconds: None,
+        }
+    }
+
+    /// Mark a transient backend failure: HTTP 503 with `Retry-After`. The
+    /// SDK retries once on this header; permanent errors stay on 500.
+    pub fn transient(message: impl Into<String>, retry_after_seconds: u64) -> Self {
+        Self {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            code: ErrorCode::Internal,
+            message: message.into(),
+            merge_conflicts: Vec::new(),
+            retry_after_seconds: Some(retry_after_seconds),
         }
     }
 
@@ -334,6 +378,7 @@ impl ApiError {
             code: ErrorCode::Conflict,
             message: summarize_merge_conflicts(&conflicts),
             merge_conflicts: conflicts,
+            retry_after_seconds: None,
         }
     }
 
@@ -353,8 +398,22 @@ impl ApiError {
                     .map(api::MergeConflictOutput::from)
                     .collect(),
             ),
-            OmniError::Lance(message) => Self::internal(format!("storage: {message}")),
-            OmniError::Io(err) => Self::internal(format!("io: {err}")),
+            OmniError::Lance(message) => {
+                if lance_message_is_transient(&message) {
+                    Self::transient(
+                        format!("storage: {message}"),
+                        DEFAULT_RETRY_AFTER_SECONDS,
+                    )
+                } else {
+                    Self::internal(format!("storage: {message}"))
+                }
+            }
+            OmniError::Io(err) => match err.kind() {
+                io::ErrorKind::TimedOut | io::ErrorKind::Interrupted => {
+                    Self::transient(format!("io: {err}"), DEFAULT_RETRY_AFTER_SECONDS)
+                }
+                _ => Self::internal(format!("io: {err}")),
+            },
         }
     }
 }
@@ -389,7 +448,8 @@ fn summarize_merge_conflicts(conflicts: &[api::MergeConflictOutput]) -> String {
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
-        (
+        let retry_after = self.retry_after_seconds;
+        let mut response = (
             self.status,
             Json(ErrorOutput {
                 error: self.message,
@@ -397,7 +457,15 @@ impl IntoResponse for ApiError {
                 merge_conflicts: self.merge_conflicts,
             }),
         )
-            .into_response()
+            .into_response();
+        if let Some(seconds) = retry_after {
+            if let Ok(value) = axum::http::HeaderValue::from_str(&seconds.to_string()) {
+                response
+                    .headers_mut()
+                    .insert(axum::http::header::RETRY_AFTER, value);
+            }
+        }
+        response
     }
 }
 
@@ -1528,12 +1596,31 @@ fn server_bearer_tokens_from_env() -> Result<Vec<(String, String)>> {
 #[cfg(test)]
 mod tests {
     use super::{
-        hash_bearer_token, load_server_settings, normalize_bearer_token, parse_bearer_tokens_json,
-        server_bearer_tokens_from_env,
+        hash_bearer_token, lance_message_is_transient, load_server_settings,
+        normalize_bearer_token, parse_bearer_tokens_json, server_bearer_tokens_from_env,
     };
     use std::env;
     use std::fs;
     use tempfile::tempdir;
+
+    #[test]
+    fn lance_transient_patterns_are_recognized() {
+        assert!(lance_message_is_transient("503 Service Unavailable"));
+        assert!(lance_message_is_transient("ThrottlingException: Rate exceeded"));
+        assert!(lance_message_is_transient(
+            "S3 returned SlowDown: please reduce your request rate"
+        ));
+        assert!(lance_message_is_transient("Request timeout while writing"));
+    }
+
+    #[test]
+    fn lance_non_transient_messages_are_not_flagged() {
+        assert!(!lance_message_is_transient("data corruption: bad checksum"));
+        assert!(!lance_message_is_transient(
+            "Clone operation should not enter build_manifest"
+        ));
+        assert!(!lance_message_is_transient("permission denied"));
+    }
 
     #[test]
     fn hash_bearer_token_produces_32_byte_output() {

--- a/crates/omnigraph-server/tests/server.rs
+++ b/crates/omnigraph-server/tests/server.rs
@@ -12,7 +12,7 @@ use omnigraph_server::api::{
     BranchCreateRequest, BranchMergeRequest, ChangeRequest, ErrorOutput, ExportRequest,
     IngestRequest, ReadRequest, SchemaApplyRequest, SchemaOutput,
 };
-use omnigraph_server::{AppState, build_app};
+use omnigraph_server::{ApiError, AppState, build_app};
 use serde_json::{Value, json};
 use serial_test::serial;
 use tower::ServiceExt;
@@ -651,6 +651,38 @@ fn mock_embedding(input: &str, dim: usize) -> Vec<f32> {
         out.push((ratio * 2.0) - 1.0);
     }
     normalize_vector(out)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn transient_api_error_emits_503_with_retry_after() {
+    use axum::response::IntoResponse;
+    let response = ApiError::transient("storage: 503 Service Unavailable", 7).into_response();
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let header = response
+        .headers()
+        .get(axum::http::header::RETRY_AFTER)
+        .expect("Retry-After missing")
+        .to_str()
+        .unwrap()
+        .to_owned();
+    assert_eq!(header, "7");
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let value: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(value["code"], "internal");
+    assert_eq!(value["error"], "storage: 503 Service Unavailable");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn permanent_api_error_has_no_retry_after() {
+    use axum::response::IntoResponse;
+    let response = ApiError::internal("storage: data corrupt").into_response();
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert!(
+        response
+            .headers()
+            .get(axum::http::header::RETRY_AFTER)
+            .is_none()
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary

Adds `ApiError::transient(message, retry_after_seconds)` and wires it into the two known-transient error classes:

- `OmniError::Lance(message)` whose message matches cloud-storage transient patterns (`throttl`, `slowdown`, `503 service`, `service unavailable`, `rate limit`, `request timeout`)
- `OmniError::Io(err)` with `ErrorKind::TimedOut` or `Interrupted`

Permanent errors (data corruption, manifest conflicts, IO permission denied) stay on 5xx without `Retry-After` — no client-side retry pile-up on real failures.

The TypeScript SDK already implements the matching client behavior: respect `Retry-After` once on 503; no exponential-backoff invention.

This is **Part A3** of the Stripe-style TypeScript SDK rollout (omnigraph-ts#2).

## Why a heuristic instead of structured error types

`OmniError::Lance` flattens the underlying error to `String` at every conversion site (~16 of them in `crates/omnigraph/src/table_store.rs` etc.). Structurally-typed transient detection means a bigger plumbing PR. Pattern-matching on the message shape is cheap, conservative (only six well-known signatures), and easy to extend if new transient patterns surface.

## Test plan

- [x] `cargo test -p omnigraph-server --lib lance_` — 2 unit tests on `lance_message_is_transient` (positive: throttling, SlowDown, 503; negative: corruption, manifest errors, permission)
- [x] `cargo test -p omnigraph-server --test server transient` — `ApiError::transient(...)` emits `503` with `Retry-After: <seconds>`
- [x] `cargo test -p omnigraph-server --test server permanent` — `ApiError::internal(...)` stays at 500 with no `Retry-After`
- [x] `cargo test -p omnigraph-server` — full server suite green (43 tests)
- [x] No spec drift (`Retry-After` is transport-layer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how certain backend failures are surfaced over HTTP (500 -> 503 with `Retry-After`), which can alter client retry behavior and operational load if misclassified.
> 
> **Overview**
> **Transient error signaling:** `ApiError` now supports `ApiError::transient(...)`, storing an optional `retry_after_seconds` and emitting a `Retry-After` header when present.
> 
> **Error classification changes:** `ApiError::from_omni` now maps likely-transient `OmniError::Lance` messages (via substring heuristics) and `io::ErrorKind::{TimedOut, Interrupted}` to `503 Service Unavailable` (defaulting to 5s), while leaving other failures as `500`.
> 
> **Tests:** Adds unit tests for the Lance transient-message heuristic and integration tests asserting `Retry-After` is present for transient errors and absent for permanent ones.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dff04673d5df48a4f36118e918270b2e04050ec4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tag transient backend failures as HTTP 503 and include a Retry-After header so clients retry once and avoid hammering permanent errors. Matches the TypeScript SDK behavior from omnigraph-ts#2.

- New Features
  - Added `ApiError::transient(message, retry_after_seconds)` to return 503 with `Retry-After`.
  - Updated `from_omni` to treat `OmniError::Lance` messages matching common transient patterns and `OmniError::Io` with `TimedOut`/`Interrupted` as transient (default 5s). Other errors remain 500 with no `Retry-After`.
  - Added tests for header emission and message-pattern detection.

<sup>Written for commit dff04673d5df48a4f36118e918270b2e04050ec4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

