### PR TITLE
Prefix commit and run IDs with cmt_ / run_

### DIFF
--- a/crates/omnigraph-cli/src/main.rs
+++ b/crates/omnigraph-cli/src/main.rs
@@ -20,7 +20,7 @@ use omnigraph_server::api::{
     CommitOutput, ErrorOutput, ExportRequest, IngestOutput, IngestRequest, ReadOutput, ReadRequest,
     RunListOutput, RunOutput, SchemaApplyOutput, SchemaApplyRequest, SchemaOutput, SnapshotOutput,
     SnapshotTableOutput, commit_output, ingest_output, read_output, run_output,
-    schema_apply_output, snapshot_payload,
+    schema_apply_output, snapshot_payload, unprefix_commit_id, unprefix_run_id,
 };
 use omnigraph_server::{
     AliasCommand, OmnigraphConfig, PolicyAction, PolicyDecision, PolicyEngine, PolicyRequest,
@@ -2006,7 +2006,7 @@ async fn main() -> Result<()> {
                     .await?
                 } else {
                     let db = Omnigraph::open(&uri).await?;
-                    commit_output(&db.get_commit(&commit_id).await?)
+                    commit_output(&db.get_commit(unprefix_commit_id(&commit_id)).await?)
                 };
                 if json {
                     print_json(&commit)?;
@@ -2247,7 +2247,10 @@ async fn main() -> Result<()> {
                     .await?
                 } else {
                     let db = Omnigraph::open(&uri).await?;
-                    run_output(&db.get_run(&RunId::new(run_id)).await?)
+                    run_output(
+                        &db.get_run(&RunId::new(unprefix_run_id(&run_id).to_owned()))
+                            .await?,
+                    )
                 };
                 if json {
                     print_json(&run)?;
@@ -2277,8 +2280,9 @@ async fn main() -> Result<()> {
                     .await?
                 } else {
                     let mut db = Omnigraph::open(&uri).await?;
-                    db.publish_run(&RunId::new(run_id.clone())).await?;
-                    run_output(&db.get_run(&RunId::new(run_id)).await?)
+                    let bare = unprefix_run_id(&run_id).to_owned();
+                    db.publish_run(&RunId::new(bare.clone())).await?;
+                    run_output(&db.get_run(&RunId::new(bare)).await?)
                 };
                 if json {
                     print_json(&run)?;
@@ -2308,7 +2312,10 @@ async fn main() -> Result<()> {
                     .await?
                 } else {
                     let mut db = Omnigraph::open(&uri).await?;
-                    run_output(&db.abort_run(&RunId::new(run_id)).await?)
+                    run_output(
+                        &db.abort_run(&RunId::new(unprefix_run_id(&run_id).to_owned()))
+                            .await?,
+                    )
                 };
                 if json {
                     print_json(&run)?;

--- a/crates/omnigraph-cli/src/main.rs
+++ b/crates/omnigraph-cli/src/main.rs
@@ -1444,7 +1444,7 @@ fn inferred_config_path(uri: &str) -> Result<PathBuf> {
 
 fn read_target_from_cli(branch: Option<String>, snapshot: Option<String>) -> ReadTarget {
     if let Some(snapshot) = snapshot {
-        ReadTarget::snapshot(SnapshotId::new(snapshot))
+        ReadTarget::snapshot(SnapshotId::new(unprefix_commit_id(&snapshot).to_owned()))
     } else {
         ReadTarget::branch(branch.unwrap_or_else(|| "main".to_string()))
     }

--- a/crates/omnigraph-cli/tests/cli.rs
+++ b/crates/omnigraph-cli/tests/cli.rs
@@ -1975,9 +1975,15 @@ fn run_publish_promotes_manual_running_run() {
             .arg("--json"),
     );
     let payload: Value = serde_json::from_slice(&publish_output.stdout).unwrap();
-    assert_eq!(payload["run_id"], run_id);
+    assert_eq!(payload["run_id"], format!("run_{}", run_id));
     assert_eq!(payload["status"], "published");
     assert!(payload["published_snapshot_id"].is_string());
+    assert!(
+        payload["published_snapshot_id"]
+            .as_str()
+            .unwrap()
+            .starts_with("cmt_")
+    );
 
     let runtime = tokio::runtime::Runtime::new().unwrap();
     runtime.block_on(async {
@@ -2018,6 +2024,6 @@ fn run_abort_marks_manual_running_run_aborted() {
             .arg("--json"),
     );
     let payload: Value = serde_json::from_slice(&abort_output.stdout).unwrap();
-    assert_eq!(payload["run_id"], run_id);
+    assert_eq!(payload["run_id"], format!("run_{}", run_id));
     assert_eq!(payload["status"], "aborted");
 }

--- a/crates/omnigraph-server/src/api.rs
+++ b/crates/omnigraph-server/src/api.rs
@@ -9,6 +9,43 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use utoipa::{IntoParams, ToSchema};
 
+/// Prefix prepended to graph commit IDs when surfaced via the API.
+pub const COMMIT_ID_PREFIX: &str = "cmt_";
+/// Prefix prepended to run IDs when surfaced via the API.
+pub const RUN_ID_PREFIX: &str = "run_";
+
+/// Wrap a bare ULID with the commit-ID prefix, leaving an already-prefixed
+/// value untouched. Used at API output sites.
+pub fn prefix_commit_id(id: &str) -> String {
+    if id.starts_with(COMMIT_ID_PREFIX) {
+        id.to_owned()
+    } else {
+        format!("{COMMIT_ID_PREFIX}{id}")
+    }
+}
+
+/// Wrap a bare ULID with the run-ID prefix, leaving an already-prefixed
+/// value untouched. Used at API output sites.
+pub fn prefix_run_id(id: &str) -> String {
+    if id.starts_with(RUN_ID_PREFIX) {
+        id.to_owned()
+    } else {
+        format!("{RUN_ID_PREFIX}{id}")
+    }
+}
+
+/// Strip the commit-ID prefix if present so storage lookups (which key on
+/// bare ULIDs) work whether the caller passed `cmt_01KQ…` or just `01KQ…`.
+pub fn unprefix_commit_id(input: &str) -> &str {
+    input.strip_prefix(COMMIT_ID_PREFIX).unwrap_or(input)
+}
+
+/// Strip the run-ID prefix if present so storage lookups (which key on
+/// bare ULIDs) work whether the caller passed `run_01KQ…` or just `01KQ…`.
+pub fn unprefix_run_id(input: &str) -> &str {
+    input.strip_prefix(RUN_ID_PREFIX).unwrap_or(input)
+}
+
 /// Shadow enum for documenting [`LoadMode`] in the OpenAPI schema.
 #[derive(ToSchema)]
 #[schema(as = LoadMode)]
@@ -374,15 +411,18 @@ pub fn schema_apply_output(uri: &str, result: SchemaApplyResult) -> SchemaApplyO
 
 pub fn run_output(run: &RunRecord) -> RunOutput {
     RunOutput {
-        run_id: run.run_id.as_str().to_string(),
+        run_id: prefix_run_id(run.run_id.as_str()),
         target_branch: run.target_branch.clone(),
         run_branch: run.run_branch.clone(),
-        base_snapshot_id: run.base_snapshot_id.as_str().to_string(),
+        base_snapshot_id: prefix_commit_id(run.base_snapshot_id.as_str()),
         base_manifest_version: run.base_manifest_version,
         operation_hash: run.operation_hash.clone(),
         actor_id: run.actor_id.clone(),
         status: run.status.as_str().to_string(),
-        published_snapshot_id: run.published_snapshot_id.clone(),
+        published_snapshot_id: run
+            .published_snapshot_id
+            .as_deref()
+            .map(prefix_commit_id),
         created_at: run.created_at,
         updated_at: run.updated_at,
     }
@@ -390,11 +430,14 @@ pub fn run_output(run: &RunRecord) -> RunOutput {
 
 pub fn commit_output(commit: &GraphCommit) -> CommitOutput {
     CommitOutput {
-        graph_commit_id: commit.graph_commit_id.clone(),
+        graph_commit_id: prefix_commit_id(&commit.graph_commit_id),
         manifest_branch: commit.manifest_branch.clone(),
         manifest_version: commit.manifest_version,
-        parent_commit_id: commit.parent_commit_id.clone(),
-        merged_parent_commit_id: commit.merged_parent_commit_id.clone(),
+        parent_commit_id: commit.parent_commit_id.as_deref().map(prefix_commit_id),
+        merged_parent_commit_id: commit
+            .merged_parent_commit_id
+            .as_deref()
+            .map(prefix_commit_id),
         actor_id: commit.actor_id.clone(),
         created_at: commit.created_at,
     }
@@ -443,7 +486,67 @@ pub fn read_target_output(target: &ReadTarget) -> ReadTargetOutput {
         },
         ReadTarget::Snapshot(snapshot) => ReadTargetOutput {
             branch: None,
-            snapshot: Some(snapshot.as_str().to_string()),
+            snapshot: Some(prefix_commit_id(snapshot.as_str())),
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefix_commit_id_adds_prefix_to_bare_ulid() {
+        assert_eq!(prefix_commit_id("01KQ2JK3PC35ZZW3867A5H7Q15"), "cmt_01KQ2JK3PC35ZZW3867A5H7Q15");
+    }
+
+    #[test]
+    fn prefix_commit_id_is_idempotent() {
+        let already = "cmt_01KQ2JK3PC35ZZW3867A5H7Q15";
+        assert_eq!(prefix_commit_id(already), already);
+    }
+
+    #[test]
+    fn prefix_run_id_adds_prefix_to_bare_ulid() {
+        assert_eq!(prefix_run_id("01KQ2KB5KFPNB7KMFM7816S6J2"), "run_01KQ2KB5KFPNB7KMFM7816S6J2");
+    }
+
+    #[test]
+    fn prefix_run_id_is_idempotent() {
+        let already = "run_01KQ2KB5KFPNB7KMFM7816S6J2";
+        assert_eq!(prefix_run_id(already), already);
+    }
+
+    #[test]
+    fn unprefix_commit_id_strips_prefix() {
+        assert_eq!(
+            unprefix_commit_id("cmt_01KQ2JK3PC35ZZW3867A5H7Q15"),
+            "01KQ2JK3PC35ZZW3867A5H7Q15"
+        );
+    }
+
+    #[test]
+    fn unprefix_commit_id_passes_through_bare_ulid() {
+        // Forward-compat: callers holding old-format IDs from logs continue to work.
+        assert_eq!(
+            unprefix_commit_id("01KQ2JK3PC35ZZW3867A5H7Q15"),
+            "01KQ2JK3PC35ZZW3867A5H7Q15"
+        );
+    }
+
+    #[test]
+    fn unprefix_run_id_strips_prefix() {
+        assert_eq!(
+            unprefix_run_id("run_01KQ2KB5KFPNB7KMFM7816S6J2"),
+            "01KQ2KB5KFPNB7KMFM7816S6J2"
+        );
+    }
+
+    #[test]
+    fn unprefix_run_id_passes_through_bare_ulid() {
+        assert_eq!(
+            unprefix_run_id("01KQ2KB5KFPNB7KMFM7816S6J2"),
+            "01KQ2KB5KFPNB7KMFM7816S6J2"
+        );
     }
 }

--- a/crates/omnigraph-server/src/lib.rs
+++ b/crates/omnigraph-server/src/lib.rs
@@ -16,6 +16,7 @@ use api::{
     CommitListQuery, ErrorCode, ErrorOutput, ExportRequest, HealthOutput, IngestOutput,
     IngestRequest, ReadOutput, ReadRequest, RunListOutput, SchemaApplyOutput, SchemaApplyRequest,
     SchemaOutput, SnapshotQuery, ingest_output, schema_apply_output, snapshot_payload,
+    unprefix_commit_id, unprefix_run_id,
 };
 use axum::body::{Body, Bytes};
 use axum::extract::DefaultBodyLimit;
@@ -1227,7 +1228,7 @@ async fn server_run_show(
     )?;
     let run = {
         let db = Arc::clone(&state.db).read_owned().await;
-        db.get_run(&RunId::new(run_id))
+        db.get_run(&RunId::new(unprefix_run_id(&run_id).to_owned()))
             .await
             .map_err(ApiError::from_omni)?
     };
@@ -1255,7 +1256,7 @@ async fn server_run_publish(
     actor: Option<Extension<AuthenticatedActor>>,
     Path(run_id): Path<String>,
 ) -> std::result::Result<Json<api::RunOutput>, ApiError> {
-    let run_id = RunId::new(run_id);
+    let run_id = RunId::new(unprefix_run_id(&run_id).to_owned());
     let actor_id = actor.as_ref().map(|Extension(actor)| actor.as_str());
     let target_branch = {
         let db = Arc::clone(&state.db).read_owned().await;
@@ -1305,7 +1306,7 @@ async fn server_run_abort(
     actor: Option<Extension<AuthenticatedActor>>,
     Path(run_id): Path<String>,
 ) -> std::result::Result<Json<api::RunOutput>, ApiError> {
-    let run_id = RunId::new(run_id);
+    let run_id = RunId::new(unprefix_run_id(&run_id).to_owned());
     let target_branch = {
         let db = Arc::clone(&state.db).read_owned().await;
         db.get_run(&run_id)
@@ -1411,7 +1412,7 @@ async fn server_commit_show(
     )?;
     let commit = {
         let db = Arc::clone(&state.db).read_owned().await;
-        db.get_commit(&commit_id)
+        db.get_commit(unprefix_commit_id(&commit_id))
             .await
             .map_err(ApiError::from_omni)?
     };
@@ -1420,7 +1421,9 @@ async fn server_commit_show(
 
 fn read_target_from_request(branch: Option<String>, snapshot: Option<String>) -> ReadTarget {
     if let Some(snapshot) = snapshot {
-        ReadTarget::snapshot(omnigraph::db::SnapshotId::new(snapshot))
+        ReadTarget::snapshot(omnigraph::db::SnapshotId::new(
+            unprefix_commit_id(&snapshot).to_owned(),
+        ))
     } else {
         ReadTarget::branch(branch.unwrap_or_else(|| "main".to_string()))
     }

--- a/crates/omnigraph-server/tests/server.rs
+++ b/crates/omnigraph-server/tests/server.rs
@@ -1095,13 +1095,12 @@ async fn policy_uses_resolved_branch_for_snapshot_reads() {
 
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["target"]["branch"], Value::Null);
+    // The server prefixes commit IDs in responses; inputs accept either form.
+    // The assertion locks the prefixed form so a future regression that drops
+    // `prefix_commit_id` in `read_target_output` is caught here.
     let returned_snapshot = body["target"]["snapshot"].as_str().unwrap();
     let expected = read.snapshot.as_deref().unwrap();
-    // The server prefixes commit IDs in responses (`cmt_…`); inputs accept either form.
-    assert!(
-        returned_snapshot == expected
-            || returned_snapshot == format!("cmt_{}", expected)
-    );
+    assert_eq!(returned_snapshot, format!("cmt_{}", expected));
     assert_eq!(body["row_count"], 1);
 }
 

--- a/crates/omnigraph-server/tests/server.rs
+++ b/crates/omnigraph-server/tests/server.rs
@@ -1095,9 +1095,12 @@ async fn policy_uses_resolved_branch_for_snapshot_reads() {
 
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["target"]["branch"], Value::Null);
-    assert_eq!(
-        body["target"]["snapshot"].as_str(),
-        read.snapshot.as_deref()
+    let returned_snapshot = body["target"]["snapshot"].as_str().unwrap();
+    let expected = read.snapshot.as_deref().unwrap();
+    // The server prefixes commit IDs in responses (`cmt_…`); inputs accept either form.
+    assert!(
+        returned_snapshot == expected
+            || returned_snapshot == format!("cmt_{}", expected)
     );
     assert_eq!(body["row_count"], 1);
 }


### PR DESCRIPTION
## Summary

Surface ULIDs through the API with type-tag prefixes:

| Before | After |
|---|---|
| `01KQ2JK3PC35ZZW3867A5H7Q15` | `cmt_01KQ2JK3PC35ZZW3867A5H7Q15` (commit) |
| `01KQ2KB5KFPNB7KMFM7816S6J2` | `run_01KQ2KB5KFPNB7KMFM7816S6J2` (run) |

Logs, dashboards, and bug reports now disambiguate the two ID families at a glance. Snapshot IDs also pick up the `cmt_` prefix since they refer to commit IDs.

This is **Part A2** of the Stripe-style TypeScript SDK rollout (omnigraph-ts#2).

## Where prefixing happens

Storage stays on bare ULIDs — no migration of existing data. Prefixing happens at the API serialization boundary in `commit_output()`, `run_output()`, and `read_target_output()`. Inputs accept either form (`unprefix_commit_id()` and `unprefix_run_id()` strip the prefix before storage lookups), so callers holding old-format IDs from logs continue to work.

## Test plan

- [x] `cargo test -p omnigraph-server --lib api::tests` — 8 unit tests covering: prefix adds, prefix is idempotent, unprefix strips, unprefix passes through bare ULID
- [x] `cargo test -p omnigraph-server` — 41 server tests pass (`policy_uses_resolved_branch_for_snapshot_reads` updated to accept prefixed snapshot id)
- [x] `cargo test -p omnigraph-cli` — 85 CLI tests pass (`run_publish_*` and `run_abort_*` updated to assert prefixed return values)
- [x] `cargo test -p omnigraph-server --test openapi` — 65 OpenAPI tests pass; no spec drift (prefixing is a value-level concern, not a schema change)

## Companion CLI changes

The CLI's local-path commit/run commands now strip prefixes before hitting `db.get_commit` / `RunId::new` so users can paste the displayed `cmt_…` or `run_…` IDs back into `omnigraph commit show` and `omnigraph run show/publish/abort`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes API/CLI-visible identifier formats for commits, runs, and snapshot targets, which can break downstream consumers that assume bare ULIDs despite input-side compatibility shims.
> 
> **Overview**
> API responses now **prefix commit, run, and snapshot IDs** with type tags (`cmt_…` for commits/snapshots, `run_…` for runs) via new helpers in `omnigraph-server` (`prefix_*`/`unprefix_*`) applied in `commit_output`, `run_output`, and `read_target_output`.
> 
> Server routes and the CLI now **accept both prefixed and bare IDs** by stripping prefixes before DB lookups (e.g., run/commit show, run publish/abort, and snapshot read targets), and tests are updated to assert the new prefixed values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f0050092b9e6c23800500fb4fb56b051a9ed096. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefix API-visible IDs to disambiguate types: commit IDs now use `cmt_…`, run IDs use `run_…`, and snapshot IDs use `cmt_…`. Storage stays on bare ULIDs, and inputs accept both prefixed and bare forms.

- **New Features**
  - `omnigraph-server` responses prefix commit (`cmt_…`) and run (`run_…`) IDs; parent/merged parent commit IDs, base/published snapshot IDs, and read-target snapshot IDs are also prefixed.
  - Prefixing happens at serialization; server routes and `omnigraph-cli` strip prefixes on input for backward compatibility.

- **Bug Fixes**
  - `omnigraph-cli` `read --snapshot` now strips `cmt_` so pasted IDs work locally; server test tightened to require prefixed snapshot IDs in responses.

<sup>Written for commit 5f0050092b9e6c23800500fb4fb56b051a9ed096. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

