### PR TITLE
feat(cli): RFC-010 Slice 1 — declared plane capability surface + honest addressing

### DIFF
--- a/crates/omnigraph-cli/src/helpers.rs
+++ b/crates/omnigraph-cli/src/helpers.rs
@@ -464,8 +464,11 @@ pub(crate) fn resolve_local_graph(
     let graph = resolve_cli_graph(config, cli_uri, cli_target)?;
     if graph.is_remote {
         bail!(
-            "{} is only supported against local graph URIs in this milestone",
-            operation
+            "`{}` is a storage-plane command and needs direct storage access; \
+             the resolved target is a remote server ({}). Pass the graph's \
+             file:// or s3:// URI.",
+            operation,
+            graph.uri
         );
     }
     Ok(graph)

--- a/crates/omnigraph-cli/src/main.rs
+++ b/crates/omnigraph-cli/src/main.rs
@@ -49,6 +49,7 @@ mod cli;
 mod client;
 mod helpers;
 mod output;
+mod planes;
 use cli::*;
 use helpers::*;
 use output::*;
@@ -70,6 +71,10 @@ async fn main() -> Result<()> {
         Cli::from_arg_matches(&matches)?
     };
     let http_client = build_http_client()?;
+    // RFC-010 Slice 1: reject data-plane addressing flags (--server/--graph) on
+    // a verb that doesn't live on the data plane, from one declared table —
+    // before any per-command dispatch.
+    planes::guard_addressing(&cli)?;
     match cli.command {
         Command::Config { command } => match command {
             ConfigCommand::Migrate { config, write, json } => {
@@ -781,7 +786,7 @@ async fn main() -> Result<()> {
             json,
         } => {
             let config = load_cli_config(config.as_ref())?;
-            let uri = resolve_uri(&config, uri, target.as_deref())?;
+            let uri = resolve_local_uri(&config, uri, target.as_deref(), "optimize")?;
             let db = Omnigraph::open(&uri).await?;
             let stats = db.optimize().await?;
             if json {
@@ -823,7 +828,7 @@ async fn main() -> Result<()> {
             json,
         } => {
             let config = load_cli_config(config.as_ref())?;
-            let uri = resolve_uri(&config, uri, target.as_deref())?;
+            let uri = resolve_local_uri(&config, uri, target.as_deref(), "repair")?;
             let db = Omnigraph::open(&uri).await?;
             let stats = db
                 .repair(omnigraph::db::RepairOptions { confirm, force })
@@ -907,7 +912,7 @@ async fn main() -> Result<()> {
             json,
         } => {
             let config = load_cli_config(config.as_ref())?;
-            let uri = resolve_uri(&config, uri, target.as_deref())?;
+            let uri = resolve_local_uri(&config, uri, target.as_deref(), "cleanup")?;
 
             let older_than_dur = older_than.as_deref().map(parse_duration_arg).transpose()?;
 

--- a/crates/omnigraph-cli/src/planes.rs
+++ b/crates/omnigraph-cli/src/planes.rs
@@ -1,0 +1,151 @@
+//! Declared CLI "planes" (RFC-010 Slice 1).
+//!
+//! Every subcommand belongs to exactly one plane. This classification is the
+//! single source of truth the wrong-plane guard consumes — and that later
+//! RFC-010 slices (the capability surface, plane-grouped help) will consume
+//! too. The `command_plane` match is **exhaustive on purpose**: adding a
+//! `Command` variant is a compile error until its plane is declared, so the
+//! surface cannot silently drift from the command set.
+//!
+//! See [docs/dev/rfc-010-cli-planes-restructure.md].
+
+use color_eyre::Result;
+use color_eyre::eyre::bail;
+
+use crate::cli::{Cli, Command, QueriesCommand, SchemaCommand};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Plane {
+    /// Runs against a graph, embedded **or** via `--server` (the `GraphClient`
+    /// axis). The only plane on which the data-plane addressing flags
+    /// (`--server`/`--graph`) apply.
+    Data,
+    /// Direct storage access; no server. Maintenance + local-only inspection
+    /// that must work with the server down.
+    Storage,
+    /// Operates on a cluster directory, not a graph URI.
+    Control,
+    /// Touches no graph at all — session / config / local tooling.
+    Session,
+}
+
+impl std::fmt::Display for Plane {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Plane::Data => "data",
+            Plane::Storage => "storage",
+            Plane::Control => "control",
+            Plane::Session => "session",
+        })
+    }
+}
+
+/// The plane a subcommand belongs to. Exhaustive — a new `Command` variant
+/// will not compile until classified. Descends into the nested enums where
+/// the plane differs per subcommand (`schema plan` is storage while `schema
+/// show`/`apply` are data; `queries validate` opens the graph while `queries
+/// list` only reads config).
+pub(crate) fn command_plane(cmd: &Command) -> Plane {
+    match cmd {
+        Command::Query { .. }
+        | Command::Mutate { .. }
+        | Command::Load { .. }
+        | Command::Ingest { .. }
+        | Command::Branch { .. }
+        | Command::Snapshot { .. }
+        | Command::Export { .. }
+        | Command::Commit { .. }
+        | Command::Graphs { .. } => Plane::Data,
+        Command::Schema {
+            command: SchemaCommand::Show { .. } | SchemaCommand::Apply { .. },
+        } => Plane::Data,
+        Command::Schema {
+            command: SchemaCommand::Plan { .. },
+        } => Plane::Storage,
+        Command::Queries {
+            command: QueriesCommand::Validate { .. },
+        } => Plane::Storage,
+        Command::Queries {
+            command: QueriesCommand::List { .. },
+        } => Plane::Session,
+        Command::Init { .. }
+        | Command::Optimize { .. }
+        | Command::Repair { .. }
+        | Command::Cleanup { .. }
+        | Command::Lint { .. } => Plane::Storage,
+        Command::Cluster { .. } => Plane::Control,
+        Command::Policy { .. }
+        | Command::Embed(_)
+        | Command::Login { .. }
+        | Command::Logout { .. }
+        | Command::Config { .. }
+        | Command::Version => Plane::Session,
+    }
+}
+
+/// User-facing label for a subcommand (descends one level for the nested
+/// families so messages read `schema plan`, `queries validate`, etc.).
+pub(crate) fn command_label(cmd: &Command) -> &'static str {
+    match cmd {
+        Command::Version => "version",
+        Command::Login { .. } => "login",
+        Command::Logout { .. } => "logout",
+        Command::Config { .. } => "config",
+        Command::Embed(_) => "embed",
+        Command::Init { .. } => "init",
+        Command::Load { .. } => "load",
+        Command::Ingest { .. } => "ingest",
+        Command::Branch { .. } => "branch",
+        Command::Schema { command } => match command {
+            SchemaCommand::Plan { .. } => "schema plan",
+            SchemaCommand::Apply { .. } => "schema apply",
+            SchemaCommand::Show { .. } => "schema show",
+        },
+        Command::Lint { .. } => "lint",
+        Command::Queries { command } => match command {
+            QueriesCommand::Validate { .. } => "queries validate",
+            QueriesCommand::List { .. } => "queries list",
+        },
+        Command::Snapshot { .. } => "snapshot",
+        Command::Export { .. } => "export",
+        Command::Commit { .. } => "commit",
+        Command::Query { .. } => "query",
+        Command::Mutate { .. } => "mutate",
+        Command::Policy { .. } => "policy",
+        Command::Optimize { .. } => "optimize",
+        Command::Repair { .. } => "repair",
+        Command::Cleanup { .. } => "cleanup",
+        Command::Cluster { .. } => "cluster",
+        Command::Graphs { .. } => "graphs",
+    }
+}
+
+/// Reject the data-plane addressing flags (`--server`/`--graph`) on any verb
+/// that does not live on the data plane. This replaces the old silent-ignore
+/// — e.g. `optimize --server prod` previously dropped `--server` and tried to
+/// resolve a default target, failing (if at all) with an unrelated message.
+/// Now it fails with one honest, declared error. RFC-010 Slice 1.
+pub(crate) fn guard_addressing(cli: &Cli) -> Result<()> {
+    if cli.server.is_none() && cli.graph.is_none() {
+        return Ok(());
+    }
+    let plane = command_plane(&cli.command);
+    if plane == Plane::Data {
+        return Ok(());
+    }
+    let label = command_label(&cli.command);
+    let how = match plane {
+        // `init` is the one storage verb with no `--target` today (it takes a
+        // required positional URI), so its remediation drops the `--target` half.
+        Plane::Storage => match cli.command {
+            Command::Init { .. } => "Pass a storage URI.",
+            _ => "Use --target <name> or a storage URI.",
+        },
+        Plane::Control => "It operates on a cluster directory (pass --config <dir>).",
+        Plane::Session => "It does not address a graph.",
+        Plane::Data => unreachable!("data plane returned early"),
+    };
+    bail!(
+        "`{label}` is a {plane}-plane command; --server/--graph address the data plane and do not apply. {how}"
+    );
+}

--- a/crates/omnigraph-cli/tests/cli_data.rs
+++ b/crates/omnigraph-cli/tests/cli_data.rs
@@ -143,6 +143,47 @@ fn embed_seed_preserves_non_entity_rows() {
 }
 
 #[test]
+fn optimize_json_succeeds_on_local_graph() {
+    // Happy path for the resolve_local_uri swap (RFC-010 Slice 1): a positional
+    // local path still resolves and runs embedded.
+    let temp = tempdir().unwrap();
+    let graph = graph_path(temp.path());
+    init_graph(&graph);
+    load_fixture(&graph);
+
+    let output = output_success(cli().arg("optimize").arg("--json").arg(&graph));
+    let payload: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(payload["tables"].as_array().is_some());
+}
+
+#[test]
+fn optimize_with_server_flag_errors_wrong_plane() {
+    // RFC-010 Slice 1: --server is a data-plane addressing flag; on a
+    // storage-plane verb the guard rejects it loudly (was: silently ignored).
+    let output = output_failure(cli().arg("optimize").arg("--server").arg("prod"));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("`optimize` is a storage-plane command")
+            && stderr.contains("--server/--graph address the data plane and do not apply")
+            && stderr.contains("Use --target <name> or a storage URI."),
+        "wrong-plane guard message not found; got: {stderr}"
+    );
+}
+
+#[test]
+fn optimize_with_remote_target_errors_storage_plane() {
+    // RFC-010 Slice 1: a maintenance verb pointed at a remote URI fails loudly
+    // and declaratively (was: whatever Omnigraph::open said about an https URI).
+    let output = output_failure(cli().arg("optimize").arg("https://graph.example.invalid"));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("`optimize` is a storage-plane command and needs direct storage access")
+            && stderr.contains("remote server"),
+        "storage-plane remote-target message not found; got: {stderr}"
+    );
+}
+
+#[test]
 fn repair_json_reports_noop_on_clean_graph() {
     let temp = tempdir().unwrap();
     let graph = graph_path(temp.path());
@@ -542,8 +583,12 @@ query list_people() {
             .arg("http://127.0.0.1:8080"),
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
+    // RFC-010 Slice 1: the storage-plane verbs now share one declared message
+    // (was: "query lint is only supported against local graph URIs …").
     assert!(
-        stderr.contains("query lint is only supported against local graph URIs in this milestone")
+        stderr.contains("`query lint` is a storage-plane command and needs direct storage access")
+            && stderr.contains("remote server"),
+        "storage-plane remote-target message not found; got: {stderr}"
     );
 }
 

--- a/crates/omnigraph-cli/tests/cli_schema_config.rs
+++ b/crates/omnigraph-cli/tests/cli_schema_config.rs
@@ -73,6 +73,28 @@ fn schema_plan_json_reports_supported_additive_change() {
 }
 
 #[test]
+fn schema_plan_with_server_flag_errors_wrong_plane() {
+    // RFC-010 Slice 1: `schema plan` is storage-plane while `schema show/apply`
+    // are data-plane — the guard rejects --server on plan with the per-subcommand
+    // label (proving command_plane/command_label descend into the nested enum).
+    let output = output_failure(
+        cli()
+            .arg("schema")
+            .arg("plan")
+            .arg("--schema")
+            .arg(fixture("test.pg"))
+            .arg("--server")
+            .arg("prod"),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("`schema plan` is a storage-plane command")
+            && stderr.contains("Use --target <name> or a storage URI."),
+        "schema plan wrong-plane message not found; got: {stderr}"
+    );
+}
+
+#[test]
 fn schema_plan_json_reports_unsupported_type_change() {
     let temp = tempdir().unwrap();
     let graph = graph_path(temp.path());


### PR DESCRIPTION
First implementation slice of [RFC-010](docs/dev/rfc-010-cli-planes-restructure.md). Makes the CLI's planes **declared** and graph addressing **honest** — the backbone + the headline addressing win together.

## What changed

**Capability surface + wrong-plane guard** (`c92d756`)
- New `planes.rs`: `Plane` enum + `command_plane` — an **exhaustive match**, so adding a `Command` variant is a compile error until its plane is declared (the surface can't silently drift from the command set). Descends into nested enums so per-subcommand splits are real (`schema plan`=Storage vs `show/apply`=Data; `queries validate`=Storage vs `list`=Session).
- `guard_addressing(&cli)?` runs once before dispatch: `--server`/`--graph` on any non-Data verb now fails with **one declared, pinned error** instead of being silently ignored (`optimize --server prod` previously dropped `--server`).

**Storage-plane remote-target honesty** (`4b1d479`)
- `optimize`/`repair`/`cleanup` switch `resolve_uri` → `resolve_local_uri`; the `resolve_local_graph` bail is reworded to a storage-plane message, so every storage verb (`schema plan`, `queries validate`, `lint`) speaks with one voice. `optimize --target knowledge` → storage URI embedded; `optimize --target prod` (remote) → loud declared failure.

## Verification
- Compile-time exhaustiveness guarantees the capability surface matches the command set.
- Pinned-string tests: `cli_data` (optimize happy path, `--server` wrong-plane, `<https>` storage-plane) + `cli_schema_config` (`schema plan --server` proves the per-subcommand label); updated the one existing test that pinned the old message.
- `parity_matrix` unaffected (still green — not a parity axis).
- Full `cargo test --workspace --locked` → exit 0, zero failures (run locally; Test Workspace is off PRs per #212).

## Deferred (per RFC + plan)
plane-grouped `--help` (clap can't cleanly group subcommands), the `--cluster --graph` cluster resolver (open Q2 + global-`--graph` collision), the `init`→`cluster apply` signpost, and RFC-009 Phase 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements RFC-010 Slice 1: it adds a `planes.rs` module with an exhaustive `command_plane` match that classifies every CLI subcommand onto one of four planes, then gates the entry point with `guard_addressing` to reject data-plane addressing flags (`--server`/`--graph`) on non-Data verbs before dispatch. Storage-plane verbs (`optimize`, `repair`, `cleanup`) also switch from `resolve_uri` to `resolve_local_uri`, so passing a remote target now fails with a declared, consistent error instead of a silent drop or an unrelated downstream message.

- `planes.rs` introduces `Plane`, `command_plane`, `command_label`, and `guard_addressing`; the exhaustive match ensures new `Command` variants cannot be added without a plane declaration.
- `resolve_local_graph`'s error message is reworded to a storage-plane framing, unifying the error voice across all storage verbs (`schema plan`, `queries validate`, `lint`, `optimize`, `repair`, `cleanup`).
- Three new pinned tests cover the optimize happy path, the wrong-plane guard, and the remote-target storage-plane error; the existing lint remote-target test is updated to the new message.

<h3>Confidence Score: 4/5</h3>

Safe to merge after resolving the lint label inconsistency; the wrong-plane guard and storage-plane errors are otherwise well-structured and well-tested.

The `command_label` function returns `"lint"` for `Command::Lint`, but `execute_query_lint` hardcodes `"query lint"` as the operation string for `resolve_local_uri`. Two error messages for the same subcommand now use different names depending on which check fires, and both forms are locked in by pinned tests. The rest of the changes — the exhaustive plane dispatch, the guard placement in `main`, the `resolve_local_uri` switches — are clean and well-tested. Documentation for the changed error-message text is also missing per the repo's maintenance contract.

The `lint` label in `command_label` (planes.rs line 104) and the `"query lint"` operation string in `execute_query_lint` (helpers.rs line 760) need to be aligned. `docs/user/cli-reference.md` and `docs/user/maintenance.md` should also be updated to reflect the new error behaviors.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/omnigraph-cli/src/planes.rs | New module introducing Plane enum, command_plane, command_label, and guard_addressing. Exhaustive match is well-designed; a label inconsistency for `lint` vs `query lint` creates divergent error messages depending on which guard fires. |
| crates/omnigraph-cli/src/helpers.rs | resolve_local_graph error message reworded to storage-plane framing; resolve_local_uri wrapper unchanged. The operation string "query lint" hardcoded in execute_query_lint is the source of the label inconsistency with command_label. |
| crates/omnigraph-cli/src/main.rs | guard_addressing hooked in correctly before dispatch; optimize/repair/cleanup switched to resolve_local_uri. Changes are minimal and correctly scoped. |
| crates/omnigraph-cli/tests/cli_data.rs | Three new pinned tests for optimize (happy path, wrong-plane guard, remote-target). Updated existing lint remote-target test to new message; note the updated test pins "query lint" which diverges from command_label's "lint" label. |
| crates/omnigraph-cli/tests/cli_schema_config.rs | New schema plan wrong-plane test correctly verifies per-subcommand label descent; no issues found. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CLI args parsed] --> B[guard_addressing &cli]
    B --> C{server.is_none AND graph.is_none?}
    C -- yes --> D[pass through]
    C -- no --> E[command_plane &cli.command]
    E --> F{Plane::Data?}
    F -- yes --> D
    F -- no --> G[command_label &cli.command]
    G --> H[bail: label is plane-plane command]

    D --> I[match cli.command dispatch]

    I --> J[Optimize / Repair / Cleanup]
    J --> K[resolve_local_uri config, uri, target, op_str]
    K --> L[resolve_local_graph]
    L --> M{graph.is_remote?}
    M -- no --> N[return URI]
    M -- yes --> O[bail: op_str is storage-plane command needs direct storage access]

    I --> P[Lint → execute_query_lint]
    P --> Q[resolve_local_uri config, uri, target, 'query lint']
    Q --> L

    style H fill:#f99,stroke:#c00
    style O fill:#f99,stroke:#c00
    style G fill:#ff9,stroke:#a80
    style Q fill:#ff9,stroke:#a80
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fomnigraph-cli%2Fsrc%2Fplanes.rs%3A104%0A**Inconsistent%20label%20for%20%60lint%60%20between%20the%20two%20error%20paths**%0A%0A%60command_label%60%20returns%20%60%22lint%22%60%20for%20%60Command%3A%3ALint%60%2C%20but%20%60execute_query_lint%60%20hardcodes%20%60%22query%20lint%22%60%20as%20the%20operation%20string%20passed%20to%20%60resolve_local_uri%60.%20This%20means%20the%20same%20subcommand%20produces%20two%20different%20names%20in%20its%20error%20messages%3A%20running%20%60lint%20--server%20prod%60%20fires%20the%20wrong-plane%20guard%20and%20emits%20%60%60%20%60lint%60%20is%20a%20storage-plane%20command%20%E2%80%A6%20%60%60%2C%20while%20running%20%60lint%20https%3A%2F%2Fremote.example.com%60%20passes%20the%20guard%20and%20emits%20%60%60%20%60query%20lint%60%20is%20a%20storage-plane%20command%20%E2%80%A6%20%60%60%20from%20%60resolve_local_graph%60.%20The%20existing%20pinned%20test%20in%20%60cli_data.rs%60%20asserts%20%60%22query%20lint%22%60%20for%20the%20second%20path%2C%20so%20both%20divergent%20forms%20are%20now%20locked%20in%20as%20observable%20behavior.%20Since%20%60command_label%60%20is%20documented%20as%20the%20single%20source%20of%20truth%20for%20user-facing%20labels%2C%20the%20fix%20is%20to%20align%20them%20%E2%80%94%20either%20change%20the%20label%20here%20to%20%60%22query%20lint%22%60%20to%20match%20the%20pre-existing%20operation%20string%2C%20or%20update%20%60execute_query_lint%60%20in%20%60helpers.rs%60%20to%20pass%20%60%22lint%22%60%20instead.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fomnigraph-cli%2Fsrc%2Fplanes.rs%3A1-10%0A**Doc%20update%20required%20by%20AGENTS.md%20maintenance%20contract%20%28rule%201%29**%0A%0AAGENTS.md%20rule%201%20requires%20updating%20%60docs%2Fuser%2F%60%20in%20the%20same%20PR%20for%20any%20user-visible%20behavior%20change%2C%20and%20the%20deny-list%20explicitly%20lists%20error-message%20text%20as%20observable%20behavior.%20This%20PR%20changes%20the%20error%20message%20emitted%20by%20%60resolve_local_graph%60%20for%20all%20storage-plane%20verbs%20and%20adds%20new%20wrong-plane%20rejection%20errors%20that%20users%20will%20encounter.%20Neither%20%60docs%2Fuser%2Fcli-reference.md%60%20nor%20%60docs%2Fuser%2Fmaintenance.md%60%20appears%20to%20be%20updated%20in%20this%20diff.%20The%20new%20error%20texts%20are%20now%20pinned%20by%20tests%2C%20so%20they%20are%20part%20of%20the%20public%20contract%3B%20the%20docs%20should%20reflect%20that%20contract.%0A%0A&repo=modernrelay%2Fomnigraph&pr=217&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(cli): storage-plane verbs fail loud..."](https://github.com/modernrelay/omnigraph/commit/4b1d4795561d1ee8274ddc15bfcce9be5c98aef5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37424699)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=59169be6-01cf-4bae-80fc-604b6a708098))

<!-- /greptile_comment -->