### PR TITLE
ci(codeowners): add aaltshuler to engineering role

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,9 +8,9 @@
 # CI fails if this file drifts from its source, and rejects PRs that
 # edit this file directly without also editing the yml.
 
-*             @ragnorc
+*             @ragnorc @aaltshuler
 
-crates/**     @ragnorc
+crates/**     @ragnorc @aaltshuler
 docs/**       @ragnorc
 README.md     @ragnorc
 AGENTS.md     @ragnorc

--- a/.github/codeowners-roles.yml
+++ b/.github/codeowners-roles.yml
@@ -22,6 +22,7 @@ roles:
       compiler.
     members:
       - ragnorc
+      - aaltshuler
 
   docs:
     description: >

--- a/docs/dev/codeowners.md
+++ b/docs/dev/codeowners.md
@@ -14,8 +14,8 @@ The tables below are **generated** from `.github/codeowners-roles.yml` by `.gith
 
 | Path | Owners | Role(s) |
 |---|---|---|
-| `*` | @ragnorc | engineering |
-| `crates/**` | @ragnorc | engineering |
+| `*` | @ragnorc @aaltshuler | engineering |
+| `crates/**` | @ragnorc @aaltshuler | engineering |
 | `docs/**` | @ragnorc | docs |
 | `README.md` | @ragnorc | docs |
 | `AGENTS.md` | @ragnorc | docs |
@@ -26,7 +26,7 @@ The tables below are **generated** from `.github/codeowners-roles.yml` by `.gith
 
 | Role | Members | Description |
 |---|---|---|
-| `engineering` | @ragnorc | All production code under crates/**. Engine, CLI, server, compiler. |
+| `engineering` | @ragnorc @aaltshuler | All production code under crates/**. Engine, CLI, server, compiler. |
 | `docs` | @ragnorc | Documentation under docs/**, plus repo-level docs (README.md, AGENTS.md, CLAUDE.md symlink, SECURITY.md). |
 
 <!-- END GENERATED OWNERSHIP -->


### PR DESCRIPTION
## Summary
Restores `@aaltshuler` as an `engineering` code-owner (removed in #142). The `engineering` role owns `crates/**` and the repo-infra `default` catch-all; it currently has a single member (`@ragnorc`), which means author-`ragnorc` PRs touching `crates/**` (e.g. #132) have **no eligible code-owner approver** — GitHub forbids self-approval. Adding a second owner unblocks that.

## By the book
- Edited the source of truth `.github/codeowners-roles.yml` (added `aaltshuler` to `roles.engineering.members`).
- Re-rendered `.github/CODEOWNERS` and the `docs/dev/codeowners.md` owner tables via `.github/scripts/render-codeowners.py`.
- All three artifacts committed together — satisfies the `CODEOWNERS / drift` and `CODEOWNERS / noedit` checks.

`docs` role left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/modernrelay/omnigraph/pull/147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->