### PR TITLE
docs(readme): hard-break manifesto lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
 
 **Lakehouse native graph engine built for context assembly**
 
-Schema AS CODE
-Context AS CODE
-Security AS CODE
+Schema AS CODE<br>
+Context AS CODE<br>
+Security AS CODE<br>
 Dashboards AS CODE
 
-Git-style snapshots & branching
-Object storage native (S3, RustFS)
-VPC, On-prem, hybrid deployment
+Git-style snapshots & branching<br>
+Object storage native (S3, RustFS)<br>
+VPC, On-prem, hybrid deployment<br>
 Lance format as storage layer
 
 ## Core Use Cases


### PR DESCRIPTION
Append `<br>` to the X-as-code and feature blocks so each item renders on its own line in all markdown renderers (bare single newlines were collapsing onto one line). Flat manifesto layout preserved — no conversion to bullets.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/modernrelay/omnigraph/pull/123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->