### PR TITLE
Drop macOS x86_64 build target

### DIFF
--- a/.github/workflows/release-edge.yml
+++ b/.github/workflows/release-edge.yml
@@ -41,8 +41,6 @@ jobs:
         include:
           - runner: ubuntu-latest
             asset_name: omnigraph-linux-x86_64
-          - runner: macos-15-intel
-            asset_name: omnigraph-macos-x86_64
           - runner: macos-14
             asset_name: omnigraph-macos-arm64
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,6 @@ jobs:
         include:
           - runner: ubuntu-latest
             asset_name: omnigraph-linux-x86_64
-          - runner: macos-15-intel
-            asset_name: omnigraph-macos-x86_64
           - runner: macos-14
             asset_name: omnigraph-macos-arm64
     env:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -35,9 +35,6 @@ platform_asset_name() {
     Linux/x86_64)
       printf 'omnigraph-linux-x86_64.tar.gz\n'
       ;;
-    Darwin/x86_64)
-      printf 'omnigraph-macos-x86_64.tar.gz\n'
-      ;;
     Darwin/arm64)
       printf 'omnigraph-macos-arm64.tar.gz\n'
       ;;

--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -46,14 +46,12 @@ VERSION="${TAG#v}"
 RELEASE_JSON="$(gh release view "$TAG" --repo "$REPO_SLUG" --json assets)"
 
 MACOS_ARM_URL="https://github.com/${REPO_SLUG}/releases/download/${TAG}/omnigraph-macos-arm64.tar.gz"
-MACOS_X86_URL="https://github.com/${REPO_SLUG}/releases/download/${TAG}/omnigraph-macos-x86_64.tar.gz"
 LINUX_X86_URL="https://github.com/${REPO_SLUG}/releases/download/${TAG}/omnigraph-linux-x86_64.tar.gz"
 
 MACOS_ARM_SHA="$(asset_digest "$RELEASE_JSON" "omnigraph-macos-arm64.tar.gz")"
-MACOS_X86_SHA="$(asset_digest "$RELEASE_JSON" "omnigraph-macos-x86_64.tar.gz")"
 LINUX_X86_SHA="$(asset_digest "$RELEASE_JSON" "omnigraph-linux-x86_64.tar.gz")"
 
-for value in "$MACOS_ARM_SHA" "$MACOS_X86_SHA" "$LINUX_X86_SHA"; do
+for value in "$MACOS_ARM_SHA" "$LINUX_X86_SHA"; do
   if [[ -z "$value" ]]; then
     printf 'error: failed to resolve one or more release asset digests for %s\n' "$TAG" >&2
     exit 1
@@ -70,13 +68,9 @@ class Omnigraph < Formula
   version "${VERSION}"
 
   on_macos do
-    if Hardware::CPU.arm?
-      url "${MACOS_ARM_URL}"
-      sha256 "${MACOS_ARM_SHA}"
-    else
-      url "${MACOS_X86_URL}"
-      sha256 "${MACOS_X86_SHA}"
-    end
+    depends_on arch: :arm64
+    url "${MACOS_ARM_URL}"
+    sha256 "${MACOS_ARM_SHA}"
   end
 
   on_linux do


### PR DESCRIPTION
## Summary

Stop producing the `omnigraph-macos-x86_64` archive in the stable and edge release workflows. The `macos-15-intel` runner was the slowest entry in the build matrix and Apple Silicon is now the default Mac developer target.

## Changes

- **`release.yml` + `release-edge.yml`** — drop the `macos-15-intel` matrix entry. Linux x86_64 and macOS arm64 builds are unaffected.
- **`scripts/install.sh`** — drop the `Darwin/x86_64` case so Intel Macs hit the existing `*) return 1` fall-through and get the clear `no prebuilt binary is available for Darwin/x86_64` error rather than attempting an absent download.
- **`scripts/update-homebrew-formula.sh`** — drop the `MACOS_X86_*` URL/SHA pair and emit an arm64-only formula. The `on_macos` block now declares `depends_on arch: :arm64` so `brew install` on Intel fails fast with a clear architecture mismatch message instead of installing an arm64 binary that errors at exec time.

## Impact

- Intel Mac users on Homebrew get a clean refusal at install time.
- Intel Mac users on the curl `install.sh` path get a clean error.
- Existing v0.3.1 release assets are untouched (still has the macOS x86_64 archive). This change applies to v0.3.2 and onward.

## Test plan

- [ ] CI green (workflow YAML validates)
- [ ] Eyeball the rendered Homebrew formula on the next release tag (run `scripts/update-homebrew-formula.sh` against an existing release locally to dry-check)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drop macOS x86_64 builds and make macOS releases arm64-only. This shortens release times and gives Intel Macs a clear, early error.

- **Migration**
  - Homebrew: formula now `depends_on arch: :arm64`; Intel `brew install` fails fast with an arch mismatch.
  - Install script: Intel macOS returns "no prebuilt binary is available for Darwin/x86_64" instead of attempting a download.
  - Other targets unchanged (Linux x86_64, macOS arm64). Past releases remain as-is; applies to new tags only.

<sup>Written for commit fb07fe10d85be9102705212a2b6c220a718b52ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

