### PR TITLE
ci: pin RustFS to 1.0.0-beta.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,14 +306,12 @@ jobs:
             . -> target
 
       - name: Start RustFS
-        # Pinned to 1.0.0-beta.3 (2026-05-14) — the last known-good tag.
-        # `rustfs/rustfs:latest` (1.0.0-beta.4, 2026-05-21) added a
-        # credentials-policy check that refuses to start when
-        # AWS_ACCESS_KEY_ID/SECRET_ACCESS_KEY are values it considers
-        # "default" (rustfsadmin/rustfsadmin in our case). Bumping to
-        # beta.4+ requires either rotating those creds to less-default
-        # values or setting RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS=true
-        # — deliberate work, not an emergency. Pin first; upgrade later.
+        # Pinned to 1.0.0-beta.8 (2026-06-10). beta.4+ refuses "default"
+        # credentials (rustfsadmin/rustfsadmin) unless
+        # RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS=true is set — fine for
+        # an ephemeral CI container. The three S3 suites were validated
+        # against the beta.8 binary locally before this bump. Keep the pin
+        # explicit (never `latest`) so upgrades are deliberate.
         run: |
           docker rm -f rustfs >/dev/null 2>&1 || true
           docker run -d \
@@ -322,7 +320,8 @@ jobs:
             -p 9001:9001 \
             -e RUSTFS_ACCESS_KEY="${AWS_ACCESS_KEY_ID}" \
             -e RUSTFS_SECRET_KEY="${AWS_SECRET_ACCESS_KEY}" \
-            rustfs/rustfs:1.0.0-beta.3 \
+            -e RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS=true \
+            rustfs/rustfs:1.0.0-beta.8 \
             /data
 
       - name: Install AWS CLI

--- a/scripts/local-rustfs-bootstrap.sh
+++ b/scripts/local-rustfs-bootstrap.sh
@@ -6,14 +6,12 @@ SOURCE_REF="${SOURCE_REF:-main}"
 RELEASE_CHANNEL="${RELEASE_CHANNEL:-edge}"
 WORKDIR="${WORKDIR:-$PWD/.omnigraph-rustfs-demo}"
 RUSTFS_CONTAINER_NAME="${RUSTFS_CONTAINER_NAME:-omnigraph-rustfs-demo}"
-# Pinned to 1.0.0-beta.3 (2026-05-14) — the last known-good tag, matching CI
-# (.github/workflows/ci.yml). `rustfs/rustfs:latest` (1.0.0-beta.4, 2026-05-21)
-# added a credentials-policy check that refuses to start when the access/secret
-# keys are values it considers "default" (rustfsadmin/rustfsadmin here). This
-# script still works on beta.4+ because it passes
-# RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS=true below — so overriding
-# RUSTFS_IMAGE to a newer tag is safe.
-RUSTFS_IMAGE="${RUSTFS_IMAGE:-rustfs/rustfs:1.0.0-beta.3}"
+# Pinned to 1.0.0-beta.8 (2026-06-10), matching CI (.github/workflows/ci.yml).
+# beta.4+ has a credentials-policy check that refuses to start when the
+# access/secret keys are values it considers "default" (rustfsadmin/rustfsadmin
+# here); this script passes RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS=true
+# below, so overriding RUSTFS_IMAGE to another tag is safe.
+RUSTFS_IMAGE="${RUSTFS_IMAGE:-rustfs/rustfs:1.0.0-beta.8}"
 RUSTFS_DATA_DIR="${RUSTFS_DATA_DIR:-$WORKDIR/rustfs-data}"
 BUCKET="${BUCKET:-omnigraph-local}"
 PREFIX="${PREFIX:-repos/context}"


### PR DESCRIPTION
Bumps the RustFS pin from 1.0.0-beta.3 (2026-05-14) to **1.0.0-beta.8** (2026-06-10, current latest) in both the CI job and `scripts/local-rustfs-bootstrap.sh`.

The old pin existed because beta.4 introduced a credentials-policy check that refuses "default"-looking keys (`rustfsadmin`/`rustfsadmin`); the documented unblock — `RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS=true` — is now set on the CI container (the bootstrap script already passed it). Fine for an ephemeral test container; the pin stays explicit (never `latest`) so future upgrades remain deliberate.

Validated before the bump: all three S3 suites (`s3_storage`, the server S3 graph test, the CLI S3 e2e) plus the full `system_local` file pass against the **beta.8 binary** locally. This PR touches `ci.yml`, so the classify filter runs the RustFS job here — the container path validates itself before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Advances the explicit RustFS Docker image pin from `1.0.0-beta.3` to `1.0.0-beta.8` in both CI and the local bootstrap script, and adds `RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS=true` to the CI `docker run` invocation so the container accepts the default `rustfsadmin`/`rustfsadmin` test credentials that beta.4+ started rejecting.

- **`ci.yml`**: Adds `-e RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS=true` (already present in the bootstrap script) alongside the image tag bump; all three S3 test suites are exercised in the same job.
- **`scripts/local-rustfs-bootstrap.sh`**: Default `RUSTFS_IMAGE` tag updated to match CI; `start_rustfs()` already passed the insecure-credentials flag, so the only change here is the pin and its comment.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the only changes are a version tag bump and an env var addition that unblocks the new tag; both files are updated consistently and the bootstrap script already carried the same flag.

Both files are updated in lockstep (same tag, same flag), the insecure-credentials flag was already present in the bootstrap script so no net new security surface is introduced, and the PR description documents local validation against beta.8 across all three S3 test suites before the bump.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Bumps RustFS image from 1.0.0-beta.3 to 1.0.0-beta.8 and adds RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS=true to the docker run command so the container starts with default test credentials under beta.4+. |
| scripts/local-rustfs-bootstrap.sh | Updates RUSTFS_IMAGE default pin from 1.0.0-beta.3 to 1.0.0-beta.8 and refreshes the comment; the script already had RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS=true in start_rustfs(), so no functional change beyond the version bump. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant Docker as Docker (RustFS 1.0.0-beta.8)
    participant AWS as AWS CLI
    participant Tests as Cargo Tests

    GHA->>Docker: "docker run -e RUSTFS_ACCESS_KEY -e RUSTFS_SECRET_KEY<br/>-e RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS=true<br/>rustfs/rustfs:1.0.0-beta.8 /data"
    Docker-->>GHA: Container started (port 9000/9001)
    GHA->>AWS: Install AWS CLI
    loop Wait up to 60s
        GHA->>Docker: s3api list-buckets (health check)
        Docker-->>GHA: ready / not ready
    end
    GHA->>Docker: s3api create-bucket (test bucket)
    GHA->>Tests: cargo test s3_storage
    GHA->>Tests: cargo test server_opens_s3_repo_directly...
    GHA->>Tests: cargo test local_cli_s3_end_to_end...
    Tests-->>GHA: pass / fail
    GHA->>Docker: docker logs rustfs (on failure only)
```

<sub>Reviews (1): Last reviewed commit: ["ci: pin RustFS to 1.0.0-beta.8"](https://github.com/modernrelay/omnigraph/commit/711e04a161655c95c7a46e7f9a13bd64cb6a7473) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36743320)</sub>

<!-- /greptile_comment -->