### PR TITLE
ci(publish-crates): include omnigraph-policy (v0.5.0 follow-up)

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -93,7 +93,12 @@ jobs:
             cargo publish -p "$crate" --locked
           }
 
+          # Order matters: each crate must precede anything that depends on it.
+          # omnigraph-compiler and omnigraph-policy have no internal deps;
+          # omnigraph-engine depends on both; server depends on engine + the
+          # two leaf crates; cli depends on everything.
           publish_if_new omnigraph-compiler
+          publish_if_new omnigraph-policy
           publish_if_new omnigraph-engine
           publish_if_new omnigraph-server
           publish_if_new omnigraph-cli


### PR DESCRIPTION
## Summary

Hotfix for the v0.5.0 publish: \`omnigraph-policy\` is a new crate this release cycle but was never added to \`.github/workflows/publish-crates.yml\`. Tag \`v0.5.0\` triggered the publish run; \`omnigraph-compiler\` published, then \`omnigraph-engine\` failed because its \`omnigraph-policy\` dep doesn't exist on crates.io yet.

## Current crates.io state (as of 13:02 UTC 2026-05-23)

| Crate | Published version |
|---|---|
| omnigraph-compiler | **0.5.0** ✅ (published during the failed run) |
| omnigraph-policy | — (never published) |
| omnigraph-engine | 0.4.2 (waiting for 0.5.0) |
| omnigraph-server | 0.4.2 (waiting for 0.5.0) |
| omnigraph-cli | 0.4.2 (waiting for 0.5.0) |

## Fix

One-line addition to the workflow's publish list. \`publish_if_new omnigraph-policy\` between compiler and engine (either of the two leaf crates can go first — policy has no internal deps, same as compiler).

## Recovery plan

After this merges:
1. Manually trigger \`publish-crates.yml\` via \`workflow_dispatch\` against tag \`v0.5.0\`, OR push a new \`v0.5.0\` re-trigger (idempotent — already-published crates skip).
2. Watch the run publish policy, engine, server, cli in dep order.

## Test plan

- [x] Workflow YAML syntax checks out (cargo metadata + jq invocations unchanged)
- [x] Dependency order verified: compiler/policy → engine → server → cli
- [x] \`publish_if_new\` is already idempotent — safe to re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/modernrelay/omnigraph/pull/116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->