### PR TITLE
feat(cluster): Stage 2C — exact-id cluster force-unlock + richer lock metadata

### DIFF
--- a/crates/omnigraph-cli/src/main.rs
+++ b/crates/omnigraph-cli/src/main.rs
@@ -11,8 +11,9 @@ use omnigraph::db::{Omnigraph, ReadTarget, SnapshotId};
 use omnigraph::loader::LoadMode;
 use omnigraph::storage::normalize_root_uri;
 use omnigraph_cluster::{
-    DiagnosticSeverity, PlanOutput, StateSyncOutput, StatusOutput, ValidateOutput,
-    import_config_dir, plan_config_dir, refresh_config_dir, status_config_dir, validate_config_dir,
+    DiagnosticSeverity, ForceUnlockOutput, PlanOutput, StateSyncOutput, StatusOutput,
+    ValidateOutput, force_unlock_config_dir, import_config_dir, plan_config_dir,
+    refresh_config_dir, status_config_dir, validate_config_dir,
 };
 use omnigraph_compiler::query::parser::parse_query;
 use omnigraph_compiler::schema::parser::parse_schema;
@@ -380,6 +381,17 @@ enum ClusterCommand {
     },
     /// Import initial local JSON state from declared graph observations.
     Import {
+        /// Cluster config directory containing cluster.yaml.
+        #[arg(long, default_value = ".")]
+        config: PathBuf,
+        /// Emit JSON instead of human text.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Remove a held local JSON state lock after operator confirmation.
+    ForceUnlock {
+        /// Exact lock id from cluster status or a state_lock_held diagnostic.
+        lock_id: String,
         /// Cluster config directory containing cluster.yaml.
         #[arg(long, default_value = ".")]
         config: PathBuf,
@@ -804,10 +816,7 @@ fn print_cluster_status_human(output: &StatusOutput) {
                 println!("  applied config: {digest}");
             }
             if state.locked {
-                match state.lock_id.as_deref() {
-                    Some(lock_id) => println!("  lock: held ({lock_id})"),
-                    None => println!("  lock: held"),
-                }
+                println!("  lock: held{}", cluster_lock_summary(state));
             } else {
                 println!("  lock: not held");
             }
@@ -835,10 +844,7 @@ fn print_cluster_state_sync_human(output: &StateSyncOutput) {
             println!("  state_cas: {cas}");
         }
         if state.locked {
-            match state.lock_id.as_deref() {
-                Some(lock_id) => println!("  lock: acquired ({lock_id})"),
-                None => println!("  lock: acquired"),
-            }
+            println!("  lock: acquired{}", cluster_lock_summary(state));
         } else {
             println!("  lock: not acquired");
         }
@@ -846,6 +852,48 @@ fn print_cluster_state_sync_human(output: &StateSyncOutput) {
         println!("cluster {operation} failed");
     }
     print_cluster_diagnostics(&output.diagnostics);
+}
+
+fn print_cluster_force_unlock_human(output: &ForceUnlockOutput) {
+    if output.ok {
+        if output.lock_removed {
+            println!(
+                "cluster force-unlock: removed lock{}",
+                cluster_lock_summary(&output.state_observations)
+            );
+        } else {
+            println!("cluster force-unlock: no lock removed");
+        }
+    } else {
+        println!("cluster force-unlock failed");
+        if output.state_observations.locked {
+            println!(
+                "  lock: held{}",
+                cluster_lock_summary(&output.state_observations)
+            );
+        }
+    }
+    print_cluster_diagnostics(&output.diagnostics);
+}
+
+fn cluster_lock_summary(state: &omnigraph_cluster::StateObservations) -> String {
+    let Some(lock_id) = state.lock_id.as_deref() else {
+        return String::new();
+    };
+    let mut parts = vec![format!("id={lock_id}")];
+    if let Some(operation) = state.lock_operation.as_deref() {
+        parts.push(format!("operation={operation}"));
+    }
+    if let Some(pid) = state.lock_pid {
+        parts.push(format!("pid={pid}"));
+    }
+    if let Some(created_at) = state.lock_created_at.as_deref() {
+        parts.push(format!("created_at={created_at}"));
+    }
+    if let Some(age_seconds) = state.lock_age_seconds {
+        parts.push(format!("age_seconds={age_seconds}"));
+    }
+    format!(" ({})", parts.join(", "))
 }
 
 fn print_cluster_diagnostics(diagnostics: &[omnigraph_cluster::Diagnostic]) {
@@ -905,6 +953,19 @@ fn finish_cluster_state_sync(output: &StateSyncOutput, json: bool) -> Result<()>
         print_json(output)?;
     } else {
         print_cluster_state_sync_human(output);
+    }
+    if !output.ok {
+        io::stdout().flush()?;
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+fn finish_cluster_force_unlock(output: &ForceUnlockOutput, json: bool) -> Result<()> {
+    if json {
+        print_json(output)?;
+    } else {
+        print_cluster_force_unlock_human(output);
     }
     if !output.ok {
         io::stdout().flush()?;
@@ -3442,6 +3503,14 @@ async fn main() -> Result<()> {
             ClusterCommand::Import { config, json } => {
                 let output = import_config_dir(config).await;
                 finish_cluster_state_sync(&output, json)?;
+            }
+            ClusterCommand::ForceUnlock {
+                lock_id,
+                config,
+                json,
+            } => {
+                let output = force_unlock_config_dir(config, lock_id);
+                finish_cluster_force_unlock(&output, json)?;
             }
         },
         Command::Graphs { command } => match command {

--- a/crates/omnigraph-cli/tests/cli.rs
+++ b/crates/omnigraph-cli/tests/cli.rs
@@ -156,6 +156,18 @@ fn init_cluster_derived_graph(root: &std::path::Path) {
     );
 }
 
+fn write_cluster_lock(root: &std::path::Path, lock_id: &str, operation: &str) {
+    let state_dir = root.join("__cluster");
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(
+        state_dir.join("lock.json"),
+        format!(
+            r#"{{"version":1,"lock_id":"{lock_id}","operation":"{operation}","created_at":"1970-01-01T00:00:00Z","pid":123}}"#
+        ),
+    )
+    .unwrap();
+}
+
 #[test]
 fn version_command_prints_current_cli_version() {
     let output = output_success(cli().arg("version"));
@@ -272,6 +284,32 @@ fn cluster_status_json_reports_missing_state() {
 }
 
 #[test]
+fn cluster_status_json_reports_lock_metadata() {
+    let temp = tempdir().unwrap();
+    write_cluster_config_fixture(temp.path());
+    write_cluster_lock(temp.path(), "held-lock", "refresh");
+
+    let json = parse_stdout_json(&output_success(
+        cli()
+            .arg("cluster")
+            .arg("status")
+            .arg("--config")
+            .arg(temp.path())
+            .arg("--json"),
+    ));
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["state_observations"]["locked"], true);
+    assert_eq!(json["state_observations"]["lock_id"], "held-lock");
+    assert_eq!(json["state_observations"]["lock_operation"], "refresh");
+    assert_eq!(json["state_observations"]["lock_pid"], 123);
+    assert_eq!(
+        json["state_observations"]["lock_created_at"],
+        "1970-01-01T00:00:00Z"
+    );
+    assert!(json["state_observations"]["lock_age_seconds"].is_number());
+}
+
+#[test]
 fn cluster_status_json_reports_extended_state() {
     let temp = tempdir().unwrap();
     write_cluster_config_fixture(temp.path());
@@ -372,21 +410,7 @@ fn cluster_plan_json_includes_state_cas_revision_and_lock_observation() {
 fn cluster_plan_locked_state_exits_nonzero() {
     let temp = tempdir().unwrap();
     write_cluster_config_fixture(temp.path());
-    let state_dir = temp.path().join("__cluster");
-    fs::create_dir_all(&state_dir).unwrap();
-    fs::write(
-        state_dir.join("lock.json"),
-        r#"
-{
-  "version": 1,
-  "lock_id": "held-lock",
-  "operation": "plan",
-  "created_at": "2026-06-08T00:00:00Z",
-  "pid": 123
-}
-"#,
-    )
-    .unwrap();
+    write_cluster_lock(temp.path(), "held-lock", "plan");
 
     let output = output_failure(
         cli()
@@ -401,14 +425,113 @@ fn cluster_plan_locked_state_exits_nonzero() {
     assert_eq!(json["state_observations"]["locked"], true);
     assert_eq!(json["state_observations"]["lock_acquired"], false);
     assert_eq!(json["state_observations"]["lock_id"], "held-lock");
+    assert_eq!(json["state_observations"]["lock_operation"], "plan");
+    assert_eq!(json["state_observations"]["lock_pid"], 123);
+    assert_eq!(
+        json["state_observations"]["lock_created_at"],
+        "1970-01-01T00:00:00Z"
+    );
+    assert!(json["state_observations"]["lock_age_seconds"].is_number());
     assert!(
         json["diagnostics"]
             .as_array()
             .unwrap()
             .iter()
-            .any(|diagnostic| diagnostic["code"] == "state_lock_held"),
+            .any(|diagnostic| diagnostic["code"] == "state_lock_held"
+                && diagnostic["message"]
+                    .as_str()
+                    .unwrap()
+                    .contains("force-unlock held-lock")),
         "locked state should produce a useful diagnostic: {json}"
     );
+}
+
+#[test]
+fn cluster_force_unlock_json_removes_lock() {
+    let temp = tempdir().unwrap();
+    write_cluster_config_fixture(temp.path());
+    write_cluster_lock(temp.path(), "held-lock", "plan");
+
+    let json = parse_stdout_json(&output_success(
+        cli()
+            .arg("cluster")
+            .arg("force-unlock")
+            .arg("held-lock")
+            .arg("--config")
+            .arg(temp.path())
+            .arg("--json"),
+    ));
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["lock_removed"], true);
+    assert_eq!(json["state_observations"]["lock_id"], "held-lock");
+    assert_eq!(json["state_observations"]["lock_operation"], "plan");
+    assert!(!temp.path().join("__cluster/lock.json").exists());
+}
+
+#[test]
+fn cluster_force_unlock_wrong_id_exits_nonzero() {
+    let temp = tempdir().unwrap();
+    write_cluster_config_fixture(temp.path());
+    write_cluster_lock(temp.path(), "held-lock", "plan");
+
+    let json = parse_stdout_json(&output_failure(
+        cli()
+            .arg("cluster")
+            .arg("force-unlock")
+            .arg("other-lock")
+            .arg("--config")
+            .arg(temp.path())
+            .arg("--json"),
+    ));
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["lock_removed"], false);
+    assert!(
+        json["diagnostics"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|diagnostic| diagnostic["code"] == "state_lock_id_mismatch")
+    );
+    assert!(temp.path().join("__cluster/lock.json").exists());
+}
+
+#[test]
+fn cluster_locked_plan_then_force_unlock_then_plan_succeeds() {
+    let temp = tempdir().unwrap();
+    write_cluster_config_fixture(temp.path());
+    write_cluster_lock(temp.path(), "held-lock", "plan");
+
+    let locked = parse_stdout_json(&output_failure(
+        cli()
+            .arg("cluster")
+            .arg("plan")
+            .arg("--config")
+            .arg(temp.path())
+            .arg("--json"),
+    ));
+    assert_eq!(locked["ok"], false);
+    assert_eq!(locked["state_observations"]["lock_id"], "held-lock");
+
+    let unlocked = parse_stdout_json(&output_success(
+        cli()
+            .arg("cluster")
+            .arg("force-unlock")
+            .arg("held-lock")
+            .arg("--config")
+            .arg(temp.path())
+            .arg("--json"),
+    ));
+    assert_eq!(unlocked["lock_removed"], true);
+
+    let planned = parse_stdout_json(&output_success(
+        cli()
+            .arg("cluster")
+            .arg("plan")
+            .arg("--config")
+            .arg(temp.path())
+            .arg("--json"),
+    ));
+    assert_eq!(planned["ok"], true);
 }
 
 #[test]

--- a/crates/omnigraph-cluster/src/lib.rs
+++ b/crates/omnigraph-cluster/src/lib.rs
@@ -110,6 +110,25 @@ pub struct StateObservations {
     pub lock_acquired: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub acquired_lock_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lock_operation: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lock_created_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lock_pid: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lock_age_seconds: Option<u64>,
+}
+
+impl StateObservations {
+    fn observe_lock_metadata(&mut self, lock: &StateLockFile) {
+        self.locked = true;
+        self.lock_id = Some(lock.lock_id.clone());
+        self.lock_operation = Some(lock.operation.clone());
+        self.lock_created_at = Some(lock.created_at.clone());
+        self.lock_pid = Some(lock.pid);
+        self.lock_age_seconds = lock_age_seconds(&lock.created_at);
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -205,6 +224,15 @@ pub struct StateSyncOutput {
     pub resource_digests: BTreeMap<String, String>,
     pub resource_statuses: BTreeMap<String, ResourceStatusRecord>,
     pub observations: BTreeMap<String, serde_json::Value>,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ForceUnlockOutput {
+    pub ok: bool,
+    pub config_dir: String,
+    pub state_observations: StateObservations,
+    pub lock_removed: bool,
     pub diagnostics: Vec<Diagnostic>,
 }
 
@@ -518,6 +546,35 @@ pub fn status_config_dir(config_dir: impl AsRef<Path>) -> StatusOutput {
     }
 }
 
+pub fn force_unlock_config_dir(
+    config_dir: impl AsRef<Path>,
+    lock_id: impl AsRef<str>,
+) -> ForceUnlockOutput {
+    let parsed = parse_cluster_config(config_dir.as_ref());
+    let mut diagnostics = parsed.diagnostics;
+    let backend = LocalStateBackend::new(&parsed.config_dir);
+    let mut observations = backend.observations();
+    let mut lock_removed = false;
+
+    if let Some(raw) = parsed.raw.as_ref() {
+        let _settings = validate_cluster_header(raw, &mut diagnostics);
+        if !has_errors(&diagnostics) {
+            match backend.force_unlock(lock_id.as_ref(), &mut observations) {
+                Ok(()) => lock_removed = true,
+                Err(diagnostic) => diagnostics.push(diagnostic),
+            }
+        }
+    }
+
+    ForceUnlockOutput {
+        ok: !has_errors(&diagnostics),
+        config_dir: display_path(&parsed.config_dir),
+        state_observations: observations,
+        lock_removed,
+        diagnostics,
+    }
+}
+
 pub async fn refresh_config_dir(config_dir: impl AsRef<Path>) -> StateSyncOutput {
     sync_config_dir(config_dir.as_ref(), StateSyncOperation::Refresh).await
 }
@@ -791,7 +848,7 @@ fn validate_cluster_header(
             diagnostics.push(Diagnostic::error(
                 "unsupported_state_backend",
                 "state.backend",
-                "Stage 2B supports only omitted state.backend or `cluster`",
+                "Stage 2C supports only omitted state.backend or `cluster`",
             ));
         }
     }
@@ -824,6 +881,10 @@ impl LocalStateBackend {
             lock_id: None,
             lock_acquired: false,
             acquired_lock_id: None,
+            lock_operation: None,
+            lock_created_at: None,
+            lock_pid: None,
+            lock_age_seconds: None,
         }
     }
 
@@ -1035,11 +1096,11 @@ impl LocalStateBackend {
                 })
             }
             Err(err) if err.kind() == ErrorKind::AlreadyExists => {
-                self.observe_lock_id(observations);
+                self.observe_lock_metadata_lossy(observations);
                 Err(Diagnostic::error(
                     "state_lock_held",
                     CLUSTER_LOCK_FILE,
-                    "cluster state lock already exists; remove it only after confirming no cluster operation is active",
+                    state_lock_held_message(observations),
                 ))
             }
             Err(err) => Err(Diagnostic::error(
@@ -1048,6 +1109,52 @@ impl LocalStateBackend {
                 format!("could not acquire state lock: {err}"),
             )),
         }
+    }
+
+    fn force_unlock(
+        &self,
+        requested_lock_id: &str,
+        observations: &mut StateObservations,
+    ) -> Result<(), Diagnostic> {
+        let text = match fs::read_to_string(&self.lock_path) {
+            Ok(text) => text,
+            Err(err) if err.kind() == ErrorKind::NotFound => {
+                return Err(Diagnostic::error(
+                    "state_lock_missing",
+                    CLUSTER_LOCK_FILE,
+                    "cluster state lock is not present; nothing was unlocked",
+                ));
+            }
+            Err(err) => {
+                return Err(Diagnostic::error(
+                    "state_lock_read_error",
+                    CLUSTER_LOCK_FILE,
+                    format!("could not read state lock: {err}"),
+                ));
+            }
+        };
+        observations.locked = true;
+        let lock = parse_lock_file_for_unlock(&text)?;
+        observations.observe_lock_metadata(&lock);
+
+        if lock.lock_id != requested_lock_id {
+            return Err(Diagnostic::error(
+                "state_lock_id_mismatch",
+                CLUSTER_LOCK_FILE,
+                format!(
+                    "cluster state lock id is {}; refusing to unlock with requested id {requested_lock_id}",
+                    lock.lock_id
+                ),
+            ));
+        }
+
+        fs::remove_file(&self.lock_path).map_err(|err| {
+            Diagnostic::error(
+                "state_unlock_error",
+                CLUSTER_LOCK_FILE,
+                format!("could not remove state lock: {err}"),
+            )
+        })
     }
 
     fn observe_lock(
@@ -1060,7 +1167,7 @@ impl LocalStateBackend {
             match fs::read_to_string(&self.lock_path) {
                 Ok(text) => match serde_json::from_str::<StateLockFile>(&text) {
                     Ok(lock) if lock.version == 1 => {
-                        observations.lock_id = Some(lock.lock_id);
+                        observations.observe_lock_metadata(&lock);
                     }
                     Ok(lock) => diagnostics.push(Diagnostic::warning(
                         "unsupported_state_lock_version",
@@ -1082,12 +1189,12 @@ impl LocalStateBackend {
         }
     }
 
-    fn observe_lock_id(&self, observations: &mut StateObservations) {
+    fn observe_lock_metadata_lossy(&self, observations: &mut StateObservations) {
         observations.locked = true;
         if let Ok(text) = fs::read_to_string(&self.lock_path) {
             if let Ok(lock) = serde_json::from_str::<StateLockFile>(&text) {
                 if lock.version == 1 {
-                    observations.lock_id = Some(lock.lock_id);
+                    observations.observe_lock_metadata(&lock);
                 }
             }
         }
@@ -1097,6 +1204,33 @@ impl LocalStateBackend {
 impl Drop for StateLockGuard {
     fn drop(&mut self) {
         let _ = fs::remove_file(&self.path);
+    }
+}
+
+fn parse_lock_file_for_unlock(text: &str) -> Result<StateLockFile, Diagnostic> {
+    let lock = serde_json::from_str::<StateLockFile>(text).map_err(|err| {
+        Diagnostic::error(
+            "invalid_state_lock",
+            CLUSTER_LOCK_FILE,
+            format!("could not parse state lock: {err}"),
+        )
+    })?;
+    if lock.version != 1 {
+        return Err(Diagnostic::error(
+            "unsupported_state_lock_version",
+            CLUSTER_LOCK_FILE,
+            format!("unsupported cluster state lock version {}", lock.version),
+        ));
+    }
+    Ok(lock)
+}
+
+fn state_lock_held_message(observations: &StateObservations) -> String {
+    match observations.lock_id.as_deref() {
+        Some(lock_id) => format!(
+            "cluster state lock already exists (lock id {lock_id}); run `omnigraph cluster force-unlock {lock_id}` only after confirming no cluster operation is active"
+        ),
+        None => "cluster state lock already exists; remove it only after confirming no cluster operation is active".to_string(),
     }
 }
 
@@ -1953,6 +2087,15 @@ fn now_rfc3339() -> String {
         .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())
 }
 
+fn lock_age_seconds(created_at: &str) -> Option<u64> {
+    let created_at = OffsetDateTime::parse(created_at, &Rfc3339).ok()?;
+    Some(
+        (OffsetDateTime::now_utc() - created_at)
+            .whole_seconds()
+            .max(0) as u64,
+    )
+}
+
 fn state_sync_operation_label(operation: StateSyncOperation) -> &'static str {
     match operation {
         StateSyncOperation::Refresh => "refresh",
@@ -2032,6 +2175,23 @@ policies:
         Omnigraph::init(graph.to_string_lossy().as_ref(), SCHEMA)
             .await
             .unwrap();
+    }
+
+    fn write_lock_file(config_dir: &Path, lock_id: &str, operation: &str) {
+        let state_dir = config_dir.join(CLUSTER_STATE_DIR);
+        fs::create_dir_all(&state_dir).unwrap();
+        fs::write(
+            state_dir.join("lock.json"),
+            json!({
+                "version": 1,
+                "lock_id": lock_id,
+                "operation": operation,
+                "created_at": "1970-01-01T00:00:00Z",
+                "pid": 123
+            })
+            .to_string(),
+        )
+        .unwrap();
     }
 
     #[test]
@@ -2384,6 +2544,164 @@ policies:
     }
 
     #[test]
+    fn status_surfaces_full_lock_metadata() {
+        let dir = fixture();
+        write_lock_file(dir.path(), "held-lock", "refresh");
+
+        let out = status_config_dir(dir.path());
+        assert!(out.ok, "{:?}", out.diagnostics);
+        assert!(out.state_observations.locked);
+        assert_eq!(out.state_observations.lock_id.as_deref(), Some("held-lock"));
+        assert_eq!(
+            out.state_observations.lock_operation.as_deref(),
+            Some("refresh")
+        );
+        assert_eq!(
+            out.state_observations.lock_created_at.as_deref(),
+            Some("1970-01-01T00:00:00Z")
+        );
+        assert_eq!(out.state_observations.lock_pid, Some(123));
+        assert!(out.state_observations.lock_age_seconds.is_some());
+    }
+
+    #[test]
+    fn force_unlock_matching_id_removes_lock() {
+        let dir = fixture();
+        write_lock_file(dir.path(), "held-lock", "plan");
+
+        let out = force_unlock_config_dir(dir.path(), "held-lock");
+        assert!(out.ok, "{:?}", out.diagnostics);
+        assert!(out.lock_removed);
+        assert_eq!(out.state_observations.lock_id.as_deref(), Some("held-lock"));
+        assert_eq!(
+            out.state_observations.lock_operation.as_deref(),
+            Some("plan")
+        );
+        assert!(!dir.path().join(CLUSTER_LOCK_FILE).exists());
+    }
+
+    #[test]
+    fn force_unlock_wrong_id_fails_and_preserves_lock() {
+        let dir = fixture();
+        write_lock_file(dir.path(), "held-lock", "plan");
+
+        let out = force_unlock_config_dir(dir.path(), "other-lock");
+        assert!(!out.ok);
+        assert!(!out.lock_removed);
+        assert_eq!(out.state_observations.lock_id.as_deref(), Some("held-lock"));
+        assert!(
+            out.diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "state_lock_id_mismatch")
+        );
+        assert!(dir.path().join(CLUSTER_LOCK_FILE).exists());
+    }
+
+    #[test]
+    fn force_unlock_missing_lock_fails() {
+        let dir = fixture();
+
+        let out = force_unlock_config_dir(dir.path(), "held-lock");
+        assert!(!out.ok);
+        assert!(!out.lock_removed);
+        assert!(!out.state_observations.locked);
+        assert!(
+            out.diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "state_lock_missing")
+        );
+    }
+
+    #[test]
+    fn force_unlock_invalid_lock_json_fails_and_preserves_lock() {
+        let dir = fixture();
+        let state_dir = dir.path().join(CLUSTER_STATE_DIR);
+        fs::create_dir_all(&state_dir).unwrap();
+        fs::write(state_dir.join("lock.json"), "{").unwrap();
+
+        let out = force_unlock_config_dir(dir.path(), "held-lock");
+        assert!(!out.ok);
+        assert!(!out.lock_removed);
+        assert!(
+            out.diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "invalid_state_lock")
+        );
+        assert!(dir.path().join(CLUSTER_LOCK_FILE).exists());
+    }
+
+    #[test]
+    fn force_unlock_unsupported_lock_version_fails_and_preserves_lock() {
+        let dir = fixture();
+        let state_dir = dir.path().join(CLUSTER_STATE_DIR);
+        fs::create_dir_all(&state_dir).unwrap();
+        fs::write(
+            state_dir.join("lock.json"),
+            r#"{"version":2,"lock_id":"held-lock","operation":"plan","created_at":"1970-01-01T00:00:00Z","pid":123}"#,
+        )
+        .unwrap();
+
+        let out = force_unlock_config_dir(dir.path(), "held-lock");
+        assert!(!out.ok);
+        assert!(!out.lock_removed);
+        assert!(
+            out.diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "unsupported_state_lock_version")
+        );
+        assert!(dir.path().join(CLUSTER_LOCK_FILE).exists());
+    }
+
+    #[test]
+    fn force_unlock_external_state_backend_rejected() {
+        let dir = fixture();
+        write_lock_file(dir.path(), "held-lock", "plan");
+        fs::write(
+            dir.path().join(CLUSTER_CONFIG_FILE),
+            r#"
+version: 1
+state:
+  backend: s3://state-bucket/cluster
+graphs:
+  knowledge:
+    schema: ./people.pg
+"#,
+        )
+        .unwrap();
+
+        let out = force_unlock_config_dir(dir.path(), "held-lock");
+        assert!(!out.ok);
+        assert!(!out.lock_removed);
+        assert!(
+            out.diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "unsupported_state_backend")
+        );
+        assert!(dir.path().join(CLUSTER_LOCK_FILE).exists());
+    }
+
+    #[test]
+    fn plan_succeeds_after_force_unlock() {
+        let dir = fixture();
+        write_lock_file(dir.path(), "held-lock", "plan");
+
+        let locked = plan_config_dir(dir.path());
+        assert!(!locked.ok);
+        assert!(
+            locked
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "state_lock_held")
+        );
+
+        let unlocked = force_unlock_config_dir(dir.path(), "held-lock");
+        assert!(unlocked.ok, "{:?}", unlocked.diagnostics);
+
+        let out = plan_config_dir(dir.path());
+        assert!(out.ok, "{:?}", out.diagnostics);
+    }
+
+    #[test]
     fn plan_reports_state_cas_revision_and_removes_lock() {
         let dir = fixture();
         let state_dir = dir.path().join(CLUSTER_STATE_DIR);
@@ -2440,11 +2758,19 @@ policies:
         assert_eq!(out.state_observations.lock_id.as_deref(), Some("held-lock"));
         assert!(!out.state_observations.lock_acquired);
         assert!(out.state_observations.acquired_lock_id.is_none());
+        assert_eq!(
+            out.state_observations.lock_operation.as_deref(),
+            Some("plan")
+        );
         assert!(
             out.diagnostics
                 .iter()
                 .any(|diagnostic| diagnostic.code == "state_lock_held")
         );
+        assert!(out.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "state_lock_held"
+                && diagnostic.message.contains("force-unlock held-lock")
+        }));
     }
 
     #[test]
@@ -2706,11 +3032,19 @@ graphs:
         assert!(out.state_observations.locked);
         assert_eq!(out.state_observations.lock_id.as_deref(), Some("held-lock"));
         assert!(!out.state_observations.lock_acquired);
+        assert_eq!(
+            out.state_observations.lock_operation.as_deref(),
+            Some("refresh")
+        );
         assert!(
             out.diagnostics
                 .iter()
                 .any(|diagnostic| diagnostic.code == "state_lock_held")
         );
+        assert!(out.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "state_lock_held"
+                && diagnostic.message.contains("force-unlock held-lock")
+        }));
     }
 
     #[tokio::test]

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -8,7 +8,7 @@ This file is the always-on map of the test surface. **Consult it before every ta
 |---|---|---|
 | `omnigraph` (engine) | `crates/omnigraph/tests/` | Integration tests (21 files), fixture-driven, share `tests/helpers/mod.rs` |
 | `omnigraph-cli` | `crates/omnigraph-cli/tests/` | `cli.rs` (unit-ish), `system_local.rs`, `system_remote.rs`, share `tests/support/mod.rs` |
-| `omnigraph-cluster` | mostly in-source `#[cfg(test)] mod tests` | Cluster config parser, local JSON state diff, state CAS/lock handling, read-only validate/plan/status plus explicit refresh/import graph observations |
+| `omnigraph-cluster` | mostly in-source `#[cfg(test)] mod tests` | Cluster config parser, local JSON state diff, state CAS/lock handling/recovery, read-only validate/plan/status plus explicit refresh/import graph observations |
 | `omnigraph-server` | `crates/omnigraph-server/tests/` | `server.rs` (HTTP-level), `openapi.rs` (OpenAPI drift / regeneration) |
 | `omnigraph-compiler` | mostly in-source `#[cfg(test)] mod tests` | Parser, type-checker, IR lowering, lint |
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -19,7 +19,7 @@ Top-level command families and subcommands. Graph-targeting commands accept eith
 | `commit list \| show` | inspect commit graph |
 | `schema plan \| apply \| show (alias: get)` | migrations |
 | `lint` (alias: `check`) | offline / graph-backed query validation. Replaces `query lint` / `query check`, which are kept as deprecated argv-level shims that print a one-line warning and rewrite to `omnigraph lint` |
-| `cluster validate \| plan \| status \| refresh \| import` | cluster-control preview. `validate` checks a local `cluster.yaml` folder and referenced schema/query/policy files; `plan` diffs it against local JSON state at `__cluster/state.json`; `status` reads the state ledger; `refresh`/`import` explicitly update local JSON state from read-only graph observations. No apply, graph-resource mutation, server change, or `plan --refresh` occurs in Stage 2B |
+| `cluster validate \| plan \| status \| refresh \| import \| force-unlock` | cluster-control preview. `validate` checks a local `cluster.yaml` folder and referenced schema/query/policy files; `plan` diffs it against local JSON state at `__cluster/state.json`; `status` reads the state ledger; `refresh`/`import` explicitly update local JSON state from read-only graph observations; `force-unlock <LOCK_ID>` manually removes a held local state lock by exact id. No apply, graph-resource mutation, server change, automatic stale-lock breaking, or `plan --refresh` occurs in Stage 2C |
 | `optimize` | non-destructive Lance compaction (skips tables with `Blob` columns or uncovered drift; `--json` reports `skipped`) |
 | `repair [--confirm] [--force]` | preview or explicitly publish uncovered manifest/head drift. `--confirm` heals verified maintenance drift and exits non-zero if suspicious/unverifiable drift is refused; `--force --confirm` publishes suspicious/unverifiable drift after operator review |
 | `cleanup --keep N --older-than 7d --confirm` | destructive version GC |
@@ -81,19 +81,22 @@ omnigraph cluster plan     --config ./company-brain --json
 omnigraph cluster status   --config ./company-brain --json
 omnigraph cluster refresh  --config ./company-brain --json
 omnigraph cluster import   --config ./company-brain --json
+omnigraph cluster force-unlock <LOCK_ID> --config ./company-brain --json
 ```
 
 `--config` is a directory containing `cluster.yaml`; it defaults to `.`.
-Stage 2B accepts graphs, schemas, stored queries, and policy bundle file
+Stage 2C accepts graphs, schemas, stored queries, and policy bundle file
 references. `cluster plan` reads local JSON state from
 `<config-dir>/__cluster/state.json`; a missing file means empty state. Plan,
 refresh, and import acquire `__cluster/lock.json` by default and release it
 before returning. `cluster status` reads state only and reports any existing
-lock. `refresh` requires an existing `state.json`; `import` creates one only
-when it is missing. Both observe declared graphs read-only at
+lock metadata. `force-unlock` removes a lock only when the supplied id exactly
+matches the lock file. `refresh` requires an existing `state.json`; `import`
+creates one only when it is missing. Both observe declared graphs read-only at
 `<config-dir>/graphs/<graph-id>.omni`. External state backends, apply,
-`plan --refresh`, pipelines, UI specs, embeddings, aliases, and bindings are
-reserved for later stages. See [cluster-config.md](cluster-config.md).
+automatic stale-lock breaking, `plan --refresh`, pipelines, UI specs,
+embeddings, aliases, and bindings are reserved for later stages. See
+[cluster-config.md](cluster-config.md).
 
 ## Output formats (`query` command, alias: `read`)
 

--- a/docs/user/cluster-config.md
+++ b/docs/user/cluster-config.md
@@ -1,13 +1,13 @@
 # Cluster Config
 
-**Status:** Stage 2B state-observation preview.
+**Status:** Stage 2C state-lock recovery preview.
 
 Cluster config is the future control-plane configuration surface for a whole
 OmniGraph deployment. In this stage, OmniGraph can validate a local
 `cluster.yaml` folder, produce a deterministic read-only plan, inspect the
 local JSON state ledger, and explicitly refresh/import graph observations into
-that ledger. It does not apply desired changes, start servers, or write graph
-resources.
+that ledger. It can also manually remove a held local state lock by exact lock
+id. It does not apply desired changes, start servers, or write graph resources.
 
 ## Commands
 
@@ -17,6 +17,7 @@ omnigraph cluster plan     --config ./company-brain --json
 omnigraph cluster status   --config ./company-brain --json
 omnigraph cluster refresh  --config ./company-brain --json
 omnigraph cluster import   --config ./company-brain --json
+omnigraph cluster force-unlock <LOCK_ID> --config ./company-brain --json
 ```
 
 `--config` points at a directory, not a file. The directory must contain
@@ -24,7 +25,7 @@ omnigraph cluster import   --config ./company-brain --json
 
 ## Supported `cluster.yaml`
 
-Stage 2B accepts only the read-only resource subset:
+Stage 2C accepts only the read-only resource subset:
 
 ```yaml
 version: 1
@@ -53,7 +54,9 @@ policies:
 defaults to `true`. When enabled, `cluster plan`, `cluster refresh`, and
 `cluster import` briefly acquire `<config-dir>/__cluster/lock.json`, then remove
 it before returning. `cluster status` never acquires the lock; it only reports
-whether one is present.
+whether one is present. `cluster force-unlock` is the only lock-removal command;
+it requires the exact lock id and should be run only after confirming no cluster
+operation is active.
 
 ## Validation
 
@@ -116,19 +119,22 @@ Missing `state_revision` is treated as `0`. Resource status values are
 Plan output compares desired resource digests against state resource digests
 and reports `create`, `update`, and `delete` changes. It also reports the state
 CAS (`sha256:<digest>`) and state revision. `state_observations.locked` means an
-existing lock file was observed; a successful `plan` instead reports
-`lock_acquired: true` and an `acquired_lock_id`, then releases the lock before
-returning. The command never writes `state.json` and does not scan live graphs.
-Use explicit `cluster refresh` / `cluster import` when the state ledger should
-be updated from live observations. Apply and live drift scans during plan are
-later-stage work.
+existing lock file was observed, along with its metadata (`lock_id`,
+`lock_operation`, `lock_created_at`, `lock_pid`, `lock_age_seconds`); a
+successful `plan` instead reports `lock_acquired: true` and an
+`acquired_lock_id`, then releases the lock before returning. The command never
+writes `state.json` and does not scan live graphs. Use explicit
+`cluster refresh` / `cluster import` when the state ledger should be updated
+from live observations. Apply and live drift scans during plan are later-stage
+work.
 
 ## Status
 
 `cluster status` reads the same local JSON state ledger and prints what the
 ledger says is deployed. It does not validate referenced schema/query/policy
 files and does not inspect live graphs. Missing `state.json` succeeds with a
-warning; invalid state JSON or an unsupported state version fails.
+warning; invalid state JSON or an unsupported state version fails. If a lock is
+present, status reports its id, operation, creation time, pid, and age.
 
 ## Refresh And Import
 
@@ -150,3 +156,14 @@ initial state.
 
 Refresh/import do not observe query or policy resources yet. Existing query and
 policy state digests are preserved on refresh and are not invented on import.
+
+## Force Unlock
+
+`cluster force-unlock <LOCK_ID>` removes `<config-dir>/__cluster/lock.json` only
+when the file exists, is valid version-1 lock JSON, and its `lock_id` exactly
+matches the argument. A wrong id, missing lock, invalid lock JSON, or unsupported
+lock version exits non-zero and leaves the file untouched.
+
+This is manual recovery for abandoned local locks. OmniGraph does not perform
+PID-liveness checks, TTL expiry, stale-lock breaking, or automatic unlock in
+Stage 2C.


### PR DESCRIPTION
Stage 2C of the cluster config rollout (follows Stage 2B, PR #159). Scope kept deliberately narrow per docs/dev/cluster-config-specs.md:

- `omnigraph cluster force-unlock <LOCK_ID>` — manually remove a held local state lock, requiring an exact lock-id match; wrong id or invalid lock JSON preserves the lock
- Richer lock metadata in observations and diagnostics: `lock_operation`, `lock_created_at`, `lock_pid`, `lock_age_seconds`; `state_lock_held` errors now tell the operator exactly which lock to force-unlock
- Docs: cli-reference and cluster-config updated in the same change

Explicitly **not** included (later stages): apply, automatic stale-lock breaking, external state backends.

Rebased onto current main: the branch's copy of the refresh/import commit was dropped (main's d00d422 is a refined superset), and the lock-recovery commit was reconciled with main's `lock_acquired`/`acquired_lock_id` plan observations — acquire-success reports `lock_acquired: true` while `locked`/lock metadata describe an observed held lock.

## Test plan

- `cargo test -p omnigraph-cluster` — 40 passed
- `cargo test -p omnigraph-cli --test cli cluster` — 17 passed
- Workspace gate runs in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/modernrelay/omnigraph/pull/163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR (Stage 2C) adds `omnigraph cluster force-unlock <LOCK_ID>` — an exact-id-matched manual recovery command for stuck local JSON state locks — and enriches `StateObservations` with `lock_operation`, `lock_created_at`, `lock_pid`, and `lock_age_seconds` so operators can identify and target a held lock from `status` or a `state_lock_held` diagnostic.

- The `force_unlock` path is deliberately conservative: invalid JSON, wrong version, or an ID mismatch all leave the lock untouched and exit non-zero; the new `state_lock_held` message now embeds the exact `force-unlock <id>` command operators need.
- `ForceUnlockOutput` is missing `Deserialize` (all other output structs in the file derive both); the `write_cluster_lock` test helper in `cli.rs` uses `format!()` string interpolation for JSON where the equivalent `lib.rs` helper uses the `json!()` macro; and the two parse-failure error paths (`invalid_state_lock`, `unsupported_state_lock_version`) leave `locked: true` with no `lock_id` in observations — a shape that is not explicitly tested or documented.

<h3>Confidence Score: 4/5</h3>

The force-unlock command is narrowly scoped to local state and exits non-zero on every error path that could silently corrupt state; the exact-ID guard makes accidental removals very unlikely.

Two error paths in force_unlock (invalid_state_lock, unsupported_state_lock_version) produce an output shape — locked: true with no lock_id — that is not explicitly asserted in the tests, leaving the observable JSON contract for those cases unspecified. The missing Deserialize derivation on ForceUnlockOutput is inconsistent with every other output struct in the file. Both are non-blocking quality issues, but the untested observation state means a follow-up change could silently regress the output without a test failing.

crates/omnigraph-cluster/src/lib.rs — specifically the force_unlock method's error paths and the ForceUnlockOutput struct derivation.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/omnigraph-cluster/src/lib.rs | Core logic change: adds force_unlock method, ForceUnlockOutput struct, enriched StateObservations with lock metadata fields, and helper functions; well-covered by new unit tests with one minor observation-state gap on parse-failure paths. |
| crates/omnigraph-cli/src/main.rs | Adds ForceUnlock command variant, human-text printer, and lock-summary helper; mechanical refactor of status/sync lock display to use cluster_lock_summary; no logic concerns. |
| crates/omnigraph-cli/tests/cli.rs | Good integration test coverage for force-unlock happy path, wrong-ID, and end-to-end plan→unlock→plan; write_cluster_lock helper uses format!() string interpolation for JSON rather than json!() macro used in lib.rs's equivalent helper. |
| docs/user/cli-reference.md | Stage 2B → 2C bump; force-unlock added to command table and example block; accurate description of exact-ID requirement. |
| docs/user/cluster-config.md | Adds Force Unlock section, updates lock-metadata description, bumps stage label; consistent with implementation. |
| docs/dev/testing.md | Single-line update to reflect lock recovery in the omnigraph-cluster test-surface description. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["omnigraph cluster force-unlock LOCK_ID"] --> B[parse_cluster_config]
    B --> C{raw present?}
    C -- No --> ERR1[ok=false, lock_removed=false]
    C -- Yes --> D[validate_cluster_header]
    D --> E{has_errors?}
    E -- Yes --> ERR1
    E -- No --> F[LocalStateBackend::force_unlock]
    F --> G{lock.json exists?}
    G -- NotFound --> ERR2[state_lock_missing]
    G -- Read error --> ERR3[state_lock_read_error]
    G -- Read OK --> H[observations.locked = true]
    H --> I{parse JSON version == 1?}
    I -- invalid JSON --> ERR4[invalid_state_lock: locked=true, lock_id=null]
    I -- wrong version --> ERR5[unsupported_state_lock_version: locked=true, lock_id=null]
    I -- OK --> J[observe_lock_metadata]
    J --> K{lock_id matches?}
    K -- No --> ERR6[state_lock_id_mismatch, lock preserved]
    K -- Yes --> L[fs::remove_file]
    L -- Err --> ERR7[state_unlock_error]
    L -- Ok --> M[lock_removed=true, ok=true]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acrates%2Fomnigraph-cluster%2Fsrc%2Flib.rs%3A1136-1138%0A**%60locked%3A%20true%60%20leaks%20into%20output%20when%20parse%20fails%2C%20but%20is%20untested**%0A%0A%60observations.locked%20%3D%20true%60%20is%20set%20before%20%60parse_lock_file_for_unlock%60%20is%20called.%20If%20parsing%20fails%20%28invalid%20JSON%20or%20unsupported%20version%29%2C%20the%20early%20return%20propagates%20the%20error%20but%20leaves%20%60locked%3A%20true%60%20with%20all%20metadata%20fields%20as%20%60None%60%20in%20the%20caller's%20observations.%20The%20tests%20for%20%60force_unlock_invalid_lock_json_fails_and_preserves_lock%60%20and%20%60force_unlock_unsupported_lock_version_fails_and_preserves_lock%60%20do%20not%20assert%20on%20%60state_observations.locked%60%2C%20so%20this%20output%20shape%20is%20unspecified.%20Operators%20reading%20the%20JSON%20output%20would%20see%20%60locked%3A%20true%60%20without%20any%20%60lock_id%60%20%E2%80%94%20different%20from%20every%20other%20error%20path%20%E2%80%94%20and%20have%20no%20ID%20to%20supply%20for%20retry.%20Consider%20moving%20the%20%60observations.locked%20%3D%20true%60%20assignment%20to%20after%20a%20successful%20%60observe_lock_metadata%60%20call%2C%20or%20adding%20explicit%20assertions%20on%20%60locked%60%20in%20the%20two%20affected%20tests%20to%20pin%20the%20current%20behaviour%20as%20intentional.%0A%0A%23%23%23%20Issue%202%20of%203%0Acrates%2Fomnigraph-cluster%2Fsrc%2Flib.rs%3A230-231%0A%60ForceUnlockOutput%60%20is%20the%20only%20output%20struct%20in%20this%20file%20that%20does%20not%20derive%20%60Deserialize%60.%20Every%20other%20public%20output%20type%20%28%60StatusOutput%60%2C%20%60ValidateOutput%60%2C%20%60PlanOutput%60%2C%20%60StateSyncOutput%60%29%20derives%20both%20%60Serialize%60%20and%20%60Deserialize%60.%20Omitting%20%60Deserialize%60%20here%20is%20inconsistent%20with%20the%20rest%20of%20the%20codebase%20pattern%20and%20prevents%20external%20code%20from%20round-tripping%20or%20unit-testing%20the%20output%20without%20resorting%20to%20%60serde_json%3A%3AValue%60.%0A%0A%60%60%60suggestion%0A%23%5Bderive%28Debug%2C%20Clone%2C%20Serialize%2C%20Deserialize%29%5D%0Apub%20struct%20ForceUnlockOutput%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Acrates%2Fomnigraph-cli%2Ftests%2Fcli.rs%3A159-169%0A%60write_cluster_lock%60%20constructs%20its%20JSON%20payload%20via%20%60format!%28%29%60%20string%20interpolation%2C%20while%20the%20equivalent%20%60write_lock_file%60%20in%20%60lib.rs%60%20uses%20the%20%60json!%28%29%60%20macro.%20If%20a%20future%20test%20passes%20a%20%60lock_id%60%20or%20%60operation%60%20containing%20a%20double-quote%20or%20backslash%2C%20this%20helper%20silently%20produces%20invalid%20JSON.%20Using%20%60serde_json%3A%3Ajson!%28%29%60%20is%20consistent%20with%20the%20library%20test%20helper%20and%20avoids%20the%20fragility.%0A%0A&repo=modernrelay%2Fomnigraph&pr=163&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Add cluster state lock recovery"](https://github.com/modernrelay/omnigraph/commit/6f19a8f1bfc2a0c6e54e590d956634b5287c9fe0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36534061)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->