### PR TITLE
docs(cluster): descope ETL pipelines to a separate project; keep the socket

### DIFF
--- a/docs/dev/cluster-config-implementation-spec.md
+++ b/docs/dev/cluster-config-implementation-spec.md
@@ -529,7 +529,7 @@ These are the concrete "what requires downstream" rules.
 | Server registry | Boot from cluster state, eventually reload/reconcile graph handles, expose statuses | High | Affects routing, OpenAPI, auth, and workload admission |
 | API types/OpenAPI | Plan/status/apply DTOs if HTTP management endpoints ship | Medium/high | OpenAPI drift must be regenerated |
 | UI specs | New renderer/spec validator/binding checker | High | New product surface, not currently implemented |
-| Pipelines | New scheduler/runtime/connector/mapping/idempotency/run ledger | Very high | Second data-plane seam; large product and correctness surface |
+| Pipelines | New scheduler/runtime/connector/mapping/idempotency/run ledger | Very high | **Separate project** (socket reserved here); second data-plane seam, large product and correctness surface |
 | Embeddings | Cluster-level defaults, env refs, model/dimension validation, index interaction | Medium | Existing embedding code is mostly offline/client-side |
 | Docs | User docs for cluster config, policy, server, CLI; dev docs for invariants/testing | High | Public contract changes |
 | Tests | New cluster suites plus extensions to config/server/policy/recovery/schema/query tests | High | Needs boundary-matched coverage |
@@ -616,13 +616,22 @@ actor threading, 4A/4B/4C staging).
   docs and migrations say it can be narrowed.
 - Deprecate and later remove `mcp.expose` from target-state cluster config.
 
-### Phase 7: Pipeline Runtime
+### Pipelines: separate project (socket only)
 
-- Add scheduler/worker/runtime.
-- Add source connector contracts, mapping validation, idempotency keys,
-  per-target run status, and retry behavior.
-- Treat fan-out execution as data-plane writes unless explicitly staged through
-  branch/merge.
+Pipelines are **descoped from this rollout** (2026-06-10): the runtime
+(scheduler/worker, connector contracts, mapping validation, idempotency keys,
+per-target run status, retry behavior) is a separate project with its own
+RFC. This rollout guarantees only the socket:
+
+- `pipelines:` stays a reserved config field, rejected with a typed
+  `future_phase_field` diagnostic (enforced + test-covered in
+  `omnigraph-cluster`).
+- `pipeline.<name>` stays a reserved typed address; the resource model
+  (kind-agnostic state entries, extensible sidecar kinds, dependency edges)
+  accepts the new kind without reshaping.
+- Axiom 13 is the contract the future implementation must satisfy: the
+  definition is reconciled, the execution is data-plane; fan-out is statusful,
+  never silently atomic.
 
 ## Test Ownership
 
@@ -725,4 +734,4 @@ Before implementation begins beyond parser/validate, the RFC must answer:
 6. Bootstrap authority and first-actor story.
 7. Server startup and migration path from `omnigraph.yaml`.
 8. Per-query policy schema and compatibility bridge for `mcp.expose`.
-9. Pipeline runtime owner, status schema, and idempotency contract.
+9. Pipeline runtime owner, status schema, and idempotency contract — **deferred to the separate pipelines project's own RFC**; this rollout only reserves the socket.

--- a/docs/dev/cluster-config-specs.md
+++ b/docs/dev/cluster-config-specs.md
@@ -178,6 +178,21 @@ but it remains a separate CAS step from graph manifest movement. -->
 
 ## ETL pipelines (the second data-plane seam)
 
+> **Scope note (2026-06-10): descoped to a separate project.** Pipelines are
+> a product surface of their own (scheduler, connectors, mapping language,
+> idempotency, run ledger) and will be designed and built outside the cluster
+> control-plane track. What this spec retains is the **socket** they plug
+> into, which is already enforced: (1) the `pipelines:` config field is
+> reserved — `cluster validate` rejects it with a typed `future_phase_field`
+> diagnostic, so it can never be silently squatted; (2) the typed address
+> form `pipeline.<name>` and the `Pipeline` resource kind are reserved in the
+> resource model; (3) axiom 13 fixes the contract any future implementation
+> must satisfy — the pipeline *definition* is a reconciled cluster resource,
+> its *execution* is data-plane and never reconciled. The design text below
+> stands as the requirements record for that project, not as a phase of this
+> one.
+
+
 External data — from another database, an API, a file drop, a stream — is a first-class config asset, not glue code that lives nowhere.
 
 A **Pipeline** is declared in config: a **source** (e.g. `notion`, `github`, `slack`, `gdrive`, `postgres`, `http`, `s3-files`, `kafka`), an optional **schedule/trigger**, and **one or more target graphs**, each with its own **mapping/transform** (external records → graph types & properties). A single feed can **fan out across graphs** — e.g. a GitHub sync that populates both the `engineering` graph and the people/teams in `knowledge`. It is reconciled like any resource — `apply` creates / updates / deletes / (re)schedules the pipeline *definition*. This is the canonical "company brain" move: the deployment's graphs are continuously assembled from the SaaS tools the org already uses.


### PR DESCRIPTION
Per roadmap decision: pipelines are a big separate product surface and leave the cluster control-plane rollout. This PR encodes the descoping in the specs while pinning the **socket** they will plug into — all of which already exists and is enforced in code:

1. **Config field reservation**: `pipelines:` in `cluster.yaml` is rejected with a typed `future_phase_field` diagnostic (enforced + test-covered in `omnigraph-cluster`) — the name can never be silently squatted.
2. **Resource-model reservation**: the `pipeline.<name>` typed address and `Pipeline` resource kind stay reserved; the state model (kind-agnostic entries, extensible sidecar kinds, dependency edges) accepts the new kind without reshaping.
3. **The contract**: axiom 13 — the pipeline *definition* is a reconciled cluster resource; its *execution* is data-plane and never reconciled; fan-out is statusful, never silently atomic.

Changes: scope note atop the high-level spec's ETL section (which now stands as the requirements record for the future project), the implementation spec's Phase 7 section reframed as "separate project (socket only)", the blast-radius row annotated, and exit criterion 9 deferred to the pipelines project's own RFC.

Docs-only; `scripts/check-agents-md.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This docs-only PR encodes the roadmap decision to descope ETL pipeline runtime from the cluster control-plane rollout while preserving the socket (reserved config field, typed address, and axiom 13 contract) that the future pipelines project will plug into.

- **`cluster-config-specs.md`**: Adds a blockquote scope note at the top of the ETL section clarifying that the design text below is now a requirements record for the separate pipelines project, not a phase of this rollout.
- **`cluster-config-implementation-spec.md`**: Renames \"Phase 7: Pipeline Runtime\" to \"Pipelines: separate project (socket only)\", rewrites the section to document only the three socket guarantees (field rejection, address reservation, axiom 13), annotates the blast-radius table row, and defers exit criterion 9 to the pipelines project's RFC.

<h3>Confidence Score: 4/5</h3>

Safe to merge; purely documentation with no code changes.

The PR consistently annotates Phase 7, the blast-radius row, and exit criterion 9, but the two pipeline rows in the Test Ownership section (lines 660 and 672) were left unannotated — a developer reading that section after merge has no indication those test requirements belong to the separate pipelines project rather than this crate.

The Test Ownership tables in `docs/dev/cluster-config-implementation-spec.md` (lines 660 and 672) would benefit from the same "separate project" annotation applied elsewhere in the file.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docs/dev/cluster-config-implementation-spec.md | Phase 7 section reframed as "separate project (socket only)", blast-radius row and exit criterion 9 annotated; Test Ownership pipeline rows on lines 660 and 672 were not updated to reflect the descoping. |
| docs/dev/cluster-config-specs.md | Adds a blockquote scope note at the top of the ETL pipelines section documenting the descoping decision and what the socket reservation covers; existing design text is preserved as requirements record. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[cluster.yaml with pipelines: field] -->|cluster validate| B{future_phase_field diagnostic}
    B -->|rejected| C[User told: reserved, separate project]
    B -->|no silent squatting| D[Socket reservation holds]

    E[pipeline.name typed address] --> F[Reserved in resource model]
    F --> G[Kind-agnostic state entries accept Pipeline kind]

    H[Axiom 13 contract] --> I[definition = reconciled cluster resource]
    H --> J[execution = data-plane, never reconciled]
    H --> K[fan-out = statusful, never silently atomic]

    D --> L[Future Pipelines Project RFC]
    G --> L
    K --> L
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `docs/dev/cluster-config-implementation-spec.md`, line 660-672 ([link](https://github.com/modernrelay/omnigraph/blob/578141378d050d158640905f5a7e935893258d60/docs/dev/cluster-config-implementation-spec.md#L660-L672)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Test ownership rows not annotated for descoping**

   The PR annotates Phase 7, the blast-radius table row, and exit criterion 9 — but the two pipeline rows in the Test Ownership section were not updated. Line 660 lists `New runtime/mapping/idempotency/run-ledger suites` as outstanding work for this crate, and line 672 describes "Pipeline phase" fan-out assertions without any note that both belong to the separate pipelines project. A developer skimming this section after the PR merges has no signal that those test requirements have moved, creating the same confusion the rest of the PR is trying to prevent.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20docs%2Fdev%2Fcluster-config-implementation-spec.md%0ALine%3A%20660-672%0A%0AComment%3A%0A**Test%20ownership%20rows%20not%20annotated%20for%20descoping**%0A%0AThe%20PR%20annotates%20Phase%207%2C%20the%20blast-radius%20table%20row%2C%20and%20exit%20criterion%209%20%E2%80%94%20but%20the%20two%20pipeline%20rows%20in%20the%20Test%20Ownership%20section%20were%20not%20updated.%20Line%20660%20lists%20%60New%20runtime%2Fmapping%2Fidempotency%2Frun-ledger%20suites%60%20as%20outstanding%20work%20for%20this%20crate%2C%20and%20line%20672%20describes%20%22Pipeline%20phase%22%20fan-out%20assertions%20without%20any%20note%20that%20both%20belong%20to%20the%20separate%20pipelines%20project.%20A%20developer%20skimming%20this%20section%20after%20the%20PR%20merges%20has%20no%20signal%20that%20those%20test%20requirements%20have%20moved%2C%20creating%20the%20same%20confusion%20the%20rest%20of%20the%20PR%20is%20trying%20to%20prevent.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modernrelay%2Fomnigraph&pr=172&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fdev%2Fcluster-config-implementation-spec.md%3A660-672%0A**Test%20ownership%20rows%20not%20annotated%20for%20descoping**%0A%0AThe%20PR%20annotates%20Phase%207%2C%20the%20blast-radius%20table%20row%2C%20and%20exit%20criterion%209%20%E2%80%94%20but%20the%20two%20pipeline%20rows%20in%20the%20Test%20Ownership%20section%20were%20not%20updated.%20Line%20660%20lists%20%60New%20runtime%2Fmapping%2Fidempotency%2Frun-ledger%20suites%60%20as%20outstanding%20work%20for%20this%20crate%2C%20and%20line%20672%20describes%20%22Pipeline%20phase%22%20fan-out%20assertions%20without%20any%20note%20that%20both%20belong%20to%20the%20separate%20pipelines%20project.%20A%20developer%20skimming%20this%20section%20after%20the%20PR%20merges%20has%20no%20signal%20that%20those%20test%20requirements%20have%20moved%2C%20creating%20the%20same%20confusion%20the%20rest%20of%20the%20PR%20is%20trying%20to%20prevent.%0A%0A&repo=modernrelay%2Fomnigraph&pr=172&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(cluster): descope ETL pipelines to ..."](https://github.com/modernrelay/omnigraph/commit/578141378d050d158640905f5a7e935893258d60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36691758)</sub>

<!-- /greptile_comment -->