### PR TITLE
fix(cli): align lint plane label + document the plane model (RFC-010 follow-up)

### DIFF
--- a/crates/omnigraph-cli/src/helpers.rs
+++ b/crates/omnigraph-cli/src/helpers.rs
@@ -754,10 +754,10 @@ pub(crate) async fn execute_query_lint(
     let has_graph_target =
         cli_uri.is_some() || cli_target.is_some() || config.cli_graph_name().is_some();
     if !has_graph_target {
-        bail!("query lint requires --schema <schema.pg> or a resolvable graph target");
+        bail!("lint requires --schema <schema.pg> or a resolvable graph target");
     }
 
-    let uri = resolve_local_uri(config, cli_uri, cli_target, "query lint")?;
+    let uri = resolve_local_uri(config, cli_uri, cli_target, "lint")?;
     let db = Omnigraph::open(&uri).await?;
     Ok(lint_query_file(
         &db.catalog(),

--- a/crates/omnigraph-cli/tests/cli_data.rs
+++ b/crates/omnigraph-cli/tests/cli_data.rs
@@ -586,7 +586,7 @@ query list_people() {
     // RFC-010 Slice 1: the storage-plane verbs now share one declared message
     // (was: "query lint is only supported against local graph URIs …").
     assert!(
-        stderr.contains("`query lint` is a storage-plane command and needs direct storage access")
+        stderr.contains("`lint` is a storage-plane command and needs direct storage access")
             && stderr.contains("remote server"),
         "storage-plane remote-target message not found; got: {stderr}"
     );
@@ -615,7 +615,7 @@ query list_people() {
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("query lint requires --schema <schema.pg> or a resolvable graph target")
+        stderr.contains("lint requires --schema <schema.pg> or a resolvable graph target")
     );
 }
 

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -28,6 +28,21 @@ Top-level command families and subcommands. Graph-targeting commands accept a po
 | `policy validate \| test \| explain` | Cedar tooling. Selects `cli.graph`, else `server.graph`, else top-level `policy.file` |
 | `version` / `-v` | print `omnigraph 0.3.x` |
 
+## Command planes
+
+Every command lives on one **plane**, which determines how it reaches a graph and which addressing flags apply (RFC-010):
+
+- **Data plane** — `query`, `mutate`, `load`, `ingest`, `branch *`, `snapshot`, `export`, `commit *`, `schema show`, `schema apply` (and `graphs list`, remote-only today). Run against a graph **embedded or via a server**: accept a positional `URI` / `--target` / `--server` (+ `--graph` for multi-graph servers).
+- **Storage / maintenance plane** — `init`, `optimize`, `repair`, `cleanup`, `schema plan`, `queries validate`, `lint`. Run with **direct storage access** (`file://` / `s3://`), never through a server. They accept a positional `URI` or `--target`, but **not** `--server` / `--graph`, and a `--target` that resolves to a remote (`http(s)://`) server is rejected. (`init` takes only a positional `URI` today — no `--target`.)
+- **Control plane** — `cluster *`. Operates on a cluster directory via `--config <dir>`.
+
+These restrictions are enforced and reported, not silent:
+
+- A data-plane addressing flag on a non-data verb fails loudly, e.g.: ``optimize is a storage-plane command; --server/--graph address the data plane and do not apply. Use --target <name> or a storage URI.``
+- A storage-plane verb pointed at a remote target fails loudly, e.g.: ``optimize is a storage-plane command and needs direct storage access; the resolved target is a remote server (https://…). Pass the graph's file:// or s3:// URI.``
+
+To maintain a server-backed graph, run the maintenance verbs from a host with storage access against the graph's storage URI (or `--target`), out-of-band from the serving process — there are no server routes for `optimize` / `repair` / `cleanup` by design.
+
 ## Config surfaces
 
 Two config surfaces with single owners (RFC-007/RFC-008), plus a zero-config

--- a/docs/user/maintenance.md
+++ b/docs/user/maintenance.md
@@ -2,6 +2,8 @@
 
 `db/omnigraph/optimize.rs` and `db/omnigraph/repair.rs`.
 
+**Addressing (RFC-010).** `optimize`, `repair`, and `cleanup` are **storage-plane** CLI commands: they run with direct storage access against a positional `URI` or `--target`, never through a server, and reject `--server` / `--graph` or a `--target` that resolves to a remote (`http(s)://`) URL with a declared error. There are no server routes for them by design — to maintain a server-backed graph, run them out-of-band against the graph's storage URI. See the *Command planes* section of [cli-reference.md](cli-reference.md).
+
 ## `optimize_all_tables(db)` — non-destructive
 
 - Lance `compact_files()` on every node + edge table on `main`, then **publishes the compacted version to the `__manifest`** so the manifest's `table_version` tracks the compacted Lance HEAD. Reads pin the manifest version, so without this publish compaction would be invisible to readers *and* would break the HEAD-vs-manifest precondition of the next schema apply / strict update/delete ("stale view … refresh and retry"). The publish advances the graph version (a system-attributed commit) only for tables that actually compacted.


### PR DESCRIPTION
Addresses the **Greptile review on #217** (which merged before these could be folded in).

### P1 — `lint` reported two different names (correctness)
`command_label` returns `lint`, but `execute_query_lint` passed `"query lint"` to the resolver, so:
- `lint --server prod` → "`lint` is a storage-plane command…"
- `lint https://…` → "`query lint` is a storage-plane command…"

Both were pinned by tests. `query lint` is the **deprecated** alias (argv-rewritten to `lint`), so the canonical name is `lint`. Switched both user-facing strings in `execute_query_lint` (the storage-plane bail label and the requires-schema/target usage message) to `lint`, and updated the two pinned `cli_data.rs` assertions. `command_label` is now the consistent single source of truth.

### P2 — user-doc debt (AGENTS.md rule 1)
Error-message text is observable behavior (deny-list), and rule 1 requires `docs/user/` updates in the same change. Slice 1 (#217) shipped without them. This adds:
- A **Command planes** section to `cli-reference.md` — data vs storage/maintenance vs control, which addressing flags apply per plane, the declared wrong-plane / remote-target errors, and the "maintenance runs out-of-band, no server routes" note.
- An addressing note in `maintenance.md` cross-referencing it.

### Verification
Targeted suites green (`cli_data` 53, `cli_schema_config` 20); link check clean; full `cargo test --workspace --locked` → exit 0, zero failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an inconsistent command label in `execute_query_lint` — both user-facing error strings now use `"lint"` instead of `"query lint"`, matching `command_label()` as the single source of truth — and backfills the user-doc debt from #217 by adding a "Command planes" section to `cli-reference.md` and an addressing note to `maintenance.md`.

- **Label fix (`helpers.rs`)**: replaces `"query lint"` with `"lint"` in the `bail!` message and the `resolve_local_uri` call; two pinned assertions in `cli_data.rs` are updated to match.
- **Doc additions**: `cli-reference.md` gains a "Command planes" section covering data/storage/control plane definitions, accepted addressing flags, and the declared wrong-plane errors; `maintenance.md` adds a short cross-reference note.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the code change is a two-line label correction with existing test coverage, and the docs are well-structured. One example string in the new planes section is slightly off from actual terminal output.

The Rust change is minimal and the tests verify both corrected messages end-to-end. The only issue is that the error-message examples in the new docs section omit the literal backtick characters the code wraps around the command label — a small but concrete inaccuracy given the PR explicitly frames these messages as observable contract text.

docs/user/cli-reference.md — the two error-message examples in the "Command planes" section need the backtick characters around the command label to match what the code actually emits.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/omnigraph-cli/src/helpers.rs | Aligns both user-facing error strings in `execute_query_lint` from "query lint" to "lint", consistent with `command_label()` and `resolve_local_graph`'s format string. |
| crates/omnigraph-cli/tests/cli_data.rs | Updates two pinned assertions to match the corrected label; tests remain behaviorally equivalent and correct. |
| docs/user/cli-reference.md | Adds the "Command planes" section documenting data/storage/control planes; error-message examples omit the backtick characters the code emits around the command label. |
| docs/user/maintenance.md | Adds a short addressing note with a cross-reference to `cli-reference.md`; content is accurate and link is valid. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[omnigraph lint / query lint argv] --> B{guard_addressing}
    B -->|--server or --graph passed| C[bail: lint is a storage-plane command\n--server/--graph do not apply]
    B -->|no data-plane flags| D[execute_query_lint]
    D -->|--schema provided| E[lint_query_file\nfrom schema file]
    D -->|no --schema| F{has graph target?}
    F -->|no| G[bail: lint requires --schema\nor a resolvable graph target]
    F -->|yes| H[resolve_local_uri\noperation = lint]
    H -->|target is remote http://| I[bail: lint is a storage-plane command\nneeds direct storage access]
    H -->|local file:// or s3://| J[Omnigraph::open\nlint_query_file from graph catalog]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fuser%2Fcli-reference.md%3A41-42%0AThe%20error-message%20examples%20omit%20the%20backtick%20characters%20that%20the%20code%20actually%20emits%20around%20the%20command%20label.%20Both%20error-generation%20sites%20wrap%20the%20label%20in%20backticks%3A%20%60resolve_local_graph%60%20in%20%60helpers.rs%60%20uses%20%60%60%20%22%60%7B%7D%60%20is%20a%20storage-plane%20command...%22%20%60%60%20and%20%60guard_addressing%60%20in%20%60planes.rs%60%20uses%20%60%60%20%22%60%7Blabel%7D%60%20is%20a%20%7Bplane%7D-plane%20command...%22%20%60%60.%20A%20user%20diffing%20their%20actual%20terminal%20output%20against%20these%20examples%20would%20see%20%60%60%20%60optimize%60%20is%20a%20%E2%80%A6%20%60%60%20in%20practice%2C%20not%20%60optimize%20is%20a%20%E2%80%A6%60.%20Given%20the%20PR%20explicitly%20invokes%20the%20deny-list%20rule%20that%20error-message%20text%20is%20observable%20behavior%2C%20the%20documented%20examples%20should%20match%20what%20the%20code%20emits%20verbatim.%0A%0A%60%60%60suggestion%0A-%20A%20data-plane%20addressing%20flag%20on%20a%20non-data%20verb%20fails%20loudly%2C%20e.g.%3A%20%60%60%20%60optimize%60%20is%20a%20storage-plane%20command%3B%20--server%2F--graph%20address%20the%20data%20plane%20and%20do%20not%20apply.%20Use%20--target%20%3Cname%3E%20or%20a%20storage%20URI.%20%60%60%0A-%20A%20storage-plane%20verb%20pointed%20at%20a%20remote%20target%20fails%20loudly%2C%20e.g.%3A%20%60%60%20%60optimize%60%20is%20a%20storage-plane%20command%20and%20needs%20direct%20storage%20access%3B%20the%20resolved%20target%20is%20a%20remote%20server%20%28https%3A%2F%2F%E2%80%A6%29.%20Pass%20the%20graph's%20file%3A%2F%2F%20or%20s3%3A%2F%2F%20URI.%20%60%60%0A%60%60%60%0A%0A&repo=modernrelay%2Fomnigraph&pr=218&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): align lint plane label + docum..."](https://github.com/modernrelay/omnigraph/commit/565c0118171ebf01c77c105b0ca56a7324882e40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37428275)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=59169be6-01cf-4bae-80fc-604b6a708098))

<!-- /greptile_comment -->