### PR TITLE
feat(cli): operator config surface — identity + output defaults (RFC-007 PR 1)

### DIFF
--- a/crates/omnigraph-cli/src/helpers.rs
+++ b/crates/omnigraph-cli/src/helpers.rs
@@ -3,6 +3,7 @@
 //! main.rs in the modularization).
 
 use super::*;
+use crate::operator;
 
 pub(crate) fn ensure_local_graph_parent(uri: &str) -> Result<()> {
     if !uri.contains("://") {
@@ -167,18 +168,40 @@ pub(crate) async fn open_local_db_with_policy(graph: &ResolvedCliGraph) -> Resul
     }
 }
 
+/// THE actor chain (RFC-007 §D3) — every command that needs an identity
+/// resolves through this one function (one path per concern):
+/// `--as` > legacy `cli.actor` in omnigraph.yaml (RFC-008 window) >
+/// `operator.actor` in ~/.omnigraph/config.yaml > none.
+pub(crate) fn resolve_actor(
+    cli_as: Option<&str>,
+    legacy_config_actor: Option<&str>,
+) -> Result<Option<String>> {
+    if let Some(actor) = cli_as {
+        return Ok(Some(actor.to_string()));
+    }
+    if let Some(actor) = legacy_config_actor {
+        return Ok(Some(actor.to_string()));
+    }
+    Ok(operator::load_operator_config()?
+        .actor()
+        .map(str::to_string))
+}
+
 pub(crate) fn resolve_cluster_actor(cli_as: Option<&str>) -> Result<Option<String>> {
     if let Some(actor) = cli_as {
         return Ok(Some(actor.to_string()));
     }
     let config = load_config(None).wrap_err(
-        "resolving the default actor from the per-operator omnigraph.yaml (pass --as <ACTOR> to skip this lookup)",
+        "resolving the default actor from omnigraph.yaml (pass --as <ACTOR> to skip this lookup)",
     )?;
-    Ok(config.cli.actor.clone())
+    resolve_actor(None, config.cli.actor.as_deref())
 }
 
-pub(crate) fn resolve_cli_actor<'a>(cli_as: Option<&'a str>, config: &'a OmnigraphConfig) -> Option<&'a str> {
-    cli_as.or(config.cli.actor.as_deref())
+pub(crate) fn resolve_cli_actor(
+    cli_as: Option<&str>,
+    config: &OmnigraphConfig,
+) -> Result<Option<String>> {
+    resolve_actor(cli_as, config.cli.actor.as_deref())
 }
 
 pub(crate) fn resolve_policy_tests_path(context: &ResolvedPolicyContext) -> PathBuf {
@@ -460,6 +483,9 @@ pub(crate) fn merged_params_json(
     }
 }
 
+/// The format cascade (RFC-007 §D3): `--json` > `--format` > alias format >
+/// legacy `cli.output_format` (RFC-008 window) > operator `defaults.output`
+/// > table.
 pub(crate) fn resolve_read_format(
     config: &OmnigraphConfig,
     cli_format: Option<ReadOutputFormat>,
@@ -467,12 +493,17 @@ pub(crate) fn resolve_read_format(
     alias_format: Option<ReadOutputFormat>,
 ) -> ReadOutputFormat {
     if json {
-        ReadOutputFormat::Json
-    } else {
-        cli_format
-            .or(alias_format)
-            .unwrap_or_else(|| config.cli_output_format())
+        return ReadOutputFormat::Json;
     }
+    cli_format
+        .or(alias_format)
+        .or(config.cli.output_format)
+        .or_else(|| {
+            operator::load_operator_config()
+                .ok()
+                .and_then(|operator| operator.output())
+        })
+        .unwrap_or_default()
 }
 
 pub(crate) fn resolve_alias<'a>(
@@ -935,7 +966,8 @@ pub(crate) async fn execute_change(
     let (selected_name, query_params) = select_named_query(query_source, query_name)?;
     let params = query_params_from_json(&query_params, params_json)?;
     let db = open_local_db_with_policy(graph).await?;
-    let actor = resolve_cli_actor(cli_as_actor, config);
+    let actor = resolve_cli_actor(cli_as_actor, config)?;
+    let actor = actor.as_deref();
     let result = db
         .mutate_as(branch, query_source, &selected_name, &params, actor)
         .await?;

--- a/crates/omnigraph-cli/src/main.rs
+++ b/crates/omnigraph-cli/src/main.rs
@@ -42,6 +42,7 @@ use serde::de::DeserializeOwned;
 use serde_json::Value;
 
 mod embed;
+mod operator;
 mod read_format;
 
 use embed::{EmbedArgs, EmbedOutput, execute_embed};
@@ -129,7 +130,8 @@ async fn main() -> Result<()> {
                 load_output_from_tables(&uri, &branch, mode, &output)
             } else {
                 let db = open_local_db_with_policy(&graph).await?;
-                let actor = resolve_cli_actor(cli.as_actor.as_deref(), &config);
+                let actor = resolve_cli_actor(cli.as_actor.as_deref(), &config)?;
+                let actor = actor.as_deref();
                 let result = db
                     .load_file_as(
                         &branch,
@@ -196,7 +198,8 @@ async fn main() -> Result<()> {
                 .await?
             } else {
                 let db = open_local_db_with_policy(&graph).await?;
-                let actor = resolve_cli_actor(cli.as_actor.as_deref(), &config);
+                let actor = resolve_cli_actor(cli.as_actor.as_deref(), &config)?;
+                let actor = actor.as_deref();
                 let result = db
                     .load_file_as(
                         &branch,
@@ -243,7 +246,8 @@ async fn main() -> Result<()> {
                     .await?
                 } else {
                     let db = open_local_db_with_policy(&graph).await?;
-                    let actor = resolve_cli_actor(cli.as_actor.as_deref(), &config);
+                    let actor = resolve_cli_actor(cli.as_actor.as_deref(), &config)?;
+                let actor = actor.as_deref();
                     db.branch_create_from_as(ReadTarget::branch(&from), &name, actor)
                         .await?;
                     BranchCreateOutput {
@@ -316,7 +320,8 @@ async fn main() -> Result<()> {
                     .await?
                 } else {
                     let db = open_local_db_with_policy(&graph).await?;
-                    let actor = resolve_cli_actor(cli.as_actor.as_deref(), &config);
+                    let actor = resolve_cli_actor(cli.as_actor.as_deref(), &config)?;
+                let actor = actor.as_deref();
                     db.branch_delete_as(&name, actor).await?;
                     BranchDeleteOutput {
                         uri: uri.clone(),
@@ -358,7 +363,8 @@ async fn main() -> Result<()> {
                     .await?
                 } else {
                     let db = open_local_db_with_policy(&graph).await?;
-                    let actor = resolve_cli_actor(cli.as_actor.as_deref(), &config);
+                    let actor = resolve_cli_actor(cli.as_actor.as_deref(), &config)?;
+                let actor = actor.as_deref();
                     let outcome = db.branch_merge_as(&source, &into, actor).await?;
                     BranchMergeOutput {
                         source: source.clone(),
@@ -514,7 +520,8 @@ async fn main() -> Result<()> {
                     .await?
                 } else {
                     let db = open_local_db_with_policy(&graph).await?;
-                    let actor = resolve_cli_actor(cli.as_actor.as_deref(), &config);
+                    let actor = resolve_cli_actor(cli.as_actor.as_deref(), &config)?;
+                let actor = actor.as_deref();
                     let registry = load_registry_or_report(&config, graph.selected())?;
                     let registry = (!registry.is_empty()).then_some(registry);
                     let label = graph.selected().unwrap_or(&uri).to_string();

--- a/crates/omnigraph-cli/src/operator.rs
+++ b/crates/omnigraph-cli/src/operator.rs
@@ -1,0 +1,212 @@
+//! The operator config surface (RFC-007): `~/.omnigraph/config.yaml` — who
+//! the operator IS (identity, ergonomics), never what the system is (that's
+//! cluster config) and never a project file (nothing here arrives with a
+//! repo checkout).
+//!
+//! PR-1 scope: `operator.actor` + `defaults.output`. Unknown keys WARN and
+//! are preserved-by-ignoring — a file written for a newer CLI (servers,
+//! aliases, credentials keys from later slices) must load cleanly on this
+//! one. Contrast with `cluster.yaml`, where unknown keys are fatal because
+//! they change what a plan means.
+//!
+//! This module is CLI-only by design: the server never reads operator
+//! config (server-side identity comes from bearer auth — invariant 11
+//! holds by construction).
+
+use std::env;
+use std::path::{Path, PathBuf};
+
+use color_eyre::Result;
+use color_eyre::eyre::eyre;
+use serde::Deserialize;
+
+use omnigraph_server::config::ReadOutputFormat;
+
+pub(crate) const OPERATOR_HOME_ENV: &str = "OMNIGRAPH_HOME";
+pub(crate) const OPERATOR_DIR: &str = ".omnigraph";
+pub(crate) const OPERATOR_CONFIG_FILE: &str = "config.yaml";
+
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct OperatorConfig {
+    #[serde(default)]
+    pub(crate) operator: OperatorIdentity,
+    #[serde(default)]
+    pub(crate) defaults: OperatorDefaults,
+    /// Everything this CLI version doesn't know. Warned once at load,
+    /// otherwise ignored (forward compatibility within the operator layer).
+    #[serde(flatten)]
+    unknown: serde_yaml::Mapping,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct OperatorIdentity {
+    /// Default actor for every `--as` cascade (CLI direct-engine writes and
+    /// cluster commands alike): `--as` > legacy config actor (RFC-008
+    /// window) > this > none.
+    pub(crate) actor: Option<String>,
+    #[serde(flatten)]
+    unknown: serde_yaml::Mapping,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct OperatorDefaults {
+    /// Default read output format, below every more-specific source.
+    pub(crate) output: Option<ReadOutputFormat>,
+    #[serde(flatten)]
+    unknown: serde_yaml::Mapping,
+}
+
+impl OperatorConfig {
+    pub(crate) fn actor(&self) -> Option<&str> {
+        self.operator.actor.as_deref()
+    }
+
+    pub(crate) fn output(&self) -> Option<ReadOutputFormat> {
+        self.defaults.output
+    }
+}
+
+/// The operator dir: `$OMNIGRAPH_HOME` if set (tilde-expanded), else
+/// `~/.omnigraph`. Returns None when no home directory is resolvable
+/// (degenerate environments — the layer is simply absent).
+pub(crate) fn operator_dir() -> Option<PathBuf> {
+    if let Some(home_override) = env::var_os(OPERATOR_HOME_ENV) {
+        let raw = home_override.to_string_lossy().into_owned();
+        return Some(expand_tilde(&raw));
+    }
+    env::home_dir().map(|home| home.join(OPERATOR_DIR))
+}
+
+/// Load the operator layer. Absent file (or unresolvable home) is an empty
+/// layer, never an error; a present-but-malformed file is a loud error (the
+/// operator owns it and can fix it); unknown keys warn to stderr once.
+pub(crate) fn load_operator_config() -> Result<OperatorConfig> {
+    let Some(dir) = operator_dir() else {
+        return Ok(OperatorConfig::default());
+    };
+    load_operator_config_at(&dir.join(OPERATOR_CONFIG_FILE))
+}
+
+pub(crate) fn load_operator_config_at(path: &Path) -> Result<OperatorConfig> {
+    let text = match std::fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(OperatorConfig::default());
+        }
+        Err(err) => {
+            return Err(eyre!(
+                "could not read operator config '{}': {err}",
+                path.display()
+            ));
+        }
+    };
+    let config: OperatorConfig = serde_yaml::from_str(&text).map_err(|err| {
+        eyre!(
+            "could not parse operator config '{}': {err}",
+            path.display()
+        )
+    })?;
+    for warning in config.unknown_key_warnings() {
+        eprintln!("warning: {warning} in operator config '{}'", path.display());
+    }
+    Ok(config)
+}
+
+impl OperatorConfig {
+    fn unknown_key_warnings(&self) -> Vec<String> {
+        let mut warnings = Vec::new();
+        let mut collect = |mapping: &serde_yaml::Mapping, prefix: &str| {
+            for key in mapping.keys() {
+                if let Some(name) = key.as_str() {
+                    warnings.push(format!(
+                        "unknown key `{prefix}{name}` (newer CLI feature or typo); ignored"
+                    ));
+                }
+            }
+        };
+        collect(&self.unknown, "");
+        collect(&self.operator.unknown, "operator.");
+        collect(&self.defaults.unknown, "defaults.");
+        warnings
+    }
+}
+
+/// Expand a leading `~` / `~/` to the home directory (PR #139 finding 9:
+/// a literal `./~/…` path silently created a directory named `~`).
+pub(crate) fn expand_tilde(raw: &str) -> PathBuf {
+    if raw == "~" {
+        return env::home_dir().unwrap_or_else(|| PathBuf::from(raw));
+    }
+    if let Some(rest) = raw.strip_prefix("~/") {
+        if let Some(home) = env::home_dir() {
+            return home.join(rest);
+        }
+    }
+    PathBuf::from(raw)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn absent_file_is_an_empty_layer() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = load_operator_config_at(&dir.path().join("config.yaml")).unwrap();
+        assert!(config.actor().is_none());
+        assert!(config.output().is_none());
+    }
+
+    #[test]
+    fn parses_identity_and_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        fs::write(
+            &path,
+            "operator:\n  actor: act-andrew\ndefaults:\n  output: json\n",
+        )
+        .unwrap();
+        let config = load_operator_config_at(&path).unwrap();
+        assert_eq!(config.actor(), Some("act-andrew"));
+        assert_eq!(config.output(), Some(ReadOutputFormat::Json));
+    }
+
+    #[test]
+    fn unknown_keys_warn_but_load() {
+        // A file written for a later slice (servers/aliases) must load
+        // cleanly today — warn-only forward compatibility.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        fs::write(
+            &path,
+            "operator:\n  actor: act-a\n  color: green\nservers:\n  prod:\n    url: https://example.com\naliases: {}\n",
+        )
+        .unwrap();
+        let config = load_operator_config_at(&path).unwrap();
+        assert_eq!(config.actor(), Some("act-a"));
+        let warnings = config.unknown_key_warnings();
+        assert_eq!(warnings.len(), 3, "{warnings:?}");
+        assert!(warnings.iter().any(|w| w.contains("`servers`")));
+        assert!(warnings.iter().any(|w| w.contains("`aliases`")));
+        assert!(warnings.iter().any(|w| w.contains("`operator.color`")));
+    }
+
+    #[test]
+    fn malformed_yaml_is_a_loud_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        fs::write(&path, "operator: [not, a, mapping\n").unwrap();
+        let err = load_operator_config_at(&path).unwrap_err();
+        assert!(err.to_string().contains("could not parse operator config"));
+    }
+
+    #[test]
+    fn expand_tilde_resolves_home_prefix() {
+        let home = env::home_dir().unwrap();
+        assert_eq!(expand_tilde("~"), home);
+        assert_eq!(expand_tilde("~/x/y"), home.join("x/y"));
+        assert_eq!(expand_tilde("/abs/path"), PathBuf::from("/abs/path"));
+        assert_eq!(expand_tilde("rel/path"), PathBuf::from("rel/path"));
+    }
+}

--- a/crates/omnigraph-cli/tests/cli_cluster.rs
+++ b/crates/omnigraph-cli/tests/cli_cluster.rs
@@ -726,6 +726,73 @@ fn cluster_apply_uses_cli_actor_from_local_config() {
     assert_eq!(apply(&["--as", "andrew"]), "andrew", "--as overrides cli.actor");
 }
 
+/// RFC-007 PR 1: the operator layer joins the actor chain —
+/// `--as` > legacy `cli.actor` (RFC-008 window) > `operator.actor` > none.
+#[test]
+fn cluster_apply_uses_operator_actor_from_omnigraph_home() {
+    let temp = tempdir().unwrap();
+    write_cluster_config_fixture(temp.path());
+    let operator_home = tempdir().unwrap();
+    fs::write(
+        operator_home.path().join("config.yaml"),
+        "operator:\n  actor: act-operator\n",
+    )
+    .unwrap();
+
+    let output = cli()
+        .current_dir(temp.path())
+        .env("OMNIGRAPH_HOME", operator_home.path())
+        .arg("cluster")
+        .arg("import")
+        .arg("--config")
+        .arg(temp.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{output:?}");
+
+    let apply = |extra: &[&str]| {
+        let mut command = cli();
+        command
+            .current_dir(temp.path())
+            .env("OMNIGRAPH_HOME", operator_home.path());
+        for arg in extra {
+            command.arg(arg);
+        }
+        let output = command
+            .arg("cluster")
+            .arg("apply")
+            .arg("--config")
+            .arg(temp.path())
+            .arg("--json")
+            .output()
+            .unwrap();
+        let json: serde_json::Value =
+            serde_json::from_str(String::from_utf8_lossy(&output.stdout).trim()).unwrap();
+        json["actor"].clone()
+    };
+
+    // No --as, no omnigraph.yaml: the operator identity applies.
+    assert_eq!(
+        apply(&[]),
+        "act-operator",
+        "operator.actor is the no-flag, no-legacy-config default"
+    );
+    // --as still wins over everything.
+    assert_eq!(apply(&["--as", "andrew"]), "andrew");
+
+    // A legacy cli.actor (RFC-008 window) outranks the operator layer.
+    fs::write(
+        temp.path().join("omnigraph.yaml"),
+        "cli:\n  actor: act-legacy\n",
+    )
+    .unwrap();
+    assert_eq!(
+        apply(&[]),
+        "act-legacy",
+        "legacy cli.actor wins over operator.actor during the deprecation window"
+    );
+}
+
 #[test]
 fn cluster_approve_uses_cli_actor_fallback() {
     let temp = tempdir().unwrap();

--- a/crates/omnigraph-cli/tests/cli_data.rs
+++ b/crates/omnigraph-cli/tests/cli_data.rs
@@ -984,6 +984,52 @@ fn read_csv_format_outputs_header_and_row_values() {
     assert!(stdout.contains("Alice"));
 }
 
+/// RFC-007 PR 1: the format cascade's operator hop — `defaults.output` in
+/// ~/.omnigraph/config.yaml applies when nothing more specific is given,
+/// and `--format` still wins over it.
+#[test]
+fn read_uses_operator_default_output_format() {
+    let temp = tempdir().unwrap();
+    let graph = graph_path(temp.path());
+    init_graph(&graph);
+    load_fixture(&graph);
+    let operator_home = tempdir().unwrap();
+    fs::write(
+        operator_home.path().join("config.yaml"),
+        "defaults:\n  output: csv\n",
+    )
+    .unwrap();
+
+    let read = |extra: &[&str]| {
+        let mut command = cli();
+        command
+            .env("OMNIGRAPH_HOME", operator_home.path())
+            .arg("read")
+            .arg(&graph)
+            .arg("--query")
+            .arg(fixture("test.gq"))
+            .arg("--name")
+            .arg("get_person")
+            .arg("--params")
+            .arg(r#"{"name":"Alice"}"#);
+        for arg in extra {
+            command.arg(arg);
+        }
+        stdout_string(&output_success(&mut command))
+    };
+
+    let stdout = read(&[]);
+    assert!(
+        stdout.lines().next().unwrap().contains("p.name") && stdout.contains("Alice"),
+        "operator defaults.output: csv applies with no --format: {stdout}"
+    );
+    let stdout = read(&["--format", "jsonl"]);
+    assert!(
+        stdout.starts_with('{'),
+        "--format wins over the operator default: {stdout}"
+    );
+}
+
 #[test]
 fn read_jsonl_format_outputs_metadata_header_first() {
     let temp = tempdir().unwrap();

--- a/crates/omnigraph-cli/tests/support/mod.rs
+++ b/crates/omnigraph-cli/tests/support/mod.rs
@@ -12,12 +12,24 @@ use reqwest::blocking::Client;
 use serde_json::Value;
 use tempfile::{TempDir, tempdir};
 
+/// Hermetic default: point OMNIGRAPH_HOME at a path that exists on no
+/// machine, so spawned binaries never read the developer's real
+/// ~/.omnigraph/ (an absent operator config is an empty layer). Tests
+/// exercising the operator layer override the var explicitly.
+pub const HERMETIC_OPERATOR_HOME: &str = "/nonexistent/omnigraph-test-home";
+
 pub fn cli() -> Command {
-    Command::cargo_bin("omnigraph").unwrap()
+    let mut command = Command::cargo_bin("omnigraph").unwrap();
+    command.env("OMNIGRAPH_HOME", HERMETIC_OPERATOR_HOME);
+    command.env_remove("OMNIGRAPH_CONFIG");
+    command
 }
 
 pub fn cli_process() -> StdCommand {
-    StdCommand::new(assert_cmd::cargo::cargo_bin("omnigraph"))
+    let mut command = StdCommand::new(assert_cmd::cargo::cargo_bin("omnigraph"));
+    command.env("OMNIGRAPH_HOME", HERMETIC_OPERATOR_HOME);
+    command.env_remove("OMNIGRAPH_CONFIG");
+    command
 }
 
 fn server_process() -> StdCommand {

--- a/crates/omnigraph-server/src/config.rs
+++ b/crates/omnigraph-server/src/config.rs
@@ -526,12 +526,23 @@ pub fn default_config_path() -> PathBuf {
     PathBuf::from(DEFAULT_CONFIG_FILE)
 }
 
+/// `OMNIGRAPH_CONFIG` env var: a first-class stand-in for `--config`, one
+/// name with one meaning in both binaries (the container entrypoint already
+/// uses it for the server; RFC-007 §D1 extends it to the CLI).
+pub const CONFIG_PATH_ENV: &str = "OMNIGRAPH_CONFIG";
+
 pub fn load_config(config_path: Option<&PathBuf>) -> Result<OmnigraphConfig> {
-    load_config_in(&env::current_dir()?, config_path)
+    let env_path = env::var_os(CONFIG_PATH_ENV).map(PathBuf::from);
+    load_config_in(&env::current_dir()?, config_path, env_path.as_ref())
 }
 
-fn load_config_in(cwd: &Path, config_path: Option<&PathBuf>) -> Result<OmnigraphConfig> {
-    let explicit_path = config_path.cloned();
+fn load_config_in(
+    cwd: &Path,
+    config_path: Option<&PathBuf>,
+    env_path: Option<&PathBuf>,
+) -> Result<OmnigraphConfig> {
+    // Precedence: explicit --config flag > $OMNIGRAPH_CONFIG > ./omnigraph.yaml.
+    let explicit_path = config_path.or(env_path).cloned();
     let config_path = explicit_path.or_else(|| {
         let default_path = cwd.join(DEFAULT_CONFIG_FILE);
         default_path.exists().then_some(default_path)
@@ -576,6 +587,28 @@ mod tests {
     };
 
     #[test]
+    fn env_config_path_stands_in_for_the_flag_but_loses_to_it() {
+        let temp = tempdir().unwrap();
+        let flag_path = temp.path().join("flag.yaml");
+        let env_path = temp.path().join("env.yaml");
+        fs::write(&flag_path, "cli:\n  actor: act-flag\n").unwrap();
+        fs::write(&env_path, "cli:\n  actor: act-env\n").unwrap();
+
+        // $OMNIGRAPH_CONFIG used when no flag…
+        let config = load_config_in(temp.path(), None, Some(&env_path)).unwrap();
+        assert_eq!(config.cli.actor.as_deref(), Some("act-env"));
+
+        // …loses to an explicit --config…
+        let config = load_config_in(temp.path(), Some(&flag_path), Some(&env_path)).unwrap();
+        assert_eq!(config.cli.actor.as_deref(), Some("act-flag"));
+
+        // …and beats the cwd default file.
+        fs::write(temp.path().join("omnigraph.yaml"), "cli:\n  actor: act-cwd\n").unwrap();
+        let config = load_config_in(temp.path(), None, Some(&env_path)).unwrap();
+        assert_eq!(config.cli.actor.as_deref(), Some("act-env"));
+    }
+
+    #[test]
     fn load_config_reads_yaml_defaults_from_current_dir() {
         let temp = tempdir().unwrap();
         fs::write(
@@ -598,7 +631,7 @@ policy: {}
         )
         .unwrap();
 
-        let config = load_config_in(temp.path(), None).unwrap();
+        let config = load_config_in(temp.path(), None, None).unwrap();
         assert_eq!(config.cli_graph_name(), Some("local"));
         assert_eq!(config.cli_branch(), "main");
         assert_eq!(config.cli_output_format(), ReadOutputFormat::Kv);
@@ -633,7 +666,7 @@ policy: {}
         )
         .unwrap();
 
-        let config = load_config_in(&child, None).unwrap();
+        let config = load_config_in(&child, None, None).unwrap();
         assert!(config.graphs.is_empty());
     }
 
@@ -657,7 +690,7 @@ policy: {}
             "graphs:\n  local:\n    uri: ./demo.omni\n",
         )
         .unwrap();
-        let config = load_config_in(temp.path(), None).unwrap();
+        let config = load_config_in(temp.path(), None, None).unwrap();
 
         // A known graph passes through unchanged.
         assert_eq!(config.resolve_graph_selection(Some("local")).unwrap(), Some("local"));
@@ -680,7 +713,7 @@ policy: {}
             "graphs:\n  local:\n    uri: ./demo.omni\npolicy:\n  file: ./top.yaml\n",
         )
         .unwrap();
-        let incoherent = load_config_in(temp2.path(), None).unwrap();
+        let incoherent = load_config_in(temp2.path(), None, None).unwrap();
         let err = incoherent
             .resolve_graph_selection(Some("local"))
             .unwrap_err()
@@ -705,7 +738,7 @@ policy: {}
              server:\n  graph: local\ncli:\n  graph: prod\n",
         )
         .unwrap();
-        let config = load_config_in(temp.path(), None).unwrap();
+        let config = load_config_in(temp.path(), None, None).unwrap();
         assert_eq!(
             config.resolve_policy_tooling_graph_selection().unwrap(),
             Some("prod")
@@ -717,7 +750,7 @@ policy: {}
             "graphs:\n  local:\n    uri: ./local.omni\nserver:\n  graph: local\n",
         )
         .unwrap();
-        let config = load_config_in(temp.path(), None).unwrap();
+        let config = load_config_in(temp.path(), None, None).unwrap();
         assert_eq!(
             config.resolve_policy_tooling_graph_selection().unwrap(),
             Some("local")
@@ -725,7 +758,7 @@ policy: {}
 
         let temp = tempdir().unwrap();
         fs::write(temp.path().join("omnigraph.yaml"), "policy: {}\n").unwrap();
-        let config = load_config_in(temp.path(), None).unwrap();
+        let config = load_config_in(temp.path(), None, None).unwrap();
         assert_eq!(config.resolve_policy_tooling_graph_selection().unwrap(), None);
 
         let temp = tempdir().unwrap();
@@ -734,7 +767,7 @@ policy: {}
             "graphs:\n  local:\n    uri: ./local.omni\nserver:\n  graph: ghost\n",
         )
         .unwrap();
-        let config = load_config_in(temp.path(), None).unwrap();
+        let config = load_config_in(temp.path(), None, None).unwrap();
         let err = config
             .resolve_policy_tooling_graph_selection()
             .unwrap_err()
@@ -760,7 +793,7 @@ policy: {}
         )
         .unwrap();
 
-        let config = load_config_in(temp.path(), None).unwrap();
+        let config = load_config_in(temp.path(), None, None).unwrap();
         let resolved = config.resolve_query_path(Path::new("test.gq")).unwrap();
         assert_eq!(resolved, temp.path().join("queries").join("test.gq"));
     }
@@ -777,7 +810,7 @@ policy: {}
         fs::write(ambient_dir.join("local.gq"), "query ambient { return {} }").unwrap();
 
         let config =
-            load_config_in(&ambient_dir, Some(&config_dir.join("omnigraph.yaml"))).unwrap();
+            load_config_in(&ambient_dir, Some(&config_dir.join("omnigraph.yaml")), None).unwrap();
         let resolved = config.resolve_query_path(Path::new("local.gq")).unwrap();
 
         assert_eq!(resolved, config_dir.join("local.gq"));
@@ -807,7 +840,7 @@ queries:
         )
         .unwrap();
 
-        let config = load_config_in(temp.path(), None).unwrap();
+        let config = load_config_in(temp.path(), None, None).unwrap();
 
         // Per-graph registry (multi-graph mode).
         let prod = config.target_query_entries("prod").unwrap();
@@ -848,7 +881,7 @@ queries:
              policy:\n      file: ./prod.yaml\n  bare:\n    uri: s3://b/bare\n",
         )
         .unwrap();
-        let config = load_config_in(temp.path(), None).unwrap();
+        let config = load_config_in(temp.path(), None, None).unwrap();
 
         // Named graph with its own policy → per-graph (not top-level).
         assert!(
@@ -884,7 +917,7 @@ queries:
         )
         .unwrap();
 
-        let config = load_config_in(temp.path(), None).unwrap();
+        let config = load_config_in(temp.path(), None, None).unwrap();
         // Additive: no `queries:` anywhere → empty registries everywhere.
         assert!(config.query_entries().is_empty());
         assert!(
@@ -904,7 +937,7 @@ queries:
         )
         .unwrap();
 
-        let config = load_config_in(temp.path(), None).unwrap();
+        let config = load_config_in(temp.path(), None, None).unwrap();
         assert_eq!(
             config.resolve_policy_file().unwrap(),
             temp.path().join("policy.yaml")
@@ -927,7 +960,7 @@ cli:
         )
         .unwrap();
 
-        let config = load_config_in(temp.path(), None).unwrap();
+        let config = load_config_in(temp.path(), None, None).unwrap();
         assert_eq!(
             config.graph_bearer_token_env(
                 Some("https://override.example.com"),

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -76,6 +76,7 @@ Working documents for in-flight feature work. Removed when the work lands.
 | Future cluster control plane — declarative as-code config, JSON state ledger, reconciler | [cluster-config-specs.md](cluster-config-specs.md), [cluster-axioms.md](cluster-axioms.md), [cluster-config-implementation-spec.md](cluster-config-implementation-spec.md) |
 | Cluster graph & schema apply — Phase 4 sidecars, roll-forward recovery, approval artifacts | [rfc-004-cluster-graph-schema-apply.md](rfc-004-cluster-graph-schema-apply.md) |
 | Server boots from cluster state — Phase 5 mode switch, applied-revision serving | [rfc-005-server-cluster-boot.md](rfc-005-server-cluster-boot.md) |
+| Per-operator config — `~/.omnigraph/` identity, keyed credentials, named servers (the operator slice of RFC-002) | [rfc-007-operator-config.md](rfc-007-operator-config.md) |
 
 ## Boundary
 

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -77,6 +77,7 @@ Working documents for in-flight feature work. Removed when the work lands.
 | Cluster graph & schema apply — Phase 4 sidecars, roll-forward recovery, approval artifacts | [rfc-004-cluster-graph-schema-apply.md](rfc-004-cluster-graph-schema-apply.md) |
 | Server boots from cluster state — Phase 5 mode switch, applied-revision serving | [rfc-005-server-cluster-boot.md](rfc-005-server-cluster-boot.md) |
 | Per-operator config — `~/.omnigraph/` identity, keyed credentials, named servers (the operator slice of RFC-002) | [rfc-007-operator-config.md](rfc-007-operator-config.md) |
+| Deprecate `omnigraph.yaml` — one concern per config surface; key-by-key migration map and staged retirement | [rfc-008-deprecate-omnigraph-yaml.md](rfc-008-deprecate-omnigraph-yaml.md) |
 
 ## Boundary
 

--- a/docs/dev/rfc-007-operator-config.md
+++ b/docs/dev/rfc-007-operator-config.md
@@ -246,7 +246,17 @@ Three PRs, each independently useful, each landable without the next:
   version) — slice 1 or slice 2? It materially helps debugging precedence,
   which argues early.
 
-## Relationship to RFC-002
+## Relationship to RFC-002 and RFC-008
+
+**RFC-008 supersedes this RFC's "project layer" framing**: with
+`omnigraph.yaml` deprecated
+([rfc-008-deprecate-omnigraph-yaml.md](rfc-008-deprecate-omnigraph-yaml.md)),
+the project layer *is* the cluster checkout. References to project
+`omnigraph.yaml` in §D3/§D5 describe the transitional window only; the
+trust-boundary rules apply unchanged to whatever the project layer is at a
+given stage. Sequencing couples them: RFC-007 PRs 1–2 must land before
+RFC-008's migration stages can begin (the operator layer is what keys
+migrate *to*).
 
 RFC-002 remains the umbrella architecture. This RFC implements its §2
 (layered config, global-first), §4 (file naming / one dir), and §5

--- a/docs/dev/rfc-007-operator-config.md
+++ b/docs/dev/rfc-007-operator-config.md
@@ -3,27 +3,28 @@
 **Status:** Proposed
 **Date:** 2026-06-11
 **Builds on:** [rfc-002-config-cli-architecture.md](rfc-002-config-cli-architecture.md) (Proposed; implementation parked — PRs #139/#162 closed over review findings), [rfc-005-server-cluster-boot.md](rfc-005-server-cluster-boot.md) (Landed), RFC-006 storage roots (#186/#190/#194, landed). The #139 review record is a normative input: every design rule in §D6 traces to a confirmed finding.
+**Paired with:** [rfc-008-deprecate-omnigraph-yaml.md](rfc-008-deprecate-omnigraph-yaml.md) — together they define the two-surface architecture this RFC's operator half belongs to.
 **Target release:** unversioned (staged; see Sequencing).
 
 ## Summary
 
-Give OmniGraph the operator half of the Terraform config split. Terraform
-separates `~/.terraformrc` (who I am, my credentials, my CLI behavior) from
-the working directory's `*.tf` (what the project declares). OmniGraph today
-has only the project half: `./omnigraph.yaml` in the current working
-directory (or `--config <path>`), and nothing else — no home-level config,
-no walk-up, no env override for the CLI. Operator identity and credentials
-must be re-declared in every directory an operator works from, and — worse —
-they end up in files that live next to repo-committed project config.
+Give OmniGraph the operator half of the **two-surface config architecture**
+(RFC-008): **cluster config** (team-owned, in a repo — what the system *is*)
+and **operator config** (person-owned, in `$HOME` — who *I* am). This is
+Terraform's split: `~/.terraformrc` for the operator, the checkout for the
+declaration. OmniGraph today has neither half cleanly — `omnigraph.yaml`
+mixes both concerns (RFC-008 retires it), and there is no home-level config
+at all: identity and credentials get re-declared per working directory, in
+files that sit next to repo-committed config.
 
-This RFC introduces **`~/.omnigraph/config.yaml`** (the operator layer) and
-a **keyed credentials chain**, scoped deliberately small:
+This RFC introduces **`~/.omnigraph/config.yaml`** (the operator surface)
+and a **keyed credentials chain**, scoped deliberately small:
 
 1. **Operator identity** — a default actor for every `--as` cascade.
 2. **Credentials by server name** — no more inventing env-var names per
-   server; secrets never inline, never in the project layer.
-3. **Named servers** — operator-owned endpoint definitions that project
-   configs can reference but not redefine.
+   server; secrets never inline, never in any repo-committed file.
+3. **Named servers** — operator-owned endpoint definitions; nothing a
+   checkout supplies can redefine them.
 
 It is explicitly a **subset of RFC-002**, sequenced to land. RFC-002 settled
 the right long-term decisions (one `~/.omnigraph/` dir, credentials keyed by
@@ -63,11 +64,14 @@ Three concrete pains, all hit in real operation this cycle:
   that problem belongs to the slice that introduces it).
 - **OS keychain integration** — the credentials *chain* (§D4) leaves a slot
   for it; this RFC ships env + file sources only.
-- **Project-file walk-up.** Terraform does not walk up from subdirectories
+- **Config-file walk-up.** Terraform does not walk up from subdirectories
   and neither do we — `--config` (or running in the directory) stays the
-  explicit, deterministic story. Rejected, not deferred: walk-up makes "which
-  config am I using" a function of cwd depth, the class of surprise this RFC
-  exists to remove.
+  explicit, deterministic story for cluster checkouts. Rejected, not
+  deferred: walk-up makes "which config am I using" a function of cwd
+  depth, the class of surprise this RFC exists to remove.
+- **Retiring `omnigraph.yaml`** — that is RFC-008's job, with its own
+  staging. This RFC builds the destination; during RFC-008's deprecation
+  window the legacy file keeps loading exactly as today.
 - **Renaming or removing anything.** No flag renames, no key renames, no
   schema-version bumps (findings #1, #3, #10).
 
@@ -95,9 +99,10 @@ Three concrete pains, all hit in real operation this cycle:
 ### D1. Files and discovery
 
 ```
-~/.omnigraph/config.yaml      # the operator layer (this RFC)
+~/.omnigraph/config.yaml      # the operator surface (this RFC)
 ~/.omnigraph/credentials      # keyed secrets, 0600, git-irrelevant (§D4)
-./omnigraph.yaml              # the project layer (unchanged)
+./cluster.yaml + checkout     # the team surface (unchanged; RFC-004..006)
+./omnigraph.yaml              # legacy, loads as today through RFC-008's window
 ```
 
 Discovery order for the operator file: `$OMNIGRAPH_HOME/config.yaml` if
@@ -105,10 +110,12 @@ Discovery order for the operator file: `$OMNIGRAPH_HOME/config.yaml` if
 empty layer, never an error. `~` is expanded wherever paths are read
 (finding #9 — today a literal `./~/...` directory gets created).
 
-`OMNIGRAPH_CONFIG=<path>` becomes a first-class override for the *project*
-file in the CLI (highest precedence below the `--config` flag), aligning the
+`OMNIGRAPH_CONFIG=<path>` becomes a first-class override for the `--config`
+argument in the CLI (highest precedence below the flag itself), aligning the
 CLI with the container contract that already uses this variable for the
-server. One name, one meaning, both binaries.
+server. One name, one meaning, both binaries — it points at whatever the
+command's `--config` would (a cluster checkout for cluster commands; the
+legacy file during RFC-008's window).
 
 Per RFC-002 §4 (adopted verbatim): `~/.omnigraph/` is the one canonical
 dir — cache/state subdirectories arrive with their own slices; XDG roots are
@@ -118,7 +125,7 @@ fallback read location if set, but is never written to).
 ### D2. The operator schema (v1 of this layer)
 
 ```yaml
-# ~/.omnigraph/config.yaml — about the OPERATOR, never about a project
+# ~/.omnigraph/config.yaml — about the OPERATOR, never about the system
 operator:
   actor: act-andrew          # default for every --as cascade
 
@@ -128,6 +135,12 @@ servers:                     # operator-owned endpoint definitions
   prod:
     url: https://graph.modernrelay.ai
     # No token here, ever. Resolution: §D4.
+
+aliases:                     # personal shorthand over CLUSTER-owned queries
+  triage:                    # (the query is the shared contract; the alias,
+    server: intel-dev        #  its defaults, and its name are mine — RFC-008)
+    graph: spike
+    query: weekly_triage
 
 defaults:
   output: table              # read --format default
@@ -140,27 +153,32 @@ change what a *plan* means).
 
 ### D3. Precedence and the merge rule
 
+The end-state cascade is short, because the team surface (cluster config)
+deliberately carries **no operator-resolvable keys** — no actor, no tokens,
+no output preferences. Identity can never come from a checkout:
+
 ```
-flag  >  env  >  project omnigraph.yaml  >  operator config  >  built-in
+flag  >  env  >  operator config  >  built-in
 ```
 
-with exactly one principled inversion (§D5): **credentials and endpoint
-definitions never come from the project layer when an operator-layer
-definition exists for the same server name.**
+During RFC-008's deprecation window, a legacy `omnigraph.yaml` slots in
+between env and operator config (its keys win over operator defaults,
+preserving today's behavior for unmigrated setups) — with the §D5
+credential inversion: **credentials and endpoint definitions never come
+from a legacy/checkout file when an operator-layer definition exists for
+the same server name.**
 
 Merging is **key-level**: scalars override per key; maps (`servers:`,
-`graphs:`) merge per *entry*, and entries merge per *field* (finding #13 —
-`merge_map` replacing whole entries silently dropped sibling fields). A
-project file referencing `server: prod` composes with the operator's
-`servers.prod.url`; it does not need to re-declare it and cannot
-accidentally clobber half of it.
+`aliases:`) merge per *entry*, and entries merge per *field* (finding #13 —
+`merge_map` replacing whole entries silently dropped sibling fields).
 
 Concretely for the two flows this slice touches:
 
-- **Actor**: `--as` > project `as:`/actor key (unchanged semantics) >
-  `operator.actor` > none (commands that need an actor keep failing loudly).
-- **Output format**: `--format` > project default > `defaults.output` >
-  `table`.
+- **Actor**: `--as` > legacy `cli.actor` (window only, unchanged semantics)
+  > `operator.actor` > none (commands that need an actor keep failing
+  loudly).
+- **Output format**: `--format` > legacy default (window only) >
+  `defaults.output` > `table`.
 
 ### D4. Credentials: keyed by server name, by-reference always
 
@@ -173,29 +191,33 @@ the same chain). For a server named `<name>`, the resolution chain is:
 3. The legacy pair — `bearer_token_env` + `auth.env_file` — exactly as
    today, for configs that already use it.
 
-No inline secrets in any YAML file, operator or project (the existing
-invariant 12 posture extended to disk). A future `omnigraph login <name>`
+No inline secrets in any YAML file, anywhere (the existing invariant 12
+posture extended to disk). A future `omnigraph login <name>`
 writes/rotates one section of the credentials file via temp + rename
 (finding #7: every operator-layer write is atomic), creating it `0600`.
 
 ### D5. The trust boundary (the security findings, made structural)
 
-Findings #4, #5, #6 share one root cause: the project layer — a file that
-arrives with a *repo checkout* — could redirect where requests go and what
-secrets they carry. The rules:
+Findings #4, #5, #6 share one root cause: a file that arrives with a
+*repo checkout* could redirect where requests go and what secrets they
+carry. In the end state this is closed by construction — cluster config has
+no server/credential keys at all, and the operator surface never comes from
+a checkout. The rules below therefore govern the **RFC-008 window** (while
+legacy `omnigraph.yaml` still loads) and stand as the permanent law for any
+future checkout-supplied surface:
 
-1. **A project file may *reference* a server by name; it may not *redefine*
-   an operator-defined server.** If `./omnigraph.yaml` declares
-   `servers.prod.url` and `~/.omnigraph/config.yaml` also defines `prod`,
-   the operator definition wins and the CLI warns about the shadowed
-   project entry. A project-only server name keeps working (legacy compat),
-   but the keyed-credentials chain (§D4 steps 1–2) never resolves for it —
-   only the legacy explicit `bearer_token_env` does. Net effect: a malicious
-   checkout cannot point `prod` at an attacker host and harvest the
-   operator's `prod` token.
-2. **`auth.env_file` keeps auto-loading (compat), but project-layer
+1. **A checkout-supplied file may *reference* a server by name; it may not
+   *redefine* an operator-defined server.** If a legacy `./omnigraph.yaml`
+   declares `servers.prod.url` and `~/.omnigraph/config.yaml` also defines
+   `prod`, the operator definition wins and the CLI warns about the
+   shadowed entry. A legacy-only server name keeps working (compat), but
+   the keyed-credentials chain (§D4 steps 1–2) never resolves for it —
+   only the legacy explicit `bearer_token_env` does. Net effect: a
+   malicious checkout cannot point `prod` at an attacker host and harvest
+   the operator's `prod` token.
+2. **`auth.env_file` keeps auto-loading (compat), but checkout-layer
    env-files cannot *override* variables already set in the process or by
-   the operator layer** — first-set-wins, operator-before-project (the
+   the operator layer** — first-set-wins, operator-before-checkout (the
    existing real-env-wins rule, extended one layer down). Finding #5's
    injection becomes a no-op against any var the operator actually uses.
 3. **A token is sent only to the server it is keyed to.** The legacy
@@ -223,16 +245,22 @@ Three PRs, each independently useful, each landable without the next:
    `~/.omnigraph/config.yaml` (+ `OMNIGRAPH_HOME`, `~`-expansion, warn-only
    unknown keys), `operator.actor` joining the `--as` cascade,
    `defaults.output` joining the format cascade, `OMNIGRAPH_CONFIG` env for
-   the CLI's project file. Docs: `cli-reference.md` gains the layer table.
+   the CLI's `--config`. Docs: `cli-reference.md` gains the two-surface
+   table.
 2. **PR 2 — keyed credentials.** `servers:` in the operator layer, the
    §D4 chain (env + credentials file), the §D5 trust rules, and
    `omnigraph login <name>` (atomic write, `0600`). Legacy mechanisms
    untouched and tested-as-untouched.
-3. **PR 3 — project references.** `server: <name>` in project
-   graph/target entries resolving through operator-defined servers, with
-   the shadowing warning. This is the *bridge* toward RFC-002's locator —
-   it gives multi-server addressing a safe, minimal form without the
-   `GraphLocator` rework.
+3. **PR 3 — operator targeting.** `--server <name>` on remote-capable
+   commands and `aliases:` in the operator layer (server + graph + query +
+   default params), resolving through operator-defined servers. This is
+   the *bridge* toward RFC-002's locator — multi-server addressing in a
+   safe, minimal form without the `GraphLocator` rework — and the
+   replacement RFC-008 needs before legacy aliases can migrate.
+
+RFC-008's deprecation stages begin only after PRs 1–2 are on main: the
+operator surface must exist before `config migrate` has somewhere to move
+keys to.
 
 ## Open questions
 
@@ -248,15 +276,13 @@ Three PRs, each independently useful, each landable without the next:
 
 ## Relationship to RFC-002 and RFC-008
 
-**RFC-008 supersedes this RFC's "project layer" framing**: with
-`omnigraph.yaml` deprecated
+**RFC-008 is the other half of this design**: this RFC builds the operator
+surface; RFC-008 retires the mixed-ownership file
 ([rfc-008-deprecate-omnigraph-yaml.md](rfc-008-deprecate-omnigraph-yaml.md)),
-the project layer *is* the cluster checkout. References to project
-`omnigraph.yaml` in §D3/§D5 describe the transitional window only; the
-trust-boundary rules apply unchanged to whatever the project layer is at a
-given stage. Sequencing couples them: RFC-007 PRs 1–2 must land before
-RFC-008's migration stages can begin (the operator layer is what keys
-migrate *to*).
+leaving exactly two config surfaces — cluster (team) and operator (person).
+Every mention of `omnigraph.yaml` in this RFC describes the deprecation
+window only. Sequencing couples them: RFC-007 PRs 1–2 land first, then
+RFC-008's migration stages run against them.
 
 RFC-002 remains the umbrella architecture. This RFC implements its §2
 (layered config, global-first), §4 (file naming / one dir), and §5

--- a/docs/dev/rfc-007-operator-config.md
+++ b/docs/dev/rfc-007-operator-config.md
@@ -1,0 +1,256 @@
+# RFC: Per-Operator Config — the Operator Slice of RFC-002
+
+**Status:** Proposed
+**Date:** 2026-06-11
+**Builds on:** [rfc-002-config-cli-architecture.md](rfc-002-config-cli-architecture.md) (Proposed; implementation parked — PRs #139/#162 closed over review findings), [rfc-005-server-cluster-boot.md](rfc-005-server-cluster-boot.md) (Landed), RFC-006 storage roots (#186/#190/#194, landed). The #139 review record is a normative input: every design rule in §D6 traces to a confirmed finding.
+**Target release:** unversioned (staged; see Sequencing).
+
+## Summary
+
+Give OmniGraph the operator half of the Terraform config split. Terraform
+separates `~/.terraformrc` (who I am, my credentials, my CLI behavior) from
+the working directory's `*.tf` (what the project declares). OmniGraph today
+has only the project half: `./omnigraph.yaml` in the current working
+directory (or `--config <path>`), and nothing else — no home-level config,
+no walk-up, no env override for the CLI. Operator identity and credentials
+must be re-declared in every directory an operator works from, and — worse —
+they end up in files that live next to repo-committed project config.
+
+This RFC introduces **`~/.omnigraph/config.yaml`** (the operator layer) and
+a **keyed credentials chain**, scoped deliberately small:
+
+1. **Operator identity** — a default actor for every `--as` cascade.
+2. **Credentials by server name** — no more inventing env-var names per
+   server; secrets never inline, never in the project layer.
+3. **Named servers** — operator-owned endpoint definitions that project
+   configs can reference but not redefine.
+
+It is explicitly a **subset of RFC-002**, sequenced to land. RFC-002 settled
+the right long-term decisions (one `~/.omnigraph/` dir, credentials keyed by
+server name, `OMNIGRAPH_CONFIG`/`OMNIGRAPH_HOME` env precedence) but its
+implementation arrived as one 4,800-line PR mixing a crate extraction with
+behavior changes, and died over ten confirmed findings. This RFC adopts
+RFC-002's settled decisions verbatim where they apply, defers everything
+else (`GraphLocator`, multi-homing, `omnigraph use`, the State layer), and
+encodes the #139 findings as design rules so the same failures cannot recur.
+
+## Motivation
+
+Three concrete pains, all hit in real operation this cycle:
+
+- **Identity repetition.** The cluster actor cascade (#180) resolves
+  `--as` from the per-operator `omnigraph.yaml` — which means every
+  operator hand-maintains a copy in every working directory (the
+  `~/exp/intel` setup needed exactly this). A repo-committed
+  `omnigraph.yaml` cannot carry `as: act-andrew` without claiming every
+  contributor is Andrew.
+- **Credential ergonomics.** `bearer_token_env` forces three coordinated
+  steps per server (invent a var name, reference it in config, set it in
+  the secret store). The peer group — AWS profiles, `gh hosts`, kubeconfig
+  users — keys secrets by the server's *name*.
+- **Cluster-era working shape.** With clusters on object storage (RFC-006),
+  the project directory is a *declaration checkout* — operators run
+  `cluster apply --config ./checkout` from anywhere. The things that are
+  about the *operator* (who am I, which servers do I know, how do I like
+  output formatted) have no home that travels with them.
+
+## Non-Goals
+
+- **`GraphLocator` / multi-homed graph resolution** (RFC-002 §1) — the
+  biggest and riskiest part of config-v2; untouched here.
+- **`omnigraph use` / the State layer** (`~/.omnigraph/state/`) — deferred
+  with it (finding #2 showed its precedence interacts badly with scaffolds;
+  that problem belongs to the slice that introduces it).
+- **OS keychain integration** — the credentials *chain* (§D4) leaves a slot
+  for it; this RFC ships env + file sources only.
+- **Project-file walk-up.** Terraform does not walk up from subdirectories
+  and neither do we — `--config` (or running in the directory) stays the
+  explicit, deterministic story. Rejected, not deferred: walk-up makes "which
+  config am I using" a function of cwd depth, the class of surprise this RFC
+  exists to remove.
+- **Renaming or removing anything.** No flag renames, no key renames, no
+  schema-version bumps (findings #1, #3, #10).
+
+## Background (verified against main)
+
+- **Project-config lookup today** (`crates/omnigraph-server/src/config.rs:529-553`,
+  shared by CLI and server): `--config <path>`, else `./omnigraph.yaml` in
+  cwd, else built-in defaults. Relative paths inside the file resolve
+  against the file's own directory (`base_dir`). No env var, no home file,
+  no walk-up.
+- **Side-effect on load** (`crates/omnigraph-cli/src/helpers.rs:102-108`):
+  `load_cli_config` also loads `auth.env_file` into the process env —
+  this is how `OMNIGRAPH_BEARER_TOKEN` reaches remote commands today.
+- **Actor resolution** (`helpers.rs:170`, #180): `--as` flag, else the
+  project config's actor — currently the end of the chain.
+- **Existing credential mechanism**: `TargetConfig.bearer_token_env` names
+  an env var; `auth.env_file` points at a git-ignored dotenv. Both keep
+  working indefinitely (RFC-002 already committed to this; finding #3
+  showed what happens otherwise).
+- **`OMNIGRAPH_CONFIG`** exists today only as the *container entrypoint's*
+  translation to the server's `--config`. The CLI does not read it.
+
+## Design
+
+### D1. Files and discovery
+
+```
+~/.omnigraph/config.yaml      # the operator layer (this RFC)
+~/.omnigraph/credentials      # keyed secrets, 0600, git-irrelevant (§D4)
+./omnigraph.yaml              # the project layer (unchanged)
+```
+
+Discovery order for the operator file: `$OMNIGRAPH_HOME/config.yaml` if
+`OMNIGRAPH_HOME` is set, else `~/.omnigraph/config.yaml`. Absent file =
+empty layer, never an error. `~` is expanded wherever paths are read
+(finding #9 — today a literal `./~/...` directory gets created).
+
+`OMNIGRAPH_CONFIG=<path>` becomes a first-class override for the *project*
+file in the CLI (highest precedence below the `--config` flag), aligning the
+CLI with the container contract that already uses this variable for the
+server. One name, one meaning, both binaries.
+
+Per RFC-002 §4 (adopted verbatim): `~/.omnigraph/` is the one canonical
+dir — cache/state subdirectories arrive with their own slices; XDG roots are
+not part of the mental model (`$XDG_CONFIG_HOME` may be honored as a
+fallback read location if set, but is never written to).
+
+### D2. The operator schema (v1 of this layer)
+
+```yaml
+# ~/.omnigraph/config.yaml — about the OPERATOR, never about a project
+operator:
+  actor: act-andrew          # default for every --as cascade
+
+servers:                     # operator-owned endpoint definitions
+  intel-dev:
+    url: http://127.0.0.1:8080
+  prod:
+    url: https://graph.modernrelay.ai
+    # No token here, ever. Resolution: §D4.
+
+defaults:
+  output: table              # read --format default
+```
+
+Unknown keys are a **warning, not an error** in this layer (an operator file
+written by a newer CLI must not brick an older one; contrast with
+`cluster.yaml`, where unknown keys are deliberately fatal because they
+change what a *plan* means).
+
+### D3. Precedence and the merge rule
+
+```
+flag  >  env  >  project omnigraph.yaml  >  operator config  >  built-in
+```
+
+with exactly one principled inversion (§D5): **credentials and endpoint
+definitions never come from the project layer when an operator-layer
+definition exists for the same server name.**
+
+Merging is **key-level**: scalars override per key; maps (`servers:`,
+`graphs:`) merge per *entry*, and entries merge per *field* (finding #13 —
+`merge_map` replacing whole entries silently dropped sibling fields). A
+project file referencing `server: prod` composes with the operator's
+`servers.prod.url`; it does not need to re-declare it and cannot
+accidentally clobber half of it.
+
+Concretely for the two flows this slice touches:
+
+- **Actor**: `--as` > project `as:`/actor key (unchanged semantics) >
+  `operator.actor` > none (commands that need an actor keep failing loudly).
+- **Output format**: `--format` > project default > `defaults.output` >
+  `table`.
+
+### D4. Credentials: keyed by server name, by-reference always
+
+Adopted from RFC-002 §5 unchanged, minus the keychain (a later source in
+the same chain). For a server named `<name>`, the resolution chain is:
+
+1. `OMNIGRAPH_TOKEN_<NAME>` (uppercased, `-`→`_`) — explicit env, wins.
+2. `[<name>]` section in `~/.omnigraph/credentials` (INI-style, `0600`;
+   the loader refuses a group/world-readable file).
+3. The legacy pair — `bearer_token_env` + `auth.env_file` — exactly as
+   today, for configs that already use it.
+
+No inline secrets in any YAML file, operator or project (the existing
+invariant 12 posture extended to disk). A future `omnigraph login <name>`
+writes/rotates one section of the credentials file via temp + rename
+(finding #7: every operator-layer write is atomic), creating it `0600`.
+
+### D5. The trust boundary (the security findings, made structural)
+
+Findings #4, #5, #6 share one root cause: the project layer — a file that
+arrives with a *repo checkout* — could redirect where requests go and what
+secrets they carry. The rules:
+
+1. **A project file may *reference* a server by name; it may not *redefine*
+   an operator-defined server.** If `./omnigraph.yaml` declares
+   `servers.prod.url` and `~/.omnigraph/config.yaml` also defines `prod`,
+   the operator definition wins and the CLI warns about the shadowed
+   project entry. A project-only server name keeps working (legacy compat),
+   but the keyed-credentials chain (§D4 steps 1–2) never resolves for it —
+   only the legacy explicit `bearer_token_env` does. Net effect: a malicious
+   checkout cannot point `prod` at an attacker host and harvest the
+   operator's `prod` token.
+2. **`auth.env_file` keeps auto-loading (compat), but project-layer
+   env-files cannot *override* variables already set in the process or by
+   the operator layer** — first-set-wins, operator-before-project (the
+   existing real-env-wins rule, extended one layer down). Finding #5's
+   injection becomes a no-op against any var the operator actually uses.
+3. **A token is sent only to the server it is keyed to.** The legacy
+   single `OMNIGRAPH_BEARER_TOKEN` fallback keeps working for the
+   single-server shape, but when a request resolves through a *named*
+   server, only that name's chain applies (finding #6's broadcast).
+
+### D6. Compatibility rules (the #139 findings as law)
+
+| Rule | Source finding |
+|---|---|
+| No flag or key is removed or renamed; new behavior is additive | #1, #3 |
+| A config that loads today loads identically after this RFC; new validation applies only to new keys | #3, #8, #10 |
+| Every operator-layer file write is temp + rename, never in-place | #7 |
+| `~` expands wherever a path is read | #9 |
+| Map merges are per-entry, per-field — never wholesale replace | #13 |
+| One resolution path per concern — the actor chain and the token chain each have exactly one implementation, called by CLI and server alike | #11, #12 |
+| Each slice lands as its own PR with the workspace gate green; no slice mixes mechanical moves with behavior changes | #139's disposition |
+
+## Sequencing
+
+Three PRs, each independently useful, each landable without the next:
+
+1. **PR 1 — the operator file + identity.** Loader for
+   `~/.omnigraph/config.yaml` (+ `OMNIGRAPH_HOME`, `~`-expansion, warn-only
+   unknown keys), `operator.actor` joining the `--as` cascade,
+   `defaults.output` joining the format cascade, `OMNIGRAPH_CONFIG` env for
+   the CLI's project file. Docs: `cli-reference.md` gains the layer table.
+2. **PR 2 — keyed credentials.** `servers:` in the operator layer, the
+   §D4 chain (env + credentials file), the §D5 trust rules, and
+   `omnigraph login <name>` (atomic write, `0600`). Legacy mechanisms
+   untouched and tested-as-untouched.
+3. **PR 3 — project references.** `server: <name>` in project
+   graph/target entries resolving through operator-defined servers, with
+   the shadowing warning. This is the *bridge* toward RFC-002's locator —
+   it gives multi-server addressing a safe, minimal form without the
+   `GraphLocator` rework.
+
+## Open questions
+
+- Should `operator.actor` apply to *local* (embedded-engine) writes too, or
+  only where a server/cluster boundary exists? Leaning yes-everywhere: one
+  identity chain (§D6 one-path rule), and local audit rows get better.
+- Does `defaults.output` belong in slice 1, or is identity-only an even
+  cleaner first PR? (Cost of including it is one cascade hop; value is
+  immediate.)
+- `omnigraph config view --resolved` (RFC-002 had it; #139 shipped a
+  version) — slice 1 or slice 2? It materially helps debugging precedence,
+  which argues early.
+
+## Relationship to RFC-002
+
+RFC-002 remains the umbrella architecture. This RFC implements its §2
+(layered config, global-first), §4 (file naming / one dir), and §5
+(credentials) in their minimal load-bearing form, and explicitly defers §1
+(`GraphLocator`/targets), §3 (roles), and the State layer. If/when the
+locator work resumes, it builds on these layers rather than re-landing
+them. RFC-002's header should gain a pointer here once this merges.

--- a/docs/dev/rfc-008-deprecate-omnigraph-yaml.md
+++ b/docs/dev/rfc-008-deprecate-omnigraph-yaml.md
@@ -1,0 +1,174 @@
+# RFC: Deprecate `omnigraph.yaml` — One Concern per Config Surface
+
+**Status:** Proposed
+**Date:** 2026-06-11
+**Builds on:** [rfc-007-operator-config.md](rfc-007-operator-config.md) (the
+operator layer that absorbs the identity/credential keys),
+[rfc-005-server-cluster-boot.md](rfc-005-server-cluster-boot.md) (Landed —
+cluster-booted serving), RFC-006 storage roots (landed: #186/#190/#194).
+**Supersedes in part:** RFC-007's "project layer" framing (§Relationship
+below) and [rfc-002-config-cli-architecture.md](rfc-002-config-cli-architecture.md)'s
+assumption that `omnigraph.yaml` remains the project manifest.
+**Target release:** staged; final removal at the next major (see Sequencing).
+
+## Summary
+
+Retire `omnigraph.yaml`. It is three unrelated concerns wearing one
+filename — server deployment config, project/CLI conveniences, and operator
+identity — and the mixture is not a cosmetic wart but the root cause of a
+recurring class of problems: operators keeping personal copies of "project"
+files, repo checkouts able to carry credential-adjacent keys (the #139
+security findings), `omnigraph init` scaffolding config into unrelated
+directories, and every config discussion needing a paragraph to establish
+which of the three files is meant.
+
+The end state is **two config surfaces with single owners**:
+
+| Surface | Owner | Declares |
+|---|---|---|
+| **Cluster config** (`cluster.yaml` + catalog) | the team, in a repo | what the system *is*: graphs, schemas, queries, policies, storage |
+| **Operator config** (`~/.omnigraph/`) | one person, in `$HOME` | who *I* am: identity, credentials, known servers, ergonomics |
+
+plus **flags/env** for the zero-config tier (one graph, one server, no
+control plane) — which already works today with no file at all.
+
+`omnigraph.yaml` has no role left once every key has a better home. This
+RFC gives each key that home, and stages the retirement so that no working
+setup breaks without a loud warning, a migration command, and a full
+deprecation cycle first.
+
+## Motivation
+
+- **It breaks the ownership logic.** A config file must have one owner. A
+  file that carries `graphs:` (team-owned, reviewable) next to `cli.actor`
+  (one person's identity) and `auth.env_file` (credential loading) can be
+  neither safely committed nor sensibly personal. Every real deployment
+  this cycle tripped on it: per-operator copies in `~/exp/intel`,
+  graph-scoped alias URIs that only make sense per-person, the #139
+  findings where a checkout-supplied file could redirect tokens.
+- **The cluster made it redundant.** Since RFC-005/006, a cluster
+  deployment serves from the applied catalog — `--cluster` mode does not
+  read `omnigraph.yaml` *at all*. Stored queries, policies, bindings, and
+  graph addressing all have authoritative homes. What remains in
+  `omnigraph.yaml` for cluster users is dead weight that can silently
+  disagree with what is actually serving.
+- **Two declarative dialects is one too many.** `cluster.yaml` and
+  `omnigraph.yaml` both declare graphs/queries/policies with different
+  schemas, different validation strictness, and different lifecycle
+  guarantees. Maintaining, documenting, and testing both — and explaining
+  when each applies — is a permanent tax (the "programming integrated over
+  time" lens says: this forks on every config-surface change).
+
+## Non-Goals
+
+- **Breaking anyone now.** Every `omnigraph.yaml` that works today keeps
+  working through the entire deprecation window, with warnings.
+- **Retiring the zero-config tier.** `omnigraph-server s3://bucket/g.omni
+  --bind …` plus env vars stays first-class forever — that tier needs *no*
+  file, which is the point.
+- **Forcing the control plane on single-graph users.** The migration target
+  for a multi-graph yaml deployment is a *minimal* cluster (file-rooted,
+  no bucket required, `cluster.yaml` barely longer than the `graphs:` map
+  it replaces) — but a single graph never needs even that.
+- **Touching `cluster.yaml`** — its schema and strictness are unchanged.
+
+## Where every key goes (the complete migration map)
+
+The full `OmnigraphConfig` surface (verified against
+`crates/omnigraph-server/src/config.rs:182-207`):
+
+| `omnigraph.yaml` key | Concern | New home |
+|---|---|---|
+| `graphs.<name>.uri` | what exists / where | `cluster.yaml` `graphs:` (storage-root-derived) — or a flag/env for the zero-config tier |
+| `graphs.<name>.queries`, top-level `queries:` | what exists | cluster catalog (`.gq` discovery, RFC-004/#183) |
+| `graphs.<name>.policy.file`, top-level `policy.file`, `server.policy.file` | what's enforced | `cluster.yaml` `policies:` + `applies_to` bindings |
+| `server.bind` | deployment runtime | `--bind` / env (already authoritative; the key is a default) |
+| `server.graph` | deployment runtime | `--target`-style flag / env in the zero-config tier; meaningless under cluster boot |
+| `graphs.<name>.bearer_token_env`, `auth.env_file` | credentials | operator credentials chain (RFC-007 §D4) |
+| `cli.actor` | identity | `operator.actor` (RFC-007 §D3) |
+| `cli.output_format`, `cli.table_*` | personal ergonomics | `defaults:` in operator config (RFC-007 §D2) |
+| `cli.graph`, `cli.branch` | personal targeting | operator config: named servers + a per-operator default target (RFC-007 PR 3) |
+| `aliases.<name>` | personal ergonomics over shared queries | operator config `aliases:` — the *queries* they invoke are cluster-owned; the *shorthand* is personal |
+| `query.roots` | discovery convenience | obsolete — cluster query discovery (#183) replaced it |
+| `project.name` | label | dropped (the cluster's `metadata.name` is the deployment label) |
+
+Two placements worth defending:
+
+- **Aliases are operator config, not cluster config.** The stored query is
+  the shared contract (catalog-owned, digest-pinned); an alias is one
+  person's shorthand with their favorite default params and target. Putting
+  aliases in the cluster would force team review on personal ergonomics;
+  leaving them per-directory recreates today's problem. Per-operator,
+  keyed by server/graph name, is the AWS-profile shape.
+- **Multi-graph serving without a control plane migrates to a minimal
+  cluster, not to a new file.** The honest cost: `cluster import` + `apply`
+  once, on a `file://` root next to the graphs. The honest benefit: one
+  declarative dialect, one validation path, one serving source — and the
+  upgrade path to buckets/approvals is a one-line `storage:` change instead
+  of a re-platform.
+
+## Deprecation mechanics
+
+Per Hyrum's Law (the repo's own deny-list: shipped observable behavior is
+contract), retirement is staged, loud, and tooled:
+
+1. **Warn.** Loading `omnigraph.yaml` emits a one-line deprecation notice
+   naming the replacement for each key actually present in the file (not a
+   generic banner — the migration map above, applied to *your* file).
+   Suppressible per-process (`OMNIGRAPH_SUPPRESS_YAML_DEPRECATION=1`) for
+   CI logs during the window.
+2. **Migrate.** `omnigraph config migrate` reads an existing
+   `omnigraph.yaml` and writes the split: the team half as a ready-to-review
+   `cluster.yaml` (+ moves query/policy files into the checkout layout),
+   the personal half merged into `~/.omnigraph/config.yaml` — printing a
+   diff-style summary and touching nothing without `--write`. The command
+   is the test of the migration map's completeness: any key it cannot
+   place is a bug in this RFC.
+3. **Stop scaffolding.** `omnigraph init` stops generating
+   `omnigraph.yaml` (it currently scaffolds one into cwd — the source of
+   the test-pollution bug). `omnigraph cluster init` (new, small) scaffolds
+   a minimal `cluster.yaml` instead.
+4. **Opt-in strict.** `OMNIGRAPH_NO_LEGACY_CONFIG=1` turns the warning into
+   an error — for teams that finished migrating and want regressions caught.
+5. **Remove at the next major.** Loading the file becomes an error pointing
+   at `config migrate`. The `OmnigraphConfig` code path, the dual
+   query-registry loaders, and the yaml-mode server boot source are deleted
+   — the payoff that makes the whole exercise worth it.
+
+Stages 1–3 can land in one release once RFC-007 PRs 1–2 exist (the operator
+layer must exist before anything can migrate *to* it). Stage 4 the release
+after. Stage 5 at the major, with the removal listed in release notes from
+stage 1 onward.
+
+## What this deletes, eventually
+
+- The `OmnigraphConfig` struct and its 12-key surface, the
+  `load_config`/`load_cli_config` pair and its env-side-effect, the
+  scaffolder, and the legacy resolution paths (`resolve_cli_graph`'s dual
+  modes — finding #11's root cause).
+- The yaml-mode multi-graph server boot (`ServerConfigMode::Multi` keeps
+  existing — cluster boot constructs it — but its `omnigraph.yaml` source
+  goes).
+- An entire class of documentation ("which file does X go in?") and the
+  #139 security surface (a checkout cannot hijack what no longer loads).
+
+## Relationship to RFC-007 and RFC-002
+
+RFC-007 ships the operator layer this RFC migrates *to*; its "project
+layer" language should be read as transitional — after this RFC, the
+project layer **is** the cluster checkout, and RFC-007's PR 3 (project
+`server:` references) applies to `cluster.yaml`-adjacent operator targeting
+rather than to `omnigraph.yaml`. RFC-002's locator/state-layer work, if
+resumed, targets the two-surface world directly. RFC-002's file-naming
+decisions (`~/.omnigraph/` as the one dir) are unaffected.
+
+## Open questions
+
+- **Window length**: one minor release between warn (stage 1) and strict
+  (stage 4), or two? Cookbooks, skills, and the deployment docs all need
+  the same pass; the migration command makes a short window defensible.
+- **`omnigraph login` vs `config migrate` ordering** — both write
+  `~/.omnigraph/`; whichever lands first establishes the file-locking and
+  atomic-write helpers the other reuses.
+- **Does the MCP server config** (RFC-003) reference `omnigraph.yaml`
+  anywhere that needs the same treatment? To be audited in stage 1.

--- a/docs/user/audit.md
+++ b/docs/user/audit.md
@@ -3,5 +3,5 @@
 - `Omnigraph::audit_actor_id: Option<String>` is the actor in effect.
 - `_as` variants of every write API let callers override the actor: `mutate_as`, `load_as`, `branch_merge_as`, `apply_schema_as`, etc.
 - Actor IDs are persisted on `GraphCommit.actor_id` with split storage in `_graph_commit_actors.lance` (the commit graph is split into `_graph_commits.lance` for the linkage and `_graph_commit_actors.lance` for the actor map).
-- HTTP server uses the bearer-token actor automatically; CLI uses the local user / explicit env (no implicit actor).
+- HTTP server uses the bearer-token actor automatically. The CLI resolves one actor chain everywhere: `--as` > legacy `cli.actor` in `omnigraph.yaml` > `operator.actor` in `~/.omnigraph/config.yaml` > none (RFC-007).
 - Pre-v0.4.0 graphs also stored actor IDs on `RunRecord.actor_id` in `_graph_runs.lance` / `_graph_run_actors.lance`. The Run state machine was removed in MR-771; those files are inert post-v0.4.0. The v2→v3 manifest migration sweeps any stale `__run__*` branches on first write-open (MR-770); the inert dataset bytes remain until a `delete_prefix` primitive lands.

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -27,7 +27,36 @@ Top-level command families and subcommands. Graph-targeting commands accept eith
 | `policy validate \| test \| explain` | Cedar tooling. Selects `cli.graph`, else `server.graph`, else top-level `policy.file` |
 | `version` / `-v` | print `omnigraph 0.3.x` |
 
-## `omnigraph.yaml` schema
+## Config surfaces
+
+Two config surfaces with single owners (RFC-007/RFC-008), plus a zero-config
+tier:
+
+| Surface | Owner | Location | Declares |
+|---|---|---|---|
+| Cluster config | the team, in a repo | `cluster.yaml` + checkout ([cluster-config.md](cluster-config.md)) | what the system **is**: graphs, schemas, queries, policies, storage |
+| Operator config | one person | `~/.omnigraph/config.yaml` (override dir with `$OMNIGRAPH_HOME`) | who **I** am: identity, ergonomics |
+| Flags / env | per invocation | — | everything, explicitly |
+
+`omnigraph.yaml` (below) is the legacy combined file — fully supported
+today, slated for staged deprecation (RFC-008); its keys' future homes are
+listed there.
+
+### `~/.omnigraph/config.yaml` (operator)
+
+```yaml
+operator:
+  actor: act-andrew     # default identity for every --as cascade:
+                        #   --as > legacy cli.actor > operator.actor > none
+defaults:
+  output: table         # read format default, below --json/--format/alias/legacy
+```
+
+Absent file = empty layer. Unknown keys warn and load (a file written for a
+newer CLI works on an older one). `$OMNIGRAPH_CONFIG=<path>` stands in for
+`--config` (the flag wins) in both the CLI and the server.
+
+## `omnigraph.yaml` schema (legacy combined file)
 
 ```yaml
 project: { name }


### PR DESCRIPTION
First implementation slice of RFC-007 (#195 carries the RFC pair; this branch includes those docs commits and will rebase to a pure code diff once #195 merges).

## What lands

- **`~/.omnigraph/config.yaml`** — the operator surface, loader in a new CLI-only module (the server never reads it; invariant 11 by construction). `$OMNIGRAPH_HOME` overrides the dir (tilde-expanded — #139 finding 9). Absent file = empty layer; **unknown keys warn and load** (a file written for the PR-2/3 keys works on this CLI); malformed YAML errors loudly.
- **THE actor chain, unified**: `--as` > legacy `cli.actor` (RFC-008 window) > `operator.actor` > none — one implementation (`resolve_actor`) behind both `resolve_cli_actor` (direct-engine writes) and `resolve_cluster_actor`, replacing two divergent copies (#139 finding 11's class).
- **Format cascade**: `--json` > `--format` > alias > legacy config > `defaults.output` > `table`.
- **`$OMNIGRAPH_CONFIG`** stands in for `--config` in `load_config` (flag > env > `./omnigraph.yaml`) — one name, one meaning, both binaries (the container entrypoint already used it for the server).

## Hermeticity

The spawned-binary test harness now pins `OMNIGRAPH_HOME` to a nonexistent path by default — no test can ever read the developer's real `~/.omnigraph/`, and operator-layer tests override it explicitly.

## Tests

Loader unit tests (parse/defaults/unknown-warn/absent/malformed/tilde), the `load_config_in` env-precedence matrix, and spawned-binary e2es: the three-hop actor chain through `cluster apply` audit output, and the format cascade through `read`. Full `cargo test --workspace --locked` green (57 suites). Zero behavior change for any existing `omnigraph.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)