### PR TITLE
[codex] add read-only cluster validate and plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Tools that support `@`-imports (Claude Code) auto-include all three files via th
 `CLAUDE.md` is a symlink to this file — there is exactly one source of truth. Edit `AGENTS.md`.
 
 **Version surveyed:** 0.6.1
-**Workspace crates:** `omnigraph-compiler`, `omnigraph` (engine), `omnigraph-policy`, `omnigraph-cli`, `omnigraph-server`
+**Workspace crates:** `omnigraph-compiler`, `omnigraph` (engine), `omnigraph-policy`, `omnigraph-cluster`, `omnigraph-cli`, `omnigraph-server`
 **Storage substrate:** Lance 6.x (columnar, versioned, branchable)
 **License:** MIT
 **Toolchain:** Rust stable, edition 2024

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4550,6 +4550,7 @@ dependencies = [
  "color-eyre",
  "lance",
  "lance-index",
+ "omnigraph-cluster",
  "omnigraph-compiler",
  "omnigraph-engine",
  "omnigraph-policy",
@@ -4561,6 +4562,19 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "tokio",
+]
+
+[[package]]
+name = "omnigraph-cluster"
+version = "0.6.1"
+dependencies = [
+ "omnigraph-compiler",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sha2",
+ "tempfile",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/omnigraph-compiler",
     "crates/omnigraph",
     "crates/omnigraph-cli",
+    "crates/omnigraph-cluster",
     "crates/omnigraph-policy",
     "crates/omnigraph-server",
 ]

--- a/crates/omnigraph-cli/Cargo.toml
+++ b/crates/omnigraph-cli/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 [dependencies]
 omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.6.1" }
 omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.6.1" }
+omnigraph-cluster = { path = "../omnigraph-cluster", version = "0.6.1" }
 omnigraph-policy = { path = "../omnigraph-policy", version = "0.6.1" }
 omnigraph-server = { path = "../omnigraph-server", version = "0.6.1" }
 clap = { workspace = true }

--- a/crates/omnigraph-cli/src/main.rs
+++ b/crates/omnigraph-cli/src/main.rs
@@ -10,6 +10,9 @@ use color_eyre::eyre::{Result, bail};
 use omnigraph::db::{Omnigraph, ReadTarget, SnapshotId};
 use omnigraph::loader::LoadMode;
 use omnigraph::storage::normalize_root_uri;
+use omnigraph_cluster::{
+    DiagnosticSeverity, PlanOutput, ValidateOutput, plan_config_dir, validate_config_dir,
+};
 use omnigraph_compiler::query::parser::parse_query;
 use omnigraph_compiler::schema::parser::parse_schema;
 use omnigraph_compiler::{
@@ -305,10 +308,37 @@ enum Command {
         #[arg(long)]
         json: bool,
     },
+    /// Validate and plan read-only cluster configuration.
+    Cluster {
+        #[command(subcommand)]
+        command: ClusterCommand,
+    },
     /// Manage graphs on a multi-graph server (MR-668)
     Graphs {
         #[command(subcommand)]
         command: GraphsCommand,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum ClusterCommand {
+    /// Validate cluster.yaml and referenced schemas, queries, and policy files.
+    Validate {
+        /// Cluster config directory containing cluster.yaml.
+        #[arg(long, default_value = ".")]
+        config: PathBuf,
+        /// Emit JSON instead of human text.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Produce a read-only plan by diffing cluster.yaml against __cluster/state.json.
+    Plan {
+        /// Cluster config directory containing cluster.yaml.
+        #[arg(long, default_value = ".")]
+        config: PathBuf,
+        /// Emit JSON instead of human text.
+        #[arg(long)]
+        json: bool,
     },
 }
 
@@ -683,6 +713,77 @@ fn print_json<T: Serialize>(value: &T) -> Result<()> {
     Ok(())
 }
 
+fn print_cluster_validate_human(output: &ValidateOutput) {
+    if output.ok {
+        println!(
+            "cluster config valid: {} resource(s), {} dependency edge(s)",
+            output.resources.len(),
+            output.dependencies.len()
+        );
+    } else {
+        println!("cluster config invalid");
+    }
+    print_cluster_diagnostics(&output.diagnostics);
+}
+
+fn print_cluster_plan_human(output: &PlanOutput) {
+    if output.ok {
+        println!(
+            "cluster plan: {} change(s), {} approval gate(s)",
+            output.changes.len(),
+            output.approvals_required.len()
+        );
+        for change in &output.changes {
+            println!("  {:?} {}", change.operation, change.resource);
+        }
+        if output.changes.is_empty() {
+            println!("  no changes");
+        }
+    } else {
+        println!("cluster plan failed");
+    }
+    print_cluster_diagnostics(&output.diagnostics);
+}
+
+fn print_cluster_diagnostics(diagnostics: &[omnigraph_cluster::Diagnostic]) {
+    for diagnostic in diagnostics {
+        let label = match diagnostic.severity {
+            DiagnosticSeverity::Error => "ERROR",
+            DiagnosticSeverity::Warning => "WARN ",
+        };
+        println!(
+            "{label} {} {}: {}",
+            diagnostic.code, diagnostic.path, diagnostic.message
+        );
+    }
+}
+
+fn finish_cluster_validate(output: &ValidateOutput, json: bool) -> Result<()> {
+    if json {
+        print_json(output)?;
+    } else {
+        print_cluster_validate_human(output);
+    }
+    if !output.ok {
+        io::stdout().flush()?;
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+fn finish_cluster_plan(output: &PlanOutput, json: bool) -> Result<()> {
+    if json {
+        print_json(output)?;
+    } else {
+        print_cluster_plan_human(output);
+    }
+    if !output.ok {
+        io::stdout().flush()?;
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
 fn is_remote_uri(uri: &str) -> bool {
     uri.starts_with("http://") || uri.starts_with("https://")
 }
@@ -801,13 +902,11 @@ struct ResolvedPolicyContext {
 
 fn resolve_policy_context(config: &OmnigraphConfig) -> Result<ResolvedPolicyContext> {
     let selected = config.resolve_policy_tooling_graph_selection()?;
-    let policy_file = config
-        .resolve_policy_file_for(selected)
-        .ok_or_else(|| {
-            color_eyre::eyre::eyre!(
-                "policy.file or graphs.<name>.policy.file must be set in omnigraph.yaml"
-            )
-        })?;
+    let policy_file = config.resolve_policy_file_for(selected).ok_or_else(|| {
+        color_eyre::eyre::eyre!(
+            "policy.file or graphs.<name>.policy.file must be set in omnigraph.yaml"
+        )
+    })?;
     let graph_id = match selected {
         Some(name) => graph_resource_id_for_selection(Some(name), ""),
         None => graph_resource_id_for_selection(None, "default"),
@@ -2166,16 +2265,14 @@ fn rewrite_deprecated_argv(args: Vec<OsString>) -> Vec<OsString> {
     }
     if let Some(sub) = args.get(1).and_then(|s| s.to_str()) {
         match sub {
-            "read" => eprintln!(
-                "warning: `omnigraph read` is deprecated; use `omnigraph query` instead"
-            ),
+            "read" => {
+                eprintln!("warning: `omnigraph read` is deprecated; use `omnigraph query` instead")
+            }
             "change" => eprintln!(
                 "warning: `omnigraph change` is deprecated; use `omnigraph mutate` instead"
             ),
             "check" => {
-                eprintln!(
-                    "warning: `omnigraph check` is deprecated; use `omnigraph lint` instead"
-                );
+                eprintln!("warning: `omnigraph check` is deprecated; use `omnigraph lint` instead");
                 // Rewrite the top-level subcommand to `lint`; pass through the rest.
                 let mut out = Vec::with_capacity(args.len());
                 out.push(args[0].clone());
@@ -3111,6 +3208,16 @@ async fn main() -> Result<()> {
                 }
             }
         }
+        Command::Cluster { command } => match command {
+            ClusterCommand::Validate { config, json } => {
+                let output = validate_config_dir(config);
+                finish_cluster_validate(&output, json)?;
+            }
+            ClusterCommand::Plan { config, json } => {
+                let output = plan_config_dir(config);
+                finish_cluster_plan(&output, json)?;
+            }
+        },
         Command::Graphs { command } => match command {
             GraphsCommand::List {
                 uri,
@@ -3157,8 +3264,8 @@ mod tests {
     use super::{
         DEFAULT_BEARER_TOKEN_ENV, apply_bearer_token, bearer_token_from_env_file,
         legacy_change_request_body, load_cli_config, load_env_file_into_process,
-        normalize_bearer_token, parse_env_assignment, resolve_policy_context,
-        resolve_cli_graph, resolve_remote_bearer_token,
+        normalize_bearer_token, parse_env_assignment, resolve_cli_graph, resolve_policy_context,
+        resolve_remote_bearer_token,
     };
     use omnigraph_server::load_config;
     use reqwest::header::AUTHORIZATION;
@@ -3420,7 +3527,8 @@ graphs:
     }
 
     #[test]
-    fn graph_identity_resolve_policy_context_named_cli_graph_uses_graph_key_not_project_name_or_uri() {
+    fn graph_identity_resolve_policy_context_named_cli_graph_uses_graph_key_not_project_name_or_uri()
+     {
         let temp = tempdir().unwrap();
         let config_path = temp.path().join("omnigraph.yaml");
         fs::write(

--- a/crates/omnigraph-cli/tests/cli.rs
+++ b/crates/omnigraph-cli/tests/cli.rs
@@ -78,6 +78,52 @@ policy:
     (config, policy)
 }
 
+fn write_cluster_config_fixture(root: &std::path::Path) {
+    fs::write(
+        root.join("people.pg"),
+        r#"
+node Person {
+  name: String @key
+  age: I32?
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("people.gq"),
+        r#"
+query find_person($name: String) {
+  match { $p: Person { name: $name } }
+  return { $p.name, $p.age }
+}
+"#,
+    )
+    .unwrap();
+    fs::write(root.join("base.policy.yaml"), "rules: []\n").unwrap();
+    fs::write(
+        root.join("cluster.yaml"),
+        r#"
+version: 1
+metadata:
+  name: company-brain
+state:
+  backend: cluster
+  lock: true
+graphs:
+  knowledge:
+    schema: ./people.pg
+    queries:
+      find_person:
+        file: ./people.gq
+policies:
+  base:
+    file: ./base.policy.yaml
+    applies_to: [knowledge]
+"#,
+    )
+    .unwrap();
+}
+
 #[test]
 fn version_command_prints_current_cli_version() {
     let output = output_success(cli().arg("version"));
@@ -87,6 +133,105 @@ fn version_command_prints_current_cli_version() {
         stdout.trim(),
         format!("omnigraph {}", env!("CARGO_PKG_VERSION"))
     );
+}
+
+#[test]
+fn cluster_validate_config_success() {
+    let temp = tempdir().unwrap();
+    write_cluster_config_fixture(temp.path());
+
+    let output = output_success(
+        cli()
+            .arg("cluster")
+            .arg("validate")
+            .arg("--config")
+            .arg(temp.path()),
+    );
+    let stdout = stdout_string(&output);
+    assert!(stdout.contains("cluster config valid"), "{stdout}");
+}
+
+#[test]
+fn cluster_validate_json_is_stable() {
+    let temp = tempdir().unwrap();
+    write_cluster_config_fixture(temp.path());
+
+    let json = parse_stdout_json(&output_success(
+        cli()
+            .arg("cluster")
+            .arg("validate")
+            .arg("--config")
+            .arg(temp.path())
+            .arg("--json"),
+    ));
+    assert_eq!(json["ok"], true);
+    assert!(json["resource_digests"]["graph.knowledge"].is_string());
+    assert!(json["resource_digests"]["query.knowledge.find_person"].is_string());
+    assert_eq!(json["dependencies"][0]["from"], "policy.base");
+    assert_eq!(json["dependencies"][0]["to"], "graph.knowledge");
+}
+
+#[test]
+fn cluster_plan_json_reads_inferred_local_state() {
+    let temp = tempdir().unwrap();
+    write_cluster_config_fixture(temp.path());
+    let state_dir = temp.path().join("__cluster");
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(
+        state_dir.join("state.json"),
+        r#"
+{
+  "version": 1,
+  "applied_revision": {
+    "config_digest": "old",
+    "resources": {
+      "graph.knowledge": { "digest": "old-graph" },
+      "policy.old": { "digest": "old-policy" }
+    }
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    let json = parse_stdout_json(&output_success(
+        cli()
+            .arg("cluster")
+            .arg("plan")
+            .arg("--config")
+            .arg(temp.path())
+            .arg("--json"),
+    ));
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["state_observations"]["state_found"], true);
+    assert!(
+        json["changes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|change| change["resource"] == "policy.old" && change["operation"] == "delete"),
+        "plan should read state and delete stale resources: {json}"
+    );
+}
+
+#[test]
+fn cluster_validate_invalid_config_exits_nonzero() {
+    let temp = tempdir().unwrap();
+    fs::write(
+        temp.path().join("cluster.yaml"),
+        "version: 1\ngraphs: {}\npipelines: {}\n",
+    )
+    .unwrap();
+
+    let output = output_failure(
+        cli()
+            .arg("cluster")
+            .arg("validate")
+            .arg("--config")
+            .arg(temp.path()),
+    );
+    let stdout = stdout_string(&output);
+    assert!(stdout.contains("future_phase_field"), "{stdout}");
 }
 
 #[test]
@@ -798,8 +943,7 @@ fn deprecated_read_and_change_subcommands_emit_warnings() {
     let output = cli().arg("read").output().unwrap();
     let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(
-        stderr.contains("`omnigraph read` is deprecated")
-            && stderr.contains("`omnigraph query`"),
+        stderr.contains("`omnigraph read` is deprecated") && stderr.contains("`omnigraph query`"),
         "expected `omnigraph read` deprecation warning; got: {stderr}"
     );
 
@@ -2394,9 +2538,19 @@ fn queries_validate_exits_zero_on_clean_registry() {
     );
     let config = graph.write_config(
         "omnigraph.yaml",
-        &queries_test_config(&graph.path().to_string_lossy(), "find_person", "find_person.gq"),
+        &queries_test_config(
+            &graph.path().to_string_lossy(),
+            "find_person",
+            "find_person.gq",
+        ),
     );
-    let output = output_success(cli().arg("queries").arg("validate").arg("--config").arg(&config));
+    let output = output_success(
+        cli()
+            .arg("queries")
+            .arg("validate")
+            .arg("--config")
+            .arg(&config),
+    );
     let stdout = stdout_string(&output);
     assert!(stdout.contains("OK"), "stdout:\n{stdout}");
 }
@@ -2405,12 +2559,21 @@ fn queries_validate_exits_zero_on_clean_registry() {
 fn queries_validate_exits_nonzero_on_type_broken_query() {
     let graph = SystemGraph::loaded();
     // `Widget` is not in the fixture schema.
-    graph.write_query("ghost.gq", "query ghost() { match { $w: Widget } return { $w.name } }");
+    graph.write_query(
+        "ghost.gq",
+        "query ghost() { match { $w: Widget } return { $w.name } }",
+    );
     let config = graph.write_config(
         "omnigraph.yaml",
         &queries_test_config(&graph.path().to_string_lossy(), "ghost", "ghost.gq"),
     );
-    let output = output_failure(cli().arg("queries").arg("validate").arg("--config").arg(&config));
+    let output = output_failure(
+        cli()
+            .arg("queries")
+            .arg("validate")
+            .arg("--config")
+            .arg(&config),
+    );
     let stdout = stdout_string(&output);
     assert!(
         stdout.contains("ghost"),
@@ -2444,7 +2607,13 @@ fn queries_list_prints_registered_query() {
             graph.path().to_string_lossy().replace('\'', "''")
         ),
     );
-    let output = output_success(cli().arg("queries").arg("list").arg("--config").arg(&config));
+    let output = output_success(
+        cli()
+            .arg("queries")
+            .arg("list")
+            .arg("--config")
+            .arg(&config),
+    );
     let stdout = stdout_string(&output);
     assert!(stdout.contains("find_person"), "stdout:\n{stdout}");
     assert!(
@@ -2480,7 +2649,13 @@ fn queries_list_requires_graph_selection_for_per_graph_only_registries() {
         ),
     );
 
-    let output = output_failure(cli().arg("queries").arg("list").arg("--config").arg(&config));
+    let output = output_failure(
+        cli()
+            .arg("queries")
+            .arg("list")
+            .arg("--config")
+            .arg(&config),
+    );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("local") && stderr.contains("--target local"),
@@ -2505,7 +2680,13 @@ fn queries_list_without_graph_selection_lists_top_level_registry() {
         ),
     );
 
-    let output = output_success(cli().arg("queries").arg("list").arg("--config").arg(&config));
+    let output = output_success(
+        cli()
+            .arg("queries")
+            .arg("list")
+            .arg("--config")
+            .arg(&config),
+    );
     let stdout = stdout_string(&output);
     assert!(stdout.contains("top_find"), "stdout:\n{stdout}");
 }
@@ -2524,7 +2705,11 @@ fn queries_list_unknown_target_errors() {
     );
     let config = graph.write_config(
         "omnigraph.yaml",
-        &queries_test_config(&graph.path().to_string_lossy(), "find_person", "find_person.gq"),
+        &queries_test_config(
+            &graph.path().to_string_lossy(),
+            "find_person",
+            "find_person.gq",
+        ),
     );
     let output = output_failure(
         cli()
@@ -2566,7 +2751,7 @@ fn queries_commands_reject_named_graph_with_populated_top_level_block() {
                 "        file: ./find_person.gq\n",
                 "cli:\n",
                 "  graph: local\n",
-                "queries:\n",                 // populated top-level block: the coherence violation
+                "queries:\n", // populated top-level block: the coherence violation
                 "  legacy:\n",
                 "    file: ./legacy.gq\n",
                 "policy: {{}}\n",
@@ -2592,8 +2777,14 @@ fn queries_validate_exits_nonzero_on_duplicate_tool_name() {
     // collision — `queries validate` must fail (offline, before the engine
     // opens) and name both queries plus the contested tool.
     let graph = SystemGraph::loaded();
-    graph.write_query("a.gq", "query a() { match { $p: Person } return { $p.name } }");
-    graph.write_query("b.gq", "query b() { match { $p: Person } return { $p.name } }");
+    graph.write_query(
+        "a.gq",
+        "query a() { match { $p: Person } return { $p.name } }",
+    );
+    graph.write_query(
+        "b.gq",
+        "query b() { match { $p: Person } return { $p.name } }",
+    );
     let config = graph.write_config(
         "omnigraph.yaml",
         &format!(
@@ -2615,7 +2806,13 @@ fn queries_validate_exits_nonzero_on_duplicate_tool_name() {
             graph.path().to_string_lossy().replace('\'', "''")
         ),
     );
-    let output = output_failure(cli().arg("queries").arg("validate").arg("--config").arg(&config));
+    let output = output_failure(
+        cli()
+            .arg("queries")
+            .arg("validate")
+            .arg("--config")
+            .arg(&config),
+    );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("dup") && stderr.contains("'a'") && stderr.contains("'b'"),
@@ -2635,7 +2832,10 @@ fn queries_validate_positional_uri_ignores_default_graph() {
     );
     // `Widget` is not in the fixture schema — the default graph's per-graph
     // query would break validate if it were (wrongly) selected.
-    graph.write_query("broken.gq", "query broken() { match { $w: Widget } return { $w.name } }");
+    graph.write_query(
+        "broken.gq",
+        "query broken() { match { $w: Widget } return { $w.name } }",
+    );
     let config = graph.write_config(
         "omnigraph.yaml",
         concat!(

--- a/crates/omnigraph-cluster/Cargo.toml
+++ b/crates/omnigraph-cluster/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "omnigraph-cluster"
+version = "0.6.1"
+edition = "2024"
+description = "Read-only cluster configuration validation and planning for Omnigraph."
+license = "MIT"
+repository = "https://github.com/ModernRelay/omnigraph"
+homepage = "https://github.com/ModernRelay/omnigraph"
+documentation = "https://docs.rs/omnigraph-cluster"
+
+[dependencies]
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.6.1" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/omnigraph-cluster/src/lib.rs
+++ b/crates/omnigraph-cluster/src/lib.rs
@@ -1,0 +1,1275 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use omnigraph_compiler::build_catalog;
+use omnigraph_compiler::query::parser::parse_query;
+use omnigraph_compiler::query::typecheck::typecheck_query_decl;
+use omnigraph_compiler::schema::parser::parse_schema;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+pub const CLUSTER_CONFIG_FILE: &str = "cluster.yaml";
+pub const CLUSTER_STATE_FILE: &str = "__cluster/state.json";
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DiagnosticSeverity {
+    Error,
+    Warning,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct Diagnostic {
+    pub code: String,
+    pub severity: DiagnosticSeverity,
+    pub path: String,
+    pub message: String,
+}
+
+impl Diagnostic {
+    fn error(code: impl Into<String>, path: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            severity: DiagnosticSeverity::Error,
+            path: path.into(),
+            message: message.into(),
+        }
+    }
+
+    fn warning(
+        code: impl Into<String>,
+        path: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            code: code.into(),
+            severity: DiagnosticSeverity::Warning,
+            path: path.into(),
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ResourceSummary {
+    pub address: String,
+    pub kind: String,
+    pub digest: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Dependency {
+    pub from: String,
+    pub to: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ValidateOutput {
+    pub ok: bool,
+    pub config_dir: String,
+    pub config_file: String,
+    pub resource_digests: BTreeMap<String, String>,
+    pub resources: Vec<ResourceSummary>,
+    pub dependencies: Vec<Dependency>,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DesiredRevision {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config_digest: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct StateObservations {
+    pub state_path: String,
+    pub state_found: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub applied_config_digest: Option<String>,
+    pub resource_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanOperation {
+    Create,
+    Update,
+    Delete,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct PlanChange {
+    pub resource: String,
+    pub operation: PlanOperation,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub before_digest: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after_digest: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct BlastRadius {
+    pub resource: String,
+    pub affected: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ApprovalRequirement {
+    pub resource: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PlanOutput {
+    pub ok: bool,
+    pub config_dir: String,
+    pub desired_revision: DesiredRevision,
+    pub resource_digests: BTreeMap<String, String>,
+    pub dependencies: Vec<Dependency>,
+    pub state_observations: StateObservations,
+    pub changes: Vec<PlanChange>,
+    pub blast_radius: Vec<BlastRadius>,
+    pub approvals_required: Vec<ApprovalRequirement>,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+#[derive(Debug, Clone)]
+struct DesiredCluster {
+    config_dir: PathBuf,
+    config_digest: String,
+    resource_digests: BTreeMap<String, String>,
+    resources: Vec<ResourceSummary>,
+    dependencies: Vec<Dependency>,
+}
+
+#[derive(Debug)]
+struct LoadOutcome {
+    desired: Option<DesiredCluster>,
+    diagnostics: Vec<Diagnostic>,
+    config_dir: PathBuf,
+    config_file: PathBuf,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawClusterConfig {
+    version: u32,
+    #[serde(default)]
+    metadata: Metadata,
+    #[serde(default)]
+    state: StateConfig,
+    #[serde(default)]
+    graphs: BTreeMap<String, GraphConfig>,
+    #[serde(default)]
+    policies: BTreeMap<String, PolicyConfig>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Metadata {
+    name: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StateConfig {
+    backend: Option<String>,
+    lock: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct GraphConfig {
+    schema: PathBuf,
+    #[serde(default)]
+    queries: BTreeMap<String, QueryConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct QueryConfig {
+    file: PathBuf,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PolicyConfig {
+    file: PathBuf,
+    applies_to: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ClusterState {
+    version: u32,
+    applied_revision: AppliedRevisionState,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AppliedRevisionState {
+    #[serde(default)]
+    config_digest: Option<String>,
+    #[serde(default)]
+    resources: BTreeMap<String, StateResource>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct StateResource {
+    digest: String,
+}
+
+pub fn validate_config_dir(config_dir: impl AsRef<Path>) -> ValidateOutput {
+    let outcome = load_desired(config_dir.as_ref());
+    let (resource_digests, resources, dependencies) = match outcome.desired {
+        Some(desired) => (
+            desired.resource_digests,
+            desired.resources,
+            desired.dependencies,
+        ),
+        None => (BTreeMap::new(), Vec::new(), Vec::new()),
+    };
+    let ok = !has_errors(&outcome.diagnostics);
+
+    ValidateOutput {
+        ok,
+        config_dir: display_path(&outcome.config_dir),
+        config_file: display_path(&outcome.config_file),
+        resource_digests,
+        resources,
+        dependencies,
+        diagnostics: outcome.diagnostics,
+    }
+}
+
+pub fn plan_config_dir(config_dir: impl AsRef<Path>) -> PlanOutput {
+    let outcome = load_desired(config_dir.as_ref());
+    let mut diagnostics = outcome.diagnostics;
+    let state_path = outcome.config_dir.join(CLUSTER_STATE_FILE);
+    let mut observations = StateObservations {
+        state_path: display_path(&state_path),
+        state_found: false,
+        applied_config_digest: None,
+        resource_count: 0,
+    };
+
+    let Some(desired) = outcome.desired else {
+        return PlanOutput {
+            ok: false,
+            config_dir: display_path(&outcome.config_dir),
+            desired_revision: DesiredRevision {
+                config_digest: None,
+            },
+            resource_digests: BTreeMap::new(),
+            dependencies: Vec::new(),
+            state_observations: observations,
+            changes: Vec::new(),
+            blast_radius: Vec::new(),
+            approvals_required: Vec::new(),
+            diagnostics,
+        };
+    };
+
+    let mut prior_resources = BTreeMap::new();
+    if state_path.exists() {
+        observations.state_found = true;
+        match fs::read_to_string(&state_path) {
+            Ok(text) => match serde_json::from_str::<ClusterState>(&text) {
+                Ok(state) if state.version == 1 => {
+                    observations.applied_config_digest = state.applied_revision.config_digest;
+                    observations.resource_count = state.applied_revision.resources.len();
+                    prior_resources = state
+                        .applied_revision
+                        .resources
+                        .into_iter()
+                        .map(|(address, resource)| (address, resource.digest))
+                        .collect();
+                }
+                Ok(state) => diagnostics.push(Diagnostic::error(
+                    "unsupported_state_version",
+                    "state.version",
+                    format!(
+                        "unsupported cluster state version {}; this build supports version 1",
+                        state.version
+                    ),
+                )),
+                Err(err) => diagnostics.push(Diagnostic::error(
+                    "invalid_state_json",
+                    CLUSTER_STATE_FILE,
+                    format!("could not parse state JSON: {err}"),
+                )),
+            },
+            Err(err) => diagnostics.push(Diagnostic::error(
+                "state_read_error",
+                CLUSTER_STATE_FILE,
+                format!("could not read state file: {err}"),
+            )),
+        }
+    }
+
+    let changes = if has_errors(&diagnostics) {
+        Vec::new()
+    } else {
+        diff_resources(&prior_resources, &desired.resource_digests)
+    };
+    let blast_radius = compute_blast_radius(&changes, &desired.dependencies);
+    let approvals_required = compute_approvals(&changes);
+    let ok = !has_errors(&diagnostics);
+
+    PlanOutput {
+        ok,
+        config_dir: display_path(&desired.config_dir),
+        desired_revision: DesiredRevision {
+            config_digest: Some(desired.config_digest),
+        },
+        resource_digests: desired.resource_digests,
+        dependencies: desired.dependencies,
+        state_observations: observations,
+        changes,
+        blast_radius,
+        approvals_required,
+        diagnostics,
+    }
+}
+
+fn load_desired(config_dir: &Path) -> LoadOutcome {
+    let config_dir = config_dir.to_path_buf();
+    let config_file = config_dir.join(CLUSTER_CONFIG_FILE);
+    let mut diagnostics = Vec::new();
+
+    if !config_dir.is_dir() {
+        diagnostics.push(Diagnostic::error(
+            "config_dir_not_found",
+            display_path(&config_dir),
+            "`--config` must point at a directory containing cluster.yaml",
+        ));
+        return LoadOutcome {
+            desired: None,
+            diagnostics,
+            config_dir,
+            config_file,
+        };
+    }
+
+    let text = match fs::read_to_string(&config_file) {
+        Ok(text) => text,
+        Err(err) => {
+            diagnostics.push(Diagnostic::error(
+                "cluster_config_read_error",
+                CLUSTER_CONFIG_FILE,
+                format!("could not read cluster.yaml: {err}"),
+            ));
+            return LoadOutcome {
+                desired: None,
+                diagnostics,
+                config_dir,
+                config_file,
+            };
+        }
+    };
+
+    diagnostics.extend(duplicate_key_diagnostics(&text));
+    diagnostics.extend(future_field_diagnostics(&text));
+    if has_errors(&diagnostics) {
+        return LoadOutcome {
+            desired: None,
+            diagnostics,
+            config_dir,
+            config_file,
+        };
+    }
+
+    let raw = match serde_yaml::from_str::<RawClusterConfig>(&text) {
+        Ok(raw) => raw,
+        Err(err) => {
+            diagnostics.push(Diagnostic::error(
+                "invalid_cluster_yaml",
+                CLUSTER_CONFIG_FILE,
+                format!("could not parse cluster.yaml: {err}"),
+            ));
+            return LoadOutcome {
+                desired: None,
+                diagnostics,
+                config_dir,
+                config_file,
+            };
+        }
+    };
+
+    if raw.version != 1 {
+        diagnostics.push(Diagnostic::error(
+            "unsupported_cluster_config_version",
+            "version",
+            format!(
+                "unsupported cluster config version {}; this build supports version 1",
+                raw.version
+            ),
+        ));
+    }
+    if let Some(name) = raw.metadata.name.as_deref() {
+        if name.trim().is_empty() {
+            diagnostics.push(Diagnostic::error(
+                "empty_metadata_name",
+                "metadata.name",
+                "metadata.name must not be empty when provided",
+            ));
+        }
+    }
+    if let Some(backend) = raw.state.backend.as_deref() {
+        if backend != "cluster" {
+            diagnostics.push(Diagnostic::error(
+                "unsupported_state_backend",
+                "state.backend",
+                "Stage 1 supports only omitted state.backend or `cluster`",
+            ));
+        }
+    }
+    let _lock_parsed_for_forward_compat = raw.state.lock;
+
+    let mut resources = BTreeMap::new();
+    let mut dependencies = BTreeSet::new();
+    let mut graph_query_digests: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
+    let mut graph_schema_digests: BTreeMap<String, String> = BTreeMap::new();
+
+    for (graph_id, graph) in &raw.graphs {
+        validate_id(
+            "graph id",
+            &format!("graphs.{graph_id}"),
+            graph_id,
+            &mut diagnostics,
+        );
+        let graph_address = graph_address(graph_id);
+        let schema_address = schema_address(graph_id);
+        dependencies.insert(Dependency {
+            from: schema_address.clone(),
+            to: graph_address.clone(),
+        });
+
+        let schema_path = resolve_config_path(&config_dir, &graph.schema);
+        let schema_source = match fs::read_to_string(&schema_path) {
+            Ok(source) => {
+                let digest = sha256_hex(source.as_bytes());
+                graph_schema_digests.insert(graph_id.clone(), digest.clone());
+                resources.insert(
+                    schema_address.clone(),
+                    ResourceSummary {
+                        address: schema_address.clone(),
+                        kind: "schema".to_string(),
+                        digest,
+                        path: Some(display_path(&schema_path)),
+                    },
+                );
+                Some(source)
+            }
+            Err(err) => {
+                diagnostics.push(Diagnostic::error(
+                    "schema_file_missing",
+                    format!("graphs.{graph_id}.schema"),
+                    format!(
+                        "could not read schema file '{}': {err}",
+                        schema_path.display()
+                    ),
+                ));
+                None
+            }
+        };
+
+        let catalog = schema_source.and_then(|source| match parse_schema(&source) {
+            Ok(schema) => match build_catalog(&schema) {
+                Ok(catalog) => Some(catalog),
+                Err(err) => {
+                    diagnostics.push(Diagnostic::error(
+                        "schema_catalog_error",
+                        format!("graphs.{graph_id}.schema"),
+                        err.to_string(),
+                    ));
+                    None
+                }
+            },
+            Err(err) => {
+                diagnostics.push(Diagnostic::error(
+                    "schema_parse_error",
+                    format!("graphs.{graph_id}.schema"),
+                    err.to_string(),
+                ));
+                None
+            }
+        });
+
+        for (query_name, query) in &graph.queries {
+            validate_id(
+                "query name",
+                &format!("graphs.{graph_id}.queries.{query_name}"),
+                query_name,
+                &mut diagnostics,
+            );
+            let query_address = query_address(graph_id, query_name);
+            dependencies.insert(Dependency {
+                from: query_address.clone(),
+                to: graph_address.clone(),
+            });
+            dependencies.insert(Dependency {
+                from: query_address.clone(),
+                to: schema_address.clone(),
+            });
+
+            let query_path = resolve_config_path(&config_dir, &query.file);
+            match fs::read_to_string(&query_path) {
+                Ok(source) => {
+                    let digest = sha256_hex(source.as_bytes());
+                    graph_query_digests
+                        .entry(graph_id.clone())
+                        .or_default()
+                        .insert(query_name.clone(), digest.clone());
+                    resources.insert(
+                        query_address.clone(),
+                        ResourceSummary {
+                            address: query_address,
+                            kind: "query".to_string(),
+                            digest,
+                            path: Some(display_path(&query_path)),
+                        },
+                    );
+                    validate_query_source(
+                        graph_id,
+                        query_name,
+                        &source,
+                        catalog.as_ref(),
+                        &mut diagnostics,
+                    );
+                }
+                Err(err) => diagnostics.push(Diagnostic::error(
+                    "query_file_missing",
+                    format!("graphs.{graph_id}.queries.{query_name}.file"),
+                    format!(
+                        "could not read query file '{}': {err}",
+                        query_path.display()
+                    ),
+                )),
+            }
+        }
+    }
+
+    for graph_id in raw.graphs.keys() {
+        let digest = graph_digest(
+            graph_id,
+            graph_schema_digests.get(graph_id),
+            graph_query_digests.get(graph_id),
+        );
+        resources.insert(
+            graph_address(graph_id),
+            ResourceSummary {
+                address: graph_address(graph_id),
+                kind: "graph".to_string(),
+                digest,
+                path: None,
+            },
+        );
+    }
+
+    for (policy_name, policy) in &raw.policies {
+        validate_id(
+            "policy name",
+            &format!("policies.{policy_name}"),
+            policy_name,
+            &mut diagnostics,
+        );
+        if policy.applies_to.is_empty() {
+            diagnostics.push(Diagnostic::error(
+                "policy_missing_applies_to",
+                format!("policies.{policy_name}.applies_to"),
+                "policy.applies_to must name `cluster` or at least one graph",
+            ));
+        }
+
+        let policy_address = policy_address(policy_name);
+        for (idx, target) in policy.applies_to.iter().enumerate() {
+            match normalize_policy_target(target) {
+                PolicyTarget::Cluster => {}
+                PolicyTarget::Graph(graph_id) => {
+                    if raw.graphs.contains_key(&graph_id) {
+                        dependencies.insert(Dependency {
+                            from: policy_address.clone(),
+                            to: graph_address(&graph_id),
+                        });
+                    } else {
+                        diagnostics.push(Diagnostic::error(
+                            "dangling_graph_reference",
+                            format!("policies.{policy_name}.applies_to[{idx}]"),
+                            format!(
+                                "policy references graph `{graph_id}`, but no graph with that id is declared"
+                            ),
+                        ));
+                    }
+                }
+                PolicyTarget::WrongKind(kind) => diagnostics.push(Diagnostic::error(
+                    "wrong_kind_reference",
+                    format!("policies.{policy_name}.applies_to[{idx}]"),
+                    format!("policy applies_to expects graph refs or `cluster`, got `{kind}`"),
+                )),
+            }
+        }
+
+        let policy_path = resolve_config_path(&config_dir, &policy.file);
+        match fs::read(&policy_path) {
+            Ok(bytes) => {
+                resources.insert(
+                    policy_address.clone(),
+                    ResourceSummary {
+                        address: policy_address,
+                        kind: "policy".to_string(),
+                        digest: sha256_hex(&bytes),
+                        path: Some(display_path(&policy_path)),
+                    },
+                );
+            }
+            Err(err) => diagnostics.push(Diagnostic::error(
+                "policy_file_missing",
+                format!("policies.{policy_name}.file"),
+                format!(
+                    "could not read policy file '{}': {err}",
+                    policy_path.display()
+                ),
+            )),
+        }
+    }
+
+    let mut resource_digests = BTreeMap::new();
+    let mut resource_list = Vec::new();
+    for (address, resource) in resources {
+        resource_digests.insert(address, resource.digest.clone());
+        resource_list.push(resource);
+    }
+    let dependencies: Vec<_> = dependencies.into_iter().collect();
+    let config_digest = desired_config_digest(&text, &resource_digests);
+
+    LoadOutcome {
+        desired: Some(DesiredCluster {
+            config_dir: config_dir.clone(),
+            config_digest,
+            resource_digests,
+            resources: resource_list,
+            dependencies,
+        }),
+        diagnostics,
+        config_dir,
+        config_file,
+    }
+}
+
+fn validate_query_source(
+    graph_id: &str,
+    query_name: &str,
+    source: &str,
+    catalog: Option<&omnigraph_compiler::catalog::Catalog>,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let path = format!("graphs.{graph_id}.queries.{query_name}");
+    match parse_query(source) {
+        Ok(query_file) => {
+            let Some(query_decl) = query_file.queries.iter().find(|q| q.name == query_name) else {
+                diagnostics.push(Diagnostic::error(
+                    "query_key_mismatch",
+                    path,
+                    format!("no `query {query_name}` declaration found in the referenced .gq file"),
+                ));
+                return;
+            };
+            if let Some(catalog) = catalog {
+                if let Err(err) = typecheck_query_decl(catalog, query_decl) {
+                    diagnostics.push(Diagnostic::error(
+                        "query_typecheck_error",
+                        format!("graphs.{graph_id}.queries.{query_name}"),
+                        err.to_string(),
+                    ));
+                }
+            } else {
+                diagnostics.push(Diagnostic::warning(
+                    "query_typecheck_skipped",
+                    format!("graphs.{graph_id}.queries.{query_name}"),
+                    "query parsed, but type-check was skipped because the graph schema is invalid",
+                ));
+            }
+        }
+        Err(err) => diagnostics.push(Diagnostic::error(
+            "query_parse_error",
+            path,
+            err.to_string(),
+        )),
+    }
+}
+
+fn diff_resources(
+    prior: &BTreeMap<String, String>,
+    desired: &BTreeMap<String, String>,
+) -> Vec<PlanChange> {
+    let mut changes = Vec::new();
+    for (address, after) in desired {
+        match prior.get(address) {
+            None => changes.push(PlanChange {
+                resource: address.clone(),
+                operation: PlanOperation::Create,
+                before_digest: None,
+                after_digest: Some(after.clone()),
+            }),
+            Some(before) if before != after => changes.push(PlanChange {
+                resource: address.clone(),
+                operation: PlanOperation::Update,
+                before_digest: Some(before.clone()),
+                after_digest: Some(after.clone()),
+            }),
+            Some(_) => {}
+        }
+    }
+    for (address, before) in prior {
+        if !desired.contains_key(address) {
+            changes.push(PlanChange {
+                resource: address.clone(),
+                operation: PlanOperation::Delete,
+                before_digest: Some(before.clone()),
+                after_digest: None,
+            });
+        }
+    }
+    changes.sort_by(|a, b| a.resource.cmp(&b.resource));
+    changes
+}
+
+fn compute_blast_radius(changes: &[PlanChange], dependencies: &[Dependency]) -> Vec<BlastRadius> {
+    changes
+        .iter()
+        .filter_map(|change| {
+            let affected: Vec<_> = dependencies
+                .iter()
+                .filter_map(|dep| (dep.to == change.resource).then_some(dep.from.clone()))
+                .collect();
+            (!affected.is_empty()).then(|| BlastRadius {
+                resource: change.resource.clone(),
+                affected,
+            })
+        })
+        .collect()
+}
+
+fn compute_approvals(changes: &[PlanChange]) -> Vec<ApprovalRequirement> {
+    changes
+        .iter()
+        .filter_map(|change| {
+            if change.operation == PlanOperation::Delete
+                && (change.resource.starts_with("graph.") || change.resource.starts_with("schema."))
+            {
+                Some(ApprovalRequirement {
+                    resource: change.resource.clone(),
+                    reason: "delete may remove deployed graph or schema definition".to_string(),
+                })
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn duplicate_key_diagnostics(text: &str) -> Vec<Diagnostic> {
+    #[derive(Debug)]
+    struct Frame {
+        indent: isize,
+        path: String,
+        keys: BTreeSet<String>,
+    }
+
+    let mut diagnostics = Vec::new();
+    let mut stack = vec![Frame {
+        indent: -1,
+        path: String::new(),
+        keys: BTreeSet::new(),
+    }];
+
+    for (line_idx, line) in text.lines().enumerate() {
+        let line_without_comment = strip_comment(line);
+        if line_without_comment.trim().is_empty() {
+            continue;
+        }
+        let indent = line_without_comment
+            .chars()
+            .take_while(|ch| *ch == ' ')
+            .count() as isize;
+        let trimmed = line_without_comment.trim_start();
+        if trimmed.starts_with('-') {
+            continue;
+        }
+        let Some((raw_key, raw_value)) = trimmed.split_once(':') else {
+            continue;
+        };
+        let key = raw_key.trim();
+        if key.is_empty() || key.starts_with('{') || key.starts_with('[') {
+            continue;
+        }
+
+        while stack.last().is_some_and(|frame| indent <= frame.indent) {
+            stack.pop();
+        }
+        let parent = stack.last_mut().expect("root frame is always present");
+        let full_path = if parent.path.is_empty() {
+            key.to_string()
+        } else {
+            format!("{}.{}", parent.path, key)
+        };
+        if !parent.keys.insert(key.to_string()) {
+            diagnostics.push(Diagnostic::error(
+                "duplicate_yaml_key",
+                full_path.clone(),
+                format!("duplicate YAML key `{key}` on line {}", line_idx + 1),
+            ));
+        }
+        if raw_value.trim().is_empty() {
+            stack.push(Frame {
+                indent,
+                path: full_path,
+                keys: BTreeSet::new(),
+            });
+        }
+    }
+
+    diagnostics
+}
+
+fn future_field_diagnostics(text: &str) -> Vec<Diagnostic> {
+    let Ok(value) = serde_yaml::from_str::<serde_yaml::Value>(text) else {
+        return Vec::new();
+    };
+    let Some(mapping) = value.as_mapping() else {
+        return Vec::new();
+    };
+    let future_fields = [
+        "apply",
+        "env_file",
+        "providers",
+        "pipelines",
+        "embeddings",
+        "ui",
+        "aliases",
+        "bindings",
+    ];
+    mapping
+        .keys()
+        .filter_map(|key| key.as_str())
+        .filter(|key| future_fields.contains(key))
+        .map(|key| {
+            Diagnostic::error(
+                "future_phase_field",
+                key,
+                format!("`{key}` is reserved for a later cluster-control phase"),
+            )
+        })
+        .collect()
+}
+
+fn strip_comment(line: &str) -> String {
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut escaped = false;
+
+    for (idx, ch) in line.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match ch {
+            '\\' if in_double_quote => escaped = true,
+            '\'' if !in_double_quote => in_single_quote = !in_single_quote,
+            '"' if !in_single_quote => in_double_quote = !in_double_quote,
+            '#' if !in_single_quote && !in_double_quote => return line[..idx].to_string(),
+            _ => {}
+        }
+    }
+
+    line.to_string()
+}
+
+fn validate_id(kind: &str, path: &str, value: &str, diagnostics: &mut Vec<Diagnostic>) {
+    let mut chars = value.chars();
+    let valid = chars
+        .next()
+        .is_some_and(|ch| ch.is_ascii_alphabetic() || ch == '_')
+        && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-');
+    if !valid {
+        diagnostics.push(Diagnostic::error(
+            "invalid_resource_id",
+            path,
+            format!("{kind} `{value}` must start with a letter or `_` and contain only ASCII letters, digits, `_`, or `-`"),
+        ));
+    }
+}
+
+enum PolicyTarget {
+    Cluster,
+    Graph(String),
+    WrongKind(String),
+}
+
+fn normalize_policy_target(value: &str) -> PolicyTarget {
+    if value == "cluster" {
+        PolicyTarget::Cluster
+    } else if let Some(graph_id) = value.strip_prefix("graph.") {
+        PolicyTarget::Graph(graph_id.to_string())
+    } else if value.contains('.') {
+        PolicyTarget::WrongKind(value.to_string())
+    } else {
+        PolicyTarget::Graph(value.to_string())
+    }
+}
+
+fn graph_address(graph_id: &str) -> String {
+    format!("graph.{graph_id}")
+}
+
+fn schema_address(graph_id: &str) -> String {
+    format!("schema.{graph_id}")
+}
+
+fn query_address(graph_id: &str, query_name: &str) -> String {
+    format!("query.{graph_id}.{query_name}")
+}
+
+fn policy_address(policy_name: &str) -> String {
+    format!("policy.{policy_name}")
+}
+
+fn resolve_config_path(config_dir: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        config_dir.join(path)
+    }
+}
+
+fn graph_digest(
+    graph_id: &str,
+    schema_digest: Option<&String>,
+    query_digests: Option<&BTreeMap<String, String>>,
+) -> String {
+    let mut input = format!(
+        "graph\0{graph_id}\0schema\0{}\0",
+        schema_digest.map_or("", String::as_str)
+    );
+    if let Some(query_digests) = query_digests {
+        for (name, digest) in query_digests {
+            input.push_str("query\0");
+            input.push_str(name);
+            input.push('\0');
+            input.push_str(digest);
+            input.push('\0');
+        }
+    }
+    sha256_hex(input.as_bytes())
+}
+
+fn desired_config_digest(
+    config_source: &str,
+    resource_digests: &BTreeMap<String, String>,
+) -> String {
+    let mut input = String::from("cluster-config\0");
+    input.push_str(config_source);
+    input.push('\0');
+    for (address, digest) in resource_digests {
+        input.push_str(address);
+        input.push('\0');
+        input.push_str(digest);
+        input.push('\0');
+    }
+    sha256_hex(input.as_bytes())
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        out.push_str(&format!("{byte:02x}"));
+    }
+    out
+}
+
+fn has_errors(diagnostics: &[Diagnostic]) -> bool {
+    diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.severity == DiagnosticSeverity::Error)
+}
+
+fn display_path(path: &Path) -> String {
+    path.display().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    const SCHEMA: &str = r#"
+node Person {
+  name: String @key
+  age: I32?
+}
+"#;
+
+    const QUERY: &str = r#"
+query find_person($name: String) {
+  match { $p: Person { name: $name } }
+  return { $p.name, $p.age }
+}
+"#;
+
+    fn fixture() -> tempfile::TempDir {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("people.pg"), SCHEMA).unwrap();
+        fs::write(dir.path().join("people.gq"), QUERY).unwrap();
+        fs::write(dir.path().join("base.policy.yaml"), "rules: []\n").unwrap();
+        fs::write(
+            dir.path().join(CLUSTER_CONFIG_FILE),
+            r#"
+version: 1
+metadata:
+  name: test
+state:
+  backend: cluster
+  lock: true
+graphs:
+  knowledge:
+    schema: ./people.pg
+    queries:
+      find_person:
+        file: ./people.gq
+policies:
+  base:
+    file: ./base.policy.yaml
+    applies_to: [knowledge]
+"#,
+        )
+        .unwrap();
+        dir
+    }
+
+    #[test]
+    fn valid_minimal_config() {
+        let dir = fixture();
+        let out = validate_config_dir(dir.path());
+        assert!(out.ok, "{:?}", out.diagnostics);
+        assert!(out.resource_digests.contains_key("graph.knowledge"));
+        assert!(out.resource_digests.contains_key("schema.knowledge"));
+        assert!(
+            out.dependencies
+                .iter()
+                .any(|dep| dep.from == "policy.base" && dep.to == "graph.knowledge")
+        );
+    }
+
+    #[test]
+    fn unknown_field_rejection() {
+        let dir = fixture();
+        fs::write(
+            dir.path().join(CLUSTER_CONFIG_FILE),
+            "version: 1\ngraphs: {}\nwat: true\n",
+        )
+        .unwrap();
+        let out = validate_config_dir(dir.path());
+        assert!(!out.ok);
+        assert!(out.diagnostics[0].message.contains("unknown field"));
+    }
+
+    #[test]
+    fn future_phase_field_rejection() {
+        let dir = fixture();
+        fs::write(
+            dir.path().join(CLUSTER_CONFIG_FILE),
+            "version: 1\ngraphs: {}\npipelines: {}\n",
+        )
+        .unwrap();
+        let out = validate_config_dir(dir.path());
+        assert!(!out.ok);
+        assert_eq!(out.diagnostics[0].code, "future_phase_field");
+    }
+
+    #[test]
+    fn duplicate_yaml_key_rejection() {
+        let dir = fixture();
+        fs::write(
+            dir.path().join(CLUSTER_CONFIG_FILE),
+            "version: 1\ngraphs: {}\ngraphs: {}\n",
+        )
+        .unwrap();
+        let out = validate_config_dir(dir.path());
+        assert!(!out.ok);
+        assert_eq!(out.diagnostics[0].code, "duplicate_yaml_key");
+    }
+
+    #[test]
+    fn duplicate_yaml_key_rejection_keeps_quoted_hashes() {
+        let diagnostics =
+            duplicate_key_diagnostics("\"name#display\": one\n\"name#display\": two\n");
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, "duplicate_yaml_key");
+    }
+
+    #[test]
+    fn missing_schema_query_and_policy_files() {
+        let dir = fixture();
+        fs::write(
+            dir.path().join(CLUSTER_CONFIG_FILE),
+            r#"
+version: 1
+graphs:
+  knowledge:
+    schema: ./missing.pg
+    queries:
+      find_person: { file: ./missing.gq }
+policies:
+  base:
+    file: ./missing.policy.yaml
+    applies_to: [knowledge]
+"#,
+        )
+        .unwrap();
+        let out = validate_config_dir(dir.path());
+        assert!(!out.ok);
+        let codes: BTreeSet<_> = out.diagnostics.iter().map(|d| d.code.as_str()).collect();
+        assert!(codes.contains("schema_file_missing"));
+        assert!(codes.contains("query_file_missing"));
+        assert!(codes.contains("policy_file_missing"));
+    }
+
+    #[test]
+    fn wrong_kind_and_dangling_refs_fail() {
+        let dir = fixture();
+        fs::write(
+            dir.path().join(CLUSTER_CONFIG_FILE),
+            r#"
+version: 1
+graphs:
+  knowledge:
+    schema: ./people.pg
+policies:
+  base:
+    file: ./base.policy.yaml
+    applies_to: [query.knowledge.find_person, missing]
+"#,
+        )
+        .unwrap();
+        let out = validate_config_dir(dir.path());
+        assert!(!out.ok);
+        let codes: BTreeSet<_> = out.diagnostics.iter().map(|d| d.code.as_str()).collect();
+        assert!(codes.contains("wrong_kind_reference"));
+        assert!(codes.contains("dangling_graph_reference"));
+    }
+
+    #[test]
+    fn query_key_mismatch_fails() {
+        let dir = fixture();
+        fs::write(
+            dir.path().join(CLUSTER_CONFIG_FILE),
+            r#"
+version: 1
+graphs:
+  knowledge:
+    schema: ./people.pg
+    queries:
+      different: { file: ./people.gq }
+"#,
+        )
+        .unwrap();
+        let out = validate_config_dir(dir.path());
+        assert!(!out.ok);
+        assert_eq!(out.diagnostics[0].code, "query_key_mismatch");
+    }
+
+    #[test]
+    fn query_typecheck_failure_fails() {
+        let dir = fixture();
+        fs::write(
+            dir.path().join("people.gq"),
+            "query find_person() { match { $d: DoesNotExist } return { $d.name } }\n",
+        )
+        .unwrap();
+        let out = validate_config_dir(dir.path());
+        assert!(!out.ok);
+        assert!(
+            out.diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "query_typecheck_error")
+        );
+    }
+
+    #[test]
+    fn missing_state_plans_creates() {
+        let dir = fixture();
+        let out = plan_config_dir(dir.path());
+        assert!(out.ok, "{:?}", out.diagnostics);
+        assert!(!out.state_observations.state_found);
+        assert!(
+            out.changes
+                .iter()
+                .all(|c| c.operation == PlanOperation::Create)
+        );
+        assert!(out.changes.iter().any(|c| c.resource == "graph.knowledge"));
+    }
+
+    #[test]
+    fn existing_state_plans_update_and_delete_deterministically() {
+        let dir = fixture();
+        let first = plan_config_dir(dir.path());
+        let state_dir = dir.path().join("__cluster");
+        fs::create_dir_all(&state_dir).unwrap();
+        fs::write(
+            state_dir.join("state.json"),
+            serde_json::to_string_pretty(&json!({
+                "version": 1,
+                "applied_revision": {
+                    "config_digest": "old",
+                    "resources": {
+                        "graph.knowledge": { "digest": first.resource_digests["graph.knowledge"] },
+                        "policy.old": { "digest": "abc" },
+                        "schema.knowledge": { "digest": "old-schema" }
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let out = plan_config_dir(dir.path());
+        assert!(out.ok, "{:?}", out.diagnostics);
+        let rendered: Vec<_> = out
+            .changes
+            .iter()
+            .map(|change| (change.resource.as_str(), &change.operation))
+            .collect();
+        assert_eq!(
+            rendered,
+            vec![
+                ("policy.base", &PlanOperation::Create),
+                ("policy.old", &PlanOperation::Delete),
+                ("query.knowledge.find_person", &PlanOperation::Create),
+                ("schema.knowledge", &PlanOperation::Update),
+            ]
+        );
+    }
+
+    #[test]
+    fn external_state_backend_rejected() {
+        let dir = fixture();
+        fs::write(
+            dir.path().join(CLUSTER_CONFIG_FILE),
+            "version: 1\nstate:\n  backend: s3://bucket/state\ngraphs: {}\n",
+        )
+        .unwrap();
+        let out = validate_config_dir(dir.path());
+        assert!(!out.ok);
+        assert_eq!(out.diagnostics[0].code, "unsupported_state_backend");
+    }
+}

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -8,6 +8,7 @@ This file is the always-on map of the test surface. **Consult it before every ta
 |---|---|---|
 | `omnigraph` (engine) | `crates/omnigraph/tests/` | Integration tests (21 files), fixture-driven, share `tests/helpers/mod.rs` |
 | `omnigraph-cli` | `crates/omnigraph-cli/tests/` | `cli.rs` (unit-ish), `system_local.rs`, `system_remote.rs`, share `tests/support/mod.rs` |
+| `omnigraph-cluster` | mostly in-source `#[cfg(test)] mod tests` | Cluster config parser, local JSON state diff, read-only validate/plan |
 | `omnigraph-server` | `crates/omnigraph-server/tests/` | `server.rs` (HTTP-level), `openapi.rs` (OpenAPI drift / regeneration) |
 | `omnigraph-compiler` | mostly in-source `#[cfg(test)] mod tests` | Parser, type-checker, IR lowering, lint |
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -2,7 +2,7 @@
 
 A reference for the `omnigraph` binary's command surface and `omnigraph.yaml` schema. For a quick-start guide, see [cli.md](cli.md).
 
-17 top-level command families, 40+ subcommands. All commands accept either a positional `URI`, `--uri`, or a `--target <name>` resolved against `omnigraph.yaml`.
+18 top-level command families, 40+ subcommands. Graph commands accept either a positional `URI`, `--uri`, or a `--target <name>` resolved against `omnigraph.yaml`; `cluster` commands instead use `--config <dir>`.
 
 ## Top-level commands
 
@@ -21,6 +21,7 @@ A reference for the `omnigraph` binary's command surface and `omnigraph.yaml` sc
 | `schema plan \| apply \| show (alias: get)` | migrations |
 | `lint` (alias: `check`) | offline / graph-backed query validation. Replaces `query lint` / `query check`, which are kept as deprecated argv-level shims that print a one-line warning and rewrite to `omnigraph lint` |
 | `queries validate \| list` | operate on the server-side stored-query registry (the `queries:` block). `validate` type-checks every stored query against the live schema offline (opens the selected graph; exits non-zero on any breakage), catching schema drift without restarting the server; `list` prints the selected registry's query names, MCP exposure, and typed params. For per-graph registries, pass `--target <graph>` or set `cli.graph`; with no graph selection, `list` shows only top-level `queries:`. Distinct from `lint`, which validates a single `.gq` file |
+| `cluster validate \| plan` | read-only cluster-control preview. `validate` checks a local `cluster.yaml` folder and referenced schema/query/policy files; `plan` diffs it against local JSON state at `__cluster/state.json`. No apply, lock, graph open, server change, or state write occurs in Stage 1 |
 | `optimize` | non-destructive Lance compaction (skips tables with `Blob` columns; `--json` reports a `skipped` field) |
 | `cleanup --keep N --older-than 7d --confirm` | destructive version GC |
 | `embed` | offline JSONL embedding pipeline |
@@ -72,6 +73,20 @@ queries:                          # top-level registry — applies only to a bar
 policy:
   file: ./policy.yaml
 ```
+
+## Cluster config preview
+
+```bash
+omnigraph cluster validate --config ./company-brain
+omnigraph cluster plan     --config ./company-brain --json
+```
+
+`--config` is a directory containing `cluster.yaml`; it defaults to `.`.
+Stage 1 accepts graphs, schemas, stored queries, and policy bundle file
+references. `cluster plan` reads local JSON state from
+`<config-dir>/__cluster/state.json`; a missing file means empty state. External
+state backends, apply, locks, pipelines, UI specs, embeddings, aliases, and
+bindings are reserved for later stages. See [cluster-config.md](cluster-config.md).
 
 ## Output formats (`query` command, alias: `read`)
 

--- a/docs/user/cluster-config.md
+++ b/docs/user/cluster-config.md
@@ -1,0 +1,95 @@
+# Cluster Config
+
+**Status:** Stage 1 read-only preview.
+
+Cluster config is the future control-plane configuration surface for a whole
+OmniGraph deployment. In this stage, OmniGraph can validate a local
+`cluster.yaml` folder and produce a deterministic read-only plan. It does not
+apply changes, acquire locks, open graph roots, start servers, or write state.
+
+## Commands
+
+```bash
+omnigraph cluster validate --config ./company-brain
+omnigraph cluster plan     --config ./company-brain --json
+```
+
+`--config` points at a directory, not a file. The directory must contain
+`cluster.yaml`. When omitted, it defaults to the current directory.
+
+## Supported `cluster.yaml`
+
+Stage 1 accepts only the read-only resource subset:
+
+```yaml
+version: 1
+metadata:
+  name: company-brain
+
+state:
+  backend: cluster
+  lock: true
+
+graphs:
+  knowledge:
+    schema: ./knowledge.pg
+    queries:
+      find_experts:
+        file: ./knowledge.gq
+
+policies:
+  base:
+    file: ./base.policy.yaml
+    applies_to: [knowledge]
+```
+
+`metadata.name` is a display label. `state.lock` is parsed for forward
+compatibility, but no lock is acquired in this read-only stage. `state.backend`
+may be omitted or set to `cluster`; external state backends are reserved for a
+later stage.
+
+## Validation
+
+`cluster validate` checks:
+
+- `cluster.yaml` syntax and supported fields
+- duplicate YAML keys
+- schema, query, and policy file existence
+- schema parsing and catalog construction
+- stored-query parsing and query-name matching
+- stored-query type-checking against the desired schema
+- policy `applies_to` graph references
+
+Fields reserved for later phases, such as `pipelines`, `embeddings`, `ui`,
+`aliases`, and `bindings`, fail with a typed diagnostic instead of being
+silently ignored.
+
+## Planning
+
+`cluster plan` first performs validation, then reads local JSON state from:
+
+```text
+<config-dir>/__cluster/state.json
+```
+
+If the file is missing, the state is treated as empty and every desired
+resource is planned as a create. If present, the file must use this shape:
+
+```json
+{
+  "version": 1,
+  "applied_revision": {
+    "config_digest": "...",
+    "resources": {
+      "graph.knowledge": { "digest": "..." },
+      "schema.knowledge": { "digest": "..." },
+      "query.knowledge.find_experts": { "digest": "..." },
+      "policy.base": { "digest": "..." }
+    }
+  }
+}
+```
+
+Plan output compares desired resource digests against state resource digests
+and reports `create`, `update`, and `delete` changes. The command never writes
+`state.json`; apply and locking are later-stage work.

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -13,6 +13,7 @@ of MRs, internal recovery mechanics, or contributor-only invariants.
 | Install OmniGraph | [install.md](install.md) |
 | Run the CLI locally | [cli.md](cli.md) |
 | Look up every CLI flag and config field | [cli-reference.md](cli-reference.md) |
+| Validate and plan cluster config | [cluster-config.md](cluster-config.md) |
 | Write schemas | [schema-language.md](schema-language.md) |
 | Read schema-lint diagnostic codes | [schema-lint.md](schema-lint.md) |
 | Write queries and mutations | [query-language.md](query-language.md) |


### PR DESCRIPTION
## Summary

Adds the Stage 1 cluster-control slice as read-only CLI functionality:

- new `omnigraph-cluster` crate for strict `cluster.yaml` validation and deterministic local JSON-state planning
- new `omnigraph cluster validate` and `omnigraph cluster plan` CLI commands
- Stage 1 diagnostics for unknown fields, duplicate YAML keys, reserved future-phase fields, missing files, invalid references, query key mismatches, and query type-check failures
- deterministic plan JSON with desired config digest, resource digests, dependencies, state observations, changes, blast radius, approvals, and diagnostics
- user-facing docs for the read-only local-state preview

## Notes

This stage does not apply changes, acquire locks, open graph roots, touch Lance control-plane state, or change server behavior. `state.lock` is parsed only for forward compatibility, and policy files are validated as file resources only.

## Validation

- `cargo test -p omnigraph-cluster`
- `cargo test -p omnigraph-cli --test cli cluster`
- `scripts/check-agents-md.sh`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces a new `omnigraph-cluster` crate and two CLI subcommands (`cluster validate`, `cluster plan`) for read-only local inspection of `cluster.yaml`. No state is written, no locks acquired, and no engine/Lance surfaces are touched in this stage.

- **`validate_config_dir`** parses and validates `cluster.yaml`, checks all referenced schema/query/policy files exist, runs the compiler type-checker on each stored query, and returns a `ValidateOutput` with per-resource SHA-256 digests, a dependency graph, and typed diagnostics.
- **`plan_config_dir`** builds on validation, reads `__cluster/state.json` for prior applied resource digests, diffs desired vs. applied to produce `create`/`update`/`delete` changes, a blast-radius map, and approval requirements; exits non-zero on any error diagnostic.

<h3>Confidence Score: 4/5</h3>

Safe to merge for Stage 1 purposes — no state is written, no engine paths are touched, and all changes are additive. The four concerns are in the new crate only and do not affect existing functionality.

All four findings are in `omnigraph-cluster/src/lib.rs` and are non-blocking for a read-only preview. The config digest instability and partial graph digest emission could confuse Stage 2 apply tooling if left unaddressed. The missing policy approval gate and block-scalar risk in the hand-rolled key checker are design gaps worth fixing before the apply stage lands, but they don't break anything in this read-only slice.

crates/omnigraph-cluster/src/lib.rs — specifically the desired_config_digest, graph_digest emission on partial failure, compute_approvals filter, and duplicate_key_diagnostics block-scalar handling.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/omnigraph-cluster/src/lib.rs | New 1275-line crate implementing cluster.yaml validation and local-state planning. Contains four P2 issues: config digest includes raw YAML text making it whitespace-sensitive, graph resource digest is emitted even when source files are missing, policy deletes are not gated by compute_approvals, and the hand-rolled duplicate-key YAML tracker misfires on block scalars. |
| crates/omnigraph-cli/src/main.rs | Adds ClusterCommand enum and two new match arms (Validate, Plan) wired to omnigraph-cluster functions. Exit-code handling with explicit stdout flush before process::exit(1) is correct. Remaining diff is pure reformatting of existing code. |
| crates/omnigraph-cli/tests/cli.rs | Four new integration tests cover validate success, validate JSON stability, plan with existing state, and invalid config exit code. Tests are well-structured and cover the key happy/unhappy paths. |
| crates/omnigraph-cluster/Cargo.toml | New crate manifest. Dependencies (serde, serde_json, serde_yaml, sha2, thiserror, omnigraph-compiler) are all workspace-pinned. tempfile correctly placed in dev-dependencies. |
| docs/user/cluster-config.md | New user-facing doc describing Stage 1 cluster config commands, supported cluster.yaml schema, validation checks, and planning behavior. Accurate and consistent with implementation. |
| AGENTS.md | Adds omnigraph-cluster to the workspace crates list. Single-line, accurate update. |
| docs/user/cli-reference.md | Updates command count from 17 to 18 families, adds cluster validate/plan row to command table, and adds a Cluster config preview section with usage examples. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([omnigraph cluster validate/plan]) --> B[load_desired]
    B --> C{config_dir exists?}
    C -- No --> ERR1[error: config_dir_not_found]
    C -- Yes --> D[read cluster.yaml]
    D --> E[duplicate_key_diagnostics]
    E -- errors --> EARLY[return desired=None]
    E -- ok --> F[future_field_diagnostics]
    F -- errors --> EARLY
    F -- ok --> G[serde_yaml parse RawClusterConfig]
    G -- error --> EARLY
    G -- ok --> H[validate version, metadata, state]
    H --> I[for each graph: read schema, parse, build catalog]
    I --> J[for each query: read file, parse, typecheck]
    J --> K[for each policy: read file, validate applies_to refs]
    K --> L[compute graph_digest per graph]
    L --> M[desired_config_digest]
    M --> N{validate or plan?}
    N -- validate --> V([ValidateOutput ok/diagnostics/resource_digests/deps])
    N -- plan --> P[read __cluster/state.json]
    P --> Q[diff_resources prior vs desired]
    Q --> R[compute_blast_radius]
    R --> S[compute_approvals]
    S --> T([PlanOutput ok/changes/blast_radius/approvals/diagnostics])
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `crates/omnigraph-cluster/src/lib.rs`, line 1592-1627 ([link](https://github.com/modernrelay/omnigraph/blob/043b02e6179629fab79b68923c1ddd3bae401138/crates/omnigraph-cluster/src/lib.rs#L1592-L1627)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`desired_config_digest` includes raw YAML source text, making the digest brittle**

   `desired_config_digest` concatenates the raw `config_source` string before hashing. Any whitespace or comment-only edit to `cluster.yaml` produces a different `config_digest`, even though no resource files changed and `diff_resources` would report zero changes. In Stage 1 this is informational, but it establishes a convention where the state field `applied_config_digest` will always differ from the plan's `config_digest` after a trivial formatting pass — which could force unnecessary full re-applies once Stage 2 apply uses this digest to gate idempotency.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fomnigraph-cluster%2Fsrc%2Flib.rs%0ALine%3A%201592-1627%0A%0AComment%3A%0A**%60desired_config_digest%60%20includes%20raw%20YAML%20source%20text%2C%20making%20the%20digest%20brittle**%0A%0A%60desired_config_digest%60%20concatenates%20the%20raw%20%60config_source%60%20string%20before%20hashing.%20Any%20whitespace%20or%20comment-only%20edit%20to%20%60cluster.yaml%60%20produces%20a%20different%20%60config_digest%60%2C%20even%20though%20no%20resource%20files%20changed%20and%20%60diff_resources%60%20would%20report%20zero%20changes.%20In%20Stage%201%20this%20is%20informational%2C%20but%20it%20establishes%20a%20convention%20where%20the%20state%20field%20%60applied_config_digest%60%20will%20always%20differ%20from%20the%20plan's%20%60config_digest%60%20after%20a%20trivial%20formatting%20pass%20%E2%80%94%20which%20could%20force%20unnecessary%20full%20re-applies%20once%20Stage%202%20apply%20uses%20this%20digest%20to%20gate%20idempotency.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modernrelay%2Fomnigraph&pr=152&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>


2. `crates/omnigraph-cluster/src/lib.rs`, line 1400-1416 ([link](https://github.com/modernrelay/omnigraph/blob/043b02e6179629fab79b68923c1ddd3bae401138/crates/omnigraph-cluster/src/lib.rs#L1400-L1416)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`compute_approvals` does not gate `policy.*` deletes**

   The approval filter matches only `graph.*` and `schema.*` deletes. Deleting a policy bundle that governs access-control across one or more graphs is at least as consequential as removing a schema definition — if the intent of the approval gate is to flag operations that reduce deployed resource coverage, policy removes should be included. The current omission means a plan that drops `policy.base` silently reports zero approvals required.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fomnigraph-cluster%2Fsrc%2Flib.rs%0ALine%3A%201400-1416%0A%0AComment%3A%0A**%60compute_approvals%60%20does%20not%20gate%20%60policy.*%60%20deletes**%0A%0AThe%20approval%20filter%20matches%20only%20%60graph.*%60%20and%20%60schema.*%60%20deletes.%20Deleting%20a%20policy%20bundle%20that%20governs%20access-control%20across%20one%20or%20more%20graphs%20is%20at%20least%20as%20consequential%20as%20removing%20a%20schema%20definition%20%E2%80%94%20if%20the%20intent%20of%20the%20approval%20gate%20is%20to%20flag%20operations%20that%20reduce%20deployed%20resource%20coverage%2C%20policy%20removes%20should%20be%20included.%20The%20current%20omission%20means%20a%20plan%20that%20drops%20%60policy.base%60%20silently%20reports%20zero%20approvals%20required.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modernrelay%2Fomnigraph&pr=152&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>


3. `crates/omnigraph-cluster/src/lib.rs`, line 1418-1480 ([link](https://github.com/modernrelay/omnigraph/blob/043b02e6179629fab79b68923c1ddd3bae401138/crates/omnigraph-cluster/src/lib.rs#L1418-L1480)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Hand-rolled YAML indent tracker misfires on block scalars**

   `duplicate_key_diagnostics` reads the file line-by-line and tracks indentation to reconstruct the key hierarchy. A YAML block scalar opener (`key: |` or `key: >`) has a non-empty `raw_value`, so no new frame is pushed — but the continuation lines (the block content) are at a deeper indent and will be interpreted as mapping keys inside a phantom child frame. A key name that appears both inside a block scalar and as a sibling key of the scalar's parent will be falsely reported as a duplicate, causing `load_desired` to return early before serde ever runs. For the current `cluster.yaml` field set block scalars are unlikely, but they could appear in `metadata.name` descriptions or policy comments if the schema expands.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fomnigraph-cluster%2Fsrc%2Flib.rs%0ALine%3A%201418-1480%0A%0AComment%3A%0A**Hand-rolled%20YAML%20indent%20tracker%20misfires%20on%20block%20scalars**%0A%0A%60duplicate_key_diagnostics%60%20reads%20the%20file%20line-by-line%20and%20tracks%20indentation%20to%20reconstruct%20the%20key%20hierarchy.%20A%20YAML%20block%20scalar%20opener%20%28%60key%3A%20%7C%60%20or%20%60key%3A%20%3E%60%29%20has%20a%20non-empty%20%60raw_value%60%2C%20so%20no%20new%20frame%20is%20pushed%20%E2%80%94%20but%20the%20continuation%20lines%20%28the%20block%20content%29%20are%20at%20a%20deeper%20indent%20and%20will%20be%20interpreted%20as%20mapping%20keys%20inside%20a%20phantom%20child%20frame.%20A%20key%20name%20that%20appears%20both%20inside%20a%20block%20scalar%20and%20as%20a%20sibling%20key%20of%20the%20scalar's%20parent%20will%20be%20falsely%20reported%20as%20a%20duplicate%2C%20causing%20%60load_desired%60%20to%20return%20early%20before%20serde%20ever%20runs.%20For%20the%20current%20%60cluster.yaml%60%20field%20set%20block%20scalars%20are%20unlikely%2C%20but%20they%20could%20appear%20in%20%60metadata.name%60%20descriptions%20or%20policy%20comments%20if%20the%20schema%20expands.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modernrelay%2Fomnigraph&pr=152&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Fomnigraph-cluster%2Fsrc%2Flib.rs%3A1592-1627%0A**%60desired_config_digest%60%20includes%20raw%20YAML%20source%20text%2C%20making%20the%20digest%20brittle**%0A%0A%60desired_config_digest%60%20concatenates%20the%20raw%20%60config_source%60%20string%20before%20hashing.%20Any%20whitespace%20or%20comment-only%20edit%20to%20%60cluster.yaml%60%20produces%20a%20different%20%60config_digest%60%2C%20even%20though%20no%20resource%20files%20changed%20and%20%60diff_resources%60%20would%20report%20zero%20changes.%20In%20Stage%201%20this%20is%20informational%2C%20but%20it%20establishes%20a%20convention%20where%20the%20state%20field%20%60applied_config_digest%60%20will%20always%20differ%20from%20the%20plan's%20%60config_digest%60%20after%20a%20trivial%20formatting%20pass%20%E2%80%94%20which%20could%20force%20unnecessary%20full%20re-applies%20once%20Stage%202%20apply%20uses%20this%20digest%20to%20gate%20idempotency.%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Fomnigraph-cluster%2Fsrc%2Flib.rs%3A1197-1214%0A**Graph%20resource%20digest%20is%20computed%20and%20emitted%20even%20when%20source%20files%20are%20missing**%0A%0AWhen%20a%20schema%20or%20query%20file%20cannot%20be%20read%2C%20the%20error%20is%20recorded%20but%20%60graph_schema_digests%60%20%2F%20%60graph_query_digests%60%20are%20simply%20left%20empty%20for%20that%20graph.%20The%20subsequent%20loop%20still%20inserts%20%60graph.%7Bgraph_id%7D%60%20into%20%60resource_digests%60%20via%20%60graph_digest%28%E2%80%A6%2C%20None%2C%20None%29%60%2C%20which%20hashes%20an%20empty-string%20placeholder%20for%20the%20schema.%20Consumers%20of%20the%20validate%20JSON%20see%20%60ok%3A%20false%60%20alongside%20a%20%60resource_digests%60%20map%20that%20contains%20the%20graph%20resource%20with%20a%20digest%20that%20does%20not%20represent%20any%20real%20file%20content.%20A%20caller%20that%20checks%20only%20the%20per-resource%20digest%20%28not%20%60ok%60%29%20could%20silently%20use%20a%20phantom%20digest%20for%20comparison%20or%20caching.%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Fomnigraph-cluster%2Fsrc%2Flib.rs%3A1400-1416%0A**%60compute_approvals%60%20does%20not%20gate%20%60policy.*%60%20deletes**%0A%0AThe%20approval%20filter%20matches%20only%20%60graph.*%60%20and%20%60schema.*%60%20deletes.%20Deleting%20a%20policy%20bundle%20that%20governs%20access-control%20across%20one%20or%20more%20graphs%20is%20at%20least%20as%20consequential%20as%20removing%20a%20schema%20definition%20%E2%80%94%20if%20the%20intent%20of%20the%20approval%20gate%20is%20to%20flag%20operations%20that%20reduce%20deployed%20resource%20coverage%2C%20policy%20removes%20should%20be%20included.%20The%20current%20omission%20means%20a%20plan%20that%20drops%20%60policy.base%60%20silently%20reports%20zero%20approvals%20required.%0A%0A%23%23%23%20Issue%204%20of%204%0Acrates%2Fomnigraph-cluster%2Fsrc%2Flib.rs%3A1418-1480%0A**Hand-rolled%20YAML%20indent%20tracker%20misfires%20on%20block%20scalars**%0A%0A%60duplicate_key_diagnostics%60%20reads%20the%20file%20line-by-line%20and%20tracks%20indentation%20to%20reconstruct%20the%20key%20hierarchy.%20A%20YAML%20block%20scalar%20opener%20%28%60key%3A%20%7C%60%20or%20%60key%3A%20%3E%60%29%20has%20a%20non-empty%20%60raw_value%60%2C%20so%20no%20new%20frame%20is%20pushed%20%E2%80%94%20but%20the%20continuation%20lines%20%28the%20block%20content%29%20are%20at%20a%20deeper%20indent%20and%20will%20be%20interpreted%20as%20mapping%20keys%20inside%20a%20phantom%20child%20frame.%20A%20key%20name%20that%20appears%20both%20inside%20a%20block%20scalar%20and%20as%20a%20sibling%20key%20of%20the%20scalar's%20parent%20will%20be%20falsely%20reported%20as%20a%20duplicate%2C%20causing%20%60load_desired%60%20to%20return%20early%20before%20serde%20ever%20runs.%20For%20the%20current%20%60cluster.yaml%60%20field%20set%20block%20scalars%20are%20unlikely%2C%20but%20they%20could%20appear%20in%20%60metadata.name%60%20descriptions%20or%20policy%20comments%20if%20the%20schema%20expands.%0A%0A&repo=modernrelay%2Fomnigraph&pr=152&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(cluster): add read-only validate an..."](https://github.com/modernrelay/omnigraph/commit/043b02e6179629fab79b68923c1ddd3bae401138) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36461229)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->