### PR TITLE
branch-protection: allow admin bypass on main

### DIFF
--- a/.github/branch-protection.json
+++ b/.github/branch-protection.json
@@ -11,7 +11,7 @@
       "CODEOWNERS / noedit"
     ]
   },
-  "enforce_admins": true,
+  "enforce_admins": false,
   "required_pull_request_reviews": {
     "dismissal_restrictions": {},
     "dismiss_stale_reviews": true,


### PR DESCRIPTION
## Summary

Flip `enforce_admins` from `true` to `false` in `.github/branch-protection.json`. Repo admins can now self-merge PRs by clicking *Merge without waiting for requirements to be met* once CI is green. The bypass action is recorded in the audit log.

Non-admins still see full enforcement: code-owner review required, 1 approving review, required status checks must pass.

## Why

As the solo owner of most CODEOWNERS scopes, the PR author cannot satisfy GitHub's "non-self approver" rule on their own PRs — every PR was blocking on a second human. Admin bypass restores the practical workflow while keeping the protection rules as the default for everyone else (Devin, future contributors).

## Test plan

- [x] API state already flipped via `gh api -X DELETE .../enforce_admins` so unblocking takes effect immediately.
- [ ] After merge, running `./scripts/apply-branch-protection.sh` should be a no-op (declarative source now matches API state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/modernrelay/omnigraph/pull/94" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->