### PR TITLE
ci(codeowners): restore ragnorc to engineering and docs roles

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,11 +8,11 @@
 # CI fails if this file drifts from its source, and rejects PRs that
 # edit this file directly without also editing the yml.
 
-*             @aaltshuler
+*             @aaltshuler @ragnorc
 
-crates/**     @aaltshuler
-docs/**       @aaltshuler
-README.md     @aaltshuler
-AGENTS.md     @aaltshuler
-CLAUDE.md     @aaltshuler
-SECURITY.md   @aaltshuler
+crates/**     @aaltshuler @ragnorc
+docs/**       @aaltshuler @ragnorc
+README.md     @aaltshuler @ragnorc
+AGENTS.md     @aaltshuler @ragnorc
+CLAUDE.md     @aaltshuler @ragnorc
+SECURITY.md   @aaltshuler @ragnorc

--- a/.github/codeowners-roles.yml
+++ b/.github/codeowners-roles.yml
@@ -22,6 +22,7 @@ roles:
       compiler.
     members:
       - aaltshuler
+      - ragnorc
 
   docs:
     description: >
@@ -29,6 +30,7 @@ roles:
       AGENTS.md, CLAUDE.md symlink, SECURITY.md).
     members:
       - aaltshuler
+      - ragnorc
 
 # Path → role mapping. GitHub CODEOWNERS uses "last match wins"
 # semantics — when multiple patterns match a file, only the last

--- a/docs/dev/codeowners.md
+++ b/docs/dev/codeowners.md
@@ -14,20 +14,20 @@ The tables below are **generated** from `.github/codeowners-roles.yml` by `.gith
 
 | Path | Owners | Role(s) |
 |---|---|---|
-| `*` | @aaltshuler | engineering |
-| `crates/**` | @aaltshuler | engineering |
-| `docs/**` | @aaltshuler | docs |
-| `README.md` | @aaltshuler | docs |
-| `AGENTS.md` | @aaltshuler | docs |
-| `CLAUDE.md` | @aaltshuler | docs |
-| `SECURITY.md` | @aaltshuler | docs |
+| `*` | @aaltshuler @ragnorc | engineering |
+| `crates/**` | @aaltshuler @ragnorc | engineering |
+| `docs/**` | @aaltshuler @ragnorc | docs |
+| `README.md` | @aaltshuler @ragnorc | docs |
+| `AGENTS.md` | @aaltshuler @ragnorc | docs |
+| `CLAUDE.md` | @aaltshuler @ragnorc | docs |
+| `SECURITY.md` | @aaltshuler @ragnorc | docs |
 
 **Roles**:
 
 | Role | Members | Description |
 |---|---|---|
-| `engineering` | @aaltshuler | All production code under crates/**. Engine, CLI, server, compiler. |
-| `docs` | @aaltshuler | Documentation under docs/**, plus repo-level docs (README.md, AGENTS.md, CLAUDE.md symlink, SECURITY.md). |
+| `engineering` | @aaltshuler @ragnorc | All production code under crates/**. Engine, CLI, server, compiler. |
+| `docs` | @aaltshuler @ragnorc | Documentation under docs/**, plus repo-level docs (README.md, AGENTS.md, CLAUDE.md symlink, SECURITY.md). |
 
 <!-- END GENERATED OWNERSHIP -->
 


### PR DESCRIPTION
Re-adds `ragnorc` to both roles in `.github/codeowners-roles.yml` and regenerates `.github/CODEOWNERS` + the ownership tables in `docs/dev/codeowners.md` (via `render-codeowners.py`, so the drift checks stay green).

Side effect worth noting: this **resolves the standing sync inconsistency from #169** — `branch-protection.json`'s `bypass_pull_request_allowances` kept `ragnorc` when his codeowners entry was removed; with this PR the hand-synced bypass list and the generated owners match again, so no protection change is needed (and nothing to re-apply).

🤖 Generated with [Claude Code](https://claude.com/claude-code)