### PR TITLE
[codex] add cluster refresh and import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4569,6 +4569,7 @@ name = "omnigraph-cluster"
 version = "0.6.2"
 dependencies = [
  "omnigraph-compiler",
+ "omnigraph-engine",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -4576,6 +4577,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "time",
+ "tokio",
  "ulid",
 ]
 

--- a/crates/omnigraph-cli/src/main.rs
+++ b/crates/omnigraph-cli/src/main.rs
@@ -11,8 +11,8 @@ use omnigraph::db::{Omnigraph, ReadTarget, SnapshotId};
 use omnigraph::loader::LoadMode;
 use omnigraph::storage::normalize_root_uri;
 use omnigraph_cluster::{
-    DiagnosticSeverity, PlanOutput, StatusOutput, ValidateOutput, plan_config_dir,
-    status_config_dir, validate_config_dir,
+    DiagnosticSeverity, PlanOutput, StateSyncOutput, StatusOutput, ValidateOutput,
+    import_config_dir, plan_config_dir, refresh_config_dir, status_config_dir, validate_config_dir,
 };
 use omnigraph_compiler::query::parser::parse_query;
 use omnigraph_compiler::schema::parser::parse_schema;
@@ -362,6 +362,24 @@ enum ClusterCommand {
     },
     /// Read the local JSON state ledger without scanning live graph resources.
     Status {
+        /// Cluster config directory containing cluster.yaml.
+        #[arg(long, default_value = ".")]
+        config: PathBuf,
+        /// Emit JSON instead of human text.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Refresh existing local JSON state from declared graph observations.
+    Refresh {
+        /// Cluster config directory containing cluster.yaml.
+        #[arg(long, default_value = ".")]
+        config: PathBuf,
+        /// Emit JSON instead of human text.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Import initial local JSON state from declared graph observations.
+    Import {
         /// Cluster config directory containing cluster.yaml.
         #[arg(long, default_value = ".")]
         config: PathBuf,
@@ -802,6 +820,34 @@ fn print_cluster_status_human(output: &StatusOutput) {
     print_cluster_diagnostics(&output.diagnostics);
 }
 
+fn print_cluster_state_sync_human(output: &StateSyncOutput) {
+    let operation = match output.operation {
+        omnigraph_cluster::StateSyncOperation::Refresh => "refresh",
+        omnigraph_cluster::StateSyncOperation::Import => "import",
+    };
+    if output.ok {
+        let state = &output.state_observations;
+        println!(
+            "cluster {operation}: revision {}, {} resource(s)",
+            state.state_revision, state.resource_count
+        );
+        if let Some(cas) = state.state_cas.as_deref() {
+            println!("  state_cas: {cas}");
+        }
+        if state.locked {
+            match state.lock_id.as_deref() {
+                Some(lock_id) => println!("  lock: acquired ({lock_id})"),
+                None => println!("  lock: acquired"),
+            }
+        } else {
+            println!("  lock: not acquired");
+        }
+    } else {
+        println!("cluster {operation} failed");
+    }
+    print_cluster_diagnostics(&output.diagnostics);
+}
+
 fn print_cluster_diagnostics(diagnostics: &[omnigraph_cluster::Diagnostic]) {
     for diagnostic in diagnostics {
         let label = match diagnostic.severity {
@@ -846,6 +892,19 @@ fn finish_cluster_status(output: &StatusOutput, json: bool) -> Result<()> {
         print_json(output)?;
     } else {
         print_cluster_status_human(output);
+    }
+    if !output.ok {
+        io::stdout().flush()?;
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+fn finish_cluster_state_sync(output: &StateSyncOutput, json: bool) -> Result<()> {
+    if json {
+        print_json(output)?;
+    } else {
+        print_cluster_state_sync_human(output);
     }
     if !output.ok {
         io::stdout().flush()?;
@@ -3375,6 +3434,14 @@ async fn main() -> Result<()> {
             ClusterCommand::Status { config, json } => {
                 let output = status_config_dir(config);
                 finish_cluster_status(&output, json)?;
+            }
+            ClusterCommand::Refresh { config, json } => {
+                let output = refresh_config_dir(config).await;
+                finish_cluster_state_sync(&output, json)?;
+            }
+            ClusterCommand::Import { config, json } => {
+                let output = import_config_dir(config).await;
+                finish_cluster_state_sync(&output, json)?;
             }
         },
         Command::Graphs { command } => match command {

--- a/crates/omnigraph-cli/tests/cli.rs
+++ b/crates/omnigraph-cli/tests/cli.rs
@@ -144,6 +144,18 @@ policies:
     .unwrap();
 }
 
+fn init_cluster_derived_graph(root: &std::path::Path) {
+    let graph_dir = root.join("graphs");
+    fs::create_dir_all(&graph_dir).unwrap();
+    output_success(
+        cli()
+            .arg("init")
+            .arg("--schema")
+            .arg(root.join("people.pg"))
+            .arg(graph_dir.join("knowledge.omni")),
+    );
+}
+
 #[test]
 fn version_command_prints_current_cli_version() {
     let output = output_success(cli().arg("version"));
@@ -396,6 +408,206 @@ fn cluster_plan_locked_state_exits_nonzero() {
             .iter()
             .any(|diagnostic| diagnostic["code"] == "state_lock_held"),
         "locked state should produce a useful diagnostic: {json}"
+    );
+}
+
+#[test]
+fn cluster_import_json_bootstraps_missing_state() {
+    let temp = tempdir().unwrap();
+    write_cluster_config_fixture(temp.path());
+    init_cluster_derived_graph(temp.path());
+
+    let json = parse_stdout_json(&output_success(
+        cli()
+            .arg("cluster")
+            .arg("import")
+            .arg("--config")
+            .arg(temp.path())
+            .arg("--json"),
+    ));
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["operation"], "import");
+    assert_eq!(json["state_observations"]["state_revision"], 1);
+    assert!(
+        json["state_observations"]["state_cas"]
+            .as_str()
+            .unwrap()
+            .starts_with("sha256:")
+    );
+    assert_eq!(json["state_observations"]["locked"], false);
+    assert_eq!(json["state_observations"]["lock_acquired"], true);
+    assert!(json["state_observations"]["acquired_lock_id"].is_string());
+    assert!(json["observations"]["graph.knowledge"]["manifest_version"].is_number());
+    assert_eq!(
+        json["resource_statuses"]["graph.knowledge"]["status"],
+        "applied"
+    );
+    assert!(temp.path().join("__cluster/state.json").exists());
+    assert!(!temp.path().join("__cluster/lock.json").exists());
+}
+
+#[test]
+fn cluster_refresh_json_updates_revision_cas_and_removes_lock() {
+    let temp = tempdir().unwrap();
+    write_cluster_config_fixture(temp.path());
+    init_cluster_derived_graph(temp.path());
+    let state_dir = temp.path().join("__cluster");
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(
+        state_dir.join("state.json"),
+        r#"
+{
+  "version": 1,
+  "state_revision": 2,
+  "applied_revision": { "resources": {} }
+}
+"#,
+    )
+    .unwrap();
+
+    let json = parse_stdout_json(&output_success(
+        cli()
+            .arg("cluster")
+            .arg("refresh")
+            .arg("--config")
+            .arg(temp.path())
+            .arg("--json"),
+    ));
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["operation"], "refresh");
+    assert_eq!(json["state_observations"]["state_revision"], 3);
+    assert!(
+        json["state_observations"]["state_cas"]
+            .as_str()
+            .unwrap()
+            .starts_with("sha256:")
+    );
+    assert_eq!(json["state_observations"]["locked"], false);
+    assert_eq!(json["state_observations"]["lock_acquired"], true);
+    assert!(json["state_observations"]["acquired_lock_id"].is_string());
+    assert!(!state_dir.join("lock.json").exists());
+}
+
+#[test]
+fn cluster_refresh_missing_state_exits_nonzero() {
+    let temp = tempdir().unwrap();
+    write_cluster_config_fixture(temp.path());
+
+    let output = output_failure(
+        cli()
+            .arg("cluster")
+            .arg("refresh")
+            .arg("--config")
+            .arg(temp.path())
+            .arg("--json"),
+    );
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["ok"], false);
+    assert!(
+        json["diagnostics"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|diagnostic| diagnostic["code"] == "state_missing"),
+        "missing state should produce a useful diagnostic: {json}"
+    );
+}
+
+#[test]
+fn cluster_import_existing_state_exits_nonzero() {
+    let temp = tempdir().unwrap();
+    write_cluster_config_fixture(temp.path());
+    let state_dir = temp.path().join("__cluster");
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(
+        state_dir.join("state.json"),
+        r#"{"version":1,"applied_revision":{"resources":{}}}"#,
+    )
+    .unwrap();
+
+    let output = output_failure(
+        cli()
+            .arg("cluster")
+            .arg("import")
+            .arg("--config")
+            .arg(temp.path())
+            .arg("--json"),
+    );
+    let json = parse_stdout_json(&output);
+    assert_eq!(json["ok"], false);
+    assert!(
+        json["diagnostics"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|diagnostic| diagnostic["code"] == "state_already_exists"),
+        "existing state should produce a useful diagnostic: {json}"
+    );
+}
+
+#[test]
+fn cluster_refresh_and_import_locked_state_exit_nonzero() {
+    let temp = tempdir().unwrap();
+    write_cluster_config_fixture(temp.path());
+    let state_dir = temp.path().join("__cluster");
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(
+        state_dir.join("state.json"),
+        r#"{"version":1,"applied_revision":{"resources":{}}}"#,
+    )
+    .unwrap();
+    fs::write(
+        state_dir.join("lock.json"),
+        r#"{"version":1,"lock_id":"held-lock","operation":"refresh","created_at":"2026-06-08T00:00:00Z","pid":123}"#,
+    )
+    .unwrap();
+
+    let refresh = parse_stdout_json(&output_failure(
+        cli()
+            .arg("cluster")
+            .arg("refresh")
+            .arg("--config")
+            .arg(temp.path())
+            .arg("--json"),
+    ));
+    assert_eq!(refresh["state_observations"]["locked"], true);
+    assert_eq!(refresh["state_observations"]["lock_id"], "held-lock");
+    assert_eq!(refresh["state_observations"]["lock_acquired"], false);
+    assert!(
+        refresh["diagnostics"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|diagnostic| diagnostic["code"] == "state_lock_held")
+    );
+
+    let temp = tempdir().unwrap();
+    write_cluster_config_fixture(temp.path());
+    let state_dir = temp.path().join("__cluster");
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(
+        state_dir.join("lock.json"),
+        r#"{"version":1,"lock_id":"held-lock","operation":"import","created_at":"2026-06-08T00:00:00Z","pid":123}"#,
+    )
+    .unwrap();
+
+    let imported = parse_stdout_json(&output_failure(
+        cli()
+            .arg("cluster")
+            .arg("import")
+            .arg("--config")
+            .arg(temp.path())
+            .arg("--json"),
+    ));
+    assert_eq!(imported["state_observations"]["locked"], true);
+    assert_eq!(imported["state_observations"]["lock_id"], "held-lock");
+    assert_eq!(imported["state_observations"]["lock_acquired"], false);
+    assert!(
+        imported["diagnostics"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|diagnostic| diagnostic["code"] == "state_lock_held")
     );
 }
 

--- a/crates/omnigraph-cluster/Cargo.toml
+++ b/crates/omnigraph-cluster/Cargo.toml
@@ -10,6 +10,7 @@ documentation = "https://docs.rs/omnigraph-cluster"
 
 [dependencies]
 omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.6.2" }
+omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.6.2" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
@@ -20,3 +21,4 @@ ulid = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+tokio = { workspace = true }

--- a/crates/omnigraph-cluster/src/lib.rs
+++ b/crates/omnigraph-cluster/src/lib.rs
@@ -4,17 +4,20 @@ use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 use std::process;
 
+use omnigraph::db::{Omnigraph, ReadTarget};
 use omnigraph_compiler::build_catalog;
 use omnigraph_compiler::query::parser::parse_query;
 use omnigraph_compiler::query::typecheck::typecheck_query_decl;
 use omnigraph_compiler::schema::parser::parse_schema;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use sha2::{Digest, Sha256};
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 use ulid::Ulid;
 
 pub const CLUSTER_CONFIG_FILE: &str = "cluster.yaml";
+pub const CLUSTER_GRAPHS_DIR: &str = "graphs";
 pub const CLUSTER_STATE_DIR: &str = "__cluster";
 pub const CLUSTER_STATE_FILE: &str = "__cluster/state.json";
 pub const CLUSTER_LOCK_FILE: &str = "__cluster/lock.json";
@@ -182,6 +185,26 @@ pub struct StatusOutput {
     pub state_observations: StateObservations,
     pub resource_digests: BTreeMap<String, String>,
     pub resource_statuses: BTreeMap<String, ResourceStatusRecord>,
+    pub observations: BTreeMap<String, serde_json::Value>,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum StateSyncOperation {
+    Refresh,
+    Import,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct StateSyncOutput {
+    pub ok: bool,
+    pub operation: StateSyncOperation,
+    pub config_dir: String,
+    pub state_observations: StateObservations,
+    pub resource_digests: BTreeMap<String, String>,
+    pub resource_statuses: BTreeMap<String, ResourceStatusRecord>,
+    pub observations: BTreeMap<String, serde_json::Value>,
     pub diagnostics: Vec<Diagnostic>,
 }
 
@@ -190,9 +213,16 @@ struct DesiredCluster {
     config_dir: PathBuf,
     config_digest: String,
     state_lock: bool,
+    graphs: Vec<DesiredGraph>,
     resource_digests: BTreeMap<String, String>,
     resources: Vec<ResourceSummary>,
     dependencies: Vec<Dependency>,
+}
+
+#[derive(Debug, Clone)]
+struct DesiredGraph {
+    id: String,
+    schema_digest: String,
 }
 
 #[derive(Debug)]
@@ -264,8 +294,10 @@ struct PolicyConfig {
     applies_to: Vec<String>,
 }
 
+// Stage 2A/2B accept these forward-compatible state sections so existing
+// ledgers won't churn while approval/recovery semantics are staged later.
 #[allow(dead_code)]
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct ClusterState {
     version: u32,
@@ -282,7 +314,7 @@ struct ClusterState {
     observations: BTreeMap<String, serde_json::Value>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct AppliedRevisionState {
     #[serde(default)]
@@ -291,7 +323,7 @@ struct AppliedRevisionState {
     resources: BTreeMap<String, StateResource>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct StateResource {
     digest: String,
@@ -317,6 +349,7 @@ struct LocalStateBackend {
 #[derive(Debug)]
 struct StateSnapshot {
     state: Option<ClusterState>,
+    state_cas: Option<String>,
 }
 
 #[derive(Debug)]
@@ -450,6 +483,7 @@ pub fn status_config_dir(config_dir: impl AsRef<Path>) -> StatusOutput {
 
     let mut resource_digests = BTreeMap::new();
     let mut resource_statuses = BTreeMap::new();
+    let mut state_observation_records = BTreeMap::new();
 
     if let Some(raw) = parsed.raw.as_ref() {
         let _settings = validate_cluster_header(raw, &mut diagnostics);
@@ -459,6 +493,7 @@ pub fn status_config_dir(config_dir: impl AsRef<Path>) -> StatusOutput {
                     if let Some(state) = snapshot.state {
                         resource_digests = state_resource_digests(&state);
                         resource_statuses = state.resource_statuses;
+                        state_observation_records = state.observations;
                     } else {
                         diagnostics.push(Diagnostic::warning(
                             "state_missing",
@@ -478,6 +513,185 @@ pub fn status_config_dir(config_dir: impl AsRef<Path>) -> StatusOutput {
         state_observations: observations,
         resource_digests,
         resource_statuses,
+        observations: state_observation_records,
+        diagnostics,
+    }
+}
+
+pub async fn refresh_config_dir(config_dir: impl AsRef<Path>) -> StateSyncOutput {
+    sync_config_dir(config_dir.as_ref(), StateSyncOperation::Refresh).await
+}
+
+pub async fn import_config_dir(config_dir: impl AsRef<Path>) -> StateSyncOutput {
+    sync_config_dir(config_dir.as_ref(), StateSyncOperation::Import).await
+}
+
+async fn sync_config_dir(config_dir: &Path, operation: StateSyncOperation) -> StateSyncOutput {
+    let outcome = load_desired(config_dir);
+    let mut diagnostics = outcome.diagnostics;
+    let backend = LocalStateBackend::new(&outcome.config_dir);
+    let mut observations = backend.observations();
+
+    let Some(desired) = outcome.desired else {
+        return StateSyncOutput {
+            ok: false,
+            operation,
+            config_dir: display_path(&outcome.config_dir),
+            state_observations: observations,
+            resource_digests: BTreeMap::new(),
+            resource_statuses: BTreeMap::new(),
+            observations: BTreeMap::new(),
+            diagnostics,
+        };
+    };
+
+    if has_errors(&diagnostics) {
+        return StateSyncOutput {
+            ok: false,
+            operation,
+            config_dir: display_path(&desired.config_dir),
+            state_observations: observations,
+            resource_digests: desired.resource_digests,
+            resource_statuses: BTreeMap::new(),
+            observations: BTreeMap::new(),
+            diagnostics,
+        };
+    }
+
+    let operation_label = state_sync_operation_label(operation);
+    let _lock_guard = if desired.state_lock {
+        match backend.acquire_lock(operation_label, &mut observations) {
+            Ok(guard) => Some(guard),
+            Err(diagnostic) => {
+                diagnostics.push(diagnostic);
+                None
+            }
+        }
+    } else {
+        diagnostics.push(Diagnostic::warning(
+            "state_lock_disabled",
+            "state.lock",
+            format!(
+                "state.lock is false; {operation_label} wrote state without acquiring the cluster state lock"
+            ),
+        ));
+        None
+    };
+
+    if has_errors(&diagnostics) {
+        return StateSyncOutput {
+            ok: false,
+            operation,
+            config_dir: display_path(&desired.config_dir),
+            state_observations: observations,
+            resource_digests: desired.resource_digests,
+            resource_statuses: BTreeMap::new(),
+            observations: BTreeMap::new(),
+            diagnostics,
+        };
+    }
+
+    let snapshot = match backend.read_state(&mut observations) {
+        Ok(snapshot) => snapshot,
+        Err(diagnostic) => {
+            diagnostics.push(diagnostic);
+            return StateSyncOutput {
+                ok: false,
+                operation,
+                config_dir: display_path(&desired.config_dir),
+                state_observations: observations,
+                resource_digests: desired.resource_digests,
+                resource_statuses: BTreeMap::new(),
+                observations: BTreeMap::new(),
+                diagnostics,
+            };
+        }
+    };
+
+    let expected_cas = snapshot.state_cas;
+    let mut state = match (operation, snapshot.state) {
+        (StateSyncOperation::Refresh, Some(state)) => state,
+        (StateSyncOperation::Refresh, None) => {
+            diagnostics.push(Diagnostic::error(
+                "state_missing",
+                CLUSTER_STATE_FILE,
+                "refresh requires an existing state.json; run `cluster import` to bootstrap state",
+            ));
+            return StateSyncOutput {
+                ok: false,
+                operation,
+                config_dir: display_path(&desired.config_dir),
+                state_observations: observations,
+                resource_digests: BTreeMap::new(),
+                resource_statuses: BTreeMap::new(),
+                observations: BTreeMap::new(),
+                diagnostics,
+            };
+        }
+        (StateSyncOperation::Import, Some(state)) => {
+            diagnostics.push(Diagnostic::error(
+                "state_already_exists",
+                CLUSTER_STATE_FILE,
+                "import creates initial state only when state.json is missing; use `cluster refresh` for an existing state ledger",
+            ));
+            return StateSyncOutput {
+                ok: false,
+                operation,
+                config_dir: display_path(&desired.config_dir),
+                state_observations: observations,
+                resource_digests: state_resource_digests(&state),
+                resource_statuses: state.resource_statuses,
+                observations: state.observations,
+                diagnostics,
+            };
+        }
+        (StateSyncOperation::Import, None) => initial_import_state(&desired),
+    };
+
+    let graph_error_count = observe_declared_graphs(&desired, &mut state).await;
+    if graph_error_count > 0 {
+        diagnostics.push(Diagnostic::error(
+            "graph_observation_error",
+            CLUSTER_GRAPHS_DIR,
+            format!("{graph_error_count} graph observation(s) failed"),
+        ));
+    }
+
+    if operation == StateSyncOperation::Import && has_errors(&diagnostics) {
+        return StateSyncOutput {
+            ok: false,
+            operation,
+            config_dir: display_path(&desired.config_dir),
+            state_observations: observations,
+            resource_digests: state_resource_digests(&state),
+            resource_statuses: state.resource_statuses,
+            observations: state.observations,
+            diagnostics,
+        };
+    }
+
+    if operation == StateSyncOperation::Import {
+        state.state_revision = 1;
+    } else {
+        state.state_revision = state.state_revision.saturating_add(1);
+    }
+
+    match backend.write_state(&state, expected_cas.as_deref(), &mut observations) {
+        Ok(()) => {}
+        Err(diagnostic) => diagnostics.push(diagnostic),
+    }
+
+    let resource_digests = state_resource_digests(&state);
+    let ok = !has_errors(&diagnostics);
+
+    StateSyncOutput {
+        ok,
+        operation,
+        config_dir: display_path(&desired.config_dir),
+        state_observations: observations,
+        resource_digests,
+        resource_statuses: state.resource_statuses,
+        observations: state.observations,
         diagnostics,
     }
 }
@@ -577,7 +791,7 @@ fn validate_cluster_header(
             diagnostics.push(Diagnostic::error(
                 "unsupported_state_backend",
                 "state.backend",
-                "Stage 2A supports only omitted state.backend or `cluster`",
+                "Stage 2B supports only omitted state.backend or `cluster`",
             ));
         }
     }
@@ -620,7 +834,10 @@ impl LocalStateBackend {
         let text = match fs::read_to_string(&self.state_path) {
             Ok(text) => text,
             Err(err) if err.kind() == ErrorKind::NotFound => {
-                return Ok(StateSnapshot { state: None });
+                return Ok(StateSnapshot {
+                    state: None,
+                    state_cas: None,
+                });
             }
             Err(err) => {
                 return Err(Diagnostic::error(
@@ -632,7 +849,8 @@ impl LocalStateBackend {
         };
 
         observations.state_found = true;
-        observations.state_cas = Some(format!("sha256:{}", sha256_hex(text.as_bytes())));
+        let state_cas = format!("sha256:{}", sha256_hex(text.as_bytes()));
+        observations.state_cas = Some(state_cas.clone());
 
         let state = serde_json::from_str::<ClusterState>(&text).map_err(|err| {
             Diagnostic::error(
@@ -657,7 +875,109 @@ impl LocalStateBackend {
         observations.state_revision = state.state_revision;
         observations.resource_count = state.applied_revision.resources.len();
 
-        Ok(StateSnapshot { state: Some(state) })
+        Ok(StateSnapshot {
+            state: Some(state),
+            state_cas: Some(state_cas),
+        })
+    }
+
+    fn write_state(
+        &self,
+        state: &ClusterState,
+        expected_cas: Option<&str>,
+        observations: &mut StateObservations,
+    ) -> Result<(), Diagnostic> {
+        fs::create_dir_all(&self.state_dir).map_err(|err| {
+            Diagnostic::error(
+                "state_write_error",
+                CLUSTER_STATE_DIR,
+                format!("could not create cluster state directory: {err}"),
+            )
+        })?;
+
+        let current_cas = self.current_state_cas()?;
+        if current_cas.as_deref() != expected_cas {
+            return Err(Diagnostic::error(
+                "state_cas_mismatch",
+                CLUSTER_STATE_FILE,
+                "state.json changed while the command was running; re-run the command against the latest state",
+            ));
+        }
+
+        let mut payload = serde_json::to_string_pretty(state).map_err(|err| {
+            Diagnostic::error(
+                "state_write_error",
+                CLUSTER_STATE_FILE,
+                format!("could not encode state JSON: {err}"),
+            )
+        })?;
+        payload.push('\n');
+
+        let tmp_path = self
+            .state_dir
+            .join(format!("state.json.tmp.{}", Ulid::new()));
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp_path)
+            .map_err(|err| {
+                Diagnostic::error(
+                    "state_write_error",
+                    display_path(&tmp_path),
+                    format!("could not create temporary state file: {err}"),
+                )
+            })?;
+        file.write_all(payload.as_bytes()).map_err(|err| {
+            Diagnostic::error(
+                "state_write_error",
+                display_path(&tmp_path),
+                format!("could not write temporary state file: {err}"),
+            )
+        })?;
+        file.sync_all().map_err(|err| {
+            Diagnostic::error(
+                "state_write_error",
+                display_path(&tmp_path),
+                format!("could not sync temporary state file: {err}"),
+            )
+        })?;
+        drop(file);
+
+        if let Err(err) = fs::rename(&tmp_path, &self.state_path) {
+            let _ = fs::remove_file(&tmp_path);
+            return Err(Diagnostic::error(
+                "state_write_error",
+                CLUSTER_STATE_FILE,
+                format!("could not replace state.json atomically: {err}"),
+            ));
+        }
+
+        let written = fs::read_to_string(&self.state_path).map_err(|err| {
+            Diagnostic::error(
+                "state_write_error",
+                CLUSTER_STATE_FILE,
+                format!("could not read state.json after write: {err}"),
+            )
+        })?;
+        observations.state_found = true;
+        observations.applied_config_digest = state.applied_revision.config_digest.clone();
+        observations.state_revision = state.state_revision;
+        observations.state_cas = Some(format!("sha256:{}", sha256_hex(written.as_bytes())));
+        observations.resource_count = state.applied_revision.resources.len();
+
+        Ok(())
+    }
+
+    fn current_state_cas(&self) -> Result<Option<String>, Diagnostic> {
+        match fs::read(&self.state_path) {
+            Ok(bytes) => Ok(Some(format!("sha256:{}", sha256_hex(&bytes)))),
+            Err(err) if err.kind() == ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(Diagnostic::error(
+                "state_read_error",
+                CLUSTER_STATE_FILE,
+                format!("could not read state file for CAS check: {err}"),
+            )),
+        }
     }
 
     fn acquire_lock(
@@ -787,6 +1107,247 @@ fn state_resource_digests(state: &ClusterState) -> BTreeMap<String, String> {
         .iter()
         .map(|(address, resource)| (address.clone(), resource.digest.clone()))
         .collect()
+}
+
+fn initial_import_state(desired: &DesiredCluster) -> ClusterState {
+    ClusterState {
+        version: 1,
+        state_revision: 0,
+        applied_revision: AppliedRevisionState {
+            config_digest: Some(desired.config_digest.clone()),
+            resources: BTreeMap::new(),
+        },
+        resource_statuses: BTreeMap::new(),
+        approval_records: BTreeMap::new(),
+        recovery_records: BTreeMap::new(),
+        observations: BTreeMap::new(),
+    }
+}
+
+async fn observe_declared_graphs(desired: &DesiredCluster, state: &mut ClusterState) -> usize {
+    let mut graph_error_count = 0;
+    for graph in &desired.graphs {
+        let graph_address = graph_address(&graph.id);
+        let schema_address = schema_address(&graph.id);
+        let graph_path = desired
+            .config_dir
+            .join(CLUSTER_GRAPHS_DIR)
+            .join(format!("{}.omni", graph.id));
+        let graph_uri = display_path(&graph_path);
+        let observed_at = now_rfc3339();
+
+        if !graph_path.exists() {
+            state.applied_revision.resources.remove(&graph_address);
+            state.applied_revision.resources.remove(&schema_address);
+            state.observations.insert(
+                graph_address.clone(),
+                graph_observation_json(GraphObservationJson {
+                    address: &graph_address,
+                    graph_uri: &graph_uri,
+                    observed_at: &observed_at,
+                    exists: false,
+                    manifest_version: None,
+                    schema_digest: None,
+                    desired_schema_digest: &graph.schema_digest,
+                    schema_matches_desired: Some(false),
+                    error: Some("derived graph root is missing"),
+                }),
+            );
+            set_resource_status(
+                state,
+                &graph_address,
+                ResourceLifecycleStatus::Drifted,
+                "graph_missing",
+                "derived graph root is missing",
+            );
+            set_resource_status(
+                state,
+                &schema_address,
+                ResourceLifecycleStatus::Drifted,
+                "graph_missing",
+                "derived graph root is missing",
+            );
+            continue;
+        }
+
+        match observe_live_graph(&graph_uri).await {
+            Ok(observation) => {
+                let schema_matches = observation.schema_digest == graph.schema_digest;
+                state.applied_revision.resources.insert(
+                    schema_address.clone(),
+                    StateResource {
+                        digest: observation.schema_digest.clone(),
+                    },
+                );
+                let query_digests = state_query_digests_for_graph(state, &graph.id);
+                let graph_digest_value = graph_digest(
+                    &graph.id,
+                    Some(&observation.schema_digest),
+                    Some(&query_digests),
+                );
+                state.applied_revision.resources.insert(
+                    graph_address.clone(),
+                    StateResource {
+                        digest: graph_digest_value,
+                    },
+                );
+                state.observations.insert(
+                    graph_address.clone(),
+                    graph_observation_json(GraphObservationJson {
+                        address: &graph_address,
+                        graph_uri: &graph_uri,
+                        observed_at: &observed_at,
+                        exists: true,
+                        manifest_version: Some(observation.manifest_version),
+                        schema_digest: Some(observation.schema_digest.as_str()),
+                        desired_schema_digest: &graph.schema_digest,
+                        schema_matches_desired: Some(schema_matches),
+                        error: None,
+                    }),
+                );
+                if schema_matches {
+                    set_resource_status_applied(state, &graph_address);
+                    set_resource_status_applied(state, &schema_address);
+                } else {
+                    set_resource_status(
+                        state,
+                        &graph_address,
+                        ResourceLifecycleStatus::Drifted,
+                        "schema_mismatch",
+                        "live schema digest differs from desired schema digest",
+                    );
+                    set_resource_status(
+                        state,
+                        &schema_address,
+                        ResourceLifecycleStatus::Drifted,
+                        "schema_mismatch",
+                        "live schema digest differs from desired schema digest",
+                    );
+                }
+            }
+            Err(error) => {
+                graph_error_count += 1;
+                state.observations.insert(
+                    graph_address.clone(),
+                    graph_observation_json(GraphObservationJson {
+                        address: &graph_address,
+                        graph_uri: &graph_uri,
+                        observed_at: &observed_at,
+                        exists: true,
+                        manifest_version: None,
+                        schema_digest: None,
+                        desired_schema_digest: &graph.schema_digest,
+                        schema_matches_desired: None,
+                        error: Some(error.as_str()),
+                    }),
+                );
+                set_resource_status(
+                    state,
+                    &graph_address,
+                    ResourceLifecycleStatus::Error,
+                    "graph_observation_error",
+                    error.as_str(),
+                );
+                set_resource_status(
+                    state,
+                    &schema_address,
+                    ResourceLifecycleStatus::Error,
+                    "graph_observation_error",
+                    error.as_str(),
+                );
+            }
+        }
+    }
+    graph_error_count
+}
+
+struct LiveGraphObservation {
+    manifest_version: u64,
+    schema_digest: String,
+}
+
+async fn observe_live_graph(graph_uri: &str) -> Result<LiveGraphObservation, String> {
+    let db = Omnigraph::open_read_only(graph_uri)
+        .await
+        .map_err(|err| err.to_string())?;
+    let snapshot = db
+        .snapshot_of(ReadTarget::branch("main"))
+        .await
+        .map_err(|err| err.to_string())?;
+    let schema_source = db.schema_source();
+    Ok(LiveGraphObservation {
+        manifest_version: snapshot.version(),
+        schema_digest: sha256_hex(schema_source.as_bytes()),
+    })
+}
+
+struct GraphObservationJson<'a> {
+    address: &'a str,
+    graph_uri: &'a str,
+    observed_at: &'a str,
+    exists: bool,
+    manifest_version: Option<u64>,
+    schema_digest: Option<&'a str>,
+    desired_schema_digest: &'a str,
+    schema_matches_desired: Option<bool>,
+    error: Option<&'a str>,
+}
+
+fn graph_observation_json(observation: GraphObservationJson<'_>) -> serde_json::Value {
+    json!({
+        "kind": "graph",
+        "address": observation.address,
+        "graph_uri": observation.graph_uri,
+        "observed_at": observation.observed_at,
+        "exists": observation.exists,
+        "manifest_version": observation.manifest_version,
+        "schema_digest": observation.schema_digest,
+        "desired_schema_digest": observation.desired_schema_digest,
+        "schema_matches_desired": observation.schema_matches_desired,
+        "error": observation.error,
+    })
+}
+
+fn state_query_digests_for_graph(state: &ClusterState, graph_id: &str) -> BTreeMap<String, String> {
+    let prefix = format!("query.{graph_id}.");
+    state
+        .applied_revision
+        .resources
+        .iter()
+        .filter_map(|(address, resource)| {
+            address
+                .strip_prefix(&prefix)
+                .map(|name| (name.to_string(), resource.digest.clone()))
+        })
+        .collect()
+}
+
+fn set_resource_status_applied(state: &mut ClusterState, address: &str) {
+    state.resource_statuses.insert(
+        address.to_string(),
+        ResourceStatusRecord {
+            status: ResourceLifecycleStatus::Applied,
+            conditions: Vec::new(),
+            message: None,
+        },
+    );
+}
+
+fn set_resource_status(
+    state: &mut ClusterState,
+    address: &str,
+    status: ResourceLifecycleStatus,
+    condition: &str,
+    message: &str,
+) {
+    state.resource_statuses.insert(
+        address.to_string(),
+        ResourceStatusRecord {
+            status,
+            conditions: vec![condition.to_string()],
+            message: Some(message.to_string()),
+        },
+    );
 }
 
 fn load_desired(config_dir: &Path) -> LoadOutcome {
@@ -1019,6 +1580,17 @@ fn load_desired(config_dir: &Path) -> LoadOutcome {
         resource_list.push(resource);
     }
     let dependencies: Vec<_> = dependencies.into_iter().collect();
+    let graphs = raw
+        .graphs
+        .keys()
+        .map(|graph_id| DesiredGraph {
+            id: graph_id.clone(),
+            schema_digest: graph_schema_digests
+                .get(graph_id)
+                .cloned()
+                .unwrap_or_default(),
+        })
+        .collect();
     let config_digest = desired_config_digest(&raw, &resource_digests);
 
     LoadOutcome {
@@ -1026,6 +1598,7 @@ fn load_desired(config_dir: &Path) -> LoadOutcome {
             config_dir: config_dir.clone(),
             config_digest,
             state_lock: settings.state_lock,
+            graphs,
             resource_digests,
             resources: resource_list,
             dependencies,
@@ -1365,11 +1938,26 @@ fn desired_config_digest(
 
 fn sha256_hex(bytes: &[u8]) -> String {
     let digest = Sha256::digest(bytes);
+    const HEX: &[u8; 16] = b"0123456789abcdef";
     let mut out = String::with_capacity(digest.len() * 2);
     for byte in digest {
-        out.push_str(&format!("{byte:02x}"));
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
     }
     out
+}
+
+fn now_rfc3339() -> String {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())
+}
+
+fn state_sync_operation_label(operation: StateSyncOperation) -> &'static str {
+    match operation {
+        StateSyncOperation::Refresh => "refresh",
+        StateSyncOperation::Import => "import",
+    }
 }
 
 fn has_errors(diagnostics: &[Diagnostic]) -> bool {
@@ -1385,7 +1973,9 @@ fn display_path(path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::path::Path;
 
+    use omnigraph::db::Omnigraph;
     use serde_json::json;
     use tempfile::tempdir;
 
@@ -1433,6 +2023,15 @@ policies:
         )
         .unwrap();
         dir
+    }
+
+    async fn init_derived_graph(root: &Path) {
+        let graph_dir = root.join(CLUSTER_GRAPHS_DIR);
+        fs::create_dir_all(&graph_dir).unwrap();
+        let graph = graph_dir.join("knowledge.omni");
+        Omnigraph::init(graph.to_string_lossy().as_ref(), SCHEMA)
+            .await
+            .unwrap();
     }
 
     #[test]
@@ -1905,5 +2504,281 @@ graphs:
                 .iter()
                 .any(|diagnostic| diagnostic.code == "unsupported_state_backend")
         );
+    }
+
+    #[tokio::test]
+    async fn import_missing_state_creates_state_with_graph_observation() {
+        let dir = fixture();
+        init_derived_graph(dir.path()).await;
+
+        let out = import_config_dir(dir.path()).await;
+        assert!(out.ok, "{:?}", out.diagnostics);
+        assert_eq!(out.state_observations.state_revision, 1);
+        assert!(out.state_observations.state_cas.is_some());
+        assert!(!out.state_observations.locked);
+        assert!(out.state_observations.lock_acquired);
+        assert!(out.state_observations.acquired_lock_id.is_some());
+        assert!(!dir.path().join(CLUSTER_LOCK_FILE).exists());
+        assert_eq!(
+            out.resource_digests
+                .get("schema.knowledge")
+                .map(String::as_str),
+            Some(sha256_hex(SCHEMA.as_bytes()).as_str())
+        );
+        assert!(out.observations["graph.knowledge"]["manifest_version"].is_number());
+        assert_eq!(
+            out.observations["graph.knowledge"]["schema_matches_desired"],
+            true
+        );
+
+        let state: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(dir.path().join(CLUSTER_STATE_FILE)).unwrap())
+                .unwrap();
+        assert_eq!(state["state_revision"], 1);
+        assert_eq!(
+            state["resource_statuses"]["graph.knowledge"]["status"],
+            "applied"
+        );
+    }
+
+    #[tokio::test]
+    async fn import_existing_state_fails() {
+        let dir = fixture();
+        let state_dir = dir.path().join(CLUSTER_STATE_DIR);
+        fs::create_dir_all(&state_dir).unwrap();
+        fs::write(
+            state_dir.join("state.json"),
+            r#"{"version":1,"applied_revision":{"resources":{}}}"#,
+        )
+        .unwrap();
+
+        let out = import_config_dir(dir.path()).await;
+        assert!(!out.ok);
+        assert!(
+            out.diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "state_already_exists")
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_missing_state_fails() {
+        let dir = fixture();
+        let out = refresh_config_dir(dir.path()).await;
+        assert!(!out.ok);
+        assert!(
+            out.diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "state_missing")
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_existing_minimal_state_increments_revision_and_updates_cas() {
+        let dir = fixture();
+        init_derived_graph(dir.path()).await;
+        let state_dir = dir.path().join(CLUSTER_STATE_DIR);
+        fs::create_dir_all(&state_dir).unwrap();
+        fs::write(
+            state_dir.join("state.json"),
+            r#"{"version":1,"applied_revision":{"config_digest":"old","resources":{"graph.knowledge":{"digest":"old"}}}}"#,
+        )
+        .unwrap();
+
+        let out = refresh_config_dir(dir.path()).await;
+        assert!(out.ok, "{:?}", out.diagnostics);
+        assert_eq!(out.state_observations.state_revision, 1);
+        assert!(out.state_observations.state_cas.is_some());
+        assert!(!out.state_observations.locked);
+        assert!(out.state_observations.lock_acquired);
+        assert_eq!(
+            out.resource_statuses["graph.knowledge"].status,
+            ResourceLifecycleStatus::Applied
+        );
+        assert!(!dir.path().join(CLUSTER_LOCK_FILE).exists());
+    }
+
+    #[tokio::test]
+    async fn refresh_records_live_schema_digest_and_manifest_version() {
+        let dir = fixture();
+        init_derived_graph(dir.path()).await;
+        let state_dir = dir.path().join(CLUSTER_STATE_DIR);
+        fs::create_dir_all(&state_dir).unwrap();
+        fs::write(
+            state_dir.join("state.json"),
+            r#"{"version":1,"state_revision":4,"applied_revision":{"resources":{}}}"#,
+        )
+        .unwrap();
+
+        let out = refresh_config_dir(dir.path()).await;
+        assert!(out.ok, "{:?}", out.diagnostics);
+        assert_eq!(out.state_observations.state_revision, 5);
+        assert_eq!(
+            out.observations["graph.knowledge"]["schema_digest"],
+            sha256_hex(SCHEMA.as_bytes())
+        );
+        assert!(out.observations["graph.knowledge"]["manifest_version"].is_u64());
+    }
+
+    #[tokio::test]
+    async fn missing_derived_graph_root_marks_drifted_and_plans_creates() {
+        let dir = fixture();
+        let state_dir = dir.path().join(CLUSTER_STATE_DIR);
+        fs::create_dir_all(&state_dir).unwrap();
+        fs::write(
+            state_dir.join("state.json"),
+            r#"{"version":1,"applied_revision":{"resources":{"graph.knowledge":{"digest":"old-graph"},"schema.knowledge":{"digest":"old-schema"}}}}"#,
+        )
+        .unwrap();
+
+        let out = refresh_config_dir(dir.path()).await;
+        assert!(out.ok, "{:?}", out.diagnostics);
+        assert_eq!(
+            out.resource_statuses["graph.knowledge"].status,
+            ResourceLifecycleStatus::Drifted
+        );
+        assert!(!out.resource_digests.contains_key("graph.knowledge"));
+        assert_eq!(out.observations["graph.knowledge"]["exists"], false);
+
+        let plan = plan_config_dir(dir.path());
+        assert!(plan.ok, "{:?}", plan.diagnostics);
+        assert!(plan.changes.iter().any(|change| {
+            change.resource == "graph.knowledge" && change.operation == PlanOperation::Create
+        }));
+        assert!(plan.changes.iter().any(|change| {
+            change.resource == "schema.knowledge" && change.operation == PlanOperation::Create
+        }));
+    }
+
+    #[tokio::test]
+    async fn live_schema_mismatch_marks_drifted_and_causes_plan_update() {
+        let dir = fixture();
+        init_derived_graph(dir.path()).await;
+        fs::write(
+            dir.path().join("people.pg"),
+            SCHEMA.replace("age: I32?", "age: I32?\n  nickname: String?"),
+        )
+        .unwrap();
+        let state_dir = dir.path().join(CLUSTER_STATE_DIR);
+        fs::create_dir_all(&state_dir).unwrap();
+        fs::write(
+            state_dir.join("state.json"),
+            r#"{"version":1,"applied_revision":{"resources":{"graph.knowledge":{"digest":"old-graph"},"schema.knowledge":{"digest":"old-schema"}}}}"#,
+        )
+        .unwrap();
+
+        let out = refresh_config_dir(dir.path()).await;
+        assert!(out.ok, "{:?}", out.diagnostics);
+        assert_eq!(
+            out.resource_statuses["schema.knowledge"].status,
+            ResourceLifecycleStatus::Drifted
+        );
+        assert_eq!(
+            out.observations["graph.knowledge"]["schema_matches_desired"],
+            false
+        );
+
+        let plan = plan_config_dir(dir.path());
+        assert!(plan.ok, "{:?}", plan.diagnostics);
+        assert!(plan.changes.iter().any(|change| {
+            change.resource == "schema.knowledge" && change.operation == PlanOperation::Update
+        }));
+    }
+
+    #[tokio::test]
+    async fn existing_lock_makes_refresh_fail() {
+        let dir = fixture();
+        let state_dir = dir.path().join(CLUSTER_STATE_DIR);
+        fs::create_dir_all(&state_dir).unwrap();
+        fs::write(
+            state_dir.join("state.json"),
+            r#"{"version":1,"applied_revision":{"resources":{}}}"#,
+        )
+        .unwrap();
+        fs::write(
+            state_dir.join("lock.json"),
+            r#"{"version":1,"lock_id":"held-lock","operation":"refresh","created_at":"2026-06-08T00:00:00Z","pid":123}"#,
+        )
+        .unwrap();
+
+        let out = refresh_config_dir(dir.path()).await;
+        assert!(!out.ok);
+        assert!(out.state_observations.locked);
+        assert_eq!(out.state_observations.lock_id.as_deref(), Some("held-lock"));
+        assert!(!out.state_observations.lock_acquired);
+        assert!(
+            out.diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "state_lock_held")
+        );
+    }
+
+    #[tokio::test]
+    async fn state_lock_false_bypasses_refresh_lock_with_warning() {
+        let dir = fixture();
+        init_derived_graph(dir.path()).await;
+        fs::write(
+            dir.path().join(CLUSTER_CONFIG_FILE),
+            r#"
+version: 1
+state:
+  backend: cluster
+  lock: false
+graphs:
+  knowledge:
+    schema: ./people.pg
+"#,
+        )
+        .unwrap();
+        let state_dir = dir.path().join(CLUSTER_STATE_DIR);
+        fs::create_dir_all(&state_dir).unwrap();
+        fs::write(
+            state_dir.join("state.json"),
+            r#"{"version":1,"applied_revision":{"resources":{}}}"#,
+        )
+        .unwrap();
+
+        let out = refresh_config_dir(dir.path()).await;
+        assert!(out.ok, "{:?}", out.diagnostics);
+        assert!(!out.state_observations.locked);
+        assert!(!out.state_observations.lock_acquired);
+        assert!(
+            out.diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "state_lock_disabled")
+        );
+    }
+
+    #[tokio::test]
+    async fn external_state_backend_refresh_rejected() {
+        let dir = fixture();
+        fs::write(
+            dir.path().join(CLUSTER_CONFIG_FILE),
+            "version: 1\nstate:\n  backend: s3://bucket/state\ngraphs: {}\n",
+        )
+        .unwrap();
+
+        let out = refresh_config_dir(dir.path()).await;
+        assert!(!out.ok);
+        assert!(
+            out.diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "unsupported_state_backend")
+        );
+    }
+
+    #[tokio::test]
+    async fn import_graph_open_error_does_not_create_state() {
+        let dir = fixture();
+        fs::create_dir_all(dir.path().join(CLUSTER_GRAPHS_DIR).join("knowledge.omni")).unwrap();
+
+        let out = import_config_dir(dir.path()).await;
+        assert!(!out.ok);
+        assert!(
+            out.diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "graph_observation_error")
+        );
+        assert!(!dir.path().join(CLUSTER_STATE_FILE).exists());
     }
 }

--- a/docs/dev/cluster-config-specs.md
+++ b/docs/dev/cluster-config-specs.md
@@ -5,6 +5,13 @@
 **Date:** 2026-06-07
 **Relationship:** generalizes today's `omnigraph.yaml` graph/query/policy configuration surface ([CLI reference](../user/cli-reference.md), [server docs](../user/server.md)) into a future cluster control plane. The distilled rules are in [cluster-axioms.md](cluster-axioms.md); detailed downstream implementation spec and blast-radius assessment in [cluster-config-implementation-spec.md](cluster-config-implementation-spec.md). This is a proposed architecture, not an implemented RFC.
 
+> **Implementation status.** The examples below describe the full target schema.
+> Stage 2B only accepts the read-only subset documented in
+> [cluster-config.md](../user/cluster-config.md). Future-phase fields such as
+> `env_file`, `apply`, `providers`, `pipelines`, `embeddings`, `ui`, `aliases`,
+> and `bindings` are intentionally rejected with typed diagnostics until their
+> reconciler semantics are implemented.
+
 > **Revision 2026-06-07 — full commitment to the Terraform paradigm.** Three changes from the earlier draft: (1) **state is an authoritative, locked ledger in a backend** (server-hosted *or* a separate cloud store), not "a mostly-rebuildable projection"; (2) `plan` is framed as the **CLI diff between local config and state**; (3) **ETL pipelines** (external data sources) are a first-class config asset — a second seam, alongside schema, where a definition triggers a data-plane effect. The full set of config assets (incl. **aliases**, **embeddings**) is enumerated below.
 
 ---

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -8,7 +8,7 @@ This file is the always-on map of the test surface. **Consult it before every ta
 |---|---|---|
 | `omnigraph` (engine) | `crates/omnigraph/tests/` | Integration tests (21 files), fixture-driven, share `tests/helpers/mod.rs` |
 | `omnigraph-cli` | `crates/omnigraph-cli/tests/` | `cli.rs` (unit-ish), `system_local.rs`, `system_remote.rs`, share `tests/support/mod.rs` |
-| `omnigraph-cluster` | mostly in-source `#[cfg(test)] mod tests` | Cluster config parser, local JSON state diff, state CAS/lock handling, read-only validate/plan/status |
+| `omnigraph-cluster` | mostly in-source `#[cfg(test)] mod tests` | Cluster config parser, local JSON state diff, state CAS/lock handling, read-only validate/plan/status plus explicit refresh/import graph observations |
 | `omnigraph-server` | `crates/omnigraph-server/tests/` | `server.rs` (HTTP-level), `openapi.rs` (OpenAPI drift / regeneration) |
 | `omnigraph-compiler` | mostly in-source `#[cfg(test)] mod tests` | Parser, type-checker, IR lowering, lint |
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -19,8 +19,7 @@ Top-level command families and subcommands. Graph-targeting commands accept eith
 | `commit list \| show` | inspect commit graph |
 | `schema plan \| apply \| show (alias: get)` | migrations |
 | `lint` (alias: `check`) | offline / graph-backed query validation. Replaces `query lint` / `query check`, which are kept as deprecated argv-level shims that print a one-line warning and rewrite to `omnigraph lint` |
-| `queries validate \| list` | operate on the server-side stored-query registry (the `queries:` block). `validate` type-checks every stored query against the live schema offline (opens the selected graph; exits non-zero on any breakage), catching schema drift without restarting the server; `list` prints the selected registry's query names, MCP exposure, and typed params. For per-graph registries, pass `--target <graph>` or set `cli.graph`; with no graph selection, `list` shows only top-level `queries:`. Distinct from `lint`, which validates a single `.gq` file |
-| `cluster validate \| plan \| status` | read-only cluster-control preview. `validate` checks a local `cluster.yaml` folder and referenced schema/query/policy files; `plan` diffs it against local JSON state at `__cluster/state.json` while briefly holding `__cluster/lock.json`; `status` reads the state ledger. No apply, graph open, live drift scan, server change, or `state.json` mutation occurs in Stage 2A |
+| `cluster validate \| plan \| status \| refresh \| import` | cluster-control preview. `validate` checks a local `cluster.yaml` folder and referenced schema/query/policy files; `plan` diffs it against local JSON state at `__cluster/state.json`; `status` reads the state ledger; `refresh`/`import` explicitly update local JSON state from read-only graph observations. No apply, graph-resource mutation, server change, or `plan --refresh` occurs in Stage 2B |
 | `optimize` | non-destructive Lance compaction (skips tables with `Blob` columns or uncovered drift; `--json` reports `skipped`) |
 | `repair [--confirm] [--force]` | preview or explicitly publish uncovered manifest/head drift. `--confirm` heals verified maintenance drift and exits non-zero if suspicious/unverifiable drift is refused; `--force --confirm` publishes suspicious/unverifiable drift after operator review |
 | `cleanup --keep N --older-than 7d --confirm` | destructive version GC |
@@ -80,16 +79,21 @@ policy:
 omnigraph cluster validate --config ./company-brain
 omnigraph cluster plan     --config ./company-brain --json
 omnigraph cluster status   --config ./company-brain --json
+omnigraph cluster refresh  --config ./company-brain --json
+omnigraph cluster import   --config ./company-brain --json
 ```
 
 `--config` is a directory containing `cluster.yaml`; it defaults to `.`.
-Stage 2A accepts graphs, schemas, stored queries, and policy bundle file
+Stage 2B accepts graphs, schemas, stored queries, and policy bundle file
 references. `cluster plan` reads local JSON state from
-`<config-dir>/__cluster/state.json`; a missing file means empty state. Plan
-acquires `__cluster/lock.json` by default and releases it before returning.
-`cluster status` reads state only and reports any existing lock. External state
-backends, apply, refresh/import, pipelines, UI specs, embeddings, aliases, and
-bindings are reserved for later stages. See [cluster-config.md](cluster-config.md).
+`<config-dir>/__cluster/state.json`; a missing file means empty state. Plan,
+refresh, and import acquire `__cluster/lock.json` by default and release it
+before returning. `cluster status` reads state only and reports any existing
+lock. `refresh` requires an existing `state.json`; `import` creates one only
+when it is missing. Both observe declared graphs read-only at
+`<config-dir>/graphs/<graph-id>.omni`. External state backends, apply,
+`plan --refresh`, pipelines, UI specs, embeddings, aliases, and bindings are
+reserved for later stages. See [cluster-config.md](cluster-config.md).
 
 ## Output formats (`query` command, alias: `read`)
 

--- a/docs/user/cluster-config.md
+++ b/docs/user/cluster-config.md
@@ -1,12 +1,13 @@
 # Cluster Config
 
-**Status:** Stage 2A read-only preview.
+**Status:** Stage 2B state-observation preview.
 
 Cluster config is the future control-plane configuration surface for a whole
 OmniGraph deployment. In this stage, OmniGraph can validate a local
-`cluster.yaml` folder, produce a deterministic read-only plan, and inspect the
-local JSON state ledger. It does not apply changes, open graph roots, scan live
-cluster state, start servers, or write graph resources.
+`cluster.yaml` folder, produce a deterministic read-only plan, inspect the
+local JSON state ledger, and explicitly refresh/import graph observations into
+that ledger. It does not apply desired changes, start servers, or write graph
+resources.
 
 ## Commands
 
@@ -14,6 +15,8 @@ cluster state, start servers, or write graph resources.
 omnigraph cluster validate --config ./company-brain
 omnigraph cluster plan     --config ./company-brain --json
 omnigraph cluster status   --config ./company-brain --json
+omnigraph cluster refresh  --config ./company-brain --json
+omnigraph cluster import   --config ./company-brain --json
 ```
 
 `--config` points at a directory, not a file. The directory must contain
@@ -21,7 +24,7 @@ omnigraph cluster status   --config ./company-brain --json
 
 ## Supported `cluster.yaml`
 
-Stage 2A accepts only the read-only resource subset:
+Stage 2B accepts only the read-only resource subset:
 
 ```yaml
 version: 1
@@ -47,10 +50,10 @@ policies:
 
 `metadata.name` is a display label. `state.backend` may be omitted or set to
 `cluster`; external state backends are reserved for a later stage. `state.lock`
-defaults to `true`. When enabled, `cluster plan` briefly acquires
-`<config-dir>/__cluster/lock.json` while it reads state, then removes it before
-returning. `cluster status` never acquires the lock; it only reports whether one
-is present.
+defaults to `true`. When enabled, `cluster plan`, `cluster refresh`, and
+`cluster import` briefly acquire `<config-dir>/__cluster/lock.json`, then remove
+it before returning. `cluster status` never acquires the lock; it only reports
+whether one is present.
 
 ## Validation
 
@@ -115,8 +118,10 @@ and reports `create`, `update`, and `delete` changes. It also reports the state
 CAS (`sha256:<digest>`) and state revision. `state_observations.locked` means an
 existing lock file was observed; a successful `plan` instead reports
 `lock_acquired: true` and an `acquired_lock_id`, then releases the lock before
-returning. The command never writes `state.json`; apply, refresh, import, and
-live drift scans are later-stage work.
+returning. The command never writes `state.json` and does not scan live graphs.
+Use explicit `cluster refresh` / `cluster import` when the state ledger should
+be updated from live observations. Apply and live drift scans during plan are
+later-stage work.
 
 ## Status
 
@@ -124,3 +129,24 @@ live drift scans are later-stage work.
 ledger says is deployed. It does not validate referenced schema/query/policy
 files and does not inspect live graphs. Missing `state.json` succeeds with a
 warning; invalid state JSON or an unsupported state version fails.
+
+## Refresh And Import
+
+`cluster refresh` updates an existing `state.json` from actual observations.
+`cluster import` creates the first `state.json` when the ledger is missing.
+Both commands open declared graphs read-only at:
+
+```text
+<config-dir>/graphs/<graph-id>.omni
+```
+
+They observe only branch `main`, recording graph existence, manifest version,
+live schema digest, desired schema digest, and schema-match status under
+`observations["graph.<id>"]`. Missing graph roots are recorded as drift and
+remove the graph/schema digests from state so a later `plan` proposes creates.
+Invalid graph roots are recorded as errors; `refresh` persists the error
+observation and exits non-zero, while `import` exits non-zero without creating
+initial state.
+
+Refresh/import do not observe query or policy resources yet. Existing query and
+policy state digests are preserved on refresh and are not invented on import.


### PR DESCRIPTION
## Summary

- Adds explicit `omnigraph cluster refresh` and `omnigraph cluster import` commands.
- Uses `Omnigraph::open_read_only` against derived `<config-dir>/graphs/<graph_id>.omni` roots to observe declared graphs on `main`.
- Writes local JSON state through the backend path with lock/CAS/atomic replacement and post-write CAS reporting.
- Extends `status --json` to include persisted observations and keeps `plan` as config-vs-state only, with no live refresh.

## Scope

This is Stage 2B only. It does **not** add apply, `plan --refresh`, server changes, external state backends, graph/resource mutation, or force-unlock.

## Validation

- `cargo test -p omnigraph-cluster`
- `cargo test -p omnigraph-cli --test cli cluster`
- `scripts/check-agents-md.sh`
- `cargo fmt -p omnigraph-cluster -- --check`
- `git diff --check origin/main..HEAD`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `omnigraph cluster refresh` and `omnigraph cluster import` commands (Stage 2B), enabling explicit state-ledger updates from read-only graph observations at `<config-dir>/graphs/<graph-id>.omni`. It also extends `status --json` to surface persisted observations and wires the new async `sync_config_dir` path through lock/CAS/atomic-rename state writes.

- `sync_config_dir` in `omnigraph-cluster` implements both operations with CAS-protected atomic rename writes, lock acquisition, and observation recording for missing/live/error graph roots.
- `observe_declared_graphs` opens each declared graph read-only on `main`, compares the live schema digest against the desired digest, and writes drift or applied status back into `ClusterState`.
- CLI, tests, and user docs are all updated in the same change per AGENTS.md rule 1.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the new commands are additive, the write path uses atomic rename + CAS, and test coverage is thorough.

The change is well-scoped to Stage 2B: it adds two new commands, does not mutate graph resources, and the existing plan/status paths are unchanged. The two issues in write_state (orphaned temp file and misleading failure report on post-write re-read) are both narrow, low-probability edge cases that don't affect the happy path or cause data loss.

crates/omnigraph-cluster/src/lib.rs — specifically the write_state function's error cleanup paths.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/omnigraph-cluster/src/lib.rs | Core new logic: sync_config_dir, observe_declared_graphs, write_state, observe_live_graph. Two resource/reporting issues in write_state: temp file not cleaned up on write/sync failure, and post-write re-read failure falsely reports the operation as failed. |
| crates/omnigraph-cli/src/main.rs | Adds Refresh and Import ClusterCommand variants, print_cluster_state_sync_human, finish_cluster_state_sync helpers, and dispatches to refresh_config_dir / import_config_dir. Clean, consistent with existing plan/status patterns. |
| crates/omnigraph-cli/tests/cli.rs | Good integration tests covering happy paths (import bootstrap, refresh revision increment), error paths (missing/existing state, locked state), and edge cases (lock bypass, external backend). Coverage is thorough for Stage 2B scope. |
| crates/omnigraph-cluster/Cargo.toml | Adds omnigraph-engine and tokio dependencies needed for the new async graph observation path. tokio is correctly placed in dev-dependencies as well for tests. |
| docs/user/cli-reference.md | Updates cluster command table and prose for Stage 2B. Previously-noted deletion of the queries validate | list row is unresolved. |
| docs/user/cluster-config.md | Adds Refresh And Import section, updates stage label to 2B, and clarifies lock behavior. Documentation is accurate and consistent with the implementation. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as omnigraph CLI
    participant SCD as sync_config_dir
    participant LSB as LocalStateBackend
    participant ODG as observe_declared_graphs
    participant OLG as observe_live_graph
    participant FS as Filesystem

    CLI->>SCD: refresh_config_dir / import_config_dir
    SCD->>SCD: load_desired (parse cluster.yaml)
    SCD->>LSB: observations()
    SCD->>LSB: acquire_lock(operation_label)
    LSB->>FS: create __cluster/lock.json
    LSB-->>SCD: LockGuard
    SCD->>LSB: read_state()
    LSB->>FS: read __cluster/state.json
    LSB-->>SCD: StateSnapshot (state, state_cas)
    SCD->>SCD: match (operation, snapshot.state)
    Note over SCD: Refresh needs existing state / Import needs missing state
    SCD->>ODG: observe_declared_graphs(desired, state)
    loop for each declared graph
        ODG->>FS: check graphs/id.omni exists
        alt graph exists
            ODG->>OLG: observe_live_graph(graph_uri)
            OLG->>FS: Omnigraph::open_read_only
            OLG->>FS: snapshot_of(branch main)
            OLG-->>ODG: LiveGraphObservation (version, schema_digest)
        else graph missing
            ODG->>ODG: record Drifted status
        end
    end
    SCD->>SCD: bump state_revision
    SCD->>LSB: write_state(state, expected_cas)
    LSB->>LSB: current_state_cas() CAS check
    LSB->>FS: write state.json.tmp.ulid
    LSB->>FS: rename tmp to state.json (atomic)
    LSB->>FS: read state.json (post-write CAS)
    LSB-->>SCD: Ok(())
    SCD-->>CLI: StateSyncOutput
    Note over LSB,FS: LockGuard drop removes lock.json
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `crates/omnigraph-cluster/src/lib.rs`, line 862-893 ([link](https://github.com/modernrelay/omnigraph/blob/b3abc2d8e53b78a67ac5158183e35f302c05701f/crates/omnigraph-cluster/src/lib.rs#L862-L893)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`schema_matches_desired: Some(false)` for missing graph conflates absence with mismatch**

   When the graph file is not present on disk, `schema_matches_desired` is set to `Some(false)`. The error observation path correctly uses `None` when the match status is genuinely unknowable. A missing file is also unknowable — there is no live schema to compare — so `None` would be more accurate here. Downstream consumers or future stages filtering specifically on `schema_matches_desired == false` (to plan an update) would incorrectly match missing-graph cases, which should instead produce a `create` plan operation. The `exists: false` field already signals the absence.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fomnigraph-cluster%2Fsrc%2Flib.rs%0ALine%3A%20862-893%0A%0AComment%3A%0A**%60schema_matches_desired%3A%20Some%28false%29%60%20for%20missing%20graph%20conflates%20absence%20with%20mismatch**%0A%0AWhen%20the%20graph%20file%20is%20not%20present%20on%20disk%2C%20%60schema_matches_desired%60%20is%20set%20to%20%60Some%28false%29%60.%20The%20error%20observation%20path%20correctly%20uses%20%60None%60%20when%20the%20match%20status%20is%20genuinely%20unknowable.%20A%20missing%20file%20is%20also%20unknowable%20%E2%80%94%20there%20is%20no%20live%20schema%20to%20compare%20%E2%80%94%20so%20%60None%60%20would%20be%20more%20accurate%20here.%20Downstream%20consumers%20or%20future%20stages%20filtering%20specifically%20on%20%60schema_matches_desired%20%3D%3D%20false%60%20%28to%20plan%20an%20update%29%20would%20incorrectly%20match%20missing-graph%20cases%2C%20which%20should%20instead%20produce%20a%20%60create%60%20plan%20operation.%20The%20%60exists%3A%20false%60%20field%20already%20signals%20the%20absence.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modernrelay%2Fomnigraph&pr=159&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

2. `crates/omnigraph-cluster/src/lib.rs`, line 850-984 ([link](https://github.com/modernrelay/omnigraph/blob/b3abc2d8e53b78a67ac5158183e35f302c05701f/crates/omnigraph-cluster/src/lib.rs#L850-L984)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Graph observations are sequential; large clusters will stall**

   `observe_declared_graphs` awaits each `observe_live_graph` call in a serial loop. Every `.omni` graph open is an async operation that may involve object-store I/O. For a cluster with N graphs this is O(N) sequential network round-trips. Consider building a `FuturesUnordered` batch (or `tokio::task::JoinSet`) so all graphs are observed concurrently, writing results back into `state` after all futures resolve.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fomnigraph-cluster%2Fsrc%2Flib.rs%0ALine%3A%20850-984%0A%0AComment%3A%0A**Graph%20observations%20are%20sequential%3B%20large%20clusters%20will%20stall**%0A%0A%60observe_declared_graphs%60%20awaits%20each%20%60observe_live_graph%60%20call%20in%20a%20serial%20loop.%20Every%20%60.omni%60%20graph%20open%20is%20an%20async%20operation%20that%20may%20involve%20object-store%20I%2FO.%20For%20a%20cluster%20with%20N%20graphs%20this%20is%20O%28N%29%20sequential%20network%20round-trips.%20Consider%20building%20a%20%60FuturesUnordered%60%20batch%20%28or%20%60tokio%3A%3Atask%3A%3AJoinSet%60%29%20so%20all%20graphs%20are%20observed%20concurrently%2C%20writing%20results%20back%20into%20%60state%60%20after%20all%20futures%20resolve.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modernrelay%2Fomnigraph&pr=159&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fomnigraph-cluster%2Fsrc%2Flib.rs%3A777-792%0A**Temporary%20file%20left%20on%20disk%20when%20write%20or%20sync%20fails**%0A%0AWhen%20%60file.write_all%28...%29%60%20or%20%60file.sync_all%28%29%60%20returns%20an%20error%2C%20the%20%60%3F%60%20propagates%20the%20%60Diagnostic%60%20up%20and%20the%20function%20returns%20without%20cleaning%20up%20%60tmp_path%60.%20The%20%60let%20_%20%3D%20fs%3A%3Aremove_file%28%26tmp_path%29%60%20cleanup%20only%20fires%20on%20the%20%60fs%3A%3Arename%60%20failure%20branch.%20Any%20failed%20write%20or%20sync%20leaves%20a%20%60state.json.tmp.%3Culid%3E%60%20file%20in%20%60__cluster%2F%60%20indefinitely.%20In%20a%20transient-failure%20loop%20%28e.g.%2C%20repeated%20disk-full%20retries%29%2C%20these%20accumulate%20and%20can%20confuse%20operators%20inspecting%20the%20state%20directory.%20Add%20%60let%20_%20%3D%20fs%3A%3Aremove_file%28%26tmp_path%29%3B%60%20before%20each%20early%20%60return%20Err%28...%29%60%20in%20the%20write%2Fsync%20paths%2C%20or%20wrap%20%60tmp_path%60%20in%20a%20guard%20type%20that%20removes%20it%20on%20drop.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fomnigraph-cluster%2Fsrc%2Flib.rs%3A801-815%0A**Post-write%20re-read%20failure%20falsely%20reports%20the%20operation%20as%20failed**%0A%0AIf%20%60fs%3A%3Aread_to_string%28%26self.state_path%29%60%20fails%20after%20the%20%60fs%3A%3Arename%60%20succeeds%2C%20%60write_state%60%20returns%20%60Err%28...%29%60.%20The%20caller%20pushes%20the%20diagnostic%20and%20%60ok%60%20is%20set%20to%20%60false%60%20%E2%80%94%20but%20%60state.json%60%20was%20already%20atomically%20replaced%20on%20disk.%20A%20user%20seeing%20the%20error%20re-runs%20%60cluster%20refresh%60%2C%20which%20reads%20the%20newly-written%20state%2C%20increments%20the%20revision%20a%20second%20time%2C%20and%20writes%20it%20again%2C%20silently%20creating%20an%20extra%20revision.%20The%20post-write%20read%20is%20only%20needed%20to%20update%20%60observations.state_cas%60%3B%20if%20it%20fails%2C%20the%20code%20can%20fall%20back%20to%20hashing%20%60payload.as_bytes%28%29%60%20%28the%20bytes%20we%20just%20wrote%29%20rather%20than%20treating%20the%20failure%20as%20a%20fatal%20write%20error.%0A%0A&repo=modernrelay%2Fomnigraph&pr=159&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Implement cluster refresh and import"](https://github.com/modernrelay/omnigraph/commit/d00d42274e9e4408df9b4b80c98467da7ae6c0ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36477624)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=59169be6-01cf-4bae-80fc-604b6a708098))

<!-- /greptile_comment -->