### PR TITLE
ci(codeowners): aaltshuler owns all paths; remove ragnorc

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,11 +8,11 @@
 # CI fails if this file drifts from its source, and rejects PRs that
 # edit this file directly without also editing the yml.
 
-*             @ragnorc @aaltshuler
+*             @aaltshuler
 
-crates/**     @ragnorc @aaltshuler
-docs/**       @ragnorc
-README.md     @ragnorc
-AGENTS.md     @ragnorc
-CLAUDE.md     @ragnorc
-SECURITY.md   @ragnorc
+crates/**     @aaltshuler
+docs/**       @aaltshuler
+README.md     @aaltshuler
+AGENTS.md     @aaltshuler
+CLAUDE.md     @aaltshuler
+SECURITY.md   @aaltshuler

--- a/.github/codeowners-roles.yml
+++ b/.github/codeowners-roles.yml
@@ -21,7 +21,6 @@ roles:
       All production code under crates/**. Engine, CLI, server,
       compiler.
     members:
-      - ragnorc
       - aaltshuler
 
   docs:
@@ -29,7 +28,7 @@ roles:
       Documentation under docs/**, plus repo-level docs (README.md,
       AGENTS.md, CLAUDE.md symlink, SECURITY.md).
     members:
-      - ragnorc
+      - aaltshuler
 
 # Path → role mapping. GitHub CODEOWNERS uses "last match wins"
 # semantics — when multiple patterns match a file, only the last

--- a/docs/dev/codeowners.md
+++ b/docs/dev/codeowners.md
@@ -14,20 +14,20 @@ The tables below are **generated** from `.github/codeowners-roles.yml` by `.gith
 
 | Path | Owners | Role(s) |
 |---|---|---|
-| `*` | @ragnorc @aaltshuler | engineering |
-| `crates/**` | @ragnorc @aaltshuler | engineering |
-| `docs/**` | @ragnorc | docs |
-| `README.md` | @ragnorc | docs |
-| `AGENTS.md` | @ragnorc | docs |
-| `CLAUDE.md` | @ragnorc | docs |
-| `SECURITY.md` | @ragnorc | docs |
+| `*` | @aaltshuler | engineering |
+| `crates/**` | @aaltshuler | engineering |
+| `docs/**` | @aaltshuler | docs |
+| `README.md` | @aaltshuler | docs |
+| `AGENTS.md` | @aaltshuler | docs |
+| `CLAUDE.md` | @aaltshuler | docs |
+| `SECURITY.md` | @aaltshuler | docs |
 
 **Roles**:
 
 | Role | Members | Description |
 |---|---|---|
-| `engineering` | @ragnorc @aaltshuler | All production code under crates/**. Engine, CLI, server, compiler. |
-| `docs` | @ragnorc | Documentation under docs/**, plus repo-level docs (README.md, AGENTS.md, CLAUDE.md symlink, SECURITY.md). |
+| `engineering` | @aaltshuler | All production code under crates/**. Engine, CLI, server, compiler. |
+| `docs` | @aaltshuler | Documentation under docs/**, plus repo-level docs (README.md, AGENTS.md, CLAUDE.md symlink, SECURITY.md). |
 
 <!-- END GENERATED OWNERSHIP -->
 


### PR DESCRIPTION
Role membership change in the source of truth (`.github/codeowners-roles.yml`): @aaltshuler becomes the sole member of both the `engineering` and `docs` roles, removing @ragnorc. Every path — the `*` catch-all, `crates/**`, `docs/**`, and the repo-level docs — now requires @aaltshuler's review.

`.github/CODEOWNERS` and the ownership tables in `docs/dev/codeowners.md` are regenerated artifacts (`render-codeowners.py`), committed together with the yml per the workflow's drift check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes `@aaltshuler` the sole member of both the `engineering` and `docs` roles by removing `@ragnorc`, regenerating `.github/CODEOWNERS` and the documentation table as required artifacts.

- **Role membership change**: `@ragnorc` is removed from `engineering` and `docs`; `@aaltshuler` now owns all paths (`*`, `crates/**`, `docs/**`, and the repo-level docs).
- **Generated artifacts consistent**: `.github/CODEOWNERS` and `docs/dev/codeowners.md` are correctly regenerated from the updated yml source of truth with no drift.

<h3>Confidence Score: 4/5</h3>

Safe to merge as a mechanical membership change, but leaves the repository with no backup reviewer and creates a merge deadlock for the sole owner's own future PRs if CODEOWNER review is required by branch protection.

The three files are internally consistent and correctly regenerated. The concern is operational: removing the second owner means any future PR authored by the sole codeowner will have no eligible reviewer to satisfy the CODEOWNER requirement, potentially blocking those PRs indefinitely or silently removing the enforcement guarantee.

.github/codeowners-roles.yml — the source-of-truth change that drives the single-owner outcome.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/codeowners-roles.yml | Removes @ragnorc from both `engineering` and `docs` roles, leaving @aaltshuler as sole owner of all paths — creates a potential merge deadlock for any PR the sole owner authors. |
| .github/CODEOWNERS | Autogenerated artifact correctly regenerated from the yml; all path entries updated consistently to reflect sole @aaltshuler ownership. |
| docs/dev/codeowners.md | Autogenerated documentation updated consistently — ownership tables and role membership tables both reflect the new single-owner state. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR opened by sole codeowner] --> B{Author is the only codeowner?}
    B -- Yes --> C[GitHub excludes author from satisfying CODEOWNER requirement]
    C --> D{Branch protection requires CODEOWNER review?}
    D -- Yes --> E[PR blocked — admin bypass required]
    D -- No --> F[PR merges without codeowner approval]
    B -- No --> G[aaltshuler reviews and approves normally]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/codeowners-roles.yml`, line 18-31 ([link](https://github.com/modernrelay/omnigraph/blob/617e4f1226777906bc5fdbfe32b103fa05c90973/.github/codeowners-roles.yml#L18-L31)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Single owner creates a merge deadlock for the sole codeowner's own PRs**

   With `@aaltshuler` as the only member of both `engineering` and `docs`, any PR authored by `@aaltshuler` will have no eligible codeowner reviewer — GitHub excludes the PR author from satisfying their own CODEOWNER requirement. If branch protection rules require a codeowner approval, every future `@aaltshuler`-authored PR will be permanently blocked or require an admin bypass. Beyond the merge mechanics, a single owner across all paths means there is no coverage when that person is unavailable.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fcodeowners-roles.yml%0ALine%3A%2018-31%0A%0AComment%3A%0A**Single%20owner%20creates%20a%20merge%20deadlock%20for%20the%20sole%20codeowner's%20own%20PRs**%0A%0AWith%20%60%40aaltshuler%60%20as%20the%20only%20member%20of%20both%20%60engineering%60%20and%20%60docs%60%2C%20any%20PR%20authored%20by%20%60%40aaltshuler%60%20will%20have%20no%20eligible%20codeowner%20reviewer%20%E2%80%94%20GitHub%20excludes%20the%20PR%20author%20from%20satisfying%20their%20own%20CODEOWNER%20requirement.%20If%20branch%20protection%20rules%20require%20a%20codeowner%20approval%2C%20every%20future%20%60%40aaltshuler%60-authored%20PR%20will%20be%20permanently%20blocked%20or%20require%20an%20admin%20bypass.%20Beyond%20the%20merge%20mechanics%2C%20a%20single%20owner%20across%20all%20paths%20means%20there%20is%20no%20coverage%20when%20that%20person%20is%20unavailable.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modernrelay%2Fomnigraph&pr=169&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fcodeowners-roles.yml%3A18-31%0A**Single%20owner%20creates%20a%20merge%20deadlock%20for%20the%20sole%20codeowner's%20own%20PRs**%0A%0AWith%20%60%40aaltshuler%60%20as%20the%20only%20member%20of%20both%20%60engineering%60%20and%20%60docs%60%2C%20any%20PR%20authored%20by%20%60%40aaltshuler%60%20will%20have%20no%20eligible%20codeowner%20reviewer%20%E2%80%94%20GitHub%20excludes%20the%20PR%20author%20from%20satisfying%20their%20own%20CODEOWNER%20requirement.%20If%20branch%20protection%20rules%20require%20a%20codeowner%20approval%2C%20every%20future%20%60%40aaltshuler%60-authored%20PR%20will%20be%20permanently%20blocked%20or%20require%20an%20admin%20bypass.%20Beyond%20the%20merge%20mechanics%2C%20a%20single%20owner%20across%20all%20paths%20means%20there%20is%20no%20coverage%20when%20that%20person%20is%20unavailable.%0A%0A&repo=modernrelay%2Fomnigraph&pr=169&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["ci(codeowners): aaltshuler owns all path..."](https://github.com/modernrelay/omnigraph/commit/617e4f1226777906bc5fdbfe32b103fa05c90973) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36601577)</sub>

<!-- /greptile_comment -->