### PR TITLE
ci(publish-crates): User-Agent + idempotent already-exists handling

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -80,8 +80,15 @@ jobs:
             version=$(cargo metadata --format-version=1 --no-deps \
               | jq -r --arg c "$crate" '.packages[] | select(.name==$c) | .version')
 
+            # crates.io API requires a User-Agent header — without it the
+            # API responds 403 and the skip check below would silently
+            # fall through to a real publish attempt that errors with
+            # "already exists on crates.io index" when re-running after a
+            # partial publish. Send a UA naming the workflow.
             local current
-            current=$(curl -fsSL "https://crates.io/api/v1/crates/${crate}" \
+            current=$(curl -fsSL \
+              -A 'ModernRelay-omnigraph-ci (https://github.com/ModernRelay/omnigraph)' \
+              "https://crates.io/api/v1/crates/${crate}" \
               | jq -r '.crate.max_version' || echo "")
 
             if [[ "$current" == "$version" ]]; then
@@ -90,7 +97,20 @@ jobs:
             fi
 
             echo "==> publishing ${crate} ${version} (current crates.io: ${current:-none})"
-            cargo publish -p "$crate" --locked
+            # Defense in depth: if the skip check missed an existing
+            # version (e.g. crates.io API hiccup), cargo publish errors
+            # with "already exists on crates.io index". Treat that as
+            # success so the workflow can be re-run idempotently.
+            local output
+            if ! output=$(cargo publish -p "$crate" --locked 2>&1); then
+              echo "$output"
+              if echo "$output" | grep -q "already exists on crates.io"; then
+                echo "==> ${crate} ${version} was already published; treating as success"
+                return 0
+              fi
+              return 1
+            fi
+            echo "$output"
           }
 
           # Order matters: each crate must precede anything that depends on it.


### PR DESCRIPTION
## Summary

Two related fixes uncovered while recovering the v0.5.0 publish (after PR #116 added \`omnigraph-policy\` to the publish list).

## Issue 1: crates.io API returns 403 without User-Agent

The \`publish_if_new\` skip check was:

\`\`\`bash
current=\$(curl -fsSL "https://crates.io/api/v1/crates/\${crate}" \\
  | jq -r '.crate.max_version' || echo "")
\`\`\`

crates.io's API requires a User-Agent header. Without one it responds **HTTP 403**, \`curl -fsSL\` exits non-zero, the pipeline returns empty \`current\`, the skip check doesn't fire, and we fall through to a real \`cargo publish\` attempt.

When that re-runs against a crate that \*did\* publish on a previous run, \`cargo publish\` errors with \`crate omnigraph-compiler@0.5.0 already exists on crates.io index\` and the whole job fails. That's exactly what happened on PR #116's recovery dispatch (run [26333581983](https://github.com/ModernRelay/omnigraph/actions/runs/26333581983)).

**Fix:** send \`User-Agent: ModernRelay-omnigraph-ci (URL)\` on the curl call.

## Issue 2: belt-and-suspenders for skip-check failures

Even with the UA, the crates.io API can hiccup. Adding an idempotent fallback inside \`publish_if_new\`: if \`cargo publish\` errors with \`already exists on crates.io\`, treat as success instead of failing the run. This makes the workflow re-runnable after any partial publish without manual intervention.

## v0.5.0 recovery sequence

After this lands:
1. Re-dispatch \`publish-crates.yml\` with \`tag=v0.5.0\` (workflow_dispatch).
2. Workflow correctly skips already-published \`omnigraph-compiler@0.5.0\`.
3. Publishes \`omnigraph-policy\` (new), then \`omnigraph-engine\`, \`omnigraph-server\`, \`omnigraph-cli\`.

## Test plan

- [x] Workflow YAML syntax checks out
- [x] Bash logic: skip-check uses UA; fallback detects "already exists" error string from cargo publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/modernrelay/omnigraph/pull/117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->