### PR TITLE
ci: raise Test Workspace timeout to 75 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,13 @@ jobs:
     name: Test Workspace
     needs: classify_changes
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # 75, not 45: a cold rust-cache (every Cargo.lock change) costs a full
+    # workspace + failpoints-feature build on a 2-core runner, which now
+    # exceeds 45 minutes on slow runner days. A timed-out run never SAVES
+    # its cache, so an undersized budget self-perpetuates: every retry
+    # starts cold and dies the same way (observed 2026-06-11, four runs).
+    # Warm-cache runs stay ~15 minutes; this is headroom, not a target.
+    timeout-minutes: 75
     permissions:
       contents: write
     env:


### PR DESCRIPTION
Unblocks #188 and main's own CI. Four consecutive 45-minute timeouts (main ×2, #188 ×2) since #186's `Cargo.lock` bump: a cold `rust-cache` costs a full workspace + failpoints-feature build on the 2-core runner, which exceeds 45 minutes on slow runner days — and **a timed-out run never saves its cache**, so the undersized budget self-perpetuates (every retry starts cold and dies the same way). Verified from the logs: zero failing tests; orphaned `cargo`/`rustc` killed mid-compile at the 45-minute mark.

Warm-cache runs remain ~15 minutes — 75 is headroom (matching the RustFS job's budget), not a target. This PR's own run executes under the new budget and, on success, saves the new-lock cache that un-colds everything downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)