### PR TITLE
test(cli): cluster e2e hardening — lost-state recovery, drift, destruction, multi-graph

### DIFF
--- a/crates/omnigraph-cli/tests/cli.rs
+++ b/crates/omnigraph-cli/tests/cli.rs
@@ -145,14 +145,18 @@ policies:
 }
 
 fn init_cluster_derived_graph(root: &std::path::Path) {
+    init_named_cluster_graph(root, "knowledge", "people.pg");
+}
+
+fn init_named_cluster_graph(root: &std::path::Path, graph_id: &str, schema_file: &str) {
     let graph_dir = root.join("graphs");
     fs::create_dir_all(&graph_dir).unwrap();
     output_success(
         cli()
             .arg("init")
             .arg("--schema")
-            .arg(root.join("people.pg"))
-            .arg(graph_dir.join("knowledge.omni")),
+            .arg(root.join(schema_file))
+            .arg(graph_dir.join(format!("{graph_id}.omni"))),
     );
 }
 
@@ -1071,6 +1075,364 @@ fn cluster_e2e_force_unlock_unblocks_apply() {
     let retried = cluster_json(temp.path(), "apply");
     assert_eq!(retried["ok"], true, "{retried}");
     assert_eq!(retried["converged"], true, "{retried}");
+}
+
+/// Two-graph fixture: `knowledge` (people) + `engineering` (services), a
+/// policy spanning both graphs, and a cluster-scoped policy with no graph
+/// dependencies.
+fn write_multi_graph_cluster_fixture(root: &std::path::Path) {
+    write_cluster_config_fixture(root);
+    fs::write(
+        root.join("services.pg"),
+        r#"
+node Service {
+  name: String @key
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("services.gq"),
+        r#"
+query find_service($name: String) {
+  match { $s: Service { name: $name } }
+  return { $s.name }
+}
+"#,
+    )
+    .unwrap();
+    fs::write(root.join("cluster_wide.policy.yaml"), "rules: []\n").unwrap();
+    fs::write(root.join("shared.policy.yaml"), "rules: []\n").unwrap();
+    fs::write(
+        root.join("cluster.yaml"),
+        r#"
+version: 1
+metadata:
+  name: company-brain
+state:
+  backend: cluster
+  lock: true
+graphs:
+  knowledge:
+    schema: ./people.pg
+    queries:
+      find_person:
+        file: ./people.gq
+  engineering:
+    schema: ./services.pg
+    queries:
+      find_service:
+        file: ./services.gq
+policies:
+  shared:
+    file: ./shared.policy.yaml
+    applies_to: [knowledge, engineering]
+  cluster_wide:
+    file: ./cluster_wide.policy.yaml
+    applies_to: [cluster]
+"#,
+    )
+    .unwrap();
+}
+
+fn change_for<'j>(json: &'j serde_json::Value, resource: &str) -> &'j serde_json::Value {
+    json["changes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|change| change["resource"] == resource)
+        .unwrap_or_else(|| panic!("missing change for {resource}: {json}"))
+}
+
+/// The spec's resilience claim — "state is reconstructable from the
+/// self-describing cluster" — proven end to end: lose the ledger, re-import
+/// from the live graph, re-apply, and converge onto the same content-addressed
+/// catalog blobs.
+#[test]
+fn cluster_e2e_lost_state_reimport_recovers_catalog() {
+    let temp = tempdir().unwrap();
+    write_cluster_config_fixture(temp.path());
+    init_cluster_derived_graph(temp.path());
+    let import = cluster_json(temp.path(), "import");
+    assert_eq!(import["ok"], true, "{import}");
+    let apply = cluster_json(temp.path(), "apply");
+    assert_eq!(apply["converged"], true, "{apply}");
+
+    let query_digest = change_for(&apply, "query.knowledge.find_person")["after_digest"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let blob = temp
+        .path()
+        .join("__cluster/resources/query/knowledge/find_person")
+        .join(format!("{query_digest}.gq"));
+    let blob_content = fs::read_to_string(&blob).unwrap();
+
+    // Disaster: the state ledger is lost.
+    fs::remove_file(temp.path().join("__cluster/state.json")).unwrap();
+
+    let reimport = cluster_json(temp.path(), "import");
+    assert_eq!(reimport["ok"], true, "{reimport}");
+    assert_eq!(reimport["state_observations"]["state_revision"], 1);
+    // Import observes graph/schema only; query/policy digests are not invented.
+    assert!(
+        reimport["resource_digests"]
+            .get("query.knowledge.find_person")
+            .is_none(),
+        "{reimport}"
+    );
+
+    let plan = cluster_json(temp.path(), "plan");
+    assert_eq!(
+        change_for(&plan, "query.knowledge.find_person")["disposition"],
+        "applied"
+    );
+    assert_eq!(change_for(&plan, "policy.base")["disposition"], "applied");
+
+    let reapply = cluster_json(temp.path(), "apply");
+    assert_eq!(reapply["ok"], true, "{reapply}");
+    assert_eq!(reapply["converged"], true, "{reapply}");
+    assert!(
+        reapply["state_observations"]["applied_config_digest"].is_string(),
+        "{reapply}"
+    );
+    // The catalog blob was reused, not rewritten with different content.
+    assert_eq!(fs::read_to_string(&blob).unwrap(), blob_content);
+
+    let replan = cluster_json(temp.path(), "plan");
+    assert!(replan["changes"].as_array().unwrap().is_empty(), "{replan}");
+}
+
+/// The Sarah/Bob violation made visible: a schema change applied directly to
+/// the graph (no config change) must surface as drift through refresh, status,
+/// and plan — and apply must never silently "correct" it.
+#[test]
+fn cluster_e2e_out_of_band_schema_change_surfaces_as_drift() {
+    let temp = tempdir().unwrap();
+    write_cluster_config_fixture(temp.path());
+    init_cluster_derived_graph(temp.path());
+    let import = cluster_json(temp.path(), "import");
+    assert_eq!(import["ok"], true, "{import}");
+    let apply = cluster_json(temp.path(), "apply");
+    assert_eq!(apply["converged"], true, "{apply}");
+
+    // Out-of-band: the live graph evolves, cluster.yaml stays put.
+    fs::write(
+        temp.path().join("people_v2.pg"),
+        r#"
+node Person {
+  name: String @key
+  age: I32?
+  bio: String?
+}
+"#,
+    )
+    .unwrap();
+    output_success(
+        cli()
+            .arg("schema")
+            .arg("apply")
+            .arg(temp.path().join("graphs/knowledge.omni"))
+            .arg("--schema")
+            .arg(temp.path().join("people_v2.pg"))
+            .arg("--json"),
+    );
+
+    let refresh = cluster_json(temp.path(), "refresh");
+    assert_eq!(refresh["ok"], true, "{refresh}");
+    assert_eq!(
+        refresh["resource_statuses"]["schema.knowledge"]["status"],
+        "drifted"
+    );
+    assert_eq!(
+        refresh["resource_statuses"]["graph.knowledge"]["status"],
+        "drifted"
+    );
+    assert_eq!(
+        refresh["observations"]["graph.knowledge"]["schema_matches_desired"],
+        false
+    );
+
+    let status = cluster_json(temp.path(), "status");
+    assert_eq!(
+        status["resource_statuses"]["schema.knowledge"]["status"],
+        "drifted"
+    );
+
+    let plan = cluster_json(temp.path(), "plan");
+    assert_eq!(change_for(&plan, "schema.knowledge")["disposition"], "deferred");
+    assert_eq!(change_for(&plan, "graph.knowledge")["disposition"], "deferred");
+    let live_schema_digest = change_for(&plan, "schema.knowledge")["before_digest"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let drift_apply = cluster_json(temp.path(), "apply");
+    assert_eq!(drift_apply["applied_count"], 0, "{drift_apply}");
+    assert_eq!(drift_apply["converged"], false, "{drift_apply}");
+    // Apply must not have "corrected" the drift: state still records the LIVE
+    // schema digest, not the desired one.
+    let state: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(temp.path().join("__cluster/state.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        state["applied_revision"]["resources"]["schema.knowledge"]["digest"],
+        live_schema_digest
+    );
+}
+
+/// Disaster input fails closed: a destroyed graph root drifts the ledger,
+/// the plan proposes deferred creates, and apply moves nothing.
+#[test]
+fn cluster_e2e_graph_root_destruction_drifts_and_apply_moves_nothing() {
+    let temp = tempdir().unwrap();
+    write_cluster_config_fixture(temp.path());
+    init_cluster_derived_graph(temp.path());
+    let import = cluster_json(temp.path(), "import");
+    assert_eq!(import["ok"], true, "{import}");
+    let apply = cluster_json(temp.path(), "apply");
+    assert_eq!(apply["converged"], true, "{apply}");
+    let query_digest = change_for(&apply, "query.knowledge.find_person")["after_digest"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    fs::remove_dir_all(temp.path().join("graphs/knowledge.omni")).unwrap();
+
+    // Missing root is drift, not an error.
+    let refresh = cluster_json(temp.path(), "refresh");
+    assert_eq!(refresh["ok"], true, "{refresh}");
+    assert_eq!(
+        refresh["resource_statuses"]["graph.knowledge"]["status"],
+        "drifted"
+    );
+    assert!(
+        refresh["resource_statuses"]["graph.knowledge"]["conditions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|condition| condition == "graph_missing"),
+        "{refresh}"
+    );
+    // Graph/schema digests removed; query/policy digests preserved.
+    assert!(refresh["resource_digests"].get("graph.knowledge").is_none());
+    assert!(refresh["resource_digests"].get("schema.knowledge").is_none());
+    assert!(
+        refresh["resource_digests"]
+            .get("query.knowledge.find_person")
+            .is_some(),
+        "{refresh}"
+    );
+
+    let plan = cluster_json(temp.path(), "plan");
+    assert_eq!(change_for(&plan, "graph.knowledge")["operation"], "create");
+    assert_eq!(change_for(&plan, "graph.knowledge")["disposition"], "deferred");
+    assert_eq!(change_for(&plan, "schema.knowledge")["disposition"], "deferred");
+    // Converged-then-destroyed: query/policy are already in state at the
+    // desired digests, so they are not changes at all.
+    assert_eq!(plan["changes"].as_array().unwrap().len(), 2, "{plan}");
+
+    let disaster_apply = cluster_json(temp.path(), "apply");
+    assert_eq!(disaster_apply["applied_count"], 0, "{disaster_apply}");
+    assert_eq!(disaster_apply["converged"], false, "{disaster_apply}");
+    let state: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(temp.path().join("__cluster/state.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        state["applied_revision"]["resources"]["query.knowledge.find_person"]["digest"],
+        query_digest
+    );
+    assert!(
+        temp.path()
+            .join("__cluster/resources/query/knowledge/find_person")
+            .join(format!("{query_digest}.gq"))
+            .exists()
+    );
+}
+
+/// The disposition matrix as a system: one apply over two graphs (one live,
+/// one not yet created) plus graph-spanning and cluster-scoped policies must
+/// produce all four dispositions at once — then converge after the second
+/// graph appears.
+#[test]
+fn cluster_e2e_multi_graph_mixed_dispositions_then_converge() {
+    let temp = tempdir().unwrap();
+    write_multi_graph_cluster_fixture(temp.path());
+    init_cluster_derived_graph(temp.path()); // knowledge only
+
+    let import = cluster_json(temp.path(), "import");
+    assert_eq!(import["ok"], true, "{import}");
+
+    let apply = cluster_json(temp.path(), "apply");
+    assert_eq!(apply["ok"], true, "{apply}");
+    assert_eq!(apply["converged"], false, "{apply}");
+    assert_eq!(apply["applied_count"], 2, "{apply}");
+    assert_eq!(
+        change_for(&apply, "query.knowledge.find_person")["disposition"],
+        "applied"
+    );
+    assert_eq!(
+        change_for(&apply, "policy.cluster_wide")["disposition"],
+        "applied"
+    );
+    assert_eq!(
+        change_for(&apply, "query.engineering.find_service")["disposition"],
+        "blocked"
+    );
+    assert_eq!(
+        change_for(&apply, "query.engineering.find_service")["reason"],
+        "dependency_missing"
+    );
+    // One missing dependency graph blocks the whole spanning policy.
+    assert_eq!(change_for(&apply, "policy.shared")["disposition"], "blocked");
+    assert_eq!(
+        change_for(&apply, "graph.engineering")["disposition"],
+        "deferred"
+    );
+    assert_eq!(
+        change_for(&apply, "schema.engineering")["disposition"],
+        "deferred"
+    );
+    assert_eq!(
+        change_for(&apply, "graph.knowledge")["disposition"],
+        "derived"
+    );
+    assert_eq!(
+        apply["resource_statuses"]["policy.shared"]["status"],
+        "blocked"
+    );
+    // Deterministic ordering: changes sorted by resource address.
+    let order: Vec<&str> = apply["changes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|change| change["resource"].as_str().unwrap())
+        .collect();
+    let mut sorted = order.clone();
+    sorted.sort_unstable();
+    assert_eq!(order, sorted, "{apply}");
+
+    // The second graph appears; refresh observes it; apply converges.
+    init_named_cluster_graph(temp.path(), "engineering", "services.pg");
+    let refresh = cluster_json(temp.path(), "refresh");
+    assert_eq!(refresh["ok"], true, "{refresh}");
+
+    let converge = cluster_json(temp.path(), "apply");
+    assert_eq!(converge["ok"], true, "{converge}");
+    assert_eq!(converge["converged"], true, "{converge}");
+    assert_eq!(
+        change_for(&converge, "query.engineering.find_service")["disposition"],
+        "applied"
+    );
+    assert_eq!(change_for(&converge, "policy.shared")["disposition"], "applied");
+
+    let final_plan = cluster_json(temp.path(), "plan");
+    assert!(
+        final_plan["changes"].as_array().unwrap().is_empty(),
+        "{final_plan}"
+    );
 }
 
 #[test]

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -7,7 +7,7 @@ This file is the always-on map of the test surface. **Consult it before every ta
 | Crate | Path | Style |
 |---|---|---|
 | `omnigraph` (engine) | `crates/omnigraph/tests/` | Integration tests (21 files), fixture-driven, share `tests/helpers/mod.rs` |
-| `omnigraph-cli` | `crates/omnigraph-cli/tests/` | `cli.rs` (unit-ish), `system_local.rs`, `system_remote.rs`, share `tests/support/mod.rs` |
+| `omnigraph-cli` | `crates/omnigraph-cli/tests/` | `cli.rs` (unit-ish; includes the `cluster_e2e_*` lifecycle compositions over the spawned binary — lost-state re-import recovery, out-of-band drift, graph-root destruction, multi-graph mixed-disposition convergence), `system_local.rs`, `system_remote.rs`, share `tests/support/mod.rs` |
 | `omnigraph-cluster` | mostly in-source `#[cfg(test)] mod tests` | Cluster config parser, local JSON state diff, state CAS/lock handling/recovery, read-only validate/plan/status plus explicit refresh/import graph observations, and config-only apply (content-addressed payload publish, disposition gating, composite-digest convergence, idempotent re-apply) |
 | `omnigraph-server` | `crates/omnigraph-server/tests/` | `server.rs` (HTTP-level), `openapi.rs` (OpenAPI drift / regeneration) |
 | `omnigraph-compiler` | mostly in-source `#[cfg(test)] mod tests` | Parser, type-checker, IR lowering, lint |


### PR DESCRIPTION
**Stacked on #165** — contains the Stage 3A commits until that merges; the reviewable delta is the top commit (`38429cd`).

Test-only follow-up adding the four lifecycle e2e compositions a gap analysis found missing. Each pins a spec claim no single-command test proves:

1. **Lost-state recovery** (`cluster_e2e_lost_state_reimport_recovers_catalog`) — delete `state.json` → `import` rebuilds graph/schema observations from the live graph (query/policy digests not invented) → `apply` re-converges onto the *same* content-addressed blobs, byte-identical. This is axiom 5's "state is reconstructable from the self-describing cluster" resilience edge, end to end.
2. **Out-of-band drift** (`cluster_e2e_out_of_band_schema_change_surfaces_as_drift`) — the Sarah/Bob violation: `omnigraph schema apply` directly against the graph, no config change. `refresh` marks graph/schema `drifted` (`schema_mismatch`), `status` and `plan` surface it (deferred dispositions), and `cluster apply` refuses to silently correct it — state keeps the **live** schema digest (axiom 8: drift correction is gated, a reconciler "just fixing drift" is never an exception).
3. **Graph-root destruction** (`cluster_e2e_graph_root_destruction_drifts_and_apply_moves_nothing`) — `rm -rf` the graph root → refresh records `graph_missing` drift, drops graph/schema digests, preserves query/policy → plan proposes deferred creates only → apply moves nothing; catalog blobs intact. Fail-closed on the worst input.
4. **Multi-graph mixed dispositions** (`cluster_e2e_multi_graph_mixed_dispositions_then_converge`) — two graphs (one live, one not yet created), a graph-spanning policy, and a cluster-scoped policy: a single apply yields all four dispositions at once (applied / derived / deferred / blocked, deterministically ordered, with `dependency_missing` blocking the spanning policy on its one absent graph), then the second graph appears → refresh → apply converges → plan empty.

Helpers: `init_named_cluster_graph` generalizes `init_cluster_derived_graph`; `write_multi_graph_cluster_fixture` builds the two-graph config. `docs/dev/testing.md` row updated.

Deliberately deferred (per scoping decision): the concurrent lock race (flake-prone) and failpoint-based crash-mid-apply/CAS-race tests — those land with the Phase 4 failpoint infrastructure, where the spec's hard gate requires them anyway.

## Test plan

- `cargo test -p omnigraph-cli --test cli cluster` — 27 passed (7 lifecycle e2es)
- `cargo test --workspace --locked` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds four lifecycle e2e test compositions to `crates/omnigraph-cli/tests/cli.rs`, each proving a specific axiom about cluster resilience and drift behavior that no single-command test previously covered. A new `init_named_cluster_graph` helper generalises the existing `init_cluster_derived_graph`, and `write_multi_graph_cluster_fixture` builds the two-graph scenario; `docs/dev/testing.md` is updated to enumerate the new coverage.

- **Lost-state recovery** — deletes `state.json`, re-imports from the live graph, verifies query/policy digests are *not* invented, re-applies, and asserts byte-identical catalog blob reuse.
- **Out-of-band schema drift** — applies a schema change directly to the graph, verifies `refresh`/`status`/`plan` all surface `drifted`, and asserts `apply` moves nothing and leaves state with the *live* digest.
- **Graph-root destruction** — `rm -rf` the graph root, verifies `graph_missing` drift, confirms plan proposes only two deferred creates, and asserts apply moves nothing while catalog blobs remain intact.
- **Multi-graph mixed dispositions** — one apply over two graphs (one missing) yields all four dispositions deterministically ordered; a second apply after the missing graph appears converges completely.

<h3>Confidence Score: 5/5</h3>

Test-only change adding four lifecycle e2e compositions; no production code is touched and all four tests follow well-established patterns already present in the file.

The change is entirely additive test code. Each new test correctly sets up a full cluster lifecycle, exercises a distinct edge case, and tears down cleanly via tempdir. The helpers generalise existing patterns without introducing new surface area. The existing assertion coverage is tight on the critical paths each test was designed to prove.

No files require special attention; both changed files are straightforward additions.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/omnigraph-cli/tests/cli.rs | Adds four lifecycle e2e tests (lost-state reimport, out-of-band schema drift, graph-root destruction, multi-graph mixed dispositions) plus two helpers; init_cluster_derived_graph is cleanly delegated to the new init_named_cluster_graph. All four tests are well-structured and cover the spec axioms they pin. |
| docs/dev/testing.md | Single-row update to the test coverage table to enumerate the four new lifecycle compositions now present in cli.rs; purely additive documentation change. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph lost_state["Lost-State Recovery"]
        LS1[init + import + apply] --> LS2[delete state.json]
        LS2 --> LS3[reimport: graph/schema only, no query digests]
        LS3 --> LS4[plan: query + policy → applied]
        LS4 --> LS5[reapply: converged, blob byte-identical]
    end

    subgraph drift["Out-of-Band Schema Drift"]
        D1[init + import + apply] --> D2[schema apply directly to graph]
        D2 --> D3[refresh: schema.knowledge + graph.knowledge → drifted]
        D3 --> D4[plan: deferred dispositions]
        D4 --> D5[apply: 0 applied, state keeps live digest]
    end

    subgraph destruction["Graph-Root Destruction"]
        GR1[init + import + apply] --> GR2[rm -rf graphs/knowledge.omni]
        GR2 --> GR3[refresh: graph_missing drift, drop graph/schema digests]
        GR3 --> GR4[plan: 2 deferred creates only]
        GR4 --> GR5[apply: 0 applied, catalog blobs intact]
    end

    subgraph multigraph["Multi-Graph Mixed Dispositions"]
        MG1[init knowledge only, import] --> MG2[apply: applied+derived+deferred+blocked]
        MG2 --> MG3[init engineering graph + refresh]
        MG3 --> MG4[apply: converged, final plan empty]
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `crates/omnigraph-cluster/src/lib.rs`, line 1814-1853 ([link](https://github.com/modernrelay/omnigraph/blob/38429cd2d78be961c8b6e21819d92d5d46196616/crates/omnigraph-cluster/src/lib.rs#L1814-L1853)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Missing `disposition` assertion for `policy.base`**

   Every other resource in this test has its `disposition` asserted (`graph.knowledge` → `Deferred`, `query.knowledge.find_person` → `Blocked`), but `policy.base` only has its `reason` checked. If the classification logic were to accidentally emit a different disposition for policy changes (e.g., `Applied` instead of `Blocked`), the test would still pass — the `reason` can be `dependency_missing` on a non-blocked change that was rejected further down. Adding `assert_eq!(by_resource["policy.base"].disposition, Some(ApplyDisposition::Blocked))` closes this gap.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fomnigraph-cluster%2Fsrc%2Flib.rs%0ALine%3A%201814-1853%0A%0AComment%3A%0A**Missing%20%60disposition%60%20assertion%20for%20%60policy.base%60**%0A%0AEvery%20other%20resource%20in%20this%20test%20has%20its%20%60disposition%60%20asserted%20%28%60graph.knowledge%60%20%E2%86%92%20%60Deferred%60%2C%20%60query.knowledge.find_person%60%20%E2%86%92%20%60Blocked%60%29%2C%20but%20%60policy.base%60%20only%20has%20its%20%60reason%60%20checked.%20If%20the%20classification%20logic%20were%20to%20accidentally%20emit%20a%20different%20disposition%20for%20policy%20changes%20%28e.g.%2C%20%60Applied%60%20instead%20of%20%60Blocked%60%29%2C%20the%20test%20would%20still%20pass%20%E2%80%94%20the%20%60reason%60%20can%20be%20%60dependency_missing%60%20on%20a%20non-blocked%20change%20that%20was%20rejected%20further%20down.%20Adding%20%60assert_eq!%28by_resource%5B%22policy.base%22%5D.disposition%2C%20Some%28ApplyDisposition%3A%3ABlocked%29%29%60%20closes%20this%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modernrelay%2Fomnigraph&pr=166&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

2. `crates/omnigraph-cli/tests/cli.rs`, line 614-656 ([link](https://github.com/modernrelay/omnigraph/blob/38429cd2d78be961c8b6e21819d92d5d46196616/crates/omnigraph-cli/tests/cli.rs#L614-L656)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Drift condition code not verified in `cluster_e2e_out_of_band_schema_change_surfaces_as_drift`**

   The companion test `cluster_e2e_graph_root_destruction_drifts_and_apply_moves_nothing` asserts the specific condition code (`graph_missing`) on the `conditions` array of `graph.knowledge`. This test checks `"status" == "drifted"` for both `schema.knowledge` and `graph.knowledge`, but never checks that the condition code on `schema.knowledge` is `schema_mismatch` (the code mentioned in the PR description as the axiom-8 signal). A regression that emits the wrong condition code would pass the test silently. Aligning this assertion with the pattern used in the destruction test would give the two tests symmetric coverage.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fomnigraph-cli%2Ftests%2Fcli.rs%0ALine%3A%20614-656%0A%0AComment%3A%0A**Drift%20condition%20code%20not%20verified%20in%20%60cluster_e2e_out_of_band_schema_change_surfaces_as_drift%60**%0A%0AThe%20companion%20test%20%60cluster_e2e_graph_root_destruction_drifts_and_apply_moves_nothing%60%20asserts%20the%20specific%20condition%20code%20%28%60graph_missing%60%29%20on%20the%20%60conditions%60%20array%20of%20%60graph.knowledge%60.%20This%20test%20checks%20%60%22status%22%20%3D%3D%20%22drifted%22%60%20for%20both%20%60schema.knowledge%60%20and%20%60graph.knowledge%60%2C%20but%20never%20checks%20that%20the%20condition%20code%20on%20%60schema.knowledge%60%20is%20%60schema_mismatch%60%20%28the%20code%20mentioned%20in%20the%20PR%20description%20as%20the%20axiom-8%20signal%29.%20A%20regression%20that%20emits%20the%20wrong%20condition%20code%20would%20pass%20the%20test%20silently.%20Aligning%20this%20assertion%20with%20the%20pattern%20used%20in%20the%20destruction%20test%20would%20give%20the%20two%20tests%20symmetric%20coverage.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modernrelay%2Fomnigraph&pr=166&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

3. `crates/omnigraph-cluster/src/lib.rs`, line 1401-1403 ([link](https://github.com/modernrelay/omnigraph/blob/38429cd2d78be961c8b6e21819d92d5d46196616/crates/omnigraph-cluster/src/lib.rs#L1401-L1403)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Existing blob trusted but never re-verified**

   The comment says "the digest re-check is the apply-side TOCTOU detector", but that detector only fires when `!target.exists()`. If an existing blob at `<digest>.gq` was accidentally overwritten or corrupted after a prior apply (file permissions, tooling error), the next apply skips writing and the catalog silently holds the wrong content while `state.json` considers the resource converged. Since blobs are content-addressed by a SHA-256 name, a re-verify on the existing file would catch this without re-writing. This is low-risk on local filesystems today but would widen the blast radius if the catalog is ever written to a networked or shared volume.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fomnigraph-cluster%2Fsrc%2Flib.rs%0ALine%3A%201401-1403%0A%0AComment%3A%0A**Existing%20blob%20trusted%20but%20never%20re-verified**%0A%0AThe%20comment%20says%20%22the%20digest%20re-check%20is%20the%20apply-side%20TOCTOU%20detector%22%2C%20but%20that%20detector%20only%20fires%20when%20%60!target.exists%28%29%60.%20If%20an%20existing%20blob%20at%20%60%3Cdigest%3E.gq%60%20was%20accidentally%20overwritten%20or%20corrupted%20after%20a%20prior%20apply%20%28file%20permissions%2C%20tooling%20error%29%2C%20the%20next%20apply%20skips%20writing%20and%20the%20catalog%20silently%20holds%20the%20wrong%20content%20while%20%60state.json%60%20considers%20the%20resource%20converged.%20Since%20blobs%20are%20content-addressed%20by%20a%20SHA-256%20name%2C%20a%20re-verify%20on%20the%20existing%20file%20would%20catch%20this%20without%20re-writing.%20This%20is%20low-risk%20on%20local%20filesystems%20today%20but%20would%20widen%20the%20blast%20radius%20if%20the%20catalog%20is%20ever%20written%20to%20a%20networked%20or%20shared%20volume.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modernrelay%2Fomnigraph&pr=166&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fomnigraph-cli%2Ftests%2Fcli.rs%3A1388-1389%0AThe%20comment%20explicitly%20says%20%22One%20missing%20dependency%20graph%20blocks%20the%20whole%20spanning%20policy%22%20but%20the%20assertion%20only%20verifies%20the%20%60disposition%60.%20Unlike%20%60query.engineering.find_service%60%20directly%20above%2C%20which%20checks%20both%20%60disposition%60%20and%20%60reason%60%2C%20%60policy.shared%60%20only%20checks%20%60disposition%60.%20A%20regression%20that%20emits%20the%20wrong%20reason%20code%20%28e.g.%2C%20a%20different%20string%29%20for%20span-policy%20blocking%20would%20pass%20the%20test%20silently.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20One%20missing%20dependency%20graph%20blocks%20the%20whole%20spanning%20policy.%0A%20%20%20%20assert_eq!%28change_for%28%26apply%2C%20%22policy.shared%22%29%5B%22disposition%22%5D%2C%20%22blocked%22%29%3B%0A%20%20%20%20assert_eq!%28%0A%20%20%20%20%20%20%20%20change_for%28%26apply%2C%20%22policy.shared%22%29%5B%22reason%22%5D%2C%0A%20%20%20%20%20%20%20%20%22dependency_missing%22%0A%20%20%20%20%29%3B%0A%60%60%60%0A%0A&repo=modernrelay%2Fomnigraph&pr=166&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["test(cli): cluster e2e hardening — lost-..."](https://github.com/modernrelay/omnigraph/commit/34d72620c3c964994ad6b8f9f567b7a3b8c7c7fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36557983)</sub>

<!-- /greptile_comment -->