### PR TITLE
refactor(cli): collapse export + graphs-list onto GraphClient (RFC-009 Phase 3c)

### DIFF
--- a/crates/omnigraph-cli/src/client.rs
+++ b/crates/omnigraph-cli/src/client.rs
@@ -21,14 +21,17 @@
 //! `apply_schema` catalog-validator closure that is not object-safe.
 //! Same one-body-two-impls collapse, less ceremony.
 
+use std::io::Write;
+
 use color_eyre::Result;
+use color_eyre::eyre::bail;
 use omnigraph::db::{Omnigraph, ReadTarget};
 use omnigraph_api_types::{
     BranchCreateOutput, BranchCreateRequest, BranchDeleteOutput, BranchListOutput,
     BranchMergeOutput, BranchMergeRequest, ChangeOutput, CommitListOutput, CommitOutput,
-    IngestOutput, IngestRequest, ReadOutput, ReadRequest, SchemaApplyOutput, SchemaApplyRequest,
-    SchemaOutput, SnapshotOutput, commit_output, ingest_output, read_output, schema_apply_output,
-    snapshot_payload,
+    ErrorOutput, ExportRequest, GraphListResponse, IngestOutput, IngestRequest, ReadOutput,
+    ReadRequest, SchemaApplyOutput, SchemaApplyRequest, SchemaOutput, SnapshotOutput, commit_output,
+    ingest_output, read_output, schema_apply_output, snapshot_payload,
 };
 use omnigraph_compiler::catalog::Catalog;
 use reqwest::Method;
@@ -36,7 +39,7 @@ use serde_json::Value;
 
 use crate::cli::CliLoadMode;
 use crate::helpers::{
-    ResolvedCliGraph, apply_server_flag, build_http_client, is_remote_uri,
+    ResolvedCliGraph, apply_bearer_token, apply_server_flag, build_http_client, is_remote_uri,
     legacy_change_request_body, open_local_db_with_policy, query_params_from_json, remote_branch_url,
     remote_json, remote_url, resolve_cli_actor, resolve_cli_graph, resolve_remote_bearer_token,
     select_named_query,
@@ -613,6 +616,88 @@ impl GraphClient {
                     .await?;
                 Ok(schema_apply_output(uri, result))
             }
+        }
+    }
+
+    /// `export` — stream the branch as JSONL into `writer`. The streaming
+    /// shape (a `W: Write`, not a returned DTO) is why this lands in 3c
+    /// rather than 3b. Opens WITHOUT policy (like reads), so it is reached
+    /// via `resolve()`; the Embedded arm opens bare. The Remote arm streams
+    /// the chunked response body straight through (no buffering the whole
+    /// export in memory).
+    pub(crate) async fn export<W: Write>(
+        &self,
+        branch: &str,
+        type_names: &[String],
+        table_keys: &[String],
+        writer: &mut W,
+    ) -> Result<()> {
+        match self {
+            GraphClient::Remote {
+                http,
+                base_url,
+                token,
+            } => {
+                let request = apply_bearer_token(
+                    http.request(Method::POST, remote_url(base_url, "/export")),
+                    token.as_deref(),
+                )
+                .json(&ExportRequest {
+                    branch: Some(branch.to_string()),
+                    type_names: type_names.to_vec(),
+                    table_keys: table_keys.to_vec(),
+                });
+                let mut response = request.send().await?;
+                let status = response.status();
+                if !status.is_success() {
+                    let text = response.text().await?;
+                    if let Ok(error) = serde_json::from_str::<ErrorOutput>(&text) {
+                        bail!(error.error);
+                    }
+                    bail!("server returned {}: {}", status, text);
+                }
+                while let Some(chunk) = response.chunk().await? {
+                    writer.write_all(&chunk)?;
+                }
+                writer.flush()?;
+                Ok(())
+            }
+            GraphClient::Embedded { uri, .. } => {
+                let db = Omnigraph::open(uri).await?;
+                db.export_jsonl_to_writer(branch, type_names, table_keys, writer)
+                    .await?;
+                writer.flush()?;
+                Ok(())
+            }
+        }
+    }
+
+    /// `graphs list` — enumerate the graphs a remote multi-graph server
+    /// serves (`GET /graphs`). Remote-only by design: there is no local
+    /// enumeration endpoint, so the Embedded arm fails loudly pointing the
+    /// operator at `omnigraph.yaml`. Routing it through the enum still buys
+    /// the shared `resolve()` addressing/token preamble.
+    pub(crate) async fn list_graphs(&self) -> Result<GraphListResponse> {
+        match self {
+            GraphClient::Remote {
+                http,
+                base_url,
+                token,
+            } => {
+                remote_json(
+                    http,
+                    Method::GET,
+                    remote_url(base_url, "/graphs"),
+                    None,
+                    token.as_deref(),
+                )
+                .await
+            }
+            GraphClient::Embedded { .. } => bail!(
+                "`omnigraph graphs list` requires a remote multi-graph server URL \
+                 (http:// or https://). To enumerate local graphs, read `omnigraph.yaml` \
+                 directly."
+            ),
         }
     }
 }

--- a/crates/omnigraph-cli/src/helpers.rs
+++ b/crates/omnigraph-cli/src/helpers.rs
@@ -678,22 +678,6 @@ pub(crate) fn normalize_legacy_alias_uri(
 }
 
 
-pub(crate) fn inferred_config_path(uri: &str) -> Result<PathBuf> {
-    if uri.contains("://") {
-        return Ok(omnigraph_server::config::default_config_path());
-    }
-
-    let path = Path::new(uri);
-    let base = if path.is_absolute() {
-        path.parent()
-            .map(Path::to_path_buf)
-            .unwrap_or(std::env::current_dir()?)
-    } else {
-        std::env::current_dir()?.join(path.parent().unwrap_or_else(|| Path::new(".")))
-    };
-    Ok(base.join(omnigraph_server::config::DEFAULT_CONFIG_FILE))
-}
-
 pub(crate) fn read_target_from_cli(branch: Option<String>, snapshot: Option<String>) -> ReadTarget {
     if let Some(snapshot) = snapshot {
         ReadTarget::snapshot(SnapshotId::new(snapshot))
@@ -996,55 +980,6 @@ pub(crate) fn legacy_change_request_body(
         body["params"] = params.clone();
     }
     body
-}
-
-pub(crate) async fn execute_export_to_writer<W: Write>(
-    uri: &str,
-    branch: &str,
-    type_names: &[String],
-    table_keys: &[String],
-    writer: &mut W,
-) -> Result<()> {
-    let db = Omnigraph::open(uri).await?;
-    db.export_jsonl_to_writer(branch, type_names, table_keys, writer)
-        .await?;
-    writer.flush()?;
-    Ok(())
-}
-
-pub(crate) async fn execute_export_remote_to_writer<W: Write>(
-    client: &reqwest::Client,
-    uri: &str,
-    branch: &str,
-    type_names: &[String],
-    table_keys: &[String],
-    bearer_token: Option<&str>,
-    writer: &mut W,
-) -> Result<()> {
-    let request = apply_bearer_token(
-        client.request(Method::POST, remote_url(uri, "/export")),
-        bearer_token,
-    )
-    .json(&ExportRequest {
-        branch: Some(branch.to_string()),
-        type_names: type_names.to_vec(),
-        table_keys: table_keys.to_vec(),
-    });
-    let mut response = request.send().await?;
-    let status = response.status();
-    if !status.is_success() {
-        let text = response.text().await?;
-        if let Ok(error) = serde_json::from_str::<ErrorOutput>(&text) {
-            bail!(error.error);
-        }
-        bail!("server returned {}: {}", status, text);
-    }
-
-    while let Some(chunk) = response.chunk().await? {
-        writer.write_all(&chunk)?;
-    }
-    writer.flush()?;
-    Ok(())
 }
 
 pub(crate) fn rewrite_deprecated_argv(args: Vec<OsString>) -> Vec<OsString> {

--- a/crates/omnigraph-cli/src/main.rs
+++ b/crates/omnigraph-cli/src/main.rs
@@ -23,8 +23,8 @@ use omnigraph_compiler::{
     json_params_to_param_map, lint_query_file,
 };
 use omnigraph_api_types::{
-    ChangeOutput, CommitOutput, ErrorOutput, ExportRequest, GraphListResponse, IngestOutput,
-    ReadOutput, SchemaApplyOutput, SnapshotTableOutput,
+    ChangeOutput, CommitOutput, ErrorOutput, IngestOutput, ReadOutput, SchemaApplyOutput,
+    SnapshotTableOutput,
 };
 use omnigraph_server::queries::{QueryRegistry, check, format_check_breakages};
 use omnigraph_server::{
@@ -525,11 +525,13 @@ async fn main() -> Result<()> {
             table_keys,
         } => {
             let config = load_cli_config(config.as_ref())?;
-            let uri =
-                apply_server_flag(cli.server.as_deref(), cli.graph.as_deref(), uri, target.as_deref())?;
-            let bearer_token =
-                resolve_remote_bearer_token(&config, uri.as_deref(), target.as_deref())?;
-            let uri = resolve_uri(&config, uri, target.as_deref())?;
+            let client = client::GraphClient::resolve(
+                &config,
+                cli.server.as_deref(),
+                cli.graph.as_deref(),
+                uri,
+                target.as_deref(),
+            )?;
             let branch = resolve_branch(&config, branch, None, "main");
             if jsonl {
                 eprintln!("warning: --jsonl is deprecated; `omnigraph export` always emits JSONL");
@@ -537,21 +539,9 @@ async fn main() -> Result<()> {
 
             let stdout = io::stdout();
             let mut stdout = stdout.lock();
-            if is_remote_uri(&uri) {
-                execute_export_remote_to_writer(
-                    &http_client,
-                    &uri,
-                    &branch,
-                    &type_names,
-                    &table_keys,
-                    bearer_token.as_deref(),
-                    &mut stdout,
-                )
+            client
+                .export(&branch, &type_names, &table_keys, &mut stdout)
                 .await?;
-            } else {
-                execute_export_to_writer(&uri, &branch, &type_names, &table_keys, &mut stdout)
-                    .await?;
-            }
         }
         Command::Query {
             uri,
@@ -1047,26 +1037,14 @@ async fn main() -> Result<()> {
                 json,
             } => {
                 let config = load_cli_config(config.as_ref())?;
-                let uri =
-                    apply_server_flag(cli.server.as_deref(), cli.graph.as_deref(), uri, target.as_deref())?;
-                let bearer_token =
-                    resolve_remote_bearer_token(&config, uri.as_deref(), target.as_deref())?;
-                let uri = resolve_uri(&config, uri, target.as_deref())?;
-                if !is_remote_uri(&uri) {
-                    bail!(
-                        "`omnigraph graphs list` requires a remote multi-graph server URL \
-                         (http:// or https://). To enumerate local graphs, read `omnigraph.yaml` \
-                         directly."
-                    );
-                }
-                let payload = remote_json::<GraphListResponse>(
-                    &http_client,
-                    Method::GET,
-                    remote_url(&uri, "/graphs"),
-                    None,
-                    bearer_token.as_deref(),
-                )
-                .await?;
+                let client = client::GraphClient::resolve(
+                    &config,
+                    cli.server.as_deref(),
+                    cli.graph.as_deref(),
+                    uri,
+                    target.as_deref(),
+                )?;
+                let payload = client.list_graphs().await?;
                 if json {
                     print_json(&payload)?;
                 } else {

--- a/crates/omnigraph-cli/src/output.rs
+++ b/crates/omnigraph-cli/src/output.rs
@@ -812,10 +812,6 @@ pub(crate) fn print_policy_explain(decision: &PolicyDecision, actor_id: &str, re
     println!("message: {}", decision.message);
 }
 
-pub(crate) fn yaml_string(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "''"))
-}
-
 #[derive(serde::Serialize)]
 pub(crate) struct QueriesIssue {
     pub(crate) query: String,

--- a/crates/omnigraph-cli/tests/parity_matrix.rs
+++ b/crates/omnigraph-cli/tests/parity_matrix.rs
@@ -179,6 +179,35 @@ fn parity_load() {
     assert_parity("load", &l, &r);
 }
 
+#[test]
+fn parity_export() {
+    let p = parity();
+    let (l, r) = p.run(&["export"]);
+    // export emits a JSONL STREAM, not a single `--json` document, so the
+    // scrubbed-single-doc `assert_parity` doesn't apply — compare line-wise.
+    // The twin graphs are byte-copies of one loaded fixture, so rows carry
+    // identical ids/versions and need no scrubbing; sort the lines so any
+    // cross-arm row-ordering difference doesn't masquerade as a divergence.
+    assert_eq!(
+        l.status.code(),
+        r.status.code(),
+        "export: exit codes diverge\nlocal {l:?}\nremote {r:?}"
+    );
+    assert!(l.status.success(), "export local arm failed: {l:?}");
+    let mut local_lines: Vec<&str> = std::str::from_utf8(&l.stdout).unwrap().lines().collect();
+    let mut remote_lines: Vec<&str> = std::str::from_utf8(&r.stdout).unwrap().lines().collect();
+    assert!(
+        !local_lines.is_empty(),
+        "export produced no rows — the parity check would be vacuous"
+    );
+    local_lines.sort_unstable();
+    remote_lines.sort_unstable();
+    assert_eq!(
+        local_lines, remote_lines,
+        "export: JSONL streams diverge (left=local, right=remote)"
+    );
+}
+
 // ---- error parity: exit codes must match for shared failure cases ----
 
 #[test]


### PR DESCRIPTION
The last two embedded-vs-remote forks move onto the `GraphClient` enum, so **every such `if` in the CLI now lives in `client.rs`** — the point of RFC-009 Phase 3. Builds on 3a (#210) and 3b (#211).

## What moved
- **`export<W: Write>`** — the streaming verb 3b deferred (writes to a writer, chunks the HTTP response body, rather than returning a DTO). Embedded calls `db.export_jsonl_to_writer`; Remote streams the chunked body through. Opens WITHOUT policy (like reads), so it routes via `resolve()`.
- **`list_graphs`** — remote-only by design (no local enumeration endpoint), so the Embedded arm keeps the loud "requires a remote multi-graph server" bail verbatim. Routing it through the enum still buys the shared `resolve()` addressing/token preamble the arm hand-rolled.

## Cleanup
Retire the now-orphaned `execute_export_to_writer` / `execute_export_remote_to_writer` pair, and sweep two pre-existing dead fns: `inferred_config_path` (helpers.rs) and `yaml_string` (output.rs, shadowed by test-local copies).

## Parity
`parity_matrix` gains one row, `parity_export` — the single intended matrix change in this phase. Export is a JSONL **stream**, not a single `--json` doc, so it compares the two arms line-wise (sorted; twin graphs are byte-copies, so rows need no scrubbing). `graphs list` gets no row — its remote-only behavior is a documented exclusion, not an equality case.

## Verification
- All 12 parity rows green (incl. `parity_export`).
- `cli_data` green (export e2e), warning-clean build.
- Full `cargo test --workspace --locked` → exit 0, zero failures (run locally — `Test Workspace` no longer runs on PRs per #212).

Out of scope: Phase 4 (plane capability advertisement) and Phase 5 (route alignment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes RFC-009 Phase 3 by moving the last two embedded-vs-remote forks — `export` and `graphs list` — onto the `GraphClient` enum, so every CLI `is_remote` branch now lives in `client.rs`. It also retires four orphaned/dead helpers (`execute_export_to_writer`, `execute_export_remote_to_writer`, `inferred_config_path`, `yaml_string`) and adds the `parity_export` row to the parity matrix.

- **`export` method** (`client.rs`): streams JSONL into a `W: Write`; Remote arm chunks the HTTP response body without buffering; Embedded arm opens without policy (consistent with reads), calls `Omnigraph::open` directly — both arms are direct transliterations of the removed helpers with no behavioral change.
- **`list_graphs` method** (`client.rs`): Remote-only by design; Embedded arm preserves the verbatim error message from the old `main.rs` guard, now buying the shared `resolve()` addressing/token preamble for free.
- **`parity_export` test**: Uses a sorted line-wise comparison instead of the usual single-doc scrub, with a non-empty guard to prevent the check from being vacuous; only a minor diagnostic gap when the remote arm returns an empty body (caught by the final `assert_eq!`, but with a less specific message).

<h3>Confidence Score: 4/5</h3>

Safe to merge; the refactor is a mechanical transliteration with no behavioral changes to either the export stream or the graphs-list error path.

The core logic changes are direct port-overs of removed helpers into `GraphClient` match arms, with the old and new code paths identical line-for-line. The only observation is a minor diagnostic gap in `parity_export`: the non-empty guard only covers the local output, so a silent empty-body response from the remote arm would surface as a generic `assert_eq!` failure rather than a targeted message.

crates/omnigraph-cli/tests/parity_matrix.rs — the `parity_export` test would benefit from a symmetric non-empty guard on `remote_lines`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/omnigraph-cli/src/client.rs | Adds `export` and `list_graphs` methods to `GraphClient`, completing RFC-009 Phase 3c; logic is a direct transliteration of the removed helpers, behavior preserved. |
| crates/omnigraph-cli/src/helpers.rs | Removes three dead functions (`execute_export_to_writer`, `execute_export_remote_to_writer`, `inferred_config_path`) now that their logic lives in `client.rs`. |
| crates/omnigraph-cli/src/main.rs | Export and `graphs list` handlers replaced with `GraphClient::resolve()` + method call; unused `ExportRequest`/`GraphListResponse` imports removed; `http_client` still required for operator-alias path. |
| crates/omnigraph-cli/src/output.rs | Removes dead `yaml_string` helper; no functional changes. |
| crates/omnigraph-cli/tests/parity_matrix.rs | Adds `parity_export` row; uses line-wise sorted comparison instead of the usual single-doc scrub; only the local arm gets an explicit non-empty guard, leaving a gap in diagnostic clarity if the remote arm silently returns an empty body. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    CLI["main.rs: Command::Export / Command::Graphs::List"]
    resolve["GraphClient::resolve(config, server, graph, uri, target)"]
    isRemote{is_remote_uri?}
    remoteVariant["GraphClient::Remote { http, base_url, token }"]
    embeddedVariant["GraphClient::Embedded { uri, graph: None, actor: None }"]

    exportRemote["export() Remote arm\nPOST /export → stream chunks → writer"]
    exportEmbedded["export() Embedded arm\nOmnigraph::open(uri)\n→ export_jsonl_to_writer → writer"]

    listRemote["list_graphs() Remote arm\nGET /graphs → GraphListResponse"]
    listEmbedded["list_graphs() Embedded arm\nbail! (remote-only)"]

    CLI --> resolve
    resolve --> isRemote
    isRemote -- yes --> remoteVariant
    isRemote -- no --> embeddedVariant
    remoteVariant --> exportRemote
    embeddedVariant --> exportEmbedded
    remoteVariant --> listRemote
    embeddedVariant --> listEmbedded
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fomnigraph-cli%2Ftests%2Fparity_matrix.rs%3A199-206%0A**Missing%20non-empty%20guard%20on%20the%20remote%20output**%0A%0A%60assert!%28!local_lines.is_empty%28%29%29%60%20guards%20against%20the%20fixture%20producing%20no%20rows%20on%20the%20local%20arm%2C%20but%20the%20remote%20arm%20has%20no%20equivalent%20check.%20If%20the%20remote%20arm%20silently%20returns%20a%20200%20with%20an%20empty%20body%20%28e.g.%2C%20a%20chunked-transfer%20bug%20where%20the%20first%20%60chunk%28%29%60%20is%20%60None%60%29%2C%20%60remote_lines%60%20will%20be%20empty%20while%20%60local_lines%60%20is%20non-empty%2C%20and%20the%20test%20will%20still%20fail%20%E2%80%94%20but%20with%20the%20generic%20%22JSONL%20streams%20diverge%22%20message%20rather%20than%20a%20diagnostic%20one%20that%20points%20directly%20at%20the%20remote%20arm%20being%20empty.%20Adding%20a%20parallel%20assert%20for%20%60remote_lines%60%20mirrors%20the%20stated%20intent%20and%20makes%20the%20failure%20mode%20self-documenting.%0A%0A&repo=modernrelay%2Fomnigraph&pr=213&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["refactor(cli): collapse export + graphs-..."](https://github.com/modernrelay/omnigraph/commit/68361bcad68fa7dffb83ada6e336b64578882167) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37413998)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->