### PR TITLE
docs(rfc): RFC-010 verification-comment current-state fixups

### DIFF
--- a/docs/dev/rfc-010-cli-planes-restructure.md
+++ b/docs/dev/rfc-010-cli-planes-restructure.md
@@ -44,18 +44,25 @@ three different ways:
 
 | Plane | Verbs | Reaches the graph by | Addressing surface |
 |---|---|---|---|
-| **Data** | `query`, `mutate`, `load`, `ingest`, `branch *`, `snapshot`, `export`, `commit *`, `schema show/apply`, `graphs list` | embedded engine **or** HTTP server (one `GraphClient`, 15 call sites) | positional URI **or** `--target` / `--graph` / `--server` (config aliases) |
-| **Storage / maintenance** | `init`, `optimize`, `repair`, `cleanup`, `schema plan`, `queries validate` | embedded engine **only**, directly on storage (`file://` or `s3://`) | positional URI **or** `--target` — **no `--server` / `--graph`** |
+| **Data** | `query`, `mutate`, `load`, `ingest`, `branch *`, `snapshot`, `export`, `commit *`, `schema show/apply` (and `graphs list`, **remote-only today** — see note) | embedded engine **or** HTTP server (one `GraphClient`) | positional URI **or** `--target` / `--graph` / `--server` (config aliases) |
+| **Storage / maintenance** | `init`, `optimize`, `repair`, `cleanup`, `schema plan`, `queries validate` | embedded engine **only**, directly on storage (`file://` or `s3://`) | positional URI **or** `--target` — **no `--server` / `--graph`** (except `init`, which today takes **only a required positional URI** — no `--target`) |
 | **Control** | `cluster validate/plan/apply/approve/status/refresh/import/force-unlock` | a cluster **directory** (`file://` or `s3://`), not a graph URI | `--config <dir>` |
 
 ### What's confusing (validated facts)
 
 1. **Two names for one graph.** Data verbs resolve `--server prod --graph
-   knowledge` through `apply_server_flag` (16 call sites). Maintenance verbs use
+   knowledge` through `GraphClient::resolve*` (the embedded/remote fork collapsed
+   in RFC-009 Phases 3a–3c; only the two `GraphClient` factories call
+   `apply_server_flag`). Maintenance verbs instead use
    `resolve_uri`/`resolve_local_uri` and accept only a positional URI or
    `--target` — so to compact the graph you *query* as `--server prod --graph
    knowledge` you must *type* `s3://bucket/knowledge.omni`. One graph, two
    addressing vocabularies.
+
+   > **Note (`graphs list`).** It is routed through `GraphClient` only to share
+   > the addressing/token resolver; its embedded arm fails loudly, so it is
+   > **remote-only today** (the later capability table and *Relationship to
+   > RFC-009* record it as remote-now / embedded-cluster-later).
 
 2. **Plane restrictions are accidental, not declared.** `graphs list` is
    server-only and `optimize`/`repair`/`cleanup`/`init` are storage-only purely
@@ -198,9 +205,19 @@ not quietly consult both and invent a precedence. The rule:
 - A maintenance verb's `--target` resolves through the **operator/legacy**
   config and its URI must already be **direct storage**; a target that resolves
   to a remote (`http(s)://`) URL **fails loudly** (see the example above).
-- **Cluster-managed graphs are addressed explicitly** via `--cluster <dir>
-  --graph <id>`, so reading cluster state is an intentional mode — never an
-  implicit fallback between operator config and `cluster.yaml`.
+- **Cluster-managed graphs are addressed explicitly** via a cluster-root +
+  graph-id pair (spelled `--cluster <dir> --graph <id>` for illustration), so
+  reading cluster state is an intentional mode — never an implicit fallback
+  between operator config and `cluster.yaml`.
+
+  > **Flag-shape caveat (deferred).** `--graph` is *already* a global flag that
+  > `requires = "server"` and appends `/graphs/<id>` to a **remote** URL — a
+  > different meaning, and clap won't permit `--graph` without `--server`. So the
+  > cluster-maintenance addressing needs either a distinct flag (e.g.
+  > `--cluster-graph <id>`) or an explicit global-flag migration. This is why
+  > the cluster-managed resolver is **deferred to a later slice** (it also rides
+  > the applied-state-vs-declared-config open question below); the
+  > operator/legacy `--target` path lands first.
 
 ### A declared, per-subcommand capability surface (RFC-009 Phase 4, expanded)
 
@@ -379,3 +396,54 @@ Testing notes for the implementation slice:
   and those strings become observable behavior.
 
   **Resolution (accepted):** captured as the *Test plan* section.
+
+## Verification comments (Codex, 2026-06-13)
+
+Follow-up verification against the current CLI/server code found a few
+remaining current-state nits. These are doc-shape issues, not objections to the
+proposal:
+
+1. **Current-state table overstates `graphs list`.** The table under *Current
+   state of affairs* still lists `graphs list` with data verbs that reach the
+   graph by embedded engine or HTTP. Current code routes it through `GraphClient`
+   only to share the resolver, but the embedded arm fails loudly; the later
+   RFC text correctly says remote today / embedded-cluster later. Make the
+   current-state row match that.
+
+   **Resolution (accepted):** the Data row now marks `graphs list` **remote-only
+   today**, with a note that it rides `GraphClient` only to share the resolver.
+
+2. **Current-state table overstates `init` addressing.** `init` is grouped with
+   maintenance verbs whose addressing surface is positional URI or `--target`.
+   Current `init` only accepts a required positional URI and has no `--target`
+   or config path. The proposal can add that capability, but the current-state
+   table should not describe it as already present.
+
+   **Resolution (accepted):** the Storage row now calls out that `init` takes
+   **only a required positional URI** today (no `--target`); adding `--target` to
+   `init` is part of the proposal, entangled with the `init`→`cluster apply`
+   signpost, not current state.
+
+3. **`apply_server_flag` call-site count is stale.** The text says data verbs
+   resolve `--server prod --graph knowledge` through `apply_server_flag` at
+   16 call sites. Current code has the fork collapsed: data verbs call
+   `GraphClient::resolve*`, and only the two `GraphClient` factories call
+   `apply_server_flag`. Rephrase the verified fact around `GraphClient`, not
+   the old pre-collapse call-site count.
+
+   **Resolution (accepted):** validated-fact #1 now describes the post-collapse
+   reality (`GraphClient::resolve*`; the two factories call `apply_server_flag`),
+   dropping the stale count.
+
+4. **`--cluster <dir> --graph <id>` collides with today's global `--graph`
+   semantics.** The target ergonomics section proposes that flag shape for
+   maintenance, but current `--graph` is a global flag that requires
+   `--server` and appends `/graphs/<id>` to a remote server URL. Either choose
+   a separate cluster-maintenance graph flag shape, or call out the clap/global
+   flag migration explicitly as part of the implementation.
+
+   **Resolution (accepted):** the *Authority rule* now carries a flag-shape
+   caveat — the cluster-managed resolver (and its flag shape, e.g.
+   `--cluster-graph` vs a `--graph` migration) is **deferred to a later slice**;
+   the operator/legacy `--target` path lands first. The illustrative
+   `--cluster <dir> --graph <id>` spelling is marked as not-final.


### PR DESCRIPTION
Applies the **Verification comments** (Codex) on RFC-010 — current-state accuracy fixups found against the now-merged 3a/3b/3c code. Kept verbatim with per-point **Resolution (accepted)** notes.

- **`graphs list`** marked remote-only today in the current-state table (embedded arm bails; rides `GraphClient` only to share the resolver).
- **`init`** noted as positional-URI-only today (no `--target`) — adding `--target` is part of the proposal, entangled with the `init`→`cluster apply` signpost, not current state.
- **Validated-fact #1** rephrased to the post-collapse reality (`GraphClient::resolve*`; only the two factories call `apply_server_flag`) — drops the stale "16 call sites" count.
- **Authority rule** gains a flag-shape caveat: `--graph` is already a global flag requiring `--server`, so the cluster-managed resolver + its flag shape are deferred to a later slice; the illustrative `--cluster <dir> --graph <id>` spelling is marked not-final.

Docs-only. This lands before the RFC-010 Slice 1 implementation so the RFC's current-state is accurate when the code starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This docs-only PR applies four current-state accuracy fixups to RFC-010 against the now-merged RFC-009 Phases 3a–3c code, each paired with a "Resolution (accepted)" note appended as a *Verification comments* appendix section.

- **`graphs list` / `init` table corrections:** The current-state plane table now marks `graphs list` as remote-only today (with an explanatory note on its `GraphClient` routing) and adds an inline caveat that `init` accepts only a required positional URI today — neither `--target` nor config aliases.
- **Validated-fact rewrite:** The stale "16 call sites through `apply_server_flag`" description is replaced with the post-collapse reality (`GraphClient::resolve*`; only the two factories call `apply_server_flag`).
- **Authority rule flag-shape deferral:** The proposed `--cluster <dir> --graph <id>` addressing for cluster-managed maintenance is now explicitly marked "for illustration" and the whole cluster-managed resolver is deferred to a later slice, because `--graph` is already a global flag requiring `--server` with a different meaning that clap cannot disambiguate.

<h3>Confidence Score: 4/5</h3>

Safe to merge — docs-only change with no code or behavior impact.

All four fixups are accurate and well-reasoned. The one issue is a cross-section inconsistency: the authority rule now marks `--cluster <dir> --graph <id>` as not-final and deferred, but the target ergonomics code block still presents that same flag shape as a clean example with no matching qualification. An implementer reading the ergonomics section first would see what looks like a settled flag contract.

The target ergonomics section of `docs/dev/rfc-010-cli-planes-restructure.md` (the `--cluster ./cluster --graph knowledge` code block, ~line 147) should carry a caveat consistent with the flag-shape deferral note added to the authority rule.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docs/dev/rfc-010-cli-planes-restructure.md | Docs-only RFC fixup: updates the current-state table to mark `graphs list` as remote-only, calls out `init`'s positional-URI-only addressing today, replaces the stale "16 call sites" count with the post-collapse `GraphClient::resolve*` description, and adds a flag-shape deferral caveat to the Authority rule. One cross-section inconsistency: the new authority-rule caveat marks `--cluster <dir> --graph <id>` as not-final/deferred, but the target ergonomics code block still presents that same flag shape as a clean end-state example without qualification. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CLI invocation] --> B{Which plane?}

    B -->|Data verb| C[GraphClient resolver]
    C --> D{--server/--graph or\n--target/positional URI?}
    D -->|--server prod --graph id| E[GraphClient::resolve*\napply_server_flag in factory]
    D -->|--target / URI| F[Embedded engine\nor HTTP per config]
    E --> G[Remote HTTP execution]
    F --> H[Embedded or Remote\nper target resolution]

    B -->|Storage/Maintenance verb| I[resolve_uri /\nresolve_local_uri]
    I --> J{Addressing form?}
    J -->|positional URI| K[Direct storage\nfile:// or s3://]
    J -->|--target| L{Resolves to?}
    L -->|direct storage| K
    L -->|remote http://| M[Loud error:\nstorage-plane needs\ndirect storage]
    J -->|init today| N[Required positional URI only\nno --target today]
    K --> O[Embedded engine\non storage]

    B -->|Control verb| P[cluster directory\nreader]
    P --> Q[--config dir\nfile:// or s3://]

    style M fill:#f88,stroke:#c00
    style N fill:#ffd,stroke:#aa0
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `docs/dev/rfc-010-cli-planes-restructure.md`, line 143-148 ([link](https://github.com/modernrelay/omnigraph/blob/fc85fb6ae5895ec9ca9ab2a01f02ab972a1895aa/docs/dev/rfc-010-cli-planes-restructure.md#L143-L148)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Target-ergonomics example inconsistent with new flag-shape caveat**

   The PR adds a flag-shape caveat in the *Authority rule* section (lines 213–220) that explicitly marks `--cluster <dir> --graph <id>` as "for illustration" and defers the cluster-managed resolver to a later slice. The target ergonomics section below (this code block plus the error-message example on ~line 140) still presents `omnigraph optimize --cluster ./cluster --graph knowledge` and `--cluster <dir> --graph <id>` as committed end-state shapes without any matching qualification. An implementer of Slice 1 who reads the ergonomics section first will see what looks like a settled flag contract, then find the deferral signal only much later in the authority rule. Given AGENTS.md rule 6 ("don't lie — replace wrong text rather than leaving it silently incorrect"), a brief inline note on this block mirroring the authority-rule caveat would make the RFC self-consistent.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20docs%2Fdev%2Frfc-010-cli-planes-restructure.md%0ALine%3A%20143-148%0A%0AComment%3A%0A**Target-ergonomics%20example%20inconsistent%20with%20new%20flag-shape%20caveat**%0A%0AThe%20PR%20adds%20a%20flag-shape%20caveat%20in%20the%20*Authority%20rule*%20section%20%28lines%20213%E2%80%93220%29%20that%20explicitly%20marks%20%60--cluster%20%3Cdir%3E%20--graph%20%3Cid%3E%60%20as%20%22for%20illustration%22%20and%20defers%20the%20cluster-managed%20resolver%20to%20a%20later%20slice.%20The%20target%20ergonomics%20section%20below%20%28this%20code%20block%20plus%20the%20error-message%20example%20on%20~line%20140%29%20still%20presents%20%60omnigraph%20optimize%20--cluster%20.%2Fcluster%20--graph%20knowledge%60%20and%20%60--cluster%20%3Cdir%3E%20--graph%20%3Cid%3E%60%20as%20committed%20end-state%20shapes%20without%20any%20matching%20qualification.%20An%20implementer%20of%20Slice%201%20who%20reads%20the%20ergonomics%20section%20first%20will%20see%20what%20looks%20like%20a%20settled%20flag%20contract%2C%20then%20find%20the%20deferral%20signal%20only%20much%20later%20in%20the%20authority%20rule.%20Given%20AGENTS.md%20rule%206%20%28%22don't%20lie%20%E2%80%94%20replace%20wrong%20text%20rather%20than%20leaving%20it%20silently%20incorrect%22%29%2C%20a%20brief%20inline%20note%20on%20this%20block%20mirroring%20the%20authority-rule%20caveat%20would%20make%20the%20RFC%20self-consistent.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modernrelay%2Fomnigraph&pr=215&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fdev%2Frfc-010-cli-planes-restructure.md%3A143-148%0A**Target-ergonomics%20example%20inconsistent%20with%20new%20flag-shape%20caveat**%0A%0AThe%20PR%20adds%20a%20flag-shape%20caveat%20in%20the%20*Authority%20rule*%20section%20%28lines%20213%E2%80%93220%29%20that%20explicitly%20marks%20%60--cluster%20%3Cdir%3E%20--graph%20%3Cid%3E%60%20as%20%22for%20illustration%22%20and%20defers%20the%20cluster-managed%20resolver%20to%20a%20later%20slice.%20The%20target%20ergonomics%20section%20below%20%28this%20code%20block%20plus%20the%20error-message%20example%20on%20~line%20140%29%20still%20presents%20%60omnigraph%20optimize%20--cluster%20.%2Fcluster%20--graph%20knowledge%60%20and%20%60--cluster%20%3Cdir%3E%20--graph%20%3Cid%3E%60%20as%20committed%20end-state%20shapes%20without%20any%20matching%20qualification.%20An%20implementer%20of%20Slice%201%20who%20reads%20the%20ergonomics%20section%20first%20will%20see%20what%20looks%20like%20a%20settled%20flag%20contract%2C%20then%20find%20the%20deferral%20signal%20only%20much%20later%20in%20the%20authority%20rule.%20Given%20AGENTS.md%20rule%206%20%28%22don't%20lie%20%E2%80%94%20replace%20wrong%20text%20rather%20than%20leaving%20it%20silently%20incorrect%22%29%2C%20a%20brief%20inline%20note%20on%20this%20block%20mirroring%20the%20authority-rule%20caveat%20would%20make%20the%20RFC%20self-consistent.%0A%0A&repo=modernrelay%2Fomnigraph&pr=215&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(rfc): RFC-010 — apply verification-..."](https://github.com/modernrelay/omnigraph/commit/fc85fb6ae5895ec9ca9ab2a01f02ab972a1895aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37422193)</sub>

<!-- /greptile_comment -->