### PR TITLE
fix(bootstrap): pin RustFS to beta.3 + allow insecure default creds

### DIFF
--- a/scripts/local-rustfs-bootstrap.sh
+++ b/scripts/local-rustfs-bootstrap.sh
@@ -6,7 +6,14 @@ SOURCE_REF="${SOURCE_REF:-main}"
 RELEASE_CHANNEL="${RELEASE_CHANNEL:-edge}"
 WORKDIR="${WORKDIR:-$PWD/.omnigraph-rustfs-demo}"
 RUSTFS_CONTAINER_NAME="${RUSTFS_CONTAINER_NAME:-omnigraph-rustfs-demo}"
-RUSTFS_IMAGE="${RUSTFS_IMAGE:-rustfs/rustfs:latest}"
+# Pinned to 1.0.0-beta.3 (2026-05-14) — the last known-good tag, matching CI
+# (.github/workflows/ci.yml). `rustfs/rustfs:latest` (1.0.0-beta.4, 2026-05-21)
+# added a credentials-policy check that refuses to start when the access/secret
+# keys are values it considers "default" (rustfsadmin/rustfsadmin here). This
+# script still works on beta.4+ because it passes
+# RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS=true below — so overriding
+# RUSTFS_IMAGE to a newer tag is safe.
+RUSTFS_IMAGE="${RUSTFS_IMAGE:-rustfs/rustfs:1.0.0-beta.3}"
 RUSTFS_DATA_DIR="${RUSTFS_DATA_DIR:-$WORKDIR/rustfs-data}"
 BUCKET="${BUCKET:-omnigraph-local}"
 PREFIX="${PREFIX:-repos/context}"
@@ -265,6 +272,7 @@ start_rustfs() {
     -v "$RUSTFS_DATA_DIR:/data" \
     -e RUSTFS_ACCESS_KEY="$AWS_ACCESS_KEY_ID" \
     -e RUSTFS_SECRET_KEY="$AWS_SECRET_ACCESS_KEY" \
+    -e RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS=true \
     "$RUSTFS_IMAGE" \
     /data >/dev/null
 }


### PR DESCRIPTION
## Problem

`scripts/local-rustfs-bootstrap.sh` defaulted `RUSTFS_IMAGE` to the floating `rustfs/rustfs:latest`. As of 2026-05-21 that tag resolves to **1.0.0-beta.4**, which added a credentials-policy check that **refuses to start** when the access/secret keys are values it considers "default" — `rustfsadmin/rustfsadmin`, which are exactly the script's defaults. So a fresh `curl … | bash` bootstrap currently dies at RustFS startup.

This is the same upstream change CI already hit and pinned around:

- `.github/workflows/ci.yml` pins `rustfs/rustfs:1.0.0-beta.3` (the last known-good tag) with a comment documenting the cred-policy check.
- `docs/releases/v0.5.0.md` records the same decision and notes the `RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS=true` escape hatch.

The bootstrap script was the one place still on floating `:latest` with **no** flag — so it broke while CI stayed green.

## Fix

1. Pin the default `RUSTFS_IMAGE` to `rustfs/rustfs:1.0.0-beta.3`, matching CI and the v0.5.0 release notes (still overridable via env).
2. Additionally pass `-e RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS=true` in `start_rustfs()`, so the script stays forward-compatible if someone overrides `RUSTFS_IMAGE` to beta.4+ (the flag is a harmless no-op on beta.3).

Belt-and-suspenders: pinned *and* flagged, so the script works whether the resolved image enforces the cred check or not.

## Test

- `bash -n scripts/local-rustfs-bootstrap.sh` — syntax OK.
- No doc edits needed: `docs/user/deployment.md` only curls the script (no inline image pin), so the script self-pinning is sufficient.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local demo/bootstrap script only; no production auth or application runtime changes.
> 
> **Overview**
> The local RustFS bootstrap script no longer defaults to floating **`rustfs/rustfs:latest`**, which now resolves to **1.0.0-beta.4** and can refuse to start with the script’s default **`rustfsadmin`** keys. The default **`RUSTFS_IMAGE`** is pinned to **`rustfs/rustfs:1.0.0-beta.3`**, aligned with CI, with comments explaining the upstream credential-policy change.
> 
> **`start_rustfs()`** also passes **`RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS=true`** so a custom **`RUSTFS_IMAGE`** on beta.4+ still boots with the same defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9243b94787eb376f58b34c791272ab45e5747ff0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->