### PR TITLE
docs: rename omnigraph-starters to omnigraph-cookbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ brew tap ModernRelay/tap
 brew install ModernRelay/tap/omnigraph
 ```
 
-For starter graphs and agent skills to bootstrap and operate Omnigraph, see [`ModernRelay/omnigraph-starters`](https://github.com/ModernRelay/omnigraph-starters).
+For starter graphs and agent skills to bootstrap and operate Omnigraph, see [`ModernRelay/omnigraph-cookbooks`](https://github.com/ModernRelay/omnigraph-cookbooks).
 
 ## One-Command Local RustFS Bootstrap
 


### PR DESCRIPTION
## Summary
- Update the README link from `ModernRelay/omnigraph-starters` to `ModernRelay/omnigraph-cookbooks` to match the renamed sibling repo.

## Test plan
- [ ] README renders with the corrected link

🤖 Generated with [Claude Code](https://claude.com/claude-code)