### PR TITLE
docs(cluster): operator how-to guide for deploying and managing clusters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ Full diagram and concurrency model: [docs/dev/architecture.md](docs/dev/architec
 | Diff / change feed (`diff_between`, `diff_commits`) | [docs/user/changes.md](docs/user/changes.md) |
 | Query execution, mutation execution, bulk loader, `load` vs `ingest` | [docs/dev/execution.md](docs/dev/execution.md) |
 | `optimize` (compaction) and `cleanup` (version GC) | [docs/user/maintenance.md](docs/user/maintenance.md) |
+| Cluster operator guide (deploy/manage clusters, approvals, recovery, serving) | [docs/user/cluster.md](docs/user/cluster.md) |
 | Cedar policy actions, scopes, CLI | [docs/user/policy.md](docs/user/policy.md) |
 | HTTP server endpoints, auth, error model, body limits | [docs/user/server.md](docs/user/server.md) |
 | CLI quick-start | [docs/user/cli.md](docs/user/cli.md) |

--- a/docs/user/cluster-config.md
+++ b/docs/user/cluster-config.md
@@ -2,6 +2,9 @@
 
 **Status:** Phase 5 — cluster-booted serving (`omnigraph-server --cluster`).
 
+> New to the cluster tooling? Start with the operator how-to guide,
+> [cluster.md](cluster.md) — this document is the reference.
+
 Cluster config is the future control-plane configuration surface for a whole
 OmniGraph deployment. In this stage, OmniGraph can validate a local
 `cluster.yaml` folder, produce a deterministic read-only plan, inspect the

--- a/docs/user/cluster.md
+++ b/docs/user/cluster.md
@@ -1,0 +1,256 @@
+# Operating an OmniGraph Cluster
+
+This is the operator's guide to the cluster control plane: how to go from an
+empty directory to a served deployment, and how to run it day to day —
+evolving schemas, rotating queries and policies, healing drift, approving
+destructive changes, and recovering from crashes.
+
+It is a **how-to**. The reference for every `cluster.yaml` key, command flag,
+state-file field, and diagnostic code is
+[cluster-config.md](cluster-config.md); the HTTP surface is
+[server.md](server.md).
+
+## The model in one paragraph
+
+You declare the entire deployment — graphs, schemas, stored queries, Cedar
+policies — as files in one directory (`cluster.yaml` plus the `.pg`/`.gq`/
+`.yaml` files it references). `cluster apply` converges reality to that
+declaration and records what it did in a state ledger
+(`__cluster/state.json`); `cluster plan` previews exactly what apply would
+do, including real schema-migration steps. A server started with
+`omnigraph-server --cluster <dir>` serves what was applied — never what is
+merely written in config. Terraform users will recognize the shape: config
+is desired state, the ledger is recorded state, plan is the diff, apply is
+the only thing that changes the world, and irreversible changes require an
+explicitly recorded approval.
+
+## 1. Deploy a cluster from zero
+
+Lay out a config directory:
+
+```
+company-brain/
+├── cluster.yaml
+├── people.pg            # schema for the "knowledge" graph
+├── people.gq            # a stored query
+└── base.policy.yaml     # a Cedar policy bundle
+```
+
+```yaml
+# cluster.yaml
+version: 1
+metadata:
+  name: company-brain
+graphs:
+  knowledge:
+    schema: ./people.pg
+    queries:
+      find_person:
+        file: ./people.gq
+policies:
+  base:
+    file: ./base.policy.yaml
+    applies_to: [knowledge]      # graph-bound; use [cluster] for server-level
+```
+
+Bring it to life:
+
+```bash
+omnigraph cluster validate --config ./company-brain   # parse + typecheck everything
+omnigraph cluster import   --config ./company-brain   # create the state ledger
+omnigraph cluster plan     --config ./company-brain   # preview: what would apply do?
+omnigraph cluster apply    --config ./company-brain   # converge
+```
+
+That single `apply` **creates the graph** (at the derived root
+`./company-brain/graphs/knowledge.omni`), applies its schema, and publishes
+the query and policy into the content-addressed catalog
+(`__cluster/resources/…`). The output lists every change with its
+disposition; `converged: true` means there is nothing left to do — re-running
+`apply` is always safe and idempotent.
+
+Load data through the normal graph plane (the control plane manages
+*definitions*, not rows):
+
+```bash
+omnigraph load --data ./seed.jsonl ./company-brain/graphs/knowledge.omni
+```
+
+Serve it:
+
+```bash
+OMNIGRAPH_SERVER_BEARER_TOKENS_JSON='{"act-reader":"s3cret"}' \
+  omnigraph-server --cluster ./company-brain --bind 0.0.0.0:8080
+```
+
+`--cluster` is an **exclusive boot source**: it cannot be combined with a
+graph URI, `--target`, or `--config`, and `omnigraph.yaml` is never read in
+this mode. Routing is always multi-graph:
+
+```bash
+curl -H 'authorization: Bearer s3cret' \
+  -X POST http://localhost:8080/graphs/knowledge/queries/find_person \
+  -H 'content-type: application/json' -d '{"params":{"name":"Ada"}}'
+```
+
+Bearer tokens and the bind address are deliberately *not* cluster facts —
+they are per-replica, set by flag or environment
+([server.md](server.md#modes) for the token sources).
+
+## 2. The day-2 loop: edit → plan → apply → restart
+
+Every change follows the same loop, whatever its kind:
+
+```bash
+$EDITOR company-brain/people.pg          # or any .gq / policy / cluster.yaml edit
+omnigraph cluster plan  --config ./company-brain
+omnigraph cluster apply --config ./company-brain --as andrew
+# restart cluster-booted servers to pick it up
+```
+
+`--as <actor>` attributes the run: it is recorded in recovery sidecars and
+audit entries and threaded into the engine's commit history. Make it a habit
+on every apply (it is required for `approve`).
+
+What each change kind does:
+
+| You edit | Plan shows | Apply does |
+|---|---|---|
+| a `.gq` file or `queries:` entry | `Update query.<g>.<n>` | publishes the new content-addressed blob, updates the ledger |
+| a policy file | `Update policy.<n>` | same — new blob, ledger update |
+| a policy's `applies_to` | `Update policy.<n> [bindings]` | records the new bindings (the file digest is unchanged; bindings are first-class changes) |
+| a `.pg` schema | `Update schema.<g>` **with the real migration steps embedded** | runs the engine's schema apply on the live graph — soft drops only, sidecar-fenced |
+| `graphs:` gains an entry | `Create graph.<g>` (+ schema, queries) | initializes the graph at its derived root; dependents apply in the same run |
+| `graphs:` loses an entry | `Delete graph.<g>` — **blocked, `approval_required`** | nothing, until approved (see §4) |
+
+Two properties worth internalizing:
+
+- **One apply, ordered correctly.** Creates run first, then schema
+  migrations, then catalog writes, then (approved) deletes — so a schema
+  change plus a query that uses the new field converge together in one run.
+- **Soft drops only.** A removed schema property disappears from the current
+  version while prior versions retain the data (reversible until `cleanup`).
+  Data-loss migrations are not reachable from cluster apply.
+
+Read the plan before applying when the change is non-trivial — for schema
+updates it embeds the engine's actual migration plan (`add_property`,
+`drop_property [soft]`, `unsupported: …`), so you see data impact before
+anything runs.
+
+## 3. Inspect: status, refresh, drift
+
+```bash
+omnigraph cluster status  --config ./company-brain --json   # ledger only, read-only
+omnigraph cluster refresh --config ./company-brain          # re-observe live graphs
+```
+
+`status` never touches the graphs; `refresh` opens them read-only and
+records what it finds — manifest versions, live schema digests, catalog blob
+integrity. If someone changed a graph behind the control plane's back (a
+direct `omnigraph schema apply`, a tampered catalog file), refresh marks the
+resource **`drifted`**.
+
+**Drift is converged, not just reported.** After a refresh records drift,
+the next `plan` proposes migrating the live graph back to the declared
+schema — with the steps visible, including the soft drops of out-of-band
+fields — and `apply` executes it like any other change. If the out-of-band
+change is the one you want, change the *config* to match instead, and apply
+converges the ledger.
+
+## 4. Destructive changes: the approval gate
+
+Removing a graph from `cluster.yaml` never executes silently:
+
+```bash
+omnigraph cluster apply --config ./company-brain
+#   Delete graph.scratch [Blocked: approval_required]
+
+omnigraph cluster approve graph.scratch --config ./company-brain --as andrew
+#   cluster approve: delete graph.scratch approved by andrew (approval 01KT…)
+
+omnigraph cluster apply --config ./company-brain --as andrew
+#   Delete graph.scratch [Applied]   ← root removed, subtree tombstoned
+```
+
+The approval artifact (`__cluster/approvals/<id>.json`) is **digest-bound**:
+it authorizes exactly the change you saw when you approved it. Any config or
+state movement afterwards invalidates it automatically (`approval_stale`
+warning) — a stale approval can never authorize a different delete. One
+approval covers the graph's whole subtree (its schema and queries ride
+along). Consumed artifacts are kept (rewritten with `consumed_at`) and
+summarized in the ledger's `approval_records`, so the audit trail of *who
+approved what* survives the loss of either store.
+
+## 5. When things go wrong
+
+**Crashes are designed for.** Every graph-moving operation (create, schema
+apply, delete) writes a recovery sidecar before acting. If an apply dies
+mid-run, the next state-mutating command sweeps the sidecars and reconciles
+— rolling the ledger forward when the operation completed on the graph,
+retiring stale intent when nothing moved, and flagging anything it cannot
+verify. You generally fix a crashed run by **running `cluster apply`
+again**.
+
+**A held lock** (a crashed process left `__cluster/lock.json`):
+
+```bash
+omnigraph cluster status --config ./company-brain      # shows the lock holder + id
+omnigraph cluster force-unlock <LOCK_ID> --config ./company-brain
+```
+
+Force-unlock requires the exact lock id (from status) — there is no blind
+unlock.
+
+**A lost or corrupted state ledger**: the cluster is self-describing.
+`cluster import` rebuilds `state.json` from the config plus read-only
+observation of the live graphs; the next `apply` re-converges onto the same
+content-addressed catalog.
+
+**A server that refuses to boot** with `--cluster` is telling you the
+applied revision is not safely servable. Each refusal names its remedy:
+
+| Boot error | Meaning | Remedy |
+|---|---|---|
+| `cluster_state_missing` | no ledger | `cluster import`, then `apply` |
+| `cluster_recovery_pending` | interrupted operation awaiting sweep | run `cluster apply` (or any state-mutating command), restart |
+| `catalog_payload_missing` / `…_digest_mismatch` | catalog blob lost or tampered | `cluster refresh`, then `apply`, restart |
+| `policy_bindings_missing` | ledger predates binding metadata | re-run `cluster apply` (backfills), restart |
+| `cluster_empty` | applied revision has no graphs | apply a cluster with ≥1 graph |
+| multiple bundles bind one scope | serving holds one policy bundle per graph + one server-level | split or merge bundles |
+
+A held *state lock* is deliberately **not** a boot error — the server reads
+the atomically-replaced ledger without locking, so serving never contends
+with an in-flight apply.
+
+## 6. Deployment patterns
+
+- **Replicas**: any number of `--cluster` servers can serve the same config
+  directory; boot is read-only. Roll out a change by `apply` once, then
+  restarting replicas (serving is static per process — there is no hot
+  reload yet).
+- **The directory is the deployable unit**: config, catalog, ledger,
+  approvals, and graph data all live under it. Back it up as a whole;
+  version the *config files* (not `__cluster/` or `graphs/`) in git.
+- **CI-driven convergence**: `validate` and `plan --json` are read-only and
+  safe in pipelines; gate `apply --as ci` on plan review. Approvals are the
+  human step by design — keep `cluster approve` out of automation.
+- **`omnigraph.yaml` still has a job**: per-operator settings (CLI defaults,
+  credentials, active context). It just no longer describes the deployment —
+  a server boots from one source or the other, never a merge of both.
+
+## What the control plane does not do (yet)
+
+- **No hot reload** — applied changes serve on the next restart.
+- **No S3-hosted cluster directories** — the config dir, ledger, catalog,
+  and derived graph roots are local-filesystem paths today. (Individual
+  *graphs* on S3 are a server feature outside cluster mode.)
+- **No data operations** — rows move through `omnigraph load / ingest /
+  mutate` against the graph roots, with branches and merges as usual.
+- **Stored-query exposure is all-or-nothing per cluster** — every applied
+  query is listed and invokable (subject to Cedar `invoke_query`); per-query
+  exposure policy is a planned phase.
+- **Pipelines (ETL)** are a separate project; the `pipelines:` key is
+  reserved and rejected loudly.
+
+For the full reference — every key, flag, status, disposition, and
+diagnostic — see [cluster-config.md](cluster-config.md).

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -13,6 +13,7 @@ of MRs, internal recovery mechanics, or contributor-only invariants.
 | Install OmniGraph | [install.md](install.md) |
 | Run the CLI locally | [cli.md](cli.md) |
 | Look up every CLI flag and config field | [cli-reference.md](cli-reference.md) |
+| Deploy and operate a cluster (how-to guide) | [cluster.md](cluster.md) |
 | Validate and plan cluster config | [cluster-config.md](cluster-config.md) |
 | Write schemas | [schema-language.md](schema-language.md) |
 | Read schema-lint diagnostic codes | [schema-lint.md](schema-lint.md) |


### PR DESCRIPTION
Adds **`docs/user/cluster.md`** — the operator's how-to for the cluster control plane, complementing `cluster-config.md` (which stays the reference). Structure:

1. **The model in one paragraph** — config = desired state, ledger = recorded state, plan = diff, apply = the only mutator, approvals for the irreversible tier
2. **Deploy from zero** — directory layout, validate → import → plan → apply, what one apply does (graph creation at derived roots, schema, catalog), data loading via the graph plane, serving with `--cluster` + bearer tokens
3. **The day-2 loop** — edit → plan → apply `--as` → restart, with a table of what each change kind (query/policy/bindings/schema/graph add/remove) shows in plan and does in apply, and the two properties worth internalizing (single ordered apply; soft drops only)
4. **Inspect** — status vs refresh, drift detection, and drift *convergence* (both directions: heal the graph or adopt into config)
5. **The approval gate** — the full approve → apply flow, digest binding, staleness, one-gate-per-subtree, durable audit
6. **When things go wrong** — crash recovery ("run apply again"), force-unlock by exact id, lost-ledger rebuild via import, and the boot-refusal table mapping every `--cluster` startup error to its remedy
7. **Deployment patterns** — replicas, the directory as the deployable/backup unit, CI gating (`approve` stays human), `omnigraph.yaml`'s remaining role
8. **What it does not do (yet)** — hot reload, S3-hosted cluster dirs, data ops, per-query exposure, pipelines

Linked from `docs/user/index.md` and the agent guide's topic map; `cluster-config.md` gains a pointer for newcomers. `scripts/check-agents-md.sh` green. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `docs/user/cluster.md`, the operator how-to guide for the cluster control plane, and wires it into `AGENTS.md`, `docs/user/index.md`, and `cluster-config.md`. The new guide covers the full operator lifecycle — deploy from zero, the day-2 edit/plan/apply loop, drift detection, the approval gate for destructive changes, crash recovery, and deployment patterns.

- `cluster.md` (256 lines) is well-structured and internally consistent; the numbered-section cross-reference (`§4`) in the day-2 table correctly resolves to the approval-gate section.
- The bearer-token env var shown in the cluster serving example (`OMNIGRAPH_SERVER_BEARER_TOKENS_JSON`) differs in name and format from the `OMNIGRAPH_SERVER_BEARER_TOKEN` in `AGENTS.md`'s quick-reference; the distinction is not explained or cross-referenced, which could confuse operators switching between the two modes.
- The `server.md#modes` anchor fragment in the token-sources note is not validated by the CI link checker and may silently resolve to the top of the file.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is documentation-only with no code or schema impact.

The new guide is coherent and covers its stated scope well. Two gaps are worth addressing before this goes live: the bearer-token env var name diverges from the quick-reference in AGENTS.md without explanation, and the server.md#modes anchor is unverified by CI. Neither blocks functionality, but both could send operators down the wrong path when setting up cluster serving for the first time.

docs/user/cluster.md — verify the bearer-token env var name against source and confirm the server.md#modes anchor exists.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/user/cluster.md | New 256-line operator how-to guide; well-structured and internally consistent, but introduces `OMNIGRAPH_SERVER_BEARER_TOKENS_JSON` without reconciling it against the `OMNIGRAPH_SERVER_BEARER_TOKEN` shown in AGENTS.md, and includes a `server.md#modes` anchor that is not verified by CI. |
| AGENTS.md | Single-row addition to the topic map pointing to the new cluster.md; follows the map-not-encyclopedia convention correctly. |
| docs/user/cluster-config.md | Three-line addition of a newcomer pointer to cluster.md at the top of the reference doc; no substantive content change. |
| docs/user/index.md | Single-row addition to the user-docs index table; correctly placed adjacent to cluster-config.md. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Edit cluster.yaml / .pg / .gq / policy] --> B[cluster validate]
    B --> C[cluster import\ninitial ledger creation]
    C --> D[cluster plan\npreview diff]
    D --> E{Destructive\nchange?}
    E -- No --> F[cluster apply --as actor\nconverge reality to config]
    E -- Yes --> G[cluster approve target\n--as actor]
    G --> H[cluster apply --as actor\nexecutes approved delete]
    F --> I{converged: true?}
    H --> I
    I -- No --> A
    I -- Yes --> J[Restart cluster-booted\nservers to pick up changes]
    J --> K[omnigraph-server --cluster dir\nserves applied state]

    subgraph Recovery
        R1[Crash mid-apply] --> R2[Run cluster apply again]
        R3[Held lock] --> R4[cluster force-unlock LOCK_ID]
        R5[Lost ledger] --> R6[cluster import rebuilds state.json]
    end
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Adocs%2Fuser%2Fcluster.md%3A80%0A**Fragment%20anchor%20%60server.md%23modes%60%20may%20not%20resolve**%0A%0AThe%20link%20%60%5Bserver.md%5D%28server.md%23modes%29%60%20includes%20an%20anchor%20fragment%20%28%60%23modes%60%29.%20%60scripts%2Fcheck-agents-md.sh%60%20verifies%20file-level%20link%20existence%20but%20does%20not%20validate%20anchor%20fragments%2C%20so%20a%20missing%20or%20renamed%20heading%20in%20%60server.md%60%20would%20produce%20a%20dead%20link%20silently.%20Confirm%20that%20a%20%60%23%23%20Modes%60%20%28or%20equivalent%29%20heading%20exists%20in%20%60server.md%60%2C%20or%20replace%20the%20fragment%20with%20the%20stable%20file-level%20link%20%60%5Bserver.md%5D%28server.md%29%60%20until%20the%20anchor%20is%20confirmed.%0A%0A%23%23%23%20Issue%202%20of%202%0Adocs%2Fuser%2Fcluster.md%3A70-72%0A**%60OMNIGRAPH_SERVER_BEARER_TOKENS_JSON%60%20differs%20from%20the%20bearer-token%20env%20var%20documented%20elsewhere**%0A%0A%60AGENTS.md%60's%20quick-reference%20shows%20%60OMNIGRAPH_SERVER_BEARER_TOKEN%3Dxxxx%60%20%28singular%2C%20plain%20string%29%2C%20while%20this%20guide%20introduces%20%60OMNIGRAPH_SERVER_BEARER_TOKENS_JSON%3D'%7B%22act-reader%22%3A%22s3cret%22%7D'%60%20%28plural%2C%20JSON%20actor-to-token%20map%29%20without%20explaining%20the%20distinction%20or%20cross-referencing%20%60server.md%60.%20Per%20the%20codebase's%20own%20rule%207%20%28%22grep%20for%20it%20in%20source%20first%20%E2%80%94%20memory%20and%20docs%20go%20stale%22%29%2C%20the%20env-var%20name%20and%20format%20used%20here%20should%20be%20verified%20against%20the%20%60omnigraph-server%60%20source.%20An%20operator%20following%20the%20quick-reference%20and%20the%20cluster%20guide%20simultaneously%20would%20encounter%20two%20inconsistent%20names%20and%20no%20explanation%20for%20which%20to%20use%20in%20cluster%20mode.%0A%0A&repo=modernrelay%2Fomnigraph&pr=179&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(cluster): operator how-to guide for..."](https://github.com/modernrelay/omnigraph/commit/97eb65e921c704c09bdd8064e8304ef074cc1184) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36794061)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->