### PR TITLE
MR-794 step 1: staged-write primitives in TableStore (stacked on #65)

### DIFF
--- a/crates/omnigraph/src/exec/mutation.rs
+++ b/crates/omnigraph/src/exec/mutation.rs
@@ -544,12 +544,15 @@ fn apply_assignments(
 /// with `Lance HEAD > manifest_version`. The next `mutate_as` against the
 /// same table will surface `ExpectedVersionMismatch` (Lance HEAD ahead of
 /// the manifest snapshot). Lance's `restore()` is *not* a rewind — it
-/// creates a new commit, monotonically advancing the version. A proper fix
-/// requires per-table Lance-internal branches (write to a transient branch,
-/// fast-forward main on success, drop branch on failure); tracked as a
-/// follow-up to MR-771. In practice this path is narrow: most validation
-/// runs before any Lance write, so single-statement mutations are
-/// unaffected. See `docs/runs.md`.
+/// creates a new commit, monotonically advancing the version. The proper
+/// fix uses Lance's distributed-write API (`write_fragments` /
+/// `Scanner::with_fragments` / `Operation::Append { fragments }`) — see
+/// [MR-794](https://linear.app/modernrelay/issue/MR-794). The staging
+/// primitives `TableStore::stage_append` / `stage_merge_insert` /
+/// `commit_staged` / `scan_with_staged` are in place; full integration
+/// with this struct is the MR-794 follow-up. In practice this path is
+/// narrow today: most validation runs before any Lance write, so
+/// single-statement mutations are unaffected. See `docs/runs.md`.
 #[derive(Default)]
 struct MutationStaging {
     expected_versions: HashMap<String, u64>,

--- a/crates/omnigraph/src/table_store.rs
+++ b/crates/omnigraph/src/table_store.rs
@@ -4,14 +4,18 @@ use arrow_select::concat::concat_batches;
 use futures::TryStreamExt;
 use lance::Dataset;
 use lance::dataset::scanner::{ColumnOrdering, DatasetRecordBatchStream, Scanner};
-use lance::dataset::{MergeInsertBuilder, WhenMatched, WhenNotMatched, WriteMode, WriteParams};
+use lance::dataset::transaction::{Operation, Transaction};
+use lance::dataset::{
+    CommitBuilder, InsertBuilder, MergeInsertBuilder, WhenMatched, WhenNotMatched, WriteMode,
+    WriteParams,
+};
 use lance::datatypes::BlobHandling;
 use lance::index::scalar::IndexDetails;
 use lance_file::version::LanceFileVersion;
 use lance_index::scalar::{InvertedIndexParams, ScalarIndexParams};
 use lance_index::{DatasetIndexExt, IndexType, is_system_index};
 use lance_linalg::distance::MetricType;
-use lance_table::format::IndexMetadata;
+use lance_table::format::{Fragment, IndexMetadata};
 use std::sync::Arc;
 
 use crate::db::manifest::{TableVersionMetadata, open_table_head_for_write};
@@ -31,6 +35,24 @@ pub struct DeleteState {
     pub row_count: u64,
     pub deleted_rows: usize,
     pub(crate) version_metadata: TableVersionMetadata,
+}
+
+/// A Lance write that has produced fragment files on object storage but is
+/// not yet committed to the dataset's manifest. Used by `MutationStaging`
+/// (`exec/mutation.rs`) and the loader to defer Lance commits to
+/// end-of-query, so a mid-query failure leaves the touched table at the
+/// pre-mutation HEAD instead of drifting ahead.
+///
+/// `transaction` is opaque from our side — Lance owns its semantics. We
+/// commit it via `CommitBuilder::execute(transaction)` (see
+/// `TableStore::commit_staged`). `new_fragments` is extracted for
+/// read-your-writes within the same query: pass it to
+/// `Scanner::with_fragments(...)` so subsequent ops in the same mutation
+/// see the staged data alongside the committed snapshot.
+#[derive(Debug, Clone)]
+pub struct StagedWrite {
+    pub transaction: Transaction,
+    pub new_fragments: Vec<Fragment>,
 }
 
 #[derive(Debug, Clone)]
@@ -498,6 +520,202 @@ impl TableStore {
             version_metadata: self
                 .dataset_version_metadata(dataset_uri, &delete_result.new_dataset)?,
         })
+    }
+
+    // ─── Staged-write API (MR-794) ───────────────────────────────────────────
+    //
+    // These primitives wrap Lance's distributed-write API: each call writes
+    // fragment files to object storage but does NOT advance the dataset's
+    // HEAD or commit a manifest entry. The returned `Transaction` is held by
+    // the caller (typically `MutationStaging` or the loader's accumulator)
+    // and committed at end-of-query via `commit_staged`. On failure the
+    // fragments remain unreferenced and are reclaimed by `cleanup_old_versions`.
+    //
+    // The extracted `Vec<Fragment>` is for read-your-writes within the same
+    // query: subsequent ops construct a `Scanner` and call
+    // `scanner.with_fragments(staged.clone())` to see staged data alongside
+    // the committed snapshot. Lance's filter pushdown, vector search, and
+    // FTS all respect the supplied fragment list.
+
+    /// Stage an append: write fragment files for `batch`, return the
+    /// uncommitted Lance transaction plus the new fragments for
+    /// read-your-writes.
+    pub async fn stage_append(&self, ds: &Dataset, batch: RecordBatch) -> Result<StagedWrite> {
+        if batch.num_rows() == 0 {
+            return Err(OmniError::manifest_internal(
+                "stage_append called with empty batch".to_string(),
+            ));
+        }
+        let params = WriteParams {
+            mode: WriteMode::Append,
+            allow_external_blob_outside_bases: true,
+            ..Default::default()
+        };
+        let transaction = InsertBuilder::new(Arc::new(ds.clone()))
+            .with_params(&params)
+            .execute_uncommitted(vec![batch])
+            .await
+            .map_err(|e| OmniError::Lance(e.to_string()))?;
+        let new_fragments = match &transaction.operation {
+            Operation::Append { fragments } => fragments.clone(),
+            Operation::Overwrite { fragments, .. } => fragments.clone(),
+            other => {
+                return Err(OmniError::manifest_internal(format!(
+                    "stage_append: unexpected Lance operation {:?}",
+                    std::mem::discriminant(other)
+                )));
+            }
+        };
+        Ok(StagedWrite {
+            transaction,
+            new_fragments,
+        })
+    }
+
+    /// Stage a merge_insert (upsert): write fragment files describing the
+    /// merge result, return the uncommitted transaction plus the new
+    /// fragments. The transaction's `Operation::Update` carries the
+    /// fragments-to-remove and fragments-to-add; for read-your-writes we
+    /// expose `new_fragments` (rows that will be visible after commit).
+    pub async fn stage_merge_insert(
+        &self,
+        ds: Dataset,
+        batch: RecordBatch,
+        key_columns: Vec<String>,
+        when_matched: WhenMatched,
+        when_not_matched: WhenNotMatched,
+    ) -> Result<StagedWrite> {
+        if batch.num_rows() == 0 {
+            return Err(OmniError::manifest_internal(
+                "stage_merge_insert called with empty batch".to_string(),
+            ));
+        }
+        let ds = Arc::new(ds);
+        let job = MergeInsertBuilder::try_new(ds, key_columns)
+            .map_err(|e| OmniError::Lance(e.to_string()))?
+            .when_matched(when_matched)
+            .when_not_matched(when_not_matched)
+            .try_build()
+            .map_err(|e| OmniError::Lance(e.to_string()))?;
+        let schema = batch.schema();
+        let reader = arrow_array::RecordBatchIterator::new(vec![Ok(batch)], schema);
+        let stream = lance_datafusion::utils::reader_to_stream(Box::new(reader));
+        let uncommitted = job
+            .execute_uncommitted(stream)
+            .await
+            .map_err(|e| OmniError::Lance(e.to_string()))?;
+        // Operation::Update { new_fragments, updated_fragments, .. } —
+        // `new_fragments` are the freshly inserted rows; `updated_fragments`
+        // are rewrites of existing fragments that include both retained and
+        // updated rows. For read-your-writes we surface BOTH so subsequent
+        // reads see updated rows even before the manifest commits.
+        let new_fragments = match &uncommitted.transaction.operation {
+            Operation::Update {
+                new_fragments,
+                updated_fragments,
+                ..
+            } => {
+                let mut all = updated_fragments.clone();
+                all.extend(new_fragments.iter().cloned());
+                all
+            }
+            Operation::Append { fragments } => fragments.clone(),
+            other => {
+                return Err(OmniError::manifest_internal(format!(
+                    "stage_merge_insert: unexpected Lance operation {:?}",
+                    std::mem::discriminant(other)
+                )));
+            }
+        };
+        Ok(StagedWrite {
+            transaction: uncommitted.transaction,
+            new_fragments,
+        })
+    }
+
+    /// Commit a previously-staged transaction onto `ds`, returning the new
+    /// dataset (with HEAD advanced). Wraps `CommitBuilder::execute`. Used by
+    /// the publisher at end-of-query to materialize all staged writes before
+    /// the meta-manifest commit.
+    pub async fn commit_staged(
+        &self,
+        ds: Arc<Dataset>,
+        transaction: Transaction,
+    ) -> Result<Dataset> {
+        CommitBuilder::new(ds)
+            .execute(transaction)
+            .await
+            .map_err(|e| OmniError::Lance(e.to_string()))
+    }
+
+    /// Run a scan with optional uncommitted staged fragments visible
+    /// alongside the committed snapshot. When `staged_fragments` is empty
+    /// this is identical to `scan(...)`.
+    pub async fn scan_with_staged(
+        &self,
+        ds: &Dataset,
+        staged_fragments: &[Fragment],
+        projection: Option<&[&str]>,
+        filter: Option<&str>,
+    ) -> Result<Vec<RecordBatch>> {
+        if staged_fragments.is_empty() {
+            return self.scan(ds, projection, filter, None).await;
+        }
+        let mut scanner = ds.scan();
+        if let Some(cols) = projection {
+            let owned: Vec<String> = cols.iter().map(|s| s.to_string()).collect();
+            scanner
+                .project(&owned)
+                .map_err(|e| OmniError::Lance(e.to_string()))?;
+        }
+        if let Some(f) = filter {
+            scanner
+                .filter(f)
+                .map_err(|e| OmniError::Lance(e.to_string()))?;
+        }
+        // Combine committed fragments (from the dataset's manifest at
+        // current version) with the supplied staged fragments. Lance's
+        // Scanner::with_fragments scopes the scan to exactly this list —
+        // pull committed fragments out of the dataset's manifest.
+        let mut combined: Vec<Fragment> = ds.manifest.fragments.iter().cloned().collect();
+        combined.extend(staged_fragments.iter().cloned());
+        scanner.with_fragments(combined);
+        let stream = scanner
+            .try_into_stream()
+            .await
+            .map_err(|e| OmniError::Lance(e.to_string()))?;
+        stream
+            .try_collect()
+            .await
+            .map_err(|e| OmniError::Lance(e.to_string()))
+    }
+
+    /// `count_rows` variant that respects staged fragments. Used for
+    /// edge-cardinality validation that needs to see staged edges before
+    /// commit.
+    pub async fn count_rows_with_staged(
+        &self,
+        ds: &Dataset,
+        staged_fragments: &[Fragment],
+        filter: Option<String>,
+    ) -> Result<usize> {
+        if staged_fragments.is_empty() {
+            return self.count_rows(ds, filter).await;
+        }
+        let mut scanner = ds.scan();
+        if let Some(f) = filter {
+            scanner
+                .filter(&f)
+                .map_err(|e| OmniError::Lance(e.to_string()))?;
+        }
+        let mut combined: Vec<Fragment> = ds.manifest.fragments.iter().cloned().collect();
+        combined.extend(staged_fragments.iter().cloned());
+        scanner.with_fragments(combined);
+        let count = scanner
+            .count_rows()
+            .await
+            .map_err(|e| OmniError::Lance(e.to_string()))?;
+        Ok(count as usize)
     }
 
     async fn user_indices_for_column(

--- a/crates/omnigraph/src/table_store.rs
+++ b/crates/omnigraph/src/table_store.rs
@@ -38,21 +38,43 @@ pub struct DeleteState {
 }
 
 /// A Lance write that has produced fragment files on object storage but is
-/// not yet committed to the dataset's manifest. Used by `MutationStaging`
-/// (`exec/mutation.rs`) and the loader to defer Lance commits to
-/// end-of-query, so a mid-query failure leaves the touched table at the
-/// pre-mutation HEAD instead of drifting ahead.
+/// not yet committed to the dataset's manifest. The staged-write primitives
+/// are defined here for later integration in `MutationStaging`
+/// (`exec/mutation.rs`) and the loader (`loader/mod.rs`) — those rewires
+/// land in [MR-794](https://linear.app/modernrelay/issue/MR-794) step 2+.
+/// The intent: defer Lance commits to end-of-query so a mid-query failure
+/// leaves the touched table at the pre-mutation HEAD instead of drifting
+/// ahead.
 ///
 /// `transaction` is opaque from our side — Lance owns its semantics. We
 /// commit it via `CommitBuilder::execute(transaction)` (see
-/// `TableStore::commit_staged`). `new_fragments` is extracted for
-/// read-your-writes within the same query: pass it to
-/// `Scanner::with_fragments(...)` so subsequent ops in the same mutation
-/// see the staged data alongside the committed snapshot.
+/// `TableStore::commit_staged`).
+///
+/// For read-your-writes within the same query, `new_fragments` and
+/// `removed_fragment_ids` together describe the post-stage view delta:
+/// `scan_with_staged` (and `count_rows_with_staged`) compose
+/// `committed - removed + new` so subsequent reads see the staged result
+/// without double-counting fragments that `Operation::Update` rewrote.
+/// Without `removed_fragment_ids`, a `stage_merge_insert` that rewrites
+/// existing fragments would yield duplicate rows (the original fragment
+/// stays in the committed manifest while its rewrite shows up in `new_fragments`).
 #[derive(Debug, Clone)]
 pub struct StagedWrite {
     pub transaction: Transaction,
+    /// Fragments to surface alongside the committed manifest in
+    /// `Scanner::with_fragments(committed - removed + new)`. For
+    /// `Operation::Append` these are the freshly-appended fragments. For
+    /// `Operation::Update` (merge_insert) these are
+    /// `updated_fragments + new_fragments` (rewrites + freshly-inserted
+    /// rows).
     pub new_fragments: Vec<Fragment>,
+    /// Fragment IDs that this staged write supersedes. The committed
+    /// manifest must filter these out before being combined with
+    /// `new_fragments` for read-your-writes scans, otherwise rewrites
+    /// yield duplicate rows. Empty for `stage_append` (`Operation::Append`
+    /// adds without removing anything); populated from
+    /// `Operation::Update.removed_fragment_ids` for `stage_merge_insert`.
+    pub removed_fragment_ids: Vec<u64>,
 }
 
 #[derive(Debug, Clone)]
@@ -569,6 +591,8 @@ impl TableStore {
         Ok(StagedWrite {
             transaction,
             new_fragments,
+            // Append never supersedes existing fragments.
+            removed_fragment_ids: Vec::new(),
         })
     }
 
@@ -604,22 +628,28 @@ impl TableStore {
             .execute_uncommitted(stream)
             .await
             .map_err(|e| OmniError::Lance(e.to_string()))?;
-        // Operation::Update { new_fragments, updated_fragments, .. } —
+        // Operation::Update { removed_fragment_ids, updated_fragments, new_fragments, .. } —
         // `new_fragments` are the freshly inserted rows; `updated_fragments`
         // are rewrites of existing fragments that include both retained and
-        // updated rows. For read-your-writes we surface BOTH so subsequent
-        // reads see updated rows even before the manifest commits.
-        let new_fragments = match &uncommitted.transaction.operation {
+        // updated rows; `removed_fragment_ids` lists the committed-manifest
+        // fragments that those rewrites supersede. For read-your-writes we
+        // expose `updated_fragments + new_fragments` and the
+        // `removed_fragment_ids` so `scan_with_staged` can filter the
+        // superseded committed fragments before combining — otherwise a
+        // single merge_insert appears as duplicate rows (original committed
+        // version + rewritten staged version).
+        let (new_fragments, removed_fragment_ids) = match &uncommitted.transaction.operation {
             Operation::Update {
                 new_fragments,
                 updated_fragments,
+                removed_fragment_ids,
                 ..
             } => {
                 let mut all = updated_fragments.clone();
                 all.extend(new_fragments.iter().cloned());
-                all
+                (all, removed_fragment_ids.clone())
             }
-            Operation::Append { fragments } => fragments.clone(),
+            Operation::Append { fragments } => (fragments.clone(), Vec::new()),
             other => {
                 return Err(OmniError::manifest_internal(format!(
                     "stage_merge_insert: unexpected Lance operation {:?}",
@@ -630,6 +660,7 @@ impl TableStore {
         Ok(StagedWrite {
             transaction: uncommitted.transaction,
             new_fragments,
+            removed_fragment_ids,
         })
     }
 
@@ -648,17 +679,25 @@ impl TableStore {
             .map_err(|e| OmniError::Lance(e.to_string()))
     }
 
-    /// Run a scan with optional uncommitted staged fragments visible
-    /// alongside the committed snapshot. When `staged_fragments` is empty
-    /// this is identical to `scan(...)`.
+    /// Run a scan with optional uncommitted staged writes visible
+    /// alongside the committed snapshot. When `staged` is empty this is
+    /// identical to `scan(...)`.
+    ///
+    /// Composes the visible fragment list as `committed - removed + new`:
+    /// the committed manifest's fragments, minus any fragment IDs that
+    /// staged `Operation::Update`s (merge_insert rewrites) have superseded,
+    /// plus the staged new/updated fragments. Without the `removed`
+    /// filter, a merge_insert that rewrites an existing fragment would
+    /// surface twice — once via the original committed fragment, once via
+    /// the rewrite in `new_fragments`.
     pub async fn scan_with_staged(
         &self,
         ds: &Dataset,
-        staged_fragments: &[Fragment],
+        staged: &[StagedWrite],
         projection: Option<&[&str]>,
         filter: Option<&str>,
     ) -> Result<Vec<RecordBatch>> {
-        if staged_fragments.is_empty() {
+        if staged.is_empty() {
             return self.scan(ds, projection, filter, None).await;
         }
         let mut scanner = ds.scan();
@@ -673,13 +712,7 @@ impl TableStore {
                 .filter(f)
                 .map_err(|e| OmniError::Lance(e.to_string()))?;
         }
-        // Combine committed fragments (from the dataset's manifest at
-        // current version) with the supplied staged fragments. Lance's
-        // Scanner::with_fragments scopes the scan to exactly this list —
-        // pull committed fragments out of the dataset's manifest.
-        let mut combined: Vec<Fragment> = ds.manifest.fragments.iter().cloned().collect();
-        combined.extend(staged_fragments.iter().cloned());
-        scanner.with_fragments(combined);
+        scanner.with_fragments(combine_committed_with_staged(ds, staged));
         let stream = scanner
             .try_into_stream()
             .await
@@ -690,16 +723,17 @@ impl TableStore {
             .map_err(|e| OmniError::Lance(e.to_string()))
     }
 
-    /// `count_rows` variant that respects staged fragments. Used for
+    /// `count_rows` variant that respects staged writes. Used for
     /// edge-cardinality validation that needs to see staged edges before
-    /// commit.
+    /// commit. Same `committed - removed + new` composition as
+    /// `scan_with_staged`.
     pub async fn count_rows_with_staged(
         &self,
         ds: &Dataset,
-        staged_fragments: &[Fragment],
+        staged: &[StagedWrite],
         filter: Option<String>,
     ) -> Result<usize> {
-        if staged_fragments.is_empty() {
+        if staged.is_empty() {
             return self.count_rows(ds, filter).await;
         }
         let mut scanner = ds.scan();
@@ -708,9 +742,7 @@ impl TableStore {
                 .filter(&f)
                 .map_err(|e| OmniError::Lance(e.to_string()))?;
         }
-        let mut combined: Vec<Fragment> = ds.manifest.fragments.iter().cloned().collect();
-        combined.extend(staged_fragments.iter().cloned());
-        scanner.with_fragments(combined);
+        scanner.with_fragments(combine_committed_with_staged(ds, staged));
         let count = scanner
             .count_rows()
             .await
@@ -837,4 +869,35 @@ impl TableStore {
             .await
             .map_err(|e| OmniError::Lance(e.to_string()))
     }
+}
+
+/// Build the `Scanner::with_fragments` argument for read-your-writes:
+/// committed manifest fragments minus any fragment IDs superseded by the
+/// staged writes, plus the staged `new_fragments`. Order is:
+///   1. committed fragments whose IDs are NOT in any staged
+///      `removed_fragment_ids` (preserves committed order),
+///   2. all staged `new_fragments` in stage order.
+/// Lance's `Scanner` does not require any particular ordering between
+/// committed and staged fragments — `with_fragments` scopes the scan to
+/// exactly the supplied list. The dedup matters because merge_insert
+/// rewrites a fragment in place at the Lance layer: the rewritten
+/// fragment is in `new_fragments`, the original (which it supersedes) is
+/// in `committed` until manifest commit, and including both would yield
+/// duplicate rows.
+fn combine_committed_with_staged(ds: &Dataset, staged: &[StagedWrite]) -> Vec<Fragment> {
+    let removed: std::collections::HashSet<u64> = staged
+        .iter()
+        .flat_map(|w| w.removed_fragment_ids.iter().copied())
+        .collect();
+    let mut combined: Vec<Fragment> = ds
+        .manifest
+        .fragments
+        .iter()
+        .filter(|f| !removed.contains(&f.id))
+        .cloned()
+        .collect();
+    for write in staged {
+        combined.extend(write.new_fragments.iter().cloned());
+    }
+    combined
 }


### PR DESCRIPTION
## Summary

Step 1 of [MR-794](https://linear.app/modernrelay/issue/MR-794) — adds the Lance distributed-write primitives that future steps will use to fix the documented mid-query partial-failure limitation in `docs/runs.md`. **Pure additions; no behavior change.** The `MutationStaging` integration that consumes these primitives is the next step (multi-file rewire of `mutate_as` + `load`).

Stacked on #65 (MR-771); base it there to keep the diff small (~229 +/− 8). Will rebase onto `main` once #65 merges.

## What lands

`crates/omnigraph/src/table_store.rs`:

- **`StagedWrite`** struct — a Lance write that has produced fragment files on object storage but is not yet committed. Wraps the uncommitted `Transaction` plus the new `Fragment` metadata (extracted for read-your-writes).
- **`stage_append(ds, batch) -> StagedWrite`** — wraps `InsertBuilder::execute_uncommitted`. `Operation::Append`.
- **`stage_merge_insert(ds, batch, key_columns, when_matched, when_not_matched) -> StagedWrite`** — wraps `MergeInsertBuilder::execute_uncommitted` (returns `UncommittedMergeInsert { transaction, .. }`). `Operation::Update`; `new_fragments` includes both updated and freshly-inserted fragments for downstream `Scanner::with_fragments` reads.
- **`commit_staged(ds: Arc<Dataset>, transaction) -> Dataset`** — wraps `CommitBuilder::execute(transaction)`. Used to commit a staged transaction at end-of-mutation.
- **`scan_with_staged(ds, staged_fragments, projection, filter)`** and **`count_rows_with_staged(ds, staged_fragments, filter)`** — pass `with_fragments(committed + staged)` to the Lance Scanner so reads see both committed and uncommitted fragments. Filter pushdown, vector search, and FTS all respect the supplied fragment list (verified by Lance's own tests `test_scalar_index_respects_fragment_list`, `test_vector_search_respects_fragment_list`, `test_fts_respects_fragment_list`).

`crates/omnigraph/src/exec/mutation.rs`:

- Doc comment on `MutationStaging` updated to reference [MR-794](https://linear.app/modernrelay/issue/MR-794) and the new primitives, so future readers find the canonical follow-up plan.

## Why this exists separately

Step 2+ of MR-794 is a coordinated multi-file rewire (mutation execute_*, loader `load_jsonl_reader`, publisher commit path, plus tests). Worth landing the primitives separately so the rewire PR's diff is purely behavioral and doesn't mix in API additions. See the MR-794 ticket for the full plan.

## Test plan

- [x] `cargo build --workspace --bins` (debug + release)
- [x] `cargo test --workspace --locked` — all 29 test suites pass, 0 failures
- [ ] No new tests in this PR — the primitives have no callers yet. Step 2+ will add direct test coverage of the staged-write path via the existing `tests/runs.rs::partial_failure_*` regression test (currently asserts the *broken* behavior; will flip to assert the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily additive APIs with no evident callers in this diff, so behavior should not change; main risk is compilation/regression from new Lance transaction/fragment handling code paths once wired in.
> 
> **Overview**
> Adds a new *staged-write API* to `TableStore` to support Lance distributed (uncommitted) writes, returning a `StagedWrite` (uncommitted `Transaction` plus fragment metadata) that can be committed later.
> 
> Introduces `stage_append`, `stage_merge_insert`, and `commit_staged`, plus read helpers `scan_with_staged` / `count_rows_with_staged` that compose visible fragments as **committed − removed + new** to avoid duplicate rows when merge-inserts rewrite fragments. Updates `MutationStaging` documentation to point at MR-794 and these new primitives as the planned fix for mid-query partial failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 730631cf4fbc26d9a9b5c04f845ce3258f0c868a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->