### PR TITLE
fix(storage): flush before acking in local write_text_if_absent

### DIFF
--- a/crates/omnigraph/src/storage.rs
+++ b/crates/omnigraph/src/storage.rs
@@ -139,6 +139,18 @@ impl StorageAdapter for LocalStorageAdapter {
             let _ = tokio::fs::remove_file(&path).await;
             return Err(err.into());
         }
+        // tokio's async File buffers internally: without an explicit flush,
+        // write_all only fills the buffer and the actual OS write happens in
+        // a background task AFTER this fn returns — a reader can then see
+        // the created-but-still-empty file (caught twice in CI as an
+        // "EOF while parsing" on a state.json read right after import).
+        // Flushing before Ok restores write-then-read consistency, matching
+        // tokio::fs::write (which flushes internally) used by every other
+        // write path here.
+        if let Err(err) = file.flush().await {
+            let _ = tokio::fs::remove_file(&path).await;
+            return Err(err.into());
+        }
         Ok(true)
     }
 
@@ -598,6 +610,25 @@ fn env_var_truthy(key: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+
+    /// Regression for the write_text_if_absent buffering bug: a reader
+    /// immediately after Ok(true) must never see the created file empty.
+    /// The failure is timing-dependent (tokio's background write task), so
+    /// this loop is a best-effort local reproducer — the recorded red is
+    /// two CI failures ("EOF while parsing" on a state.json read right
+    /// after cluster import).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn write_text_if_absent_is_read_consistent_immediately() {
+        let dir = tempfile::tempdir().unwrap();
+        let adapter = super::storage_for_uri(&format!("file://{}", dir.path().display())).unwrap();
+        let payload = "x".repeat(64 * 1024);
+        for i in 0..200 {
+            let uri = format!("file://{}/f{}.json", dir.path().display(), i);
+            assert!(adapter.write_text_if_absent(&uri, &payload).await.unwrap());
+            let read = std::fs::read_to_string(dir.path().join(format!("f{i}.json"))).unwrap();
+            assert_eq!(read.len(), payload.len(), "iteration {i}: short read");
+        }
+    }
 
     #[tokio::test]
     async fn local_versioned_cas_roundtrip() {


### PR DESCRIPTION
The "flaky" cluster test that failed CI twice (#199's first run, #202) was a real bug, not a flake.

**Root cause:** `LocalStorageAdapter::write_text_if_absent` (the create-only CAS used for the cluster's first state-write, the lock, and sidecars since #190) writes through tokio's async `File` with `write_all` but never flushes. tokio files buffer internally — the OS write happens in a background task after the function returns — so `Ok(true)` could be acknowledged with the file created but **empty**, and an immediate reader saw `EOF while parsing`. Invariant 6 (durable before acknowledgement) violated on exactly one path: the other local writes use `tokio::fs::write`, which flushes internally.

**Fix:** `flush().await` before `Ok(true)`, with the same remove-on-failure cleanup. One real line.

**Test:** best-effort tight-loop regression (`write_text_if_absent_is_read_consistent_immediately`) — the window is timing-dependent and reproduces reliably only on loaded runners, so the two recorded CI failures are the red half of the red→green pair; the commit message says so explicitly rather than pretending local determinism.

Full workspace gate green (57 suites). Unblocks #202 (the version bump), whose only failure was this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)