### PR TITLE
docs(cluster): RFC-005 — server boots from cluster state (Phase 5 design)

### DIFF
--- a/docs/dev/cluster-config-implementation-spec.md
+++ b/docs/dev/cluster-config-implementation-spec.md
@@ -601,6 +601,10 @@ actor threading, 4A/4B/4C staging).
 
 ### Phase 5: Server Reads Cluster Catalog
 
+Detailed design: [rfc-005-server-cluster-boot.md](rfc-005-server-cluster-boot.md)
+(the --cluster mode switch, applied-revision serving, serving metadata in
+state, readiness table, migration path).
+
 - Allow server startup from cluster state.
 - Add status and catalog endpoints as needed.
 - Keep the current `omnigraph.yaml` startup path as compatibility mode — an

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -75,6 +75,7 @@ Working documents for in-flight feature work. Removed when the work lands.
 | MCP server surface — full tool parity, stored queries, modular auth (MR-969 / MR-956 / MR-974) | [rfc-003-mcp-server-surface.md](rfc-003-mcp-server-surface.md) |
 | Future cluster control plane — declarative as-code config, JSON state ledger, reconciler | [cluster-config-specs.md](cluster-config-specs.md), [cluster-axioms.md](cluster-axioms.md), [cluster-config-implementation-spec.md](cluster-config-implementation-spec.md) |
 | Cluster graph & schema apply — Phase 4 sidecars, roll-forward recovery, approval artifacts | [rfc-004-cluster-graph-schema-apply.md](rfc-004-cluster-graph-schema-apply.md) |
+| Server boots from cluster state — Phase 5 mode switch, applied-revision serving | [rfc-005-server-cluster-boot.md](rfc-005-server-cluster-boot.md) |
 
 ## Boundary
 

--- a/docs/dev/rfc-005-server-cluster-boot.md
+++ b/docs/dev/rfc-005-server-cluster-boot.md
@@ -1,0 +1,139 @@
+# RFC: Server Boots from Cluster State — Phase 5 of the Cluster Control Plane
+
+**Status:** Proposed
+**Date:** 2026-06-10
+**Builds on:** Phase 4 complete ([rfc-004-cluster-graph-schema-apply.md](rfc-004-cluster-graph-schema-apply.md), Landed): `cluster apply` converges graphs, schemas, stored queries, and policies into the cluster catalog. Normative context: [cluster-config-specs.md](cluster-config-specs.md) (the migration model's "window 2"), [cluster-axioms.md](cluster-axioms.md) (axiom 15), [cluster-config-implementation-spec.md](cluster-config-implementation-spec.md) (Phase 5 rollout, Compatibility Stance #7–#9, exit criterion 7).
+**Target release:** unversioned (phased — see Sequencing).
+
+## Summary
+
+Give `omnigraph-server` a second boot source: `omnigraph-server --cluster <dir>` reads its graph set, stored queries, and Cedar policies from the **cluster catalog** — `state.json`'s applied revision plus the content-addressed blobs under `__cluster/resources/` — instead of `omnigraph.yaml`. This is the moment "applied" finally means "serving": the standing caveat in every cluster doc since Stage 3A ("the server still boots from `omnigraph.yaml`") retires for deployments that flip the switch.
+
+Three commitments:
+
+1. **An exclusive mode switch, never a merge** (axiom 15, Compatibility Stance #7). `--cluster <dir>` is mutually exclusive with the positional URI, `--target`, and `--config`. In cluster mode, `omnigraph.yaml` is not read at all — not for graphs, not for queries, not for policies. There is no precedence, no key-level aliasing, no fallback read. A deployment serves from one source.
+2. **The server serves the *applied* revision, not the desired config.** What's live is what `cluster apply` converged: graph roots recorded in state, query/policy content at the *applied* digests from the content-addressed catalog. Un-applied config drift never leaks into serving — the serving surface and the ledger cannot disagree (axiom 5 extended to the data path).
+3. **The state ledger becomes serving-sufficient.** Today one fact needed to serve is missing from state: a policy's `applies_to` bindings live only in `cluster.yaml`. A prerequisite slice (5A) records binding metadata into the applied revision at apply time, so a booting server reads state + blobs and nothing else. Without this, "boot from state" would silently become "boot from state *and* config" — the merged read axiom 15 forbids.
+
+## Motivation
+
+Phase 4 closed the convergence loop but left it inert: an operator can declare, plan, approve, and apply an entire deployment, and the running server ignores all of it. The Sarah/Bob test still fails at the last step — Sarah's applied change is visible in `cluster status` but Bob's clients hit a server still wired to a hand-maintained `omnigraph.yaml`. Phase 5 makes the catalog the serving source, which is also the precondition for Phase 6 (policy-owned query exposure must filter a catalog the server actually reads).
+
+## Non-Goals
+
+- **Runtime reconciliation / hot reload.** Cluster-mode boot is static, exactly like today's boot: the server reads the applied revision once at startup; picking up a newer applied state means restarting the process. The registry's runtime-mutation seam (the test-only `insert()` + mutate `Mutex` in `registry.rs`) stays future-proofing for a later watch-and-reload slice, not this RFC.
+- **Policy-owned query exposure** (Phase 6) — but this RFC defines the bridge it sunsets (§D5).
+- **Remote cluster roots.** `--cluster <dir>` is a local directory in this phase, same as the `cluster` CLI commands; S3-hosted cluster roots arrive with external state backends.
+- **Retiring `omnigraph.yaml` server boot.** It remains a fully supported mode indefinitely (Compatibility Stance #8: the file's job shrinks; the *server-role* keys become inert only for deployments that switch).
+- **New management endpoints** (`/cluster/status` etc.) — noted as future work; this RFC changes the boot source, not the HTTP surface (beyond OpenAPI regen if anything shifts).
+
+## Background (verified against main)
+
+- **Server boot today** (`omnigraph-server/src/main.rs`, `lib.rs:891-1029`): `load_server_settings` applies a four-rule mode inference (positional URI / `--target` / `server.graph` → Single; `--config` + `graphs:` → Multi), builds `ServerConfigMode::{Single,Multi}` with per-graph `GraphStartupConfig {graph_id, uri, policy_file, queries}`, loads `QueryRegistry` from `.gq` files at settings time (identity-checked), type-checks queries at engine open (`validate_and_attach`), loads Cedar via `PolicyEngine::load_graph`/`load_server`, installs it with `with_policy`, and assembles `GraphRegistry::from_handles` (startup-only; lock-free `ArcSwap` reads). Bind address and bearer tokens come from flags/env, not from graph config. No reload machinery exists.
+- **The catalog today** (`omnigraph-cluster`): `state.json` records `applied_revision.resources` (address → digest) for `graph.*`, `schema.*`, `query.<graph>.<name>`, `policy.<name>`, plus statuses, observations (incl. tombstones), approval and recovery records. Query/policy *content* lives content-addressed at `__cluster/resources/query/<graph>/<name>/<digest>.gq` and `policy/<name>/<digest>.yaml`. Graph roots are derived: `<dir>/graphs/<id>.omni`.
+- **The gap**: state records a policy's *digest* only; `applies_to` (cluster vs graph refs) lives in `cluster.yaml`. Queries are fine — their graph binding is encoded in the address itself.
+
+## Design
+
+### D1. The mode switch
+
+New server flag: `omnigraph-server --cluster <dir>` (the directory containing `cluster.yaml`, `__cluster/`, and `graphs/`). Mutually exclusive — a hard startup error, not a precedence rule — with the positional URI, `--target`, and `--config`. `--bind`, `--unauthenticated`, and the bearer-token env vars keep working identically: listen address and credentials are **process-operational facts**, not cluster facts (they differ per replica/host and never belonged to the shared catalog; if a `serve:` section ever joins `cluster.yaml`, that's a separate proposal).
+
+Mode inference gains rule 0: `--cluster <dir>` → **Cluster mode**, which is always multi-graph routing (`/graphs/{graph_id}/...`), even for a single declared graph. No flat-route legacy surface in cluster mode — it's a new mode with no compatibility debt to carry.
+
+### D2. What the server reads (the applied revision, and only it)
+
+`load_server_settings` grows a cluster branch that reads, in order:
+
+1. `__cluster/state.json` — **missing state is a boot error** ("run `cluster import` + `cluster apply` first"). Pending recovery sidecars under `__cluster/recoveries/` are also a boot error (`cluster_recovery_pending`): a server must not start serving a ledger that a sweep is about to rewrite.
+2. **Graph set** = state's `graph.<id>` resources (tombstoned graphs are absent by construction). Each graph's URI is the derived root `<dir>/graphs/<id>.omni`. A recorded graph whose root does not open is a boot error — same fail-fast posture as today's bad URI.
+3. **Stored queries** = state's `query.<graph>.<name>` entries, content loaded from the catalog blob at the recorded digest. Blob-missing or digest-mismatched is a boot error (the catalog verification semantics from Stage 3B, applied at boot). Queries type-check at engine open exactly as today (`validate_and_attach` — unchanged).
+4. **Policies** = state's `policy.<name>` entries, content from catalog blobs, bindings from the applied metadata of D3: bundles bound to `cluster` load as the server-level Cedar engine (`PolicyEngine::load_server`); bundles bound to graphs load per-graph (`PolicyEngine::load_graph`) and install via `with_policy` — the existing two-gate structure, unchanged.
+5. `cluster.yaml` is parsed **only** to validate that the directory is a cluster root (and for nothing else — explicitly not for resource content; a divergence between desired config and applied state is *served as applied*, visible via `cluster plan`).
+
+Everything downstream of settings construction — `GraphStartupConfig`, parallel engine opens, `GraphRegistry::from_handles`, routing middleware, auth, workload admission, OpenAPI — is reused as-is. Cluster mode is a new *source* for the same boot pipeline, not a new pipeline.
+
+### D3. Prerequisite: serving metadata in the applied revision (slice 5A)
+
+State's `StateResource` records only a digest. To make the ledger serving-sufficient, `cluster apply` (and the sweep's roll-forwards) additionally record **binding metadata** for policy resources at apply time:
+
+```json
+"applied_revision": {
+  "resources": {
+    "policy.base_rbac": {
+      "digest": "<sha256>",
+      "applies_to": ["cluster", "graph.knowledge"]
+    }
+  }
+}
+```
+
+- Additive and optional (`#[serde(default)]`) — existing state files parse unchanged; a policy entry without `applies_to` (applied before 5A) is a **boot error in cluster mode** with the remedy "re-run `cluster apply`" (one apply rewrites the metadata; the digest needn't change — the metadata write is part of the state mutation, not the blob).
+- `applies_to` is normalized to typed addresses (`cluster` | `graph.<id>`) at apply time, mirroring the validator's normalization.
+- Queries need no equivalent: the address (`query.<graph>.<name>`) already carries the binding, and the registry key/symbol invariant is enforced at apply (validate) time.
+- This is deliberately *applied* metadata, not config mirroring: if `cluster.yaml` changes a binding, the server keeps serving the old binding until `cluster apply` converges it — the same contract as every other resource.
+
+### D4. Readiness and failure posture
+
+Boot is fail-fast, matching the server's existing stance (bad policy YAML refuses boot):
+
+| Condition | Behavior |
+|---|---|
+| `state.json` missing / unparseable / unsupported version | boot error |
+| pending recovery sidecars | boot error (run any state-mutating cluster command to sweep) |
+| recorded graph root missing or unopenable | boot error |
+| query/policy blob missing or digest-mismatched | boot error (run `cluster refresh` + `apply` to self-heal, then restart) |
+| policy entry without `applies_to` metadata | boot error ("re-run cluster apply", D3) |
+| stored query fails type-check against the live schema | boot error (existing `validate_and_attach` behavior) |
+| state lock held | **not** an error — boot takes no lock; it reads a point-in-time snapshot of an immutable-once-written state file (the CAS discipline means a concurrent apply produces a *new* file atomically; the server reads whichever was current at open) |
+
+### D5. The `mcp.expose` bridge in cluster mode
+
+The cluster query registry has no `expose` flag by design (axiom 14: exposure is a policy decision — Phase 6). Until Phase 6 ships, cluster-mode servers list **all** stored queries in `GET /queries`. This is the documented bridge: *cluster mode = everything exposed; omnigraph.yaml mode = `mcp.expose` honored as today*. Its named sunset is Phase 6's policy-filtered catalog (Compatibility Stance #9). Invocation remains gated by the existing coarse `invoke_query` Cedar action in both modes.
+
+### D6. Migration path (exit criterion 7)
+
+For an operator running multi-graph from `omnigraph.yaml`:
+
+1. Author `cluster.yaml` declaring the same graphs/queries/policies; place existing graph roots under `<dir>/graphs/<id>.omni` (or start fresh).
+2. `cluster import` (observes live graphs) → `cluster plan` → `cluster apply` (publishes queries/policies into the catalog; with 5A, records policy bindings).
+3. Restart the server with `--cluster <dir>` instead of `--config omnigraph.yaml`.
+4. `omnigraph.yaml`'s `graphs:`/`serve:`/`queries:`/`policy:` keys are now inert for this deployment; the file remains the CLI's per-operator config.
+
+Rollback is the same switch in reverse — nothing in cluster mode mutates `omnigraph.yaml` or the graphs in a way the yaml mode can't serve.
+
+### D7. Invariants and axioms check
+
+- *Axiom 15 / Stance #7*: exclusive flag, hard mutual-exclusion error, zero `omnigraph.yaml` reads in cluster mode — no fact has two readers.
+- *Axiom 5*: the server serves deployed reality (applied digests), never desired intent; D3 keeps the ledger the single serving source.
+- *Axiom 12*: boot reads without the lock but relies on the atomic-replace write discipline; it never writes state.
+- *Axiom 14 / Stance #9*: the expose-all bridge is named, scoped to cluster mode, and carries its Phase 6 sunset.
+- *Loud failures (deny-list)*: every degraded condition is a typed boot error with a remedy; no partial serving, no silent fallback to the yaml.
+- *Respect the boundaries*: `omnigraph-cluster` stays free of HTTP; the server reads the catalog through a small read-only loader (either a `pub` read surface on `omnigraph-cluster` or a thin module in the server consuming the documented file formats — implementation picks the one that keeps `omnigraph-cluster` dependency-light; the state/blob formats are already a documented contract).
+
+## Sequencing
+
+| Slice | Scope | Gate |
+|---|---|---|
+| **5A: serving metadata in state** | `applies_to` recorded on policy resources at apply + sweep roll-forward; additive state schema; `status`/plan surfacing | In-crate tests: metadata written/rolled-forward; old state parses; re-apply backfills |
+| **5B: `--cluster` boot mode** | Flag + mode inference rule 0; catalog loader (state → `GraphStartupConfig`s + registries + policy engines); readiness table; OpenAPI regen if surface shifts | Server tests: boot from a converged fixture dir, serve `/graphs/{id}/query` + stored queries + Cedar gates; every D4 row refuses boot; e2e: `cluster apply` then serve — "applied means serving" |
+| **5C: docs + caveat retirement** | `cluster-config.md` mode-switch section; `server.md`/`deployment.md`; retire the "not serving" caveats for cluster-mode deployments; migration guide (D6) | `check-agents-md.sh`; doc accuracy review |
+
+## Exit-criteria coverage
+
+Answers implementation-spec exit criterion 7 (server startup + migration path) in full; touches 1 (state schema gains policy binding metadata — additive). Criteria 8 (per-query policy) and 9 (pipelines — descoped to a separate project) remain.
+
+## Open Questions
+
+1. **Loader home**: `pub` read-only API on `omnigraph-cluster` (server gains the dependency) vs a server-side reader of the documented formats. Leaning `omnigraph-cluster` API — one parser for the state schema beats two drifting ones; the crate stays HTTP-free either way.
+2. **Boot-time blob re-hash**: D4 requires digest verification at boot; for large catalogs a stat-only fast path with full hashes behind a flag may matter later. Start with full verification (catalogs are small).
+3. **`GET /graphs` enrichment**: cluster mode could expose applied digests/revision in the enumeration — deferred until a consumer exists.
+4. **Watch-and-reload**: the natural follow-up once cluster mode exists; the registry's mutation seam is ready, but reload semantics (drain? cutover?) deserve their own design.
+
+## References
+
+- [rfc-004-cluster-graph-schema-apply.md](rfc-004-cluster-graph-schema-apply.md) — the convergence machinery this serves
+- [cluster-config-specs.md](cluster-config-specs.md) §Migration model — window 2 is this RFC
+- [cluster-axioms.md](cluster-axioms.md) — axioms 5, 12, 14, 15
+- [cluster-config-implementation-spec.md](cluster-config-implementation-spec.md) — Phase 5 rollout, Compatibility Stance #7–#9, blast-radius rows for the server registry
+- `crates/omnigraph-server/src/lib.rs` (`load_server_settings`, `ServerConfigMode`, `GraphRegistry`) — the boot pipeline this extends without forking


### PR DESCRIPTION
The Phase 5 design slice, following the RFC-before-code pattern that worked for Phase 4. Docs-only.

## What the RFC settles

1. **The mode switch** (axiom 15, Compatibility Stance #7): `omnigraph-server --cluster <dir>` — mutually exclusive with the positional URI / `--target` / `--config` as a hard startup error, with **zero** `omnigraph.yaml` reads in cluster mode. Bind address and bearer tokens stay process-operational (flags/env) — they're per-replica facts, not cluster facts. Cluster mode is always multi-graph routing; no flat-route legacy surface.
2. **Serve the *applied* revision, not desired config** (§D2): graph set from state's `graph.*` resources at derived roots, stored queries and policies from the content-addressed catalog at the applied digests. Un-applied config drift never leaks into serving — `cluster plan` is where drift is visible.
3. **The load-bearing finding** (§D3): state is not yet serving-sufficient — a policy's `applies_to` bindings live only in `cluster.yaml`. Prerequisite slice **5A** records binding metadata into the applied revision at apply/roll-forward time (additive state schema; pre-5A entries are a boot error with "re-run cluster apply" as the remedy). Without this, boot-from-state silently becomes the merged read axiom 15 forbids. Cluster-scoped bundles (`applies_to: [cluster]`) map cleanly onto the existing server-level Cedar engine.
4. **Fail-fast readiness table** (§D4): missing state, pending recovery sidecars, missing graph roots, missing/mismatched catalog blobs, unbound policies, and query type-check failures all refuse boot with typed remedies. A held state lock is explicitly *not* an error (boot reads the atomically-replaced state snapshot, lock-free).
5. **The `mcp.expose` bridge** (§D5): cluster mode exposes all stored queries (the cluster registry has no expose flag by design — axiom 14); named sunset is Phase 6's policy-filtered catalog.
6. **Migration path** (§D6, exit criterion 7) and sequencing: 5A serving metadata → 5B the `--cluster` boot mode (reusing the existing `GraphStartupConfig` → registry → routing/auth pipeline as-is — a new source, not a new pipeline) → 5C docs + retiring the "applied ≠ serving" caveats.

Grounded in a full survey of the current boot anatomy (`load_server_settings` four-rule inference, `ServerConfigMode`, `GraphRegistry`'s startup-only `ArcSwap`, query/policy load + `with_policy` wiring) — all reused unchanged.

`scripts/check-agents-md.sh` green; linked from the dev index and the implementation spec's Phase 5 section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This docs-only PR introduces RFC-005, the Phase 5 design for booting `omnigraph-server` from cluster state via a new `--cluster <dir>` flag, following the RFC-before-code pattern used for Phase 4.

- **New RFC** (`rfc-005-server-cluster-boot.md`): defines the exclusive mode switch, the applied-revision serving contract, the prerequisite 5A serving-metadata state extension, the fail-fast readiness table, the expose-all `GET /queries` bridge for cluster mode, and a phased sequencing plan (5A → 5B → 5C).
- **Supporting updates**: a 4-line pointer block added to the Phase 5 section of the implementation spec, and one index row added to `docs/dev/index.md`.

<h3>Confidence Score: 3/5</h3>

The RFC is docs-only and ships no code, but it contains two spec-level design gaps that would produce subtle bugs if implemented as written — worth resolving before 5A/5B work begins.

The cluster.yaml parse-at-boot in D2/step 5 can silently block a server from a valid applied state when desired config has a post-apply syntax error, directly contradicting the RFC's stated invariant. D3's use of Vec<String> with serde(default) makes it impossible to distinguish a pre-5A absent applies_to field from an explicit empty list, so the pre-5A detection logic cannot work as described. Both issues are in the RFC text itself and need correction before implementation slices begin.

docs/dev/rfc-005-server-cluster-boot.md — D2 step 5 (cluster.yaml parse-at-boot) and D3 (applies_to sentinel type) both need revision before implementation begins.

<details open><summary><h3>Security Review</h3></summary>

- **`GET /queries` auth posture unspecified (D5)**: The RFC exposes all stored queries via `GET /queries` in cluster mode but does not state whether the list endpoint is behind the same auth middleware as query invocation. In `--unauthenticated` mode, or if the list route bypasses Cedar, the full query catalog is enumerable by any caller — a broader surface than the per-query `invoke_query` gate that is explicitly maintained.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/dev/rfc-005-server-cluster-boot.md | New RFC defining the Phase 5 cluster boot design; two implementation-level spec gaps found: cluster.yaml parse-at-boot can block serving from a valid applied state (D2/step 5), and Vec<String>+serde(default) cannot distinguish absent applies_to from an explicit empty list (D3). |
| docs/dev/cluster-config-implementation-spec.md | Adds a 4-line pointer block linking Phase 5 to the new RFC; no logic changes, consistent with the existing Phase 4 pointer pattern. |
| docs/dev/index.md | Adds one index row for RFC-005; format and link are consistent with adjacent RFC entries. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[omnigraph-server startup] --> B{Which flag?}
    B -- "--cluster dir" --> C[Cluster Mode]
    B -- "positional URI / --target / --config" --> D[omnigraph.yaml Mode]
    B -- "conflicting flags" --> E[Hard startup error]

    C --> F[Read state.json]
    F -- missing or unparseable --> ERR1[Boot error: run cluster import + apply]
    F -- pending recovery sidecars --> ERR2[Boot error: cluster_recovery_pending]
    F --> G[Load graph set from state graph.* resources]
    G -- root missing or unopenable --> ERR3[Boot error: bad graph root]
    G --> H[Load stored queries from catalog blobs at applied digests]
    H -- blob missing or digest mismatch --> ERR4[Boot error: run cluster refresh + apply]
    H --> I[Load policies from catalog blobs]
    I -- applies_to metadata absent pre-5A --> ERR5[Boot error: re-run cluster apply]
    I --> J[Type-check queries via validate_and_attach]
    J -- type-check fails --> ERR6[Boot error: existing behavior]
    J --> K[Build GraphStartupConfig and GraphRegistry]
    K --> L[Serve: multi-graph routing]

    D --> M[load_server_settings four-rule inference]
    M --> N[Single or Multi GraphStartupConfig]
    N --> O[Serve: existing routing]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Adocs%2Fdev%2Frfc-005-server-cluster-boot.md%3A72-75%0A**%60cluster.yaml%60%20parse-at-boot%20contradicts%20%22serve%20the%20applied%20revision%22**%0A%0AD2%2C%20step%205%20says%20%60cluster.yaml%60%20is%20parsed%20%22only%20to%20validate%20that%20the%20directory%20is%20a%20cluster%20root.%22%20But%20the%20RFC's%20core%20invariant%20is%20that%20un-applied%20config%20drift%20must%20never%20affect%20the%20serving%20path.%20If%20an%20operator%20edits%20%60cluster.yaml%60%20after%20the%20last%20%60cluster%20apply%60%20and%20introduces%20a%20parse%20error%20%28a%20dropped%20quote%2C%20a%20bad%20indent%29%2C%20the%20server%20would%20fail%20to%20start%20even%20though%20the%20applied%20state%20in%20%60state.json%60%20is%20perfectly%20valid.%20A%20stat%2Fexistence%20check%20on%20%60__cluster%2Fstate.json%60%20would%20confirm%20%22this%20is%20a%20cluster%20directory%22%20without%20importing%20a%20%60cluster.yaml%60%20parse%20failure%20into%20the%20serving%20path.%20As%20written%2C%20a%20typo%20in%20the%20*desired*%20config%20can%20block%20serving%20from%20the%20*applied*%20state%20%E2%80%94%20which%20is%20precisely%20the%20outcome%20the%20RFC%20says%20it%20prevents.%0A%0A%23%23%23%20Issue%202%20of%203%0Adocs%2Fdev%2Frfc-005-server-cluster-boot.md%3A87-100%0A**%60%23%5Bserde%28default%29%5D%60%20on%20%60applies_to%60%20cannot%20distinguish%20absent%20from%20explicitly%20empty**%0A%0AThe%20RFC%20describes%20the%20pre-5A%20sentinel%20as%20%22a%20policy%20entry%20*without*%20%60applies_to%60%22%20and%20says%20boot%20should%20error%20on%20those%20entries.%20With%20%60Vec%3CString%3E%60%20%2B%20%60%23%5Bserde%28default%29%5D%60%2C%20an%20absent%20%60applies_to%60%20field%20and%20an%20explicit%20%60%22applies_to%22%3A%20%5B%5D%60%20both%20deserialize%20to%20an%20empty%20%60Vec%60%20%E2%80%94%20they%20are%20indistinguishable%20at%20boot.%20A%20policy%20legitimately%20bound%20to%20no%20graphs%20would%20be%20treated%20identically%20to%20a%20pre-5A%20entry%2C%20and%20more%20importantly%2C%20a%20pre-5A%20entry%20cannot%20be%20reliably%20detected.%20The%20spec%20should%20call%20for%20%60Option%3CVec%3CString%3E%3E%60%20with%20%60%23%5Bserde%28default%29%5D%60%3A%20%60None%60%20means%20absent%20%28pre-5A%20%E2%86%92%20boot%20error%29%2C%20%60Some%28bindings%29%60%20means%20the%20field%20was%20explicitly%20written%20at%20apply%20time%20and%20is%20the%20source%20of%20truth%20%E2%80%94%20even%20if%20empty.%0A%0A%23%23%23%20Issue%203%20of%203%0Adocs%2Fdev%2Frfc-005-server-cluster-boot.md%3A107-110%0A**%60GET%20%2Fqueries%60%20auth%20posture%20in%20cluster%20mode%20is%20unspecified**%0A%0AD5%20states%20that%20cluster%20mode%20exposes%20all%20stored%20queries%20via%20%60GET%20%2Fqueries%60%20and%20that%20invocation%20stays%20gated%20behind%20the%20existing%20%60invoke_query%60%20Cedar%20action.%20It%20does%20not%20state%20whether%20the%20*list*%20endpoint%20itself%20is%20behind%20the%20same%20auth%20middleware%20or%20whether%20unauthenticated%20clients%20can%20enumerate%20every%20stored%20query%20name%20and%20signature.%20If%20%60--unauthenticated%60%20mode%20is%20in%20use%2C%20or%20if%20the%20list%20endpoint%20bypasses%20Cedar%2C%20this%20exposes%20the%20full%20query%20catalog%20to%20any%20caller%20%E2%80%94%20a%20broader%20surface%20than%20the%20per-query%20invocation%20gate.%20The%20spec%20should%20explicitly%20state%20what%20authorization%20covers%20%60GET%20%2Fqueries%60%20in%20cluster%20mode.%0A%0A&repo=modernrelay%2Fomnigraph&pr=174&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(cluster): RFC-005 — server boots fr..."](https://github.com/modernrelay/omnigraph/commit/6d66b0537e2a64df37bd66bd8a89b39cb891dced) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36699130)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->