### PR TITLE
feat(docker): cluster-mode container + AWS/Railway recipes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 !Dockerfile
 !docker/entrypoint.sh
 !target/release/omnigraph-server
+!target/release/omnigraph

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,13 @@ RUN groupadd --system omnigraph \
     && useradd --system --gid omnigraph --create-home --home-dir /var/lib/omnigraph omnigraph
 
 COPY target/release/omnigraph-server /usr/local/bin/omnigraph-server
+# The CLI ships in the image so the cluster day-2 loop (cluster
+# apply/approve/status, data loads by explicit URI) runs in-container via
+# `docker exec` / ECS exec / `railway shell` — no omnigraph.yaml required.
+COPY target/release/omnigraph /usr/local/bin/omnigraph
 COPY docker/entrypoint.sh /usr/local/bin/omnigraph-entrypoint
 
-RUN chmod 0755 /usr/local/bin/omnigraph-server /usr/local/bin/omnigraph-entrypoint
+RUN chmod 0755 /usr/local/bin/omnigraph-server /usr/local/bin/omnigraph /usr/local/bin/omnigraph-entrypoint
 
 ENV OMNIGRAPH_BIND=0.0.0.0:8080
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -9,6 +9,17 @@ fi
 
 bind="${OMNIGRAPH_BIND:-0.0.0.0:8080}"
 
+# Cluster mode first, and exclusive (the server's mode-inference rule 0):
+# a deployment serves from cluster state XOR omnigraph.yaml, never a merge.
+# Fail fast here with the same contract the server enforces.
+if [ -n "${OMNIGRAPH_CLUSTER:-}" ]; then
+  if [ -n "${OMNIGRAPH_TARGET_URI:-}" ] || [ -n "${OMNIGRAPH_CONFIG:-}" ] || [ -n "${OMNIGRAPH_TARGET:-}" ]; then
+    echo "OMNIGRAPH_CLUSTER is an exclusive boot source; unset OMNIGRAPH_TARGET_URI/OMNIGRAPH_CONFIG/OMNIGRAPH_TARGET" >&2
+    exit 64
+  fi
+  exec "$SERVER_BIN" --cluster "${OMNIGRAPH_CLUSTER}" --bind "${bind}"
+fi
+
 # URI comes from the env var (the positional arg wins over any config
 # `graphs` block in resolve_target_uri). OMNIGRAPH_CONFIG, when also set,
 # is forwarded as --config purely to supply a policy file — the two
@@ -28,6 +39,8 @@ fi
 
 cat >&2 <<'EOF'
 omnigraph-server container startup requires one of:
+  - OMNIGRAPH_CLUSTER     (serve a cluster directory's applied revision;
+                           exclusive — cannot combine with the others)
   - OMNIGRAPH_TARGET_URI
   - OMNIGRAPH_CONFIG
 

--- a/docker/entrypoint_test.sh
+++ b/docker/entrypoint_test.sh
@@ -58,6 +58,26 @@ got=$(sh "$ep" some-uri --bind 1.2.3.4:9 --extra)
 check "explicit args passthrough" \
   "ARGS: some-uri --bind 1.2.3.4:9 --extra" "$got"
 
+got=$(OMNIGRAPH_CLUSTER="/var/lib/omnigraph/company-brain" OMNIGRAPH_BIND="0.0.0.0:8080" sh "$ep")
+check "CLUSTER only (Phase 5 mode switch)" \
+  "ARGS: --cluster /var/lib/omnigraph/company-brain --bind 0.0.0.0:8080" "$got"
+
+# Exclusivity: OMNIGRAPH_CLUSTER refuses every combination, exit 64.
+for combo in "OMNIGRAPH_TARGET_URI=s3://b/g" "OMNIGRAPH_CONFIG=/etc/o.yaml" "OMNIGRAPH_TARGET=active"; do
+  if out=$(env "$combo" OMNIGRAPH_CLUSTER="/data/cluster" sh "$ep" 2>&1); then
+    echo "FAIL: CLUSTER + ${combo%%=*} unexpectedly succeeded: $out"
+    fail=1
+  else
+    status=$?
+    if [ "$status" -ne 64 ]; then
+      echo "FAIL: CLUSTER + ${combo%%=*} exited $status, want 64"
+      fail=1
+    else
+      echo "ok: CLUSTER + ${combo%%=*} refused (64)"
+    fi
+  fi
+done
+
 if [ "$fail" -ne 0 ]; then
   echo "entrypoint_test: FAILED"
   exit 1

--- a/docs/user/cluster.md
+++ b/docs/user/cluster.md
@@ -227,7 +227,8 @@ with an in-flight apply.
 - **Replicas**: any number of `--cluster` servers can serve the same config
   directory; boot is read-only. Roll out a change by `apply` once, then
   restarting replicas (serving is static per process — there is no hot
-  reload yet).
+  reload yet). Container/cloud recipes (AWS ECS+EFS, Railway volumes):
+  [deployment.md](deployment.md#cluster-mode-in-containers-aws-railway).
 - **The directory is the deployable unit**: config, catalog, ledger,
   approvals, and graph data all live under it. Back it up as a whole;
   version the *config files* (not `__cluster/` or `graphs/`) in git.

--- a/docs/user/deployment.md
+++ b/docs/user/deployment.md
@@ -45,6 +45,71 @@ omnigraph-server s3://my-bucket/graphs/example/releases/2026-04-10-v0.1.0 \
   --bind 0.0.0.0:8080
 ```
 
+## Cluster Mode in Containers (AWS, Railway)
+
+A cluster-booted deployment serves a **cluster directory** (config + state
+ledger + content-addressed catalog + graph data) from a mounted volume — the
+one structural difference from the stateless S3 single-graph shape, which
+needs no volume at all. The container contract:
+
+```bash
+docker run -d \
+  -v /srv/company-brain:/var/lib/omnigraph/cluster \
+  -e OMNIGRAPH_CLUSTER=/var/lib/omnigraph/cluster \
+  -e OMNIGRAPH_SERVER_BEARER_TOKEN=... \
+  -p 8080:8080 <image>
+```
+
+`OMNIGRAPH_CLUSTER` is exclusive: combining it with `OMNIGRAPH_TARGET_URI`,
+`OMNIGRAPH_CONFIG`, or `OMNIGRAPH_TARGET` fails fast (exit 64), the same
+rule the server itself enforces. The image also ships the `omnigraph` CLI,
+so the day-2 loop runs in-container with no `omnigraph.yaml`:
+
+```bash
+docker exec -it <container> sh -c \
+  'omnigraph cluster apply --as andrew --config /var/lib/omnigraph/cluster'
+# then restart the container to pick up the applied state
+```
+
+### AWS (ECS/Fargate + EFS)
+
+1. Push the image to ECR (the `package.yml` workflow builds it).
+2. Create an EFS filesystem; mount it in the task definition at
+   `/var/lib/omnigraph/cluster`.
+3. Task environment: `OMNIGRAPH_CLUSTER=/var/lib/omnigraph/cluster`, bearer
+   tokens via Secrets Manager/SSM into `OMNIGRAPH_SERVER_BEARER_TOKENS_JSON`
+   (or the `--features aws` build's native Secrets Manager source).
+4. ALB in front for TLS; target the container's 8080 with `/healthz` checks.
+5. Day-2: ECS exec into the task → edit/upload config on the volume →
+   `omnigraph cluster apply --as <you>` → force a new deployment (restart).
+
+For a deployment that doesn't need the cluster control plane, the classic
+stateless shape — `OMNIGRAPH_TARGET_URI=s3://bucket/graph.omni`, no volume —
+remains the simplest AWS architecture (see Binary/Container Deployment
+above).
+
+### Railway
+
+1. Create a service from the image; attach a **volume** mounted at
+   `/var/lib/omnigraph/cluster`.
+2. Variables: `OMNIGRAPH_CLUSTER=/var/lib/omnigraph/cluster`,
+   `OMNIGRAPH_SERVER_BEARER_TOKEN=<token>`. Railway terminates TLS at its
+   edge and routes to the exposed 8080.
+3. Day-2: `railway shell` (or `railway run`) → `omnigraph cluster apply
+   --as <you> --config /var/lib/omnigraph/cluster` → redeploy/restart the
+   service.
+
+### Constraints (current honest list)
+
+- **Cluster directories are local-filesystem** — the volume is mandatory;
+  S3-hosted cluster dirs are not supported.
+- **No hot reload** — applied changes serve on the next restart.
+- **Single-writer apply** — run `cluster apply` from one place at a time
+  (the state lock enforces this; CI or one operator shell, not both).
+- **Multi-replica serving off a shared volume (EFS) is documented but
+  unvalidated** — boot is lock-free read-only so it should compose, but it
+  is not yet exercised by tests.
+
 ## One-Command Local RustFS Bootstrap
 
 The easiest local S3-backed deployment path is:

--- a/docs/user/deployment.md
+++ b/docs/user/deployment.md
@@ -67,7 +67,7 @@ so the day-2 loop runs in-container with no `omnigraph.yaml`:
 
 ```bash
 docker exec -it <container> sh -c \
-  'omnigraph cluster apply --as andrew --config /var/lib/omnigraph/cluster'
+  'omnigraph cluster apply --as <you> --config /var/lib/omnigraph/cluster'
 # then restart the container to pick up the applied state
 ```
 
@@ -81,7 +81,8 @@ docker exec -it <container> sh -c \
    (or the `--features aws` build's native Secrets Manager source).
 4. ALB in front for TLS; target the container's 8080 with `/healthz` checks.
 5. Day-2: ECS exec into the task → edit/upload config on the volume →
-   `omnigraph cluster apply --as <you>` → force a new deployment (restart).
+   `omnigraph cluster apply --as <you> --config /var/lib/omnigraph/cluster`
+   → force a new deployment (restart).
 
 For a deployment that doesn't need the cluster control plane, the classic
 stateless shape — `OMNIGRAPH_TARGET_URI=s3://bucket/graph.omni`, no volume —


### PR DESCRIPTION
Release-readiness slice 2 of 2 (companion to #180): the container learns cluster mode, and the cloud recipes exist.

## Changes

- **`docker/entrypoint.sh`**: `OMNIGRAPH_CLUSTER` boots the container from a mounted cluster directory's applied revision — checked first and **exclusive** (exit 64 when combined with `OMNIGRAPH_TARGET_URI`/`CONFIG`/`TARGET`), the entrypoint-level mirror of the server's mode-inference rule 0. Usage message updated.
- **`Dockerfile` + `.dockerignore`**: the `omnigraph` CLI joins the image so the day-2 loop (`cluster apply/approve/status`, data loads by explicit URI) runs in-container via docker/ECS exec or `railway shell` — no `omnigraph.yaml` needed (pinned by #180's isolation tests). The `.dockerignore` whitelist gains the CLI binary — **without this the image build fails on the new COPY** (caught by a local `docker build`).
- **`docker/entrypoint_test.sh`**: the cluster case + all three exclusivity refusals (9 cases total; CI's "Container Entrypoint" job runs the file as-is).
- **`docs/user/deployment.md`**: "Cluster Mode in Containers" — the env/volume contract, ECS/Fargate+EFS and Railway-volume walkthroughs, the in-container day-2 loop, and the honest constraints list (volume mandatory — the one structural difference from the stateless S3 shape; no hot reload; single-writer apply; shared-volume replicas documented-but-unvalidated). Operator guide links the recipes.

## Verification

- `sh docker/entrypoint_test.sh` — all 9 cases pass
- Local `docker build` succeeds with both binaries (it failed before the `.dockerignore` fix); the exclusivity refusal verified **inside the running container** (exit 64 with the message)
- Full in-container execution couldn't be smoked on this host (Linux image vs macOS-built binaries — `exec format error` is environmental; CodeBuild compiles Linux binaries before its build)
- `scripts/check-agents-md.sh` green; docs-and-docker only, no Rust changes

With #180 + this, the cluster shape is deployment-ready; the v0.7.0 release slice (version bumps, notes, publish-order fix, tag) stays deferred until both are validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds cluster-mode support to the container image and provides cloud deployment recipes for AWS ECS/Fargate+EFS and Railway. It is the second of two release-readiness slices for the cluster shape.

- `OMNIGRAPH_CLUSTER` boot path added to `entrypoint.sh` — checked first and exclusive (exit 64 when combined with other env vars), mirroring the server's own mode-inference rule; 4 new test cases cover the cluster boot and all three exclusivity refusals.
- `omnigraph` CLI binary is now copied into the image (with the matching `.dockerignore` whitelist fix) so the day-2 loop (`cluster apply/approve/status`) runs in-container without an `omnigraph.yaml`.
- `docs/user/deployment.md` gains the "Cluster Mode in Containers" section with the env/volume contract, ECS and Railway walkthroughs, and an honest constraints list; `cluster.md` cross-links to the new recipes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all new entrypoint logic is covered by tests, the .dockerignore fix is correct, and the documentation is largely complete.

The entrypoint changes are small, well-tested (9 self-contained cases), and consistent with the server's own exclusivity contract. The Dockerfile and .dockerignore changes are mechanical and correct. The only gap is that OMNIGRAPH_CLUSTER is absent from the reference table in deployment.md, which is a documentation nit rather than a runtime defect.

docs/user/deployment.md — the canonical env-var reference table is missing the new OMNIGRAPH_CLUSTER entry.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docker/entrypoint.sh | Adds cluster-mode boot path: checks OMNIGRAPH_CLUSTER first, enforces exclusivity with exit 64, then execs the server with --cluster. Logic is correct and consistent with the server's own mode-inference contract. |
| docker/entrypoint_test.sh | Adds 4 new test cases: cluster-only boot and three exclusivity refusals; the $? capture in the else branch is correct. All 9 cases are self-contained and require no Docker. |
| Dockerfile | Adds COPY and chmod for the omnigraph CLI binary; straightforward and correct. |
| .dockerignore | Whitelists target/release/omnigraph CLI binary so the new Dockerfile COPY doesn't fail; required and correct. |
| docs/user/deployment.md | Adds the 'Cluster Mode in Containers' section with ECS/EFS and Railway walkthroughs; OMNIGRAPH_CLUSTER is missing from the canonical env-var reference table at the bottom of the file. |
| docs/user/cluster.md | Adds a cross-link from the Replicas bullet to the new deployment.md cloud recipes section. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fuser%2Fdeployment.md%3A191-196%0A%60OMNIGRAPH_CLUSTER%60%20is%20not%20present%20in%20the%20%22Container%20entrypoint%20env%20vars%22%20reference%20table%2C%20even%20though%20it%20is%20the%20entrypoint's%20highest-priority%20var.%20An%20operator%20who%20skips%20the%20new%20prose%20section%20and%20looks%20up%20the%20table%20will%20not%20find%20it%2C%20missing%20both%20the%20exclusivity%20rule%20and%20the%20volume%20requirement.%0A%0A%60%60%60suggestion%0A%7C%20Var%20%7C%20Effect%20%7C%0A%7C---%7C---%7C%0A%7C%20%60OMNIGRAPH_CLUSTER%60%20%7C%20Path%20to%20a%20mounted%20cluster%20directory%3B%20boots%20the%20server%20in%20cluster%20mode.%20**Exclusive**%20%E2%80%94%20cannot%20be%20combined%20with%20%60OMNIGRAPH_TARGET_URI%60%2C%20%60OMNIGRAPH_CONFIG%60%2C%20or%20%60OMNIGRAPH_TARGET%60%20%28exit%2064%29.%20Requires%20a%20volume%20mount.%20%7C%0A%7C%20%60OMNIGRAPH_TARGET_URI%60%20%7C%20Graph%20URI%2C%20passed%20as%20the%20positional%20argument.%20%7C%0A%7C%20%60OMNIGRAPH_CONFIG%60%20%7C%20Path%20to%20an%20%60omnigraph.yaml%60%2C%20passed%20as%20%60--config%60.%20Used%20to%20supply%20a%20%60policy.file%60%20%28Cedar%20authorization%29.%20The%20config%20file%20and%20any%20relative%20%60policy.file%60%20must%20be%20mounted%20into%20the%20container.%20%7C%0A%7C%20%60OMNIGRAPH_TARGET%60%20%7C%20Graph%20name%20to%20select%20from%20the%20config's%20%60graphs%3A%60%20block%20%28with%20%60OMNIGRAPH_CONFIG%60%2C%20when%20no%20%60OMNIGRAPH_TARGET_URI%60%29.%20%7C%0A%7C%20%60OMNIGRAPH_BIND%60%20%7C%20Listen%20address%20%28default%20%600.0.0.0%3A8080%60%29.%20%7C%0A%60%60%60%0A%0A&repo=modernrelay%2Fomnigraph&pr=181&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["docs(deploy): address review — consisten..."](https://github.com/modernrelay/omnigraph/commit/f165145b63f8380de38e30d0bb52453df2189c5b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36803315)</sub>

<!-- /greptile_comment -->