### PR TITLE
feat(cluster): Terraform-shaped query declaration; drop ./ path noise

### DIFF
--- a/crates/omnigraph-cluster/src/lib.rs
+++ b/crates/omnigraph-cluster/src/lib.rs
@@ -449,13 +449,17 @@ fn resolve_query_decls(
     graph_id: &str,
     decl: &QueriesDecl,
     diagnostics: &mut Vec<Diagnostic>,
-) -> BTreeMap<String, QueryConfig> {
+) -> (BTreeMap<String, QueryConfig>, BTreeMap<PathBuf, String>) {
     let paths: Vec<PathBuf> = match decl {
         QueriesDecl::Explicit(map) => {
-            return map
-                .iter()
-                .map(|(name, config)| (name.clone(), QueryConfig { file: config.file.clone() }))
-                .collect();
+            return (
+                map.iter()
+                    .map(|(name, config)| {
+                        (name.clone(), QueryConfig { file: config.file.clone() })
+                    })
+                    .collect(),
+                BTreeMap::new(),
+            );
         }
         QueriesDecl::Discover(path) => vec![path.clone()],
         QueriesDecl::DiscoverMany(paths) => paths.clone(),
@@ -499,6 +503,10 @@ fn resolve_query_decls(
 
     let mut registry: BTreeMap<String, QueryConfig> = BTreeMap::new();
     let mut origin: BTreeMap<String, PathBuf> = BTreeMap::new();
+    // Content read once at discovery and handed to the caller — the per-query
+    // digest/typecheck pass reuses it instead of re-reading (no N+1 reads, no
+    // window for the file to change between enumeration and validation).
+    let mut contents: BTreeMap<PathBuf, String> = BTreeMap::new();
     for (declared, resolved) in files {
         let source = match fs::read_to_string(&resolved) {
             Ok(source) => source,
@@ -539,8 +547,9 @@ fn resolve_query_decls(
             origin.insert(name.clone(), declared.clone());
             registry.insert(name, QueryConfig { file: declared.clone() });
         }
+        contents.insert(declared, source);
     }
-    registry
+    (registry, contents)
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -3725,7 +3734,8 @@ fn load_desired(config_dir: &Path) -> LoadOutcome {
             }
         });
 
-        let graph_queries = resolve_query_decls(&config_dir, graph_id, &graph.queries, &mut diagnostics);
+        let (graph_queries, query_contents) =
+            resolve_query_decls(&config_dir, graph_id, &graph.queries, &mut diagnostics);
         for (query_name, query) in &graph_queries {
             validate_id(
                 "query name",
@@ -3744,7 +3754,11 @@ fn load_desired(config_dir: &Path) -> LoadOutcome {
             });
 
             let query_path = resolve_config_path(&config_dir, &query.file);
-            match fs::read_to_string(&query_path) {
+            let source = match query_contents.get(&query.file) {
+                Some(cached) => Ok(cached.clone()),
+                None => fs::read_to_string(&query_path),
+            };
+            match source {
                 Ok(source) => {
                     let digest = sha256_hex(source.as_bytes());
                     graph_query_digests

--- a/crates/omnigraph-cluster/src/lib.rs
+++ b/crates/omnigraph-cluster/src/lib.rs
@@ -415,7 +415,132 @@ struct StateConfig {
 struct GraphConfig {
     schema: PathBuf,
     #[serde(default)]
-    queries: BTreeMap<String, QueryConfig>,
+    queries: QueriesDecl,
+}
+
+/// How a graph declares its stored queries. Terraform-style: the `.gq`
+/// files ARE the declaration — point at them (or a directory) and every
+/// `query <name>` they contain is discovered. The explicit name->file map
+/// remains for fine-grained control.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+enum QueriesDecl {
+    /// `queries: ./queries/` — a directory (top-level `*.gq`, sorted) or a
+    /// single `.gq` file; every declaration inside is registered.
+    Discover(PathBuf),
+    /// `queries: [./queries/, ./extra.gq]` — several directories/files.
+    DiscoverMany(Vec<PathBuf>),
+    /// `queries: { name: { file: ... } }` — explicit registry.
+    Explicit(BTreeMap<String, QueryConfig>),
+}
+
+impl Default for QueriesDecl {
+    fn default() -> Self {
+        QueriesDecl::Explicit(BTreeMap::new())
+    }
+}
+
+/// Expand a graph's query declaration into the canonical name->file map.
+/// Discovery reads and parses each `.gq`; unreadable or unparseable files
+/// and duplicate query names are loud validation errors — a declaration the
+/// tool cannot enumerate is broken, not partially usable.
+fn resolve_query_decls(
+    config_dir: &Path,
+    graph_id: &str,
+    decl: &QueriesDecl,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> BTreeMap<String, QueryConfig> {
+    let paths: Vec<PathBuf> = match decl {
+        QueriesDecl::Explicit(map) => {
+            return map
+                .iter()
+                .map(|(name, config)| (name.clone(), QueryConfig { file: config.file.clone() }))
+                .collect();
+        }
+        QueriesDecl::Discover(path) => vec![path.clone()],
+        QueriesDecl::DiscoverMany(paths) => paths.clone(),
+    };
+
+    let mut files: Vec<(PathBuf, PathBuf)> = Vec::new(); // (declared-relative, resolved)
+    for declared in &paths {
+        let resolved = resolve_config_path(config_dir, declared);
+        if resolved.is_dir() {
+            let mut entries: Vec<PathBuf> = match fs::read_dir(&resolved) {
+                Ok(read) => read
+                    .flatten()
+                    .map(|entry| entry.path())
+                    .filter(|path| path.extension().is_some_and(|ext| ext == "gq"))
+                    .collect(),
+                Err(err) => {
+                    diagnostics.push(Diagnostic::error(
+                        "query_dir_unreadable",
+                        format!("graphs.{graph_id}.queries"),
+                        format!("could not list query directory '{}': {err}", resolved.display()),
+                    ));
+                    continue;
+                }
+            };
+            entries.sort();
+            if entries.is_empty() {
+                diagnostics.push(Diagnostic::warning(
+                    "query_dir_empty",
+                    format!("graphs.{graph_id}.queries"),
+                    format!("query directory '{}' contains no .gq files", resolved.display()),
+                ));
+            }
+            for path in entries {
+                let relative = declared.join(path.file_name().expect("dir entries have names"));
+                files.push((relative, path));
+            }
+        } else {
+            files.push((declared.clone(), resolved));
+        }
+    }
+
+    let mut registry: BTreeMap<String, QueryConfig> = BTreeMap::new();
+    let mut origin: BTreeMap<String, PathBuf> = BTreeMap::new();
+    for (declared, resolved) in files {
+        let source = match fs::read_to_string(&resolved) {
+            Ok(source) => source,
+            Err(err) => {
+                diagnostics.push(Diagnostic::error(
+                    "query_file_missing",
+                    format!("graphs.{graph_id}.queries"),
+                    format!("could not read query file '{}': {err}", resolved.display()),
+                ));
+                continue;
+            }
+        };
+        let parsed = match parse_query(&source) {
+            Ok(parsed) => parsed,
+            Err(err) => {
+                diagnostics.push(Diagnostic::error(
+                    "query_parse_error",
+                    format!("graphs.{graph_id}.queries"),
+                    format!("'{}' does not parse: {err}", resolved.display()),
+                ));
+                continue;
+            }
+        };
+        for query_decl in &parsed.queries {
+            let name = query_decl.name.clone();
+            if let Some(previous) = origin.get(&name) {
+                diagnostics.push(Diagnostic::error(
+                    "duplicate_query_name",
+                    format!("graphs.{graph_id}.queries.{name}"),
+                    format!(
+                        "query '{name}' is declared in both '{}' and '{}'",
+                        previous.display(),
+                        declared.display()
+                    ),
+                ));
+                continue;
+            }
+            origin.insert(name.clone(), declared.clone());
+            registry.insert(name, QueryConfig { file: declared.clone() });
+        }
+    }
+    registry
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -3600,7 +3725,8 @@ fn load_desired(config_dir: &Path) -> LoadOutcome {
             }
         });
 
-        for (query_name, query) in &graph.queries {
+        let graph_queries = resolve_query_decls(&config_dir, graph_id, &graph.queries, &mut diagnostics);
+        for (query_name, query) in &graph_queries {
             validate_id(
                 "query name",
                 &format!("graphs.{graph_id}.queries.{query_name}"),
@@ -7557,6 +7683,115 @@ policies:
         assert!(
             err.iter().any(|diagnostic| diagnostic.code == "cluster_empty"),
             "{err:?}"
+        );
+    }
+
+    // ---- query discovery (Terraform-style declaration) ----
+
+    #[test]
+    fn queries_directory_discovers_every_declaration() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("people.pg"), "\nnode Person {\n  name: String @key\n}\n").unwrap();
+        fs::create_dir(dir.path().join("queries")).unwrap();
+        fs::write(
+            dir.path().join("queries/people.gq"),
+            "\nquery find_person($name: String) {\n  match { $p: Person { name: $name } }\n  return { $p.name }\n}\n\nquery all_people() {\n  match { $p: Person }\n  return { $p.name }\n}\n",
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("queries/extra.gq"),
+            "\nquery count_people() {\n  match { $p: Person }\n  return { count($p) }\n}\n",
+        )
+        .unwrap();
+        fs::write(dir.path().join("queries/notes.txt"), "ignored").unwrap();
+        fs::write(
+            dir.path().join("cluster.yaml"),
+            "version: 1\ngraphs:\n  knowledge:\n    schema: ./people.pg\n    queries: ./queries/\n",
+        )
+        .unwrap();
+
+        let out = validate_config_dir(dir.path());
+        assert!(out.ok, "{:?}", out.diagnostics);
+        let names: Vec<&str> = out
+            .resource_digests
+            .keys()
+            .filter_map(|address| address.strip_prefix("query.knowledge."))
+            .collect();
+        assert_eq!(names, vec!["all_people", "count_people", "find_person"]);
+    }
+
+    #[test]
+    fn queries_list_and_single_file_forms_discover() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("people.pg"), "\nnode Person {\n  name: String @key\n}\n").unwrap();
+        fs::write(
+            dir.path().join("a.gq"),
+            "\nquery find_person($name: String) {\n  match { $p: Person { name: $name } }\n  return { $p.name }\n}\n",
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("b.gq"),
+            "\nquery all_people() {\n  match { $p: Person }\n  return { $p.name }\n}\n",
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("cluster.yaml"),
+            "version: 1\ngraphs:\n  knowledge:\n    schema: ./people.pg\n    queries: [./a.gq, ./b.gq]\n",
+        )
+        .unwrap();
+        let out = validate_config_dir(dir.path());
+        assert!(out.ok, "{:?}", out.diagnostics);
+        assert!(out.resource_digests.contains_key("query.knowledge.find_person"));
+        assert!(out.resource_digests.contains_key("query.knowledge.all_people"));
+
+        // Single-file string form
+        fs::write(
+            dir.path().join("cluster.yaml"),
+            "version: 1\ngraphs:\n  knowledge:\n    schema: ./people.pg\n    queries: ./a.gq\n",
+        )
+        .unwrap();
+        let out = validate_config_dir(dir.path());
+        assert!(out.ok, "{:?}", out.diagnostics);
+        assert!(out.resource_digests.contains_key("query.knowledge.find_person"));
+        assert!(!out.resource_digests.contains_key("query.knowledge.all_people"));
+    }
+
+    #[test]
+    fn query_discovery_rejects_duplicates_and_parse_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("people.pg"), "\nnode Person {\n  name: String @key\n}\n").unwrap();
+        let decl = "\nquery find_person($name: String) {\n  match { $p: Person { name: $name } }\n  return { $p.name }\n}\n";
+        fs::write(dir.path().join("a.gq"), decl).unwrap();
+        fs::write(dir.path().join("b.gq"), decl).unwrap();
+        fs::write(
+            dir.path().join("cluster.yaml"),
+            "version: 1\ngraphs:\n  knowledge:\n    schema: ./people.pg\n    queries: [./a.gq, ./b.gq]\n",
+        )
+        .unwrap();
+        let out = validate_config_dir(dir.path());
+        assert!(!out.ok);
+        assert!(
+            out.diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "duplicate_query_name"),
+            "{:?}",
+            out.diagnostics
+        );
+
+        fs::write(dir.path().join("broken.gq"), "query {{{ nope").unwrap();
+        fs::write(
+            dir.path().join("cluster.yaml"),
+            "version: 1\ngraphs:\n  knowledge:\n    schema: ./people.pg\n    queries: ./broken.gq\n",
+        )
+        .unwrap();
+        let out = validate_config_dir(dir.path());
+        assert!(!out.ok);
+        assert!(
+            out.diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "query_parse_error"),
+            "{:?}",
+            out.diagnostics
         );
     }
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -54,7 +54,7 @@ cli:
 query:
   roots: [<dir>, …]   # search path for .gq files
 auth:
-  env_file: ./.env.omni
+  env_file: .env.omni
 aliases:
   <alias>:
     # accepted values: `read` / `query` (read alias), `change` / `mutate`
@@ -70,20 +70,20 @@ aliases:
 queries:                          # top-level registry — applies only to a bare-URI (anonymous) graph; a graph served by name uses its `graphs.<id>.queries`. Mirrors top-level `policy`.
   <query-name>: { file: <path-to-.gq> }   # mcp.expose defaults to true
 policy:
-  file: ./policy.yaml
+  file: policy.yaml
 ```
 
 ## Cluster config preview
 
 ```bash
-omnigraph cluster validate --config ./company-brain
-omnigraph cluster plan     --config ./company-brain --json
-omnigraph cluster apply    --config ./company-brain --json
-omnigraph cluster approve  graph.<id> --config ./company-brain --as <actor>
-omnigraph cluster status   --config ./company-brain --json
-omnigraph cluster refresh  --config ./company-brain --json
-omnigraph cluster import   --config ./company-brain --json
-omnigraph cluster force-unlock <LOCK_ID> --config ./company-brain --json
+omnigraph cluster validate --config company-brain
+omnigraph cluster plan     --config company-brain --json
+omnigraph cluster apply    --config company-brain --json
+omnigraph cluster approve  graph.<id> --config company-brain --as <actor>
+omnigraph cluster status   --config company-brain --json
+omnigraph cluster refresh  --config company-brain --json
+omnigraph cluster import   --config company-brain --json
+omnigraph cluster force-unlock <LOCK_ID> --config company-brain --json
 ```
 
 `--config` is a directory containing `cluster.yaml`; it defaults to `.`.

--- a/docs/user/cli.md
+++ b/docs/user/cli.md
@@ -3,11 +3,11 @@
 ## Core Graph Flow
 
 ```bash
-omnigraph init --schema ./schema.pg ./graph.omni
-omnigraph load --data ./data.jsonl --mode overwrite ./graph.omni
-omnigraph snapshot ./graph.omni --branch main --json
-omnigraph query  --uri ./graph.omni --query ./queries.gq --name get_person --params '{"name":"Alice"}'
-omnigraph mutate --uri ./graph.omni --query ./queries.gq --name insert_person --params '{"name":"Mina","age":28}'
+omnigraph init --schema schema.pg graph.omni
+omnigraph load --data data.jsonl --mode overwrite graph.omni
+omnigraph snapshot graph.omni --branch main --json
+omnigraph query  --uri graph.omni --query queries.gq --name get_person --params '{"name":"Alice"}'
+omnigraph mutate --uri graph.omni --query queries.gq --name insert_person --params '{"name":"Mina","age":28}'
 ```
 
 `omnigraph query` is the canonical read command (pairs with `POST /query`);
@@ -21,11 +21,11 @@ For ad-hoc reads and mutations (REPLs, AI agents, one-off scripts), pass the
 GQ source inline with `-e` / `--query-string` instead of a file path:
 
 ```bash
-omnigraph query --uri ./graph.omni \
+omnigraph query --uri graph.omni \
   -e 'query find($name: String) { match { $p: Person { name: $name } } return { $p.name, $p.age } }' \
   --params '{"name":"Alice"}'
 
-omnigraph mutate --uri ./graph.omni \
+omnigraph mutate --uri graph.omni \
   -e 'query add($name: String, $age: I32) { insert Person { name: $name, age: $age } }' \
   --params '{"name":"Inline","age":42}'
 ```
@@ -38,14 +38,14 @@ only the source loader changes.
 ## Branching And Reviewable Data Flows
 
 ```bash
-omnigraph branch create --uri ./graph.omni --from main feature-x
-omnigraph branch list --uri ./graph.omni
-omnigraph branch merge --uri ./graph.omni feature-x --into main
+omnigraph branch create --uri graph.omni --from main feature-x
+omnigraph branch list --uri graph.omni
+omnigraph branch merge --uri graph.omni feature-x --into main
 
-omnigraph ingest --data ./batch.jsonl --branch review/import-2026-04-09 ./graph.omni
-omnigraph export ./graph.omni --branch main --type Person > people.jsonl
-omnigraph commit list ./graph.omni --branch main --json
-omnigraph commit show --uri ./graph.omni <commit-id> --json
+omnigraph ingest --data batch.jsonl --branch review/import-2026-04-09 graph.omni
+omnigraph export graph.omni --branch main --type Person > people.jsonl
+omnigraph commit list graph.omni --branch main --json
+omnigraph commit show --uri graph.omni <commit-id> --json
 ```
 
 ## Remote Server Mode
@@ -53,7 +53,7 @@ omnigraph commit show --uri ./graph.omni <commit-id> --json
 Serve a graph:
 
 ```bash
-omnigraph-server ./graph.omni --bind 127.0.0.1:8080
+omnigraph-server graph.omni --bind 127.0.0.1:8080
 ```
 
 Read through the HTTP API:
@@ -61,7 +61,7 @@ Read through the HTTP API:
 ```bash
 omnigraph query \
   --target http://127.0.0.1:8080 \
-  --query ./queries.gq \
+  --query queries.gq \
   --name get_person \
   --params '{"name":"Alice"}'
 ```
@@ -87,23 +87,23 @@ Runtime add/remove is **not** in v0.6.0. To add a graph, stop the server, add a 
 Per-graph URLs: hit a graph's cluster route from any subcommand by pointing `--uri` at it:
 
 ```bash
-omnigraph read --uri http://server.example.com/graphs/beta --query ./q.gq ...
+omnigraph read --uri http://server.example.com/graphs/beta --query q.gq ...
 ```
 
 ## Runs, Policy, And Diagnostics
 
 ```bash
-omnigraph lint  --query ./queries.gq --schema ./schema.pg --json
-omnigraph check --query ./queries.gq ./graph.omni --json
+omnigraph lint  --query queries.gq --schema schema.pg --json
+omnigraph check --query queries.gq graph.omni --json
 
-omnigraph schema plan --schema ./next.pg ./graph.omni --json
-omnigraph schema apply --schema ./next.pg ./graph.omni --json
-omnigraph policy validate --config ./omnigraph.yaml
-omnigraph policy test --config ./omnigraph.yaml
-omnigraph policy explain --config ./omnigraph.yaml --actor act-alice --action read --branch main
+omnigraph schema plan --schema next.pg graph.omni --json
+omnigraph schema apply --schema next.pg graph.omni --json
+omnigraph policy validate --config omnigraph.yaml
+omnigraph policy test --config omnigraph.yaml
+omnigraph policy explain --config omnigraph.yaml --actor act-alice --action read --branch main
 
-omnigraph commit list ./graph.omni --json
-omnigraph commit show --uri ./graph.omni <commit-id> --json
+omnigraph commit list graph.omni --json
+omnigraph commit show --uri graph.omni <commit-id> --json
 ```
 
 (The legacy `omnigraph run list/show/publish/abort` subcommands were removed in MR-771; mutations and loads publish atomically and the commit graph (`omnigraph commit list`) is the audit surface.)
@@ -120,7 +120,7 @@ query roots:
 ```yaml
 graphs:
   local:
-    uri: ./demo.omni
+    uri: demo.omni
   dev:
     uri: http://127.0.0.1:8080
     bearer_token_env: OMNIGRAPH_BEARER_TOKEN

--- a/docs/user/cluster-config.md
+++ b/docs/user/cluster-config.md
@@ -20,14 +20,14 @@ or serve anything it applies: the server still boots from `omnigraph.yaml`.
 ## Commands
 
 ```bash
-omnigraph cluster validate --config ./company-brain
-omnigraph cluster plan     --config ./company-brain --json
-omnigraph cluster apply    --config ./company-brain --json
-omnigraph cluster approve  graph.<id> --config ./company-brain --as <actor>
-omnigraph cluster status   --config ./company-brain --json
-omnigraph cluster refresh  --config ./company-brain --json
-omnigraph cluster import   --config ./company-brain --json
-omnigraph cluster force-unlock <LOCK_ID> --config ./company-brain --json
+omnigraph cluster validate --config company-brain
+omnigraph cluster plan     --config company-brain --json
+omnigraph cluster apply    --config company-brain --json
+omnigraph cluster approve  graph.<id> --config company-brain --as <actor>
+omnigraph cluster status   --config company-brain --json
+omnigraph cluster refresh  --config company-brain --json
+omnigraph cluster import   --config company-brain --json
+omnigraph cluster force-unlock <LOCK_ID> --config company-brain --json
 ```
 
 `--config` points at a directory, not a file. The directory must contain
@@ -54,7 +54,7 @@ The exact contract:
   cluster state XOR `omnigraph.yaml`, never a merge.
 - **The other direction is ergonomics, not coupling**: a per-operator
   `omnigraph.yaml` may point `graphs.<name>.uri` at a cluster's derived root
-  (`./company-brain/graphs/knowledge.omni`) so data-plane commands can use
+  (`company-brain/graphs/knowledge.omni`) so data-plane commands can use
   `--target <name>` — an ordinary local path, no special handling.
 
 ## Supported `cluster.yaml`
@@ -72,16 +72,34 @@ state:
 
 graphs:
   knowledge:
-    schema: ./knowledge.pg
-    queries:
-      find_experts:
-        file: ./knowledge.gq
+    schema: knowledge.pg
+    queries: queries/          # discover every `query <name>` in queries/*.gq
 
 policies:
   base:
-    file: ./base.policy.yaml
+    file: base.policy.yaml
     applies_to: [knowledge]
 ```
+
+`queries` is Terraform-shaped — the `.gq` files are the declaration. Three
+forms:
+
+```yaml
+queries: queries/                  # directory: top-level *.gq, sorted; every declaration registers
+queries: [people.gq, extra/a.gq]   # explicit files; every declaration in each
+queries:                           # fine-grained name -> file map
+  find_experts:
+    file: knowledge.gq
+```
+
+Discovery is loud: an unreadable or unparseable `.gq`, or the same query name
+declared in two files, fails validation (`query_parse_error`,
+`duplicate_query_name`). Each discovered query is still an individually
+addressed resource (`query.<graph>.<name>`) with its own plan/apply lifecycle;
+the digest is the containing file's hash, so editing a multi-query file
+updates all of its queries together. Paths are relative to the config
+directory — the cluster is one explicit folder, so no `./` prefixes are
+needed.
 
 `metadata.name` is a display label. `state.backend` may be omitted or set to
 `cluster`; external state backends are reserved for a later stage. `state.lock`
@@ -324,7 +342,7 @@ without graph movement.
 ## Serving from the cluster (the mode switch)
 
 ```bash
-omnigraph-server --cluster ./company-brain --bind 0.0.0.0:8080
+omnigraph-server --cluster company-brain --bind 0.0.0.0:8080
 ```
 
 `--cluster <dir>` is an **exclusive boot source** (axiom 15): it cannot

--- a/docs/user/cluster.md
+++ b/docs/user/cluster.md
@@ -32,7 +32,8 @@ Lay out a config directory:
 company-brain/
 ├── cluster.yaml
 ├── people.pg            # schema for the "knowledge" graph
-├── people.gq            # a stored query
+├── queries/             # stored queries — the .gq files ARE the declaration
+│   └── people.gq
 └── base.policy.yaml     # a Cedar policy bundle
 ```
 
@@ -43,27 +44,25 @@ metadata:
   name: company-brain
 graphs:
   knowledge:
-    schema: ./people.pg
-    queries:
-      find_person:
-        file: ./people.gq
+    schema: people.pg
+    queries: queries/            # every `query <name>` in queries/*.gq registers
 policies:
   base:
-    file: ./base.policy.yaml
+    file: base.policy.yaml
     applies_to: [knowledge]      # graph-bound; use [cluster] for server-level
 ```
 
 Bring it to life:
 
 ```bash
-omnigraph cluster validate --config ./company-brain   # parse + typecheck everything
-omnigraph cluster import   --config ./company-brain   # create the state ledger
-omnigraph cluster plan     --config ./company-brain   # preview: what would apply do?
-omnigraph cluster apply    --config ./company-brain   # converge
+omnigraph cluster validate --config company-brain   # parse + typecheck everything
+omnigraph cluster import   --config company-brain   # create the state ledger
+omnigraph cluster plan     --config company-brain   # preview: what would apply do?
+omnigraph cluster apply    --config company-brain   # converge
 ```
 
 That single `apply` **creates the graph** (at the derived root
-`./company-brain/graphs/knowledge.omni`), applies its schema, and publishes
+`company-brain/graphs/knowledge.omni`), applies its schema, and publishes
 the query and policy into the content-addressed catalog
 (`__cluster/resources/…`). The output lists every change with its
 disposition; `converged: true` means there is nothing left to do — re-running
@@ -73,14 +72,14 @@ Load data through the normal graph plane (the control plane manages
 *definitions*, not rows):
 
 ```bash
-omnigraph load --data ./seed.jsonl ./company-brain/graphs/knowledge.omni
+omnigraph load --data seed.jsonl company-brain/graphs/knowledge.omni
 ```
 
 Serve it:
 
 ```bash
 OMNIGRAPH_SERVER_BEARER_TOKENS_JSON='{"act-reader":"s3cret"}' \
-  omnigraph-server --cluster ./company-brain --bind 0.0.0.0:8080
+  omnigraph-server --cluster company-brain --bind 0.0.0.0:8080
 ```
 
 `--cluster` is an **exclusive boot source**: it cannot be combined with a
@@ -103,8 +102,8 @@ Every change follows the same loop, whatever its kind:
 
 ```bash
 $EDITOR company-brain/people.pg          # or any .gq / policy / cluster.yaml edit
-omnigraph cluster plan  --config ./company-brain
-omnigraph cluster apply --config ./company-brain --as andrew
+omnigraph cluster plan  --config company-brain
+omnigraph cluster apply --config company-brain --as andrew
 # restart cluster-booted servers to pick it up
 ```
 
@@ -142,8 +141,8 @@ anything runs.
 ## 3. Inspect: status, refresh, drift
 
 ```bash
-omnigraph cluster status  --config ./company-brain --json   # ledger only, read-only
-omnigraph cluster refresh --config ./company-brain          # re-observe live graphs
+omnigraph cluster status  --config company-brain --json   # ledger only, read-only
+omnigraph cluster refresh --config company-brain          # re-observe live graphs
 ```
 
 `status` never touches the graphs; `refresh` opens them read-only and
@@ -164,13 +163,13 @@ converges the ledger.
 Removing a graph from `cluster.yaml` never executes silently:
 
 ```bash
-omnigraph cluster apply --config ./company-brain
+omnigraph cluster apply --config company-brain
 #   Delete graph.scratch [Blocked: approval_required]
 
-omnigraph cluster approve graph.scratch --config ./company-brain --as andrew
+omnigraph cluster approve graph.scratch --config company-brain --as andrew
 #   cluster approve: delete graph.scratch approved by andrew (approval 01KT…)
 
-omnigraph cluster apply --config ./company-brain --as andrew
+omnigraph cluster apply --config company-brain --as andrew
 #   Delete graph.scratch [Applied]   ← root removed, subtree tombstoned
 ```
 
@@ -196,8 +195,8 @@ again**.
 **A held lock** (a crashed process left `__cluster/lock.json`):
 
 ```bash
-omnigraph cluster status --config ./company-brain      # shows the lock holder + id
-omnigraph cluster force-unlock <LOCK_ID> --config ./company-brain
+omnigraph cluster status --config company-brain      # shows the lock holder + id
+omnigraph cluster force-unlock <LOCK_ID> --config company-brain
 ```
 
 Force-unlock requires the exact lock id (from status) — there is no blind
@@ -240,7 +239,7 @@ with an in-flight apply.
 - **`omnigraph.yaml` still has a job**: per-operator settings — your
   `cli.actor` default for `--as`, CLI defaults, credentials, and data-plane
   ergonomics (point `graphs.<name>.uri` at a derived root like
-  `./company-brain/graphs/knowledge.omni` to use `--target <name>` for
+  `company-brain/graphs/knowledge.omni` to use `--target <name>` for
   loads). It just no longer describes the deployment — a server boots from
   one source or the other, never a merge of both.
 

--- a/docs/user/deployment.md
+++ b/docs/user/deployment.md
@@ -33,7 +33,7 @@ On Windows, the binaries are `omnigraph.exe` and `omnigraph-server.exe`.
 Run against a local graph:
 
 ```bash
-omnigraph-server ./graph.omni --bind 0.0.0.0:8080
+omnigraph-server graph.omni --bind 0.0.0.0:8080
 ```
 
 Run against an object-store-backed graph:
@@ -208,7 +208,7 @@ docker run --rm -p 8080:8080 \
   -e OMNIGRAPH_CONFIG="/etc/omnigraph/omnigraph.yaml" \
   -v "$PWD/config:/etc/omnigraph:ro" \
   omnigraph-server:local
-# /etc/omnigraph/omnigraph.yaml contains `policy: { file: ./policy.yaml }`;
+# /etc/omnigraph/omnigraph.yaml contains `policy: { file: policy.yaml }`;
 # policy.yaml (+ optional policy.tests.yaml) sit beside it in the mount.
 ```
 

--- a/docs/user/policy.md
+++ b/docs/user/policy.md
@@ -35,13 +35,13 @@ In multi mode (`omnigraph.yaml` with a non-empty `graphs:` map), policy files at
 ```yaml
 server:
   policy:
-    file: ./server-policy.yaml          # server-level: graph_list
+    file: server-policy.yaml          # server-level: graph_list
 
 graphs:
   alpha:
     uri: s3://tenant-bucket/alpha
     policy:
-      file: ./policies/alpha.yaml       # per-graph: read, change, branch_*, schema_apply
+      file: policies/alpha.yaml       # per-graph: read, change, branch_*, schema_apply
   beta:
     uri: s3://tenant-bucket/beta
     # no per-graph policy → no engine-layer Cedar enforcement on beta
@@ -78,8 +78,8 @@ rules:
 
 ```yaml
 policy:
-  file: ./policy.yaml          # Cedar rules + groups
-  tests: ./policy.tests.yaml   # declarative test cases
+  file: policy.yaml          # Cedar rules + groups
+  tests: policy.tests.yaml   # declarative test cases
 
 cli:
   actor: act-andrew            # default actor for CLI direct-engine writes

--- a/docs/user/transactions.md
+++ b/docs/user/transactions.md
@@ -47,8 +47,8 @@ query register_employee_with_team($name: String, $age: I32, $team: String) {
 ```
 
 ```bash
-omnigraph change --query ./mutations.gq --name register_employee_with_team \
-    --params '{"name":"Alice","age":30,"team":"Acme"}' ./graph.omni
+omnigraph change --query mutations.gq --name register_employee_with_team \
+    --params '{"name":"Alice","age":30,"team":"Acme"}' graph.omni
 ```
 
 If the second statement fails (e.g. `Acme` doesn't exist), the publisher never publishes; `Alice` is not in the database. Atomic.
@@ -57,10 +57,10 @@ If the second statement fails (e.g. `Acme` doesn't exist), the publisher never p
 
 ```bash
 # Query 1
-omnigraph change --query ./mutations.gq --name register_employee --params '{"name":"Alice","age":30}' ./graph.omni
+omnigraph change --query mutations.gq --name register_employee --params '{"name":"Alice","age":30}' graph.omni
 
 # Query 2 — runs after Query 1 has already published
-omnigraph change --query ./mutations.gq --name link_to_team --params '{"name":"Alice","team":"Acme"}' ./graph.omni
+omnigraph change --query mutations.gq --name link_to_team --params '{"name":"Alice","team":"Acme"}' graph.omni
 ```
 
 These are **two publishes** on `main`. If Query 2 fails, Query 1's effects are already visible. There is no `ROLLBACK` for Query 1.
@@ -75,32 +75,32 @@ The pattern when you need to run multiple queries — possibly across multiple c
 
 ```bash
 # Fork a working branch from main.
-omnigraph branch create --from main onboarding/2026-04-25 ./graph.omni
+omnigraph branch create --from main onboarding/2026-04-25 graph.omni
 
 # Run any number of mutations on the branch — each one is its own publish on the branch.
 # Concurrent reads of `main` are unaffected.
 omnigraph change --branch onboarding/2026-04-25 \
-    --query ./mutations.gq --name register_employee \
-    --params '{"name":"Alice","age":30}' ./graph.omni
+    --query mutations.gq --name register_employee \
+    --params '{"name":"Alice","age":30}' graph.omni
 
 omnigraph change --branch onboarding/2026-04-25 \
-    --query ./mutations.gq --name register_employee \
-    --params '{"name":"Bob","age":25}' ./graph.omni
+    --query mutations.gq --name register_employee \
+    --params '{"name":"Bob","age":25}' graph.omni
 
 omnigraph change --branch onboarding/2026-04-25 \
-    --query ./mutations.gq --name link_to_team \
-    --params '{"name":"Alice","team":"Acme"}' ./graph.omni
+    --query mutations.gq --name link_to_team \
+    --params '{"name":"Alice","team":"Acme"}' graph.omni
 
 # Inspect the branch — read queries work just like on main.
 omnigraph read --branch onboarding/2026-04-25 \
-    --query ./queries.gq --name list_employees ./graph.omni
+    --query queries.gq --name list_employees graph.omni
 
 # Happy with what's on the branch? Merge it. This is one atomic publish:
 # `main` flips to include every commit on the branch.
-omnigraph branch merge onboarding/2026-04-25 --into main ./graph.omni
+omnigraph branch merge onboarding/2026-04-25 --into main graph.omni
 
 # OR: not happy? Throw it away. `main` is untouched.
-# omnigraph branch delete onboarding/2026-04-25 ./graph.omni
+# omnigraph branch delete onboarding/2026-04-25 graph.omni
 ```
 
 Properties:
@@ -115,16 +115,16 @@ Two agents writing to the same graph independently:
 
 ```bash
 # Agent A
-omnigraph branch create --from main agent-a/work ./graph.omni
-omnigraph change --branch agent-a/work … ./graph.omni
+omnigraph branch create --from main agent-a/work graph.omni
+omnigraph change --branch agent-a/work … graph.omni
 # … many mutations …
-omnigraph branch merge agent-a/work --into main ./graph.omni
+omnigraph branch merge agent-a/work --into main graph.omni
 
 # Agent B (running concurrently)
-omnigraph branch create --from main agent-b/work ./graph.omni
-omnigraph change --branch agent-b/work … ./graph.omni
+omnigraph branch create --from main agent-b/work graph.omni
+omnigraph change --branch agent-b/work … graph.omni
 # … many mutations …
-omnigraph branch merge agent-b/work --into main ./graph.omni
+omnigraph branch merge agent-b/work --into main graph.omni
 ```
 
 Each agent sees a consistent snapshot of `main` at the time it forked. The first merge to `main` lands as a fast-forward (or a no-op if no concurrent change). The second merge runs three-way: rows touched by both branches surface as `MergeConflict`s for the caller to resolve.


### PR DESCRIPTION
Two ergonomics fixes from cookbook-alignment feedback — the cluster config was fighting its own model:

1. **The `.gq` files are the declaration.** `graphs.<id>.queries` previously accepted only an explicit `name → file` map, forcing configs to re-enumerate every `query <name>` the files already declare (the SPIKE cookbook needed 66 entries for 6 files). Now:
   ```yaml
   queries: queries/                  # directory: every declaration in top-level *.gq (sorted)
   queries: [people.gq, extra/a.gq]   # explicit files; every declaration in each
   queries: { find_experts: { file: knowledge.gq } }   # fine-grained map, unchanged
   ```
   Discovery is loud — unreadable/unparseable files and cross-file duplicate names fail validation (`query_parse_error`, `duplicate_query_name`). Downstream is untouched: each discovered query remains an individually addressed resource (`query.<graph>.<name>`) with the containing file's digest.

2. **`./` path prefixes removed from the docs** (109 instances across user docs). Paths in `cluster.yaml` and command examples resolve against one explicit config folder — the prefix was stylistic noise. (`../` links and `./scripts` executable invocations untouched; verified no link damage + `check-agents-md.sh` green.)

## Test plan

- 3 new in-crate tests (directory discovery incl. non-`.gq` files ignored and deterministic ordering; list + single-file forms; duplicate-name and parse-error refusals); 95 total pass
- `cargo test --workspace --locked` — green (exit 0 in-log)
- Manual: a bare-paths `cluster.yaml` (`schema: people.pg`, `queries: queries/`) validates with all declarations discovered

The cookbooks PR (ModernRelay/omnigraph-cookbooks#17) collapses to the one-line form on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two ergonomics improvements to the cluster config: a Terraform-style query declaration (`QueriesDecl` enum accepting a directory path, file list, or explicit name→file map) so `.gq` files self-describe their queries instead of forcing operators to re-enumerate every name, and a 109-instance removal of `./` path-prefix noise from user docs.

- **`QueriesDecl` (`#[serde(untagged)]`)** replaces the hard `BTreeMap<String, QueryConfig>` on `GraphConfig.queries`. A new `resolve_query_decls` function reads and parses each discovered `.gq` via `parse_query`, emitting loud errors for unreadable files, parse failures, and cross-file duplicate names before handing the canonical name→file map back to the existing `load_desired` machinery. Three tests cover directory discovery, list and single-file forms, and error paths.
- **`./` prefix removal** is cosmetic/docs-only: paths in `cluster.yaml` always resolve against the config folder, so `schema: people.pg` and `schema: ./people.pg` are equivalent; the prefix was stylistic noise in examples and reference docs. `../` relative links and `./scripts` executable calls were intentionally left untouched.

<h3>Confidence Score: 4/5</h3>

Safe to merge. The new query-discovery path is additive and backward-compatible; the Explicit map form is untouched. The only behavioural changes are new error/warning codes for the new forms and the removal of cosmetic ./ prefixes from docs.

The core logic in resolve_query_decls is correct: directory enumeration, sorting, duplicate detection, and loud parse-failure handling all work as intended and are covered by the new tests. Two minor design observations remain — discovered files are read a second time per-query in load_desired (N+1 reads for N queries), and the diagnostic field path emitted during that second read uses an explicit-map–style locator that doesn't match the discovery syntax the user actually wrote — but neither affects correctness or safety.

crates/omnigraph-cluster/src/lib.rs — specifically the resolve_query_decls function and the per-query re-read block in load_desired (lines ~464–543 and ~3747–3778).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/omnigraph-cluster/src/lib.rs | Core change: introduces QueriesDecl enum (string/list/map) so .gq files are self-describing; adds resolve_query_decls to discover queries from directories and files. Logic is correct but discovery mode reads each multi-query file N+1 times and emits misleading field paths in the second-read error path. |
| docs/user/cluster-config.md | Updated cluster.yaml reference example and added Terraform-style queries section with all three forms; ./ prefix removed from path examples throughout. |
| docs/user/cluster.md | ./ path-prefix noise stripped from user-doc instances; no functional changes. |
| docs/user/cli-reference.md | ./ prefixes removed from command examples; content unchanged. |
| docs/user/cli.md | ./ prefixes removed from path examples; no functional changes. |
| docs/user/deployment.md | ./ prefixes removed from deployment examples; no functional changes. |
| docs/user/policy.md | ./ prefixes removed from policy file path examples; no functional changes. |
| docs/user/transactions.md | ./ prefixes removed from path examples; no functional changes. |
| docs/dev/cluster-pr-issues.md | Dev-facing notes; ./ prefixes cleaned up, no structural changes. |
| docs/dev/cluster-state-of-affairs.md | Dev-facing notes; ./ prefixes cleaned up, no structural changes. |
| docs/dev/omnigraph-article-long.md | ./ prefixes removed from path examples; no functional changes. |
| docs/dev/omnigraph-article.md | ./ prefixes removed from path examples; no functional changes. |
| docs/dev/omnigraph-visuals.md | ./ prefixes removed from path examples; no functional changes. |
| docs/dev/pr-139-issues.md | ./ prefixes removed from path examples; no functional changes. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["cluster.yaml\n`queries:` field"] -->|string| B["QueriesDecl::Discover(PathBuf)"]
    A -->|array| C["QueriesDecl::DiscoverMany(Vec<PathBuf>)"]
    A -->|map| D["QueriesDecl::Explicit(BTreeMap)"]

    B --> E["resolve_query_decls()"]
    C --> E
    D -->|early return| F["name→file map"]

    E --> G{is_dir?}
    G -->|yes| H["fs::read_dir\nfilter *.gq\nsort"]
    G -->|no| I["single file"]
    H --> J["For each .gq file:\nfs::read_to_string\nparse_query"]
    I --> J
    J -->|parse error| K["query_parse_error ❌"]
    J -->|ok| L["extract query names\ncheck duplicates"]
    L -->|duplicate| M["duplicate_query_name ❌"]
    L -->|ok| F

    F --> N["load_desired:\nper-query fs::read_to_string\ncompute digest\nvalidate_query_source"]
    N --> O["resource_digests &\ngraph_query_digests"]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/omnigraph-cluster/src/lib.rs`, line 3747-3778 ([link](https://github.com/modernrelay/omnigraph/blob/cebf5bf1986ab54e92b8cb0b1daece32412fcf4a/crates/omnigraph-cluster/src/lib.rs#L3747-L3778)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`query_file_missing` field path is misleading for discovered queries**

   When discovery mode is used (`queries: queries/` or `queries: [a.gq, b.gq]`), this second read can emit `query_file_missing` with field `graphs.{graph_id}.queries.{query_name}.file` — a JSON-pointer–style path that implies the user set an explicit `{ find_person: { file: … } }` map. In reality the user never wrote that field; the name was auto-discovered. If a file becomes unreadable between discovery and digest-computation, the operator will see a field path that points to something that doesn't exist in their `cluster.yaml`.

   Emitting `graphs.{graph_id}.queries` (same level used by `resolve_query_decls`) and including the file path in the message (already present) would give accurate attribution.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fomnigraph-cluster%2Fsrc%2Flib.rs%0ALine%3A%203747-3778%0A%0AComment%3A%0A**%60query_file_missing%60%20field%20path%20is%20misleading%20for%20discovered%20queries**%0A%0AWhen%20discovery%20mode%20is%20used%20%28%60queries%3A%20queries%2F%60%20or%20%60queries%3A%20%5Ba.gq%2C%20b.gq%5D%60%29%2C%20this%20second%20read%20can%20emit%20%60query_file_missing%60%20with%20field%20%60graphs.%7Bgraph_id%7D.queries.%7Bquery_name%7D.file%60%20%E2%80%94%20a%20JSON-pointer%E2%80%93style%20path%20that%20implies%20the%20user%20set%20an%20explicit%20%60%7B%20find_person%3A%20%7B%20file%3A%20%E2%80%A6%20%7D%20%7D%60%20map.%20In%20reality%20the%20user%20never%20wrote%20that%20field%3B%20the%20name%20was%20auto-discovered.%20If%20a%20file%20becomes%20unreadable%20between%20discovery%20and%20digest-computation%2C%20the%20operator%20will%20see%20a%20field%20path%20that%20points%20to%20something%20that%20doesn't%20exist%20in%20their%20%60cluster.yaml%60.%0A%0AEmitting%20%60graphs.%7Bgraph_id%7D.queries%60%20%28same%20level%20used%20by%20%60resolve_query_decls%60%29%20and%20including%20the%20file%20path%20in%20the%20message%20%28already%20present%29%20would%20give%20accurate%20attribution.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modernrelay%2Fomnigraph&pr=183&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fomnigraph-cluster%2Fsrc%2Flib.rs%3A500-543%0A**Discovery%20mode%20reads%20each%20multi-query%20file%20N%2B1%20times**%0A%0A%60resolve_query_decls%60%20reads%20and%20parses%20each%20%60.gq%60%20file%20once%20to%20enumerate%20query%20names.%20Then%20in%20%60load_desired%60%20%28line%203747%29%2C%20%60fs%3A%3Aread_to_string%60%20is%20called%20once%20per%20discovered%20query%20%E2%80%94%20so%20a%20file%20containing%20N%20queries%20is%20read%20N%2B1%20times%20total%20and%20parsed%20N%20times%20in%20%60validate_query_source%60.%20This%20creates%20a%20small%20TOCTOU%20window%3A%20if%20the%20file%20changes%20between%20the%20discovery%20read%20and%20the%20per-query%20reads%2C%20%60validate_query_source%60%20can%20emit%20%60query_key_mismatch%60%20for%20a%20query%20that%20was%20just%20discovered%2C%20which%20is%20surprising%20since%20the%20caller%20already%20verified%20the%20name%20exists%20in%20that%20file.%20The%20loud%20failure%20is%20safe%2C%20but%20the%20error%20attribution%20is%20confusing.%0A%0AReturning%20%60%28String%2C%20Vec%3CString%3E%29%60%20%28content%20%2B%20names%29%20from%20the%20file-processing%20loop%20and%20threading%20the%20content%20through%20to%20the%20downstream%20read%20would%20eliminate%20the%20redundancy%20and%20close%20the%20window%20entirely.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fomnigraph-cluster%2Fsrc%2Flib.rs%3A3747-3778%0A**%60query_file_missing%60%20field%20path%20is%20misleading%20for%20discovered%20queries**%0A%0AWhen%20discovery%20mode%20is%20used%20%28%60queries%3A%20queries%2F%60%20or%20%60queries%3A%20%5Ba.gq%2C%20b.gq%5D%60%29%2C%20this%20second%20read%20can%20emit%20%60query_file_missing%60%20with%20field%20%60graphs.%7Bgraph_id%7D.queries.%7Bquery_name%7D.file%60%20%E2%80%94%20a%20JSON-pointer%E2%80%93style%20path%20that%20implies%20the%20user%20set%20an%20explicit%20%60%7B%20find_person%3A%20%7B%20file%3A%20%E2%80%A6%20%7D%20%7D%60%20map.%20In%20reality%20the%20user%20never%20wrote%20that%20field%3B%20the%20name%20was%20auto-discovered.%20If%20a%20file%20becomes%20unreadable%20between%20discovery%20and%20digest-computation%2C%20the%20operator%20will%20see%20a%20field%20path%20that%20points%20to%20something%20that%20doesn't%20exist%20in%20their%20%60cluster.yaml%60.%0A%0AEmitting%20%60graphs.%7Bgraph_id%7D.queries%60%20%28same%20level%20used%20by%20%60resolve_query_decls%60%29%20and%20including%20the%20file%20path%20in%20the%20message%20%28already%20present%29%20would%20give%20accurate%20attribution.%0A%0A&repo=modernrelay%2Fomnigraph&pr=183&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs: drop ./ path prefixes; document qu..."](https://github.com/modernrelay/omnigraph/commit/cebf5bf1986ab54e92b8cb0b1daece32412fcf4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36835306)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->