### PR TITLE
RFC 0001 & 0002: Federated auth and staged cloud deployment

### DIFF
--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -43,6 +43,15 @@ constraints. User-facing behavior should still be documented through
 | Constants and tunables | [constants.md](../user/constants.md) |
 | Transaction model public contract | [transactions.md](../user/transactions.md) |
 
+## Design Proposals (RFCs)
+
+RFCs are proposals under review, not current truth. The authoritative
+description of shipped behavior always lives in the area docs above.
+
+| RFC | Status | Topic |
+|---|---|---|
+| [0001-federated-authentication.md](rfcs/0001-federated-authentication.md) | draft | OIDC auth with a cloud control plane plus VPC/on-prem deployment |
+
 ## Project Operations
 
 | Area | Read |

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -51,6 +51,7 @@ description of shipped behavior always lives in the area docs above.
 | RFC | Status | Topic |
 |---|---|---|
 | [0001-federated-authentication.md](rfcs/0001-federated-authentication.md) | draft | OIDC auth with a cloud control plane plus VPC/on-prem deployment |
+| [0002-cloud-deployment-architecture.md](rfcs/0002-cloud-deployment-architecture.md) | draft | Staged cloud deployment — managed, elastic, then BYOC/VPC |
 
 ## Project Operations
 

--- a/docs/dev/rfcs/0001-federated-authentication.md
+++ b/docs/dev/rfcs/0001-federated-authentication.md
@@ -1,0 +1,256 @@
+# RFC 0001 — Federated Authentication (Cloud Control Plane + VPC/On-Prem)
+
+**Type:** design proposal
+**Status:** draft — not accepted, not implemented
+**Audience:** maintainers reviewing the auth substrate and the OSS/Cloud boundary
+**Date:** 2026-05-16
+**Supersedes:** nothing — extends the current bearer-token model
+
+> This is a proposal, not current truth. Until accepted and implemented, the
+> authoritative description of auth remains [docs/user/server.md](../../user/server.md)
+> and [docs/user/policy.md](../../user/policy.md).
+
+## Summary
+
+Add OIDC-based federated authentication to `omnigraph-server` so that a
+managed cloud offering can issue identity tokens, while VPC and air-gapped
+on-prem deployments keep working with **no request-time dependency** on the
+cloud. The mechanism is a new `TokenVerifier` seam in `omnigraph-server` with
+two OSS implementations: today's static bearer tokens, and an OIDC JWT
+verifier. The cloud offering is configuration of the OSS verifier plus an
+additive, optional control-plane sync component — not a fork.
+
+## Motivation
+
+The current model (`omnigraph-server/src/auth.rs`, `lib.rs`) hashes a static
+set of bearer tokens at startup and compares per request. It is correct and
+on-prem-friendly, but it cannot:
+
+- accept identities issued by an enterprise IdP (Okta, Entra, Google) or by an
+  OmniGraph cloud control plane;
+- support short-lived, rotating credentials;
+- feed an actor allowlist from an external source (e.g. SCIM).
+
+We want a cloud offering with managed identity **without** sacrificing the VPC
+/ on-prem deployment story or violating the OSS/Cloud invariants in
+[invariants.md](../invariants.md).
+
+## Goals
+
+- One engine binary; deployment mode is configuration only.
+- Token **validation** is fully OSS and works offline (no control-plane call
+  on the request path).
+- Cloud control plane *issues* tokens and *distributes* config; it never
+  becomes a correctness dependency of the data plane.
+- Static bearer tokens remain a first-class, default-capable path for
+  machine-to-machine (M2M), CI, and air-gapped use.
+- Cedar authorization (`policy.rs`) is unchanged — it still operates on a
+  server-resolved actor.
+
+## Non-goals
+
+- Building an OmniGraph identity provider. The cloud control plane may wrap a
+  third party (e.g. WorkOS) for human SSO; that is out of scope here.
+- Browser login / session UX. This RFC covers API/CLI credential verification.
+- Changing the engine crates. `omnigraph` and `omnigraph-compiler` stay free
+  of transport/auth code (Invariant 11).
+
+## Background — current state
+
+| Concern | Today | File |
+|---|---|---|
+| Token store | SHA-256 hashes of static tokens | `omnigraph-server/src/lib.rs:58` |
+| Comparison | constant-time over all entries | `lib.rs:286` |
+| Token sources | env / file / AWS Secrets Manager | `auth.rs` (`TokenSource` trait) |
+| Actor | `AuthenticatedActor(Arc<str>)`, server-resolved | `lib.rs:135` |
+| Authz | Cedar, 8 actions, branch scopes | `policy.rs` |
+
+`TokenSource` yields a *static set to hash*. OIDC needs a per-request
+*validation* step instead, so a new seam is required rather than a new
+`TokenSource` impl.
+
+## Design
+
+### Control plane / data plane split
+
+The decoupling that makes VPC + on-prem work: **token validation never makes a
+network call.** OIDC tokens are signed by the issuer; the verifier needs only
+the issuer's public keys (JWKS). The data plane validates offline against
+cached JWKS.
+
+```
+                 CLOUD CONTROL PLANE (SaaS only, optional)
+                 - issues tokens (own IdP or WorkOS front)
+                 - publishes signed config bundle:
+                     { jwks, cedar_policy, actor_allowlist }
+                          │  (pull, periodic)
+                          ▼
+   ┌─────────────────────────────────────────────────────────┐
+   │  DATA PLANE  — omnigraph-server + engine                 │
+   │  (identical binary in SaaS / VPC / on-prem)              │
+   │                                                          │
+   │  request ─▶ TokenVerifier ─▶ AuthenticatedActor ─▶ Cedar │
+   │             reads ONLY local cached state                │
+   └─────────────────────────────────────────────────────────┘
+```
+
+In air-gapped mode the bundle is supplied as static files; the control-plane
+sync component is simply not configured. The request path is byte-identical in
+all three modes.
+
+### The `TokenVerifier` seam
+
+Lives entirely in `omnigraph-server` (Invariant 11).
+
+```rust
+/// Verifies an inbound bearer credential and resolves it to an actor.
+trait TokenVerifier: Send + Sync {
+    async fn verify(&self, presented: &str) -> Result<ResolvedActor, AuthError>;
+}
+
+struct ResolvedActor { actor_id: Arc<str>, source: AuthSource }
+```
+
+OSS implementations:
+
+- `StaticHashTokenVerifier` — current behavior, refactored behind the trait.
+  Constant-time hash compare. Default.
+- `OidcJwtVerifier` — validates JWT signature against cached JWKS, checks
+  `iss` / `aud` / `exp` (with bounded clock skew), maps a configured claim to
+  `actor_id`, optionally checks an allowlist.
+
+`require_bearer_auth()` dispatches to the configured verifier(s) and produces
+the same `AuthenticatedActor` the rest of the stack already consumes. Nothing
+downstream — Cedar, `mutate_as`, the commit actor map — changes.
+
+The "cloud verifier" is **not new code**: it is `OidcJwtVerifier` pointed at
+the OmniGraph cloud issuer.
+
+### Configuration
+
+```toml
+[auth]
+mode = "static"        # "static" | "oidc" | "hybrid"
+
+[auth.oidc]
+issuer        = "https://auth.omnigraph.cloud/"  # or a customer IdP
+audience      = "omnigraph"
+actor_claim   = "sub"                            # claim -> actor_id
+jwks_uri      = ""                               # blank = OIDC discovery
+jwks_cache_ttl   = "1h"
+jwks_offline_path = "/etc/omnigraph/jwks.json"   # air-gapped pre-seed
+jwks_stale_max    = "24h"                        # see degraded mode
+clock_skew        = "60s"
+allowed_actors_path = ""                         # optional; SCIM-fed in cloud
+
+[auth.control_plane]                              # SaaS only; omit elsewhere
+bundle_url      = "https://cp.omnigraph.cloud/v1/bundle"
+sync_interval   = "5m"
+```
+
+`hybrid` mode runs both verifiers (static tried first, then OIDC), so M2M
+service tokens and human/federated identities coexist during and after
+migration.
+
+### Control-plane sync (additive, cloud-only)
+
+An optional `ControlPlaneSync` task periodically pulls a **signed** bundle
+(`jwks`, `cedar_policy`, `actor_allowlist`), verifies its signature, and writes
+it to the same local paths the verifier and `policy.rs` already read. It is a
+distribution mechanism, not a code path the request touches — preserving the
+"no fork for Cloud" invariant.
+
+### Degraded-mode behavior
+
+VPC deployments must tolerate brief control-plane / IdP unreachability:
+
+- **JWKS refresh failure** — keep serving on cached keys; emit a loud
+  `WARN` + metric. Past `jwks_stale_max`, fail closed. Cached JWKS is safe
+  because signing keys rotate slowly.
+- **Revocation** — JWT revocation is inherently weak. Mitigate with short token
+  TTL (Databricks Lakebase uses 1h; we recommend ≤1h for cloud-issued tokens)
+  rather than a request-time denylist lookup. Optional opaque-token
+  introspection is left as future work, not a default.
+- **Control-plane bundle staleness** — last-good bundle stays in effect; loud
+  warning. Never silently fail open or drop to a weaker policy.
+
+This satisfies the deny-list "no silent failures" and Invariant 6 (any
+degraded mode is explicit, bounded, observable).
+
+### M2M for VPC
+
+In-VPC service-to-service and CI clients must not depend on the cloud at all.
+`StaticHashTokenVerifier` remains the supported M2M path (analogous to
+Lakebase's indefinitely-lived service principals). `hybrid` mode lets a
+deployment serve static service tokens and OIDC human tokens simultaneously.
+
+### Authorization interaction
+
+Unchanged. Cedar (`policy.rs`) receives the resolved actor regardless of which
+verifier produced it. The control-plane bundle may *distribute* the Cedar
+policy and actor allowlist, but enforcement, scopes, and the 8 actions are
+exactly as they are today.
+
+## Invariant analysis
+
+| Invariant / deny-list item | Outcome |
+|---|---|
+| 11 — transport/auth at the boundary | ✅ `TokenVerifier` is server-only; engine untouched |
+| 12 — bearer plaintext not retained | ✅ JWT verified per request, not stored; static path keeps constant-time compare |
+| 6 — strong consistency default | ✅ degraded mode is explicit, bounded, non-default |
+| Deny: cloud-only correctness fix | ✅ verification is OSS; cloud only issues + distributes |
+| Deny: fork the codebase for Cloud | ✅ cloud verifier = config; `ControlPlaneSync` is additive/optional |
+| Deny: silent failure | ✅ JWKS/bundle staleness is loud + metered, fails closed at a bound |
+| Deny: side-channel for semantics | ✅ actor stays a first-class server-resolved value |
+
+## Open questions — decisions needed before acceptance
+
+1. **Degraded grace window.** Is `jwks_stale_max = 24h` the right default, and
+   is fail-closed-after-bound acceptable for VPC SLAs?
+2. **Revocation.** Short TTL only, or do we also ship optional introspection /
+   a denylist for high-security tenants?
+3. **Policy authority for VPC.** Can a VPC customer override a cloud-pushed
+   Cedar policy locally, or is the cloud bundle authoritative? Security and
+   product implications.
+4. **Unknown-actor handling.** When `actor_claim` resolves to an actor absent
+   from the allowlist: reject at `verify()`, or pass through and let Cedar deny
+   (with a default-deny rule)?
+5. **Multi-issuer.** Does `hybrid` need to validate against more than one OIDC
+   issuer simultaneously (cloud issuer + customer IdP)?
+6. **Bundle signing.** What signs the control-plane bundle, and how is that
+   root of trust provisioned to an air-gapped install?
+
+## Rollout
+
+1. Land `TokenVerifier` + `StaticHashTokenVerifier` as a pure refactor —
+   `mode = "static"` is the default, behavior identical. (Separate commit, per
+   AGENTS.md rule 11.)
+2. Add `OidcJwtVerifier` + JWKS cache; `mode = "oidc"` / `"hybrid"` opt-in.
+3. Add `ControlPlaneSync` as an optional component.
+4. Update [docs/user/server.md](../../user/server.md),
+   [docs/user/policy.md](../../user/policy.md), and
+   [docs/user/deployment.md](../../user/deployment.md) in the same changes.
+
+No breaking change: existing static-token deployments keep working untouched.
+
+## Alternatives considered
+
+- **Mandatory cloud control plane (Lakebase model).** Rejected — Lakebase
+  requires the Databricks control plane reachable, which kills the air-gapped
+  on-prem story and would put correctness behind a cloud service (deny-list:
+  cloud-only correctness).
+- **Opaque tokens + request-time introspection.** Rejected as the default —
+  adds request-path egress to the issuer, defeating the VPC decoupling. Kept as
+  possible future opt-in for revocation-sensitive tenants.
+- **Build an OmniGraph IdP.** Rejected — not our domain; delegate issuance to
+  an OIDC provider or a thin cloud control plane that may wrap WorkOS.
+
+## Testing
+
+- Extend `crates/omnigraph-server/tests/server.rs` with `TokenVerifier`
+  coverage; add a focused auth test module.
+- OIDC path: test harness signs JWTs with a local key; assert accept / expired
+  / bad-audience / bad-signature / unknown-actor.
+- Degraded mode: exercise JWKS-unreachable via the `failpoints` feature; assert
+  cached-key serving, the loud warning, and fail-closed past `jwks_stale_max`.
+- Confirm `omnigraph-server` remains the only crate with auth dependencies.

--- a/docs/dev/rfcs/0002-cloud-deployment-architecture.md
+++ b/docs/dev/rfcs/0002-cloud-deployment-architecture.md
@@ -1,0 +1,278 @@
+# RFC 0002 — Cloud Deployment Architecture (Staged)
+
+**Type:** design proposal
+**Status:** draft — not accepted, not implemented
+**Audience:** maintainers reviewing the cloud offering and the OSS/Cloud boundary
+**Date:** 2026-05-17
+**Depends on:** [RFC 0001 — Federated Authentication](0001-federated-authentication.md)
+
+> This is a proposal, not current truth. Until accepted and implemented, the
+> authoritative deployment story remains [docs/user/deployment.md](../../user/deployment.md).
+
+## Summary
+
+Defines how OmniGraph is deployed as a managed cloud offering, in **three
+stages** of increasing complexity. Each stage wins one irreducible property
+and pays only the complexity that property earns:
+
+1. **Managed single-region** — a customer can sign up, get a repo, and
+   authenticate against a managed OmniGraph. Wins: *managed + authenticated +
+   multi-tenant*.
+2. **Elastic data plane + worker tier** — write scale, and maintenance
+   (indexing, compaction, recovery) moved off the request path. Wins: *scale +
+   off-path maintenance + no recovery-on-open race*.
+3. **BYOC / VPC / air-gapped** — data plane in the customer's VPC, only a
+   thin orchestrator in the vendor cloud. Wins: *data sovereignty*.
+
+The same OSS binary runs in every stage and in a customer VPC; deployment mode
+is configuration. The auth design from RFC 0001 threads through unchanged —
+each stage only moves *where the token issuer lives*, never the validation
+path.
+
+## Motivation
+
+OmniGraph's durable state lives entirely in object storage (Lance datasets +
+the `__manifest` commit log); concurrency is optimistic CAS on `__manifest`.
+That is already the object-storage-native architecture that turbopuffer,
+LanceDB, Neon, and WarpStream converged on. The task is not to adopt it but to
+*lean into it* — and to do so in stages so that a managed offering can ship and
+collect real load before the expensive pieces (the reconciler, BYOC) are built.
+
+## Goals
+
+- One OSS binary; deployment mode is configuration only.
+- A managed offering reachable in Stage 1 without building the reconciler.
+- Object storage as the only request-path dependency.
+- The control plane is dispensable: it holds only soft, derivable state.
+- Auth (RFC 0001) is identical across stages and across VPC/on-prem.
+
+## Non-goals
+
+- A new storage substrate, WAL, or metadata database (deny-list).
+- Changing the engine crates — transport/auth stay at the server boundary
+  (Invariant 11).
+- Multi-region active/active. Regions are independent stacks.
+- Browser SSO / login UX (a control-plane concern, out of scope here).
+
+## Foundational principles (hold across all stages)
+
+These are decided once and constrain every stage.
+
+### P1 — Object-storage-only commit
+
+OmniGraph writes are **batch-shaped** (`mutate_as`, `load`, merges,
+`schema_apply`) — not OLTP `COMMIT`s. Neon adds a Safekeeper quorum tier in
+front of object storage *because* OLTP commit cannot wait ~100-300ms for an S3
+PUT. OmniGraph has no such requirement, so it takes the turbopuffer path:
+**commit straight to object storage, accept ~100-300ms write latency, run no
+fast durable tier.** This is a large, deliberate simplicity win. It is
+hard to reverse — if a low-latency single-row write path ever becomes a product
+requirement, *that* is when a fast durable tier earns its complexity, via a new
+RFC.
+
+### P2 — The control plane holds only soft state
+
+WarpStream keeps an authoritative metadata store (file→offset mappings) in its
+cloud. OmniGraph does **not** need this: the `__manifest` table already *is* the
+authoritative, strongly-consistent metadata, and it lives in object storage.
+The control plane therefore stores only **soft, derivable state** — tenant
+directory, billing counters, routing hints, compaction schedules, recovery
+leases. Everything it knows is rebuildable by scanning object storage. The
+control plane is never on the request path; if it is down, existing tenants
+keep serving (the turbopuffer 99.99%-uptime property).
+
+### P3 — One binary, config-driven
+
+The `omnigraph-server` container is identical in Stage 1, Stage 2, a customer
+VPC, and air-gapped on-prem. A "cloud build" is configuration plus *additive,
+optional* control-plane services — never a fork (deny-list: no Cloud fork;
+correctness is always OSS).
+
+### P4 — Auth validation never makes a network call
+
+Per RFC 0001: tokens are validated offline against cached JWKS. The token
+*issuer* may be cloud-hosted, but the data plane never calls it on the request
+path. This is what lets the identical data plane run in Stage 3's customer VPC.
+
+## Architecture primitives
+
+```
+        CONTROL PLANE (vendor cloud; soft state only; off request path)
+        - provisioning / tenant directory   - billing / metering
+        - identity issuer (RFC 0001; may wrap WorkOS)
+        - orchestration: compaction schedule, recovery leases, routing hints
+                              │  (async, never on request path)
+   ┌──────────────────────────┼──────────────────────────────────────┐
+   │  DATA PLANE — omnigraph-server (identical OSS binary everywhere)  │
+   │    read replicas  ·  writer(s)  ·  worker tier (Stage 2+)        │
+   └──────────────────────────┬──────────────────────────────────────┘
+                              ▼
+                       OBJECT STORAGE
+        Lance datasets + __manifest  (the only request-path dependency)
+```
+
+Tiers, introduced progressively:
+
+- **Read replicas** — open `OpenMode::ReadOnly` (skips the recovery sweep),
+  snapshot-isolated, fan out freely.
+- **Writer(s)** — open `ReadWrite`; route by repo so CAS contention and cache
+  stay local.
+- **Worker tier** (Stage 2+) — background indexing, compaction, cleanup,
+  recovery. Off the request path.
+
+## Stage 1 — Managed single-region
+
+**Property won:** a customer can sign up, get a repo, authenticate, and use a
+managed OmniGraph.
+
+**Architecture.** Single region. One object store (prefix-per-tenant or
+bucket-per-tenant — see open decisions). Data plane = a pool of **read
+replicas** plus a **single writer replica** per region. The single writer is
+deliberate: it sidesteps both `__manifest` CAS contention *and* the
+recovery-on-open race **without building the worker tier**. Recovery runs on the
+writer's `open`, as today. Reads fan out across read replicas.
+
+**Control plane.** Thinnest viable: provisioning (`open-or-create` a repo —
+largely doable by the data plane itself on first request), a tenant directory,
+billing counters, and the RFC 0001 identity issuer. All soft state (P2).
+
+**Auth (RFC 0001).** `mode = static` remains the default for M2M / CI;
+`mode = oidc` available, validated offline. The control plane runs the issuer
+(its own, or wrapping WorkOS for human SSO). `hybrid` lets both coexist.
+
+**Branching as product surface.** OmniGraph already has Git-style graph
+branches with lazy fork — the same zero-copy, metadata-pointer design Neon
+sells. Stage 1 exposes this directly: instant per-PR / dev / staging branches at
+near-zero storage cost. No new engine work — a product packaging of an existing
+capability.
+
+**Deliberately not done.** No autoscaling of writes, no worker tier, no
+reconciler, no BYOC. **Accepted limitation:** per-region write throughput is
+bounded by one writer; a writer restart briefly pauses writes for that region.
+
+**Exit criteria → Stage 2.** Single-writer throughput, write-pause blast
+radius, or maintenance load (inline index builds / compaction) becomes the
+binding constraint.
+
+## Stage 2 — Elastic data plane + worker tier
+
+**Property won:** horizontal write scale, and maintenance moved off the request
+path — which also eliminates the recovery-on-open race.
+
+**Architecture.**
+
+- **Multiple writers** with **consistent-hash routing by repo URI**. A repo's
+  writes land on one node, so CAS contention is bounded and the Lance page cache
+  / warm `Omnigraph` handle stay local.
+- **Per-repo write coalescer** — concurrent `mutate_as`/`load` commits to one
+  repo batch into one manifest publish (the turbopuffer WAL-batching lesson:
+  beat contention with batching, not locks).
+- **Three-tier cache** made explicit: object storage → NVMe SSD → in-process
+  (Lance page cache + warm handle), with routing affinity keeping a repo warm.
+- **Worker tier** — background workers own index building (the deny-list
+  reconciler mandate), compaction (`optimize`), cleanup, **and recovery**.
+  Recovery moves from "every `open` runs the sweep" to "one leased worker per
+  repo owns recovery." This *is* the long-deferred background reconciler;
+  cloud is its forcing function.
+- **Per-tenant resource bounds** — close the `invariants.md` resource-bounds
+  gap: enforced per-query memory/time budgets, plus `WorkloadController`
+  admission control, so multi-tenant compute has no noisy-neighbor failure.
+- **Scale-to-zero** for cold tenants — evict idle handles, re-warm on first
+  request, bill by the second (the Neon model).
+
+**Control plane.** Gains orchestration: routing-hint distribution, compaction
+scheduling, recovery-lease coordination. Still soft state (P2), still off-path.
+
+**Auth.** No change to the validation path. The control plane's config-bundle
+sync (RFC 0001 `ControlPlaneSync`) may now feed a SCIM-sourced actor allowlist.
+
+**Optional consistency knob.** With warm caches, a per-query `stale-ok` read
+becomes viable (turbopuffer's sub-10ms eventual mode). Invariant 6 permits it
+**only** as explicit, read-only, non-default — exposed as opt-in, never the
+default.
+
+**Deliberately not done.** Data still resides in vendor-managed object storage.
+
+**Exit criteria → Stage 3.** A customer requires data sovereignty (data may not
+leave their account) or air-gapped operation.
+
+## Stage 3 — BYOC / VPC / air-gapped
+
+**Property won:** data sovereignty — the customer's graph data never leaves
+their cloud account.
+
+**Architecture.** The WarpStream BYOC split. The data plane (read replicas,
+writers, worker tier — the Stage 1 *or* Stage 2 shape) and the customer's object
+store run **inside the customer's VPC**. The vendor cloud keeps only the
+soft-state orchestrator and the identity issuer. No customer graph data crosses
+the boundary; no cross-account IAM into the customer's bucket. Air-gapped is the
+same packaging with the control plane absent and config supplied as static
+files.
+
+**Auth.** This is where RFC 0001's P4 pays off fully: the in-VPC data plane
+validates tokens **offline** against cached JWKS. The vendor identity issuer is
+the only cloud touchpoint and it is off the request path. Air-gapped: point at
+the customer's own IdP, or `mode = static`, with JWKS/policy pre-seeded.
+
+**Why this is mostly packaging.** Because P2/P3/P4 were honored from Stage 1 —
+control plane thin and off-path, one config-driven binary, auth validated
+offline — Stage 3 is boundary hardening and deployment templates (Helm /
+Terraform), not an architectural change.
+
+## Why three stages (first-principles)
+
+- **Not one stage.** The managed offering must not wait on the reconciler — a
+  large build. Stage 1's single-writer design wins a real, sellable, managed
+  product with bounded complexity, and the load it collects is the evidence
+  that justifies Stage 2 (reversible-change discipline: ship, measure, then
+  invest).
+- **Not collapsing 2 and 3.** *Scale* (Stage 2) and *sovereignty* (Stage 3) are
+  independent axes — a customer may demand BYOC before single-region scale runs
+  out, or the reverse. They share only the thin-control-plane prerequisite,
+  which is foundational (P2) anyway. **Stage 3 can therefore ship on the Stage 1
+  data-plane shape**; the 1→2→3 numbering is the expected-demand order, not a
+  hard dependency. If enterprise/sovereignty demand arrives first, do 1→3→2.
+- **Not more than three.** The natural seams are exactly *managed+auth*,
+  *elastic+maintenance*, *sovereignty*. Finer splits would be invented
+  complexity, not earned.
+
+## Open decisions
+
+1. **Tenancy isolation model** — bucket-per-tenant vs prefix-per-tenant vs
+   account-per-tenant. Strongest lever and effectively irreversible; the
+   control plane should vend short-lived per-tenant scoped credentials
+   regardless. Decide before Stage 1.
+2. **Recovery ownership** — Stage 1 leans on the single writer; Stage 2 needs a
+   per-repo recovery lease. Confirm the lease mechanism (object-store-based
+   lease vs control-plane-issued).
+3. **Commit-latency model (P1)** — ratify object-storage-only commit, or
+   identify a concrete low-latency write requirement that would justify a fast
+   durable tier.
+4. **RFC 0001 carry-overs** — degraded-mode JWKS grace window, revocation
+   strategy, whether VPC customers can override cloud-pushed Cedar policy.
+5. **Stale-read knob** — ship the optional eventual-consistency read in
+   Stage 2, or defer.
+
+## Invariant analysis
+
+| Invariant / deny-list item | Outcome |
+|---|---|
+| 2 — manifest-atomic graph visibility | ✅ unchanged; `__manifest` CAS is the commit point in every stage |
+| 5 — recovery part of commit protocol | ✅ Stage 1 = open-time sweep; Stage 2 = leased worker; never weakened |
+| 6 — strong consistency default | ✅ stale-read knob is explicit, read-only, non-default |
+| 11 — transport/auth at the boundary | ✅ engine crates untouched; auth in `omnigraph-server` |
+| 13 — failures bounded/observable | ✅ Stage 2 closes the per-query resource-bounds gap |
+| Deny: custom WAL / metadata store | ✅ P1/P2 — object storage + `__manifest` only |
+| Deny: cloud-only correctness / fork | ✅ P3 — one OSS binary, additive control plane |
+| Deny: job queue for manifest-derivable state | ✅ worker tier is a reconciler, not a queue |
+
+## Testing notes
+
+- Stage 1: extend `omnigraph-server` tests for multi-replica read fan-out and
+  single-writer routing; reuse `failpoints` for writer-restart behavior.
+- Stage 2: per-repo coalescer and routing need engine/storage-boundary tests
+  (`runs.rs`, `recovery.rs`); recovery-lease coverage belongs in `recovery.rs`.
+- Stage 3: a deployment-template smoke test (data plane against an in-VPC-style
+  object store); confirm no control-plane call on the request path.
+- Update [docs/user/deployment.md](../../user/deployment.md),
+  [docs/user/server.md](../../user/server.md) as each stage lands.


### PR DESCRIPTION
## Summary

Add two design proposals (RFCs) that define the path to a managed cloud offering while preserving the OSS/on-prem story:

- **RFC 0001 — Federated Authentication**: Introduces OIDC-based token verification with offline validation, enabling cloud-issued identities without request-path dependencies on the cloud. Keeps static bearer tokens as the default M2M path and supports hybrid mode for migration.
- **RFC 0002 — Cloud Deployment Architecture**: Proposes a three-stage rollout (managed single-region → elastic data plane + worker tier → BYOC/VPC) that wins one irreducible property per stage without building unnecessary complexity upfront.

Both RFCs are grounded in the architectural invariants from `invariants.md` and respect the deny-list constraints (no cloud-only correctness, no fork, no silent failures).

## Key changes

- **docs/dev/rfcs/0001-federated-authentication.md** (256 lines)
  - Defines `TokenVerifier` trait seam in `omnigraph-server` with two OSS implementations: `StaticHashTokenVerifier` (current behavior) and `OidcJwtVerifier` (OIDC JWT validation against cached JWKS)
  - Specifies control-plane sync as an optional, additive component that distributes signed bundles (JWKS, Cedar policy, actor allowlist)
  - Covers degraded-mode behavior (JWKS staleness, revocation via short TTL, bundle staleness) with explicit bounds and loud warnings
  - Identifies 6 open decisions (grace window, revocation strategy, policy authority for VPC, etc.) requiring acceptance before implementation
  - Includes invariant analysis confirming no engine changes, no fork, no silent failures

- **docs/dev/rfcs/0002-cloud-deployment-architecture.md** (278 lines)
  - Establishes four foundational principles: object-storage-only commit (no fast durable tier), soft-state control plane (off request path), one config-driven binary, offline token validation
  - Stage 1 (managed single-region): single writer + read replicas, thin control plane, branches as product surface; deliberately omits autoscaling and worker tier
  - Stage 2 (elastic + worker tier): multiple writers with consistent-hash routing, per-repo coalescer, explicit three-tier cache, background recovery/indexing/compaction, per-tenant resource bounds, scale-to-zero
  - Stage 3 (BYOC/VPC/air-gapped): data plane in customer VPC, vendor cloud holds only orchestrator and issuer, no graph data crosses boundary
  - Justifies three stages (not one, not collapsed 2+3, not more) and notes that Stage 3 can ship on Stage 1 data-plane shape if sovereignty demand arrives first
  - Includes 5 open decisions (tenancy isolation, recovery ownership, commit-latency ratification, RFC 0001 carry-overs, stale-read knob)
  - Invariant analysis confirms manifest atomicity, recovery protocol, strong consistency default, no custom WAL, no fork, no job queue

- **docs/dev/index.md** (modified)
  - Adds new "Design Proposals (RFCs)" section with a table linking to both RFCs and their draft status
  - Clarifies that RFCs are proposals under review, not current truth; authoritative behavior lives in area docs

## Notable implementation details

- Both RFCs are **draft status** and explicitly not accepted/implemented; they serve as design proposals for review by maintainers.
- RFC 0001 is a prerequisite for RFC 0002 (noted in the `Depends on` field).
- The design preserves all architectural invariants from `invariants.md` — no engine changes, no fork for Cloud, no silent failures, no cloud-only correctness.
- Stage 1 of RFC 0002 is deliberately minimal (single writer, no worker tier) to ship a real managed offering without waiting for the reconciler; load collected in Stage 1 justifies Stage 2 investment.
- Both RFCs emphasize that the same OSS binary runs everywhere (SaaS, VPC, on-

https://claude.ai/code/session_01N22WDYC6vv2njR5Xu96QaC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding draft RFCs; no runtime behavior or interfaces are modified.
> 
> **Overview**
> Adds a new **Design Proposals (RFCs)** section to `docs/dev/index.md` and links two new draft RFC documents.
> 
> Introduces RFC 0001 proposing an OIDC-based, offline JWT verification design (`TokenVerifier` seam, optional signed bundle sync, and bounded degraded-mode behavior) while keeping static bearer tokens as the default.
> 
> Introduces RFC 0002 proposing a three-stage managed-cloud deployment architecture (single-region managed → elastic writers/worker tier → BYOC/VPC/air-gapped) with an explicitly off-path, soft-state control plane and the same OSS data plane binary across modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e5a86580d8af7d0de684e510ee59a0d775203e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->