### PR TITLE
fix(release): generate audit-clean Homebrew formula

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,17 @@ jobs:
         run: |
           ./scripts/update-homebrew-formula.sh "${GITHUB_REF_NAME}" homebrew-tap/Formula/omnigraph.rb
 
+      - name: Audit generated formula
+        if: env.HOMEBREW_TAP_SKIP != '1'
+        run: |
+          # Audit the checked-out tap by name (brew audit rejects bare paths
+          # and needs tap context). Symlink the checkout into Homebrew's Taps
+          # tree so `modernrelay/tap/omnigraph` resolves to it.
+          tap_dir="$(brew --repository)/Library/Taps/modernrelay/homebrew-tap"
+          mkdir -p "$(dirname "$tap_dir")"
+          ln -sfn "$PWD/homebrew-tap" "$tap_dir"
+          brew audit --strict --online modernrelay/tap/omnigraph
+
       - name: Commit and push formula update
         if: env.HOMEBREW_TAP_SKIP != '1'
         working-directory: homebrew-tap

--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -64,25 +64,28 @@ cat >"$FORMULA_PATH" <<EOF
 class Omnigraph < Formula
   desc "Typed property graph database with Git-style workflows"
   homepage "https://github.com/${REPO_SLUG}"
-  license "MIT"
   version "${VERSION}"
-
-  on_macos do
-    depends_on arch: :arm64
-    url "${MACOS_ARM_URL}"
-    sha256 "${MACOS_ARM_SHA}"
-  end
-
-  on_linux do
-    url "${LINUX_X86_URL}"
-    sha256 "${LINUX_X86_SHA}"
-  end
-
+  license "MIT"
   head "https://github.com/${REPO_SLUG}.git", branch: "main"
 
   livecheck do
     url :stable
     regex(/^v?(\\d+(?:\\.\\d+)+)$/i)
+  end
+
+  on_macos do
+    depends_on arch: :arm64
+    on_arm do
+      url "${MACOS_ARM_URL}"
+      sha256 "${MACOS_ARM_SHA}"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "${LINUX_X86_URL}"
+      sha256 "${LINUX_X86_SHA}"
+    end
   end
 
   def install


### PR DESCRIPTION
## Problem

The Homebrew formula published to [`ModernRelay/homebrew-tap`](https://github.com/ModernRelay/homebrew-tap) on every release fails `brew audit --strict --online` with **5 problems**:

- `version` declared after `license` (wrong component order)
- `url` / `sha256` placed directly inside `on_macos` / `on_linux` — forbidden by `FormulaAudit/ComponentsOrder` (those blocks may only contain `depends_on`, `livecheck`, nested `on_arm`/`on_intel`, etc.)

`brew install` happens to still work, but the formula is malformed and would be rejected by any audit gate or homebrew-core submission. The root cause is the template in `scripts/update-homebrew-formula.sh`, so every release regenerated the same broken formula.

## Fix

- Reorder `version` before `license`; hoist `head` + `livecheck` above the platform blocks.
- Nest `url`/`sha256` inside `on_arm` (macOS) / `on_intel` (Linux); keep `depends_on arch: :arm64` for a clean error on unsupported arches.
- Add a `brew audit --strict --online` gate to the release workflow so a malformed formula can never be published again.

## Verification

Generated the formula from the real `v0.6.0` release and ran `brew audit --strict --online` in tap context → **exit 0, zero problems**. The live tap formula has already been corrected directly so users are unblocked now; this PR fixes the generator + adds the gate so it stays fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/modernrelay/omnigraph/pull/134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->