### PR TITLE
feat(cli): plane-grouped --help + clap 4.6.1 (RFC-010 Slice 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -104,9 +104,9 @@ checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -1314,9 +1314,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.58"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63be97961acde393029492ce0be7a1af7e323e6bae9511ebfac33751be5e6806"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1324,9 +1324,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.58"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f13174bda5dfd69d7e947827e5af4b0f2f94a4a3ee92912fba07a66150f21e2"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1336,9 +1336,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -5323,9 +5323,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ pest = "2"
 pest_derive = "2"
 thiserror = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "net", "signal", "sync"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/crates/omnigraph-cli/src/cli.rs
+++ b/crates/omnigraph-cli/src/cli.rs
@@ -15,9 +15,9 @@ pub(crate) const DEFAULT_BEARER_TOKEN_ENV: &str = "OMNIGRAPH_BEARER_TOKEN";
 #[command(after_help = "\
 COMMANDS BY PLANE:\n  \
 Data — run against a graph, embedded or via --server (query, mutate, load, \
-branch, snapshot, export, commit, schema, graphs).\n  \
+branch, snapshot, export, commit, schema [plan: storage], graphs).\n  \
 Storage — direct storage or local files; reject --server (init, optimize, \
-repair, cleanup, lint, queries).\n  \
+repair, cleanup, lint, queries [list: session]).\n  \
 Control — manage a cluster directory via --config (cluster).\n  \
 Session — no graph; local config & tooling (policy, embed, login, logout, \
 config, version).\n\

--- a/crates/omnigraph-cli/src/cli.rs
+++ b/crates/omnigraph-cli/src/cli.rs
@@ -9,15 +9,24 @@ pub(crate) const DEFAULT_BEARER_TOKEN_ENV: &str = "OMNIGRAPH_BEARER_TOKEN";
 #[command(name = "omnigraph")]
 #[command(about = "Omnigraph graph database CLI")]
 #[command(version = env!("CARGO_PKG_VERSION"), disable_version_flag = true)]
+// Subcommands are listed grouped by plane (clap renders them in declaration
+// order). clap can't print labeled headings between subcommand groups, so this
+// legend names the planes; the grouping is the variant order in `Command`.
+#[command(after_help = "\
+COMMANDS BY PLANE:\n  \
+Data — run against a graph, embedded or via --server (query, mutate, load, \
+branch, snapshot, export, commit, schema, graphs).\n  \
+Storage — direct storage or local files; reject --server (init, optimize, \
+repair, cleanup, lint, queries).\n  \
+Control — manage a cluster directory via --config (cluster).\n  \
+Session — no graph; local config & tooling (policy, embed, login, logout, \
+config, version).\n\
+See the 'Command planes' section of the CLI reference for which flags apply where.")]
 pub(crate) struct Cli {
-    /// Actor identity for direct-engine writes (MR-722). Overrides
-    /// `cli.actor` from `omnigraph.yaml`. When the configured policy
-    /// is in effect, Cedar evaluates this actor against the requested
-    /// action and scope; with policy configured but neither this flag
-    /// nor `cli.actor` set, the engine-layer footgun guard fires and
-    /// the write is denied (no silent bypass). Has no effect on remote
-    /// HTTP writes — those resolve their actor server-side from the
-    /// bearer token.
+    /// Actor id for direct-engine writes; overrides `cli.actor`. No effect on
+    /// remote writes (the server resolves the actor from the bearer token).
+    /// With a policy configured but no actor set, the write is denied — see
+    /// docs/user/policy.md.
     #[arg(long = "as", global = true, value_name = "ACTOR")]
     pub(crate) as_actor: Option<String>,
 
@@ -38,170 +47,7 @@ pub(crate) struct Cli {
 
 #[derive(Debug, Subcommand)]
 pub(crate) enum Command {
-    /// Print the CLI version
-    Version,
-    /// Store a bearer token for a named server in ~/.omnigraph/credentials
-    /// (0600). Token from --token or one line on stdin:
-    /// `echo $TOKEN | omnigraph login prod`. The keyed token applies to
-    /// requests whose URL matches the server's `url` in the operator
-    /// config's `servers:` map.
-    Login {
-        /// Server name (keys the credential; declare its url under
-        /// `servers:` in ~/.omnigraph/config.yaml)
-        name: String,
-        /// The token. Prefer piping via stdin over this flag (shell
-        /// history).
-        #[arg(long)]
-        token: Option<String>,
-        #[arg(long)]
-        json: bool,
-    },
-    /// Legacy-config tooling (RFC-008): split omnigraph.yaml into its
-    /// two destinations.
-    Config {
-        #[command(subcommand)]
-        command: ConfigCommand,
-    },
-    /// Remove a named server's stored credential. Idempotent.
-    Logout {
-        name: String,
-        #[arg(long)]
-        json: bool,
-    },
-    /// Generate, clean, or refresh explicit seed embeddings
-    Embed(EmbedArgs),
-    /// Initialize a new graph from a schema
-    Init {
-        #[arg(long)]
-        schema: PathBuf,
-        /// Graph URI (local path or s3://)
-        uri: String,
-        /// Overwrite existing schema artifacts at the URI. Without
-        /// this flag, init refuses to touch a URI that already holds
-        /// `_schema.pg`, `_schema.ir.json`, or `__schema_state.json`
-        /// — closes the re-init footgun (MR-668 follow-up). With the
-        /// flag, the operator opts in to destructive semantics.
-        #[arg(long)]
-        force: bool,
-    },
-    /// Load data into a graph (local or remote)
-    Load {
-        /// Graph URI
-        uri: Option<String>,
-        #[arg(long)]
-        target: Option<String>,
-        #[arg(long)]
-        config: Option<PathBuf>,
-        #[arg(long)]
-        data: PathBuf,
-        /// Target branch (defaults to main). Without --from it must exist.
-        #[arg(long)]
-        branch: Option<String>,
-        /// Base branch to fork --branch from when it doesn't exist yet.
-        /// Without this flag a missing branch is an error, never a fork.
-        #[arg(long)]
-        from: Option<String>,
-        /// How existing rows are handled: overwrite | append | merge.
-        /// Required — overwrite is destructive, so there is no default.
-        #[arg(long)]
-        mode: CliLoadMode,
-        #[arg(long)]
-        json: bool,
-    },
-    /// Deprecated alias of `load --from <base>` (defaults: --mode merge, --from main)
-    Ingest {
-        /// Graph URI
-        uri: Option<String>,
-        #[arg(long)]
-        target: Option<String>,
-        #[arg(long)]
-        config: Option<PathBuf>,
-        #[arg(long)]
-        data: PathBuf,
-        #[arg(long)]
-        branch: Option<String>,
-        #[arg(long)]
-        from: Option<String>,
-        #[arg(long, default_value = "merge")]
-        mode: CliLoadMode,
-        #[arg(long)]
-        json: bool,
-    },
-    /// Branch operations
-    Branch {
-        #[command(subcommand)]
-        command: BranchCommand,
-    },
-    /// Schema planning operations
-    Schema {
-        #[command(subcommand)]
-        command: SchemaCommand,
-    },
-    /// Validate queries against a schema (offline) or repo (repo-backed).
-    ///
-    /// Canonical name is `lint` (matches the `omnigraph_compiler::lint`
-    /// module and the `OG-XXX-NNN` lint-code vocabulary). Replaces the
-    /// deprecated `omnigraph query lint` / `omnigraph query check` /
-    /// `omnigraph check` invocations — each is kept as an argv-level
-    /// shim that prints a one-line stderr warning and rewrites to
-    /// `omnigraph lint`. Aliases are deliberately *not* exposed via
-    /// clap's `visible_alias` because that would advertise two
-    /// equivalent canonical names, which agents emit interchangeably
-    /// (see MR-981).
-    Lint {
-        /// Graph URI
-        uri: Option<String>,
-        #[arg(long)]
-        target: Option<String>,
-        #[arg(long)]
-        config: Option<PathBuf>,
-        #[arg(long)]
-        query: PathBuf,
-        #[arg(long)]
-        schema: Option<PathBuf>,
-        #[arg(long)]
-        json: bool,
-    },
-    /// Operate on the server-side stored-query registry (`queries:`).
-    Queries {
-        #[command(subcommand)]
-        command: QueriesCommand,
-    },
-    /// Show graph snapshot
-    Snapshot {
-        /// Graph URI
-        uri: Option<String>,
-        #[arg(long)]
-        target: Option<String>,
-        #[arg(long)]
-        config: Option<PathBuf>,
-        #[arg(long)]
-        branch: Option<String>,
-        #[arg(long)]
-        json: bool,
-    },
-    /// Export a full graph snapshot as JSONL
-    Export {
-        /// Graph URI
-        uri: Option<String>,
-        #[arg(long)]
-        target: Option<String>,
-        #[arg(long)]
-        config: Option<PathBuf>,
-        #[arg(long)]
-        branch: Option<String>,
-        #[arg(long, hide = true)]
-        jsonl: bool,
-        #[arg(long = "type")]
-        type_names: Vec<String>,
-        #[arg(long = "table")]
-        table_keys: Vec<String>,
-    },
-    /// Commit history operations
-    Commit {
-        #[command(subcommand)]
-        command: CommitCommand,
-    },
+    // ── Data plane ── run against a graph (embedded or via --server).
     /// Execute a read query against a branch or snapshot.
     ///
     /// Canonical read endpoint. The previous name `omnigraph read` is
@@ -274,10 +120,115 @@ pub(crate) enum Command {
         #[arg()]
         alias_args: Vec<String>,
     },
-    /// Policy administration and diagnostics
-    Policy {
+    /// Load data into a graph (local or remote)
+    Load {
+        /// Graph URI
+        uri: Option<String>,
+        #[arg(long)]
+        target: Option<String>,
+        #[arg(long)]
+        config: Option<PathBuf>,
+        #[arg(long)]
+        data: PathBuf,
+        /// Target branch (defaults to main). Without --from it must exist.
+        #[arg(long)]
+        branch: Option<String>,
+        /// Base branch to fork --branch from when it doesn't exist yet.
+        /// Without this flag a missing branch is an error, never a fork.
+        #[arg(long)]
+        from: Option<String>,
+        /// How existing rows are handled: overwrite | append | merge.
+        /// Required — overwrite is destructive, so there is no default.
+        #[arg(long)]
+        mode: CliLoadMode,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Deprecated alias of `load --from <base>` (defaults: --mode merge, --from main)
+    #[command(hide = true)]
+    Ingest {
+        /// Graph URI
+        uri: Option<String>,
+        #[arg(long)]
+        target: Option<String>,
+        #[arg(long)]
+        config: Option<PathBuf>,
+        #[arg(long)]
+        data: PathBuf,
+        #[arg(long)]
+        branch: Option<String>,
+        #[arg(long)]
+        from: Option<String>,
+        #[arg(long, default_value = "merge")]
+        mode: CliLoadMode,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Branch operations
+    Branch {
         #[command(subcommand)]
-        command: PolicyCommand,
+        command: BranchCommand,
+    },
+    /// Show graph snapshot
+    Snapshot {
+        /// Graph URI
+        uri: Option<String>,
+        #[arg(long)]
+        target: Option<String>,
+        #[arg(long)]
+        config: Option<PathBuf>,
+        #[arg(long)]
+        branch: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Export a full graph snapshot as JSONL
+    Export {
+        /// Graph URI
+        uri: Option<String>,
+        #[arg(long)]
+        target: Option<String>,
+        #[arg(long)]
+        config: Option<PathBuf>,
+        #[arg(long)]
+        branch: Option<String>,
+        #[arg(long, hide = true)]
+        jsonl: bool,
+        #[arg(long = "type")]
+        type_names: Vec<String>,
+        #[arg(long = "table")]
+        table_keys: Vec<String>,
+    },
+    /// Commit history operations
+    Commit {
+        #[command(subcommand)]
+        command: CommitCommand,
+    },
+    /// Schema planning operations
+    Schema {
+        #[command(subcommand)]
+        command: SchemaCommand,
+    },
+    /// Manage graphs on a multi-graph server (MR-668)
+    Graphs {
+        #[command(subcommand)]
+        command: GraphsCommand,
+    },
+
+    // ── Storage / local graph ops ── direct storage or local files; reject --server.
+    /// Initialize a new graph from a schema
+    Init {
+        #[arg(long)]
+        schema: PathBuf,
+        /// Graph URI (local path or s3://)
+        uri: String,
+        /// Overwrite existing schema artifacts at the URI. Without
+        /// this flag, init refuses to touch a URI that already holds
+        /// `_schema.pg`, `_schema.ir.json`, or `__schema_state.json`
+        /// — closes the re-init footgun (MR-668 follow-up). With the
+        /// flag, the operator opts in to destructive semantics.
+        #[arg(long)]
+        force: bool,
     },
     /// Compact small Lance fragments in every table of the graph
     Optimize {
@@ -331,16 +282,79 @@ pub(crate) enum Command {
         #[arg(long)]
         json: bool,
     },
+    /// Validate queries against a schema (offline) or repo (repo-backed).
+    ///
+    /// Canonical name is `lint` (matches the `omnigraph_compiler::lint`
+    /// module and the `OG-XXX-NNN` lint-code vocabulary). Replaces the
+    /// deprecated `omnigraph query lint` / `omnigraph query check` /
+    /// `omnigraph check` invocations — each is kept as an argv-level
+    /// shim that prints a one-line stderr warning and rewrites to
+    /// `omnigraph lint`. Aliases are deliberately *not* exposed via
+    /// clap's `visible_alias` because that would advertise two
+    /// equivalent canonical names, which agents emit interchangeably
+    /// (see MR-981).
+    Lint {
+        /// Graph URI
+        uri: Option<String>,
+        #[arg(long)]
+        target: Option<String>,
+        #[arg(long)]
+        config: Option<PathBuf>,
+        #[arg(long)]
+        query: PathBuf,
+        #[arg(long)]
+        schema: Option<PathBuf>,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Operate on the server-side stored-query registry (`queries:`).
+    Queries {
+        #[command(subcommand)]
+        command: QueriesCommand,
+    },
+
+    // ── Control plane ── manage a cluster directory (--config <dir>).
     /// Validate and plan read-only cluster configuration.
     Cluster {
         #[command(subcommand)]
         command: ClusterCommand,
     },
-    /// Manage graphs on a multi-graph server (MR-668)
-    Graphs {
+
+    // ── Session / config ── no graph addressing; local tooling.
+    /// Policy administration and diagnostics
+    Policy {
         #[command(subcommand)]
-        command: GraphsCommand,
+        command: PolicyCommand,
     },
+    /// Generate, clean, or refresh explicit seed embeddings
+    Embed(EmbedArgs),
+    /// Store a bearer token for a named server (0600 credentials file). Token
+    /// via --token or piped on stdin; see the CLI reference for token resolution.
+    Login {
+        /// Server name (keys the credential; declare its url under
+        /// `servers:` in ~/.omnigraph/config.yaml)
+        name: String,
+        /// The token. Prefer piping via stdin over this flag (shell
+        /// history).
+        #[arg(long)]
+        token: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Remove a named server's stored credential. Idempotent.
+    Logout {
+        name: String,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Legacy-config tooling (RFC-008): split omnigraph.yaml into its
+    /// two destinations.
+    Config {
+        #[command(subcommand)]
+        command: ConfigCommand,
+    },
+    /// Print the CLI version
+    Version,
 }
 
 #[derive(Debug, Subcommand)]

--- a/crates/omnigraph-cli/tests/cli_schema_config.rs
+++ b/crates/omnigraph-cli/tests/cli_schema_config.rs
@@ -25,6 +25,38 @@ fn version_command_prints_current_cli_version() {
 }
 
 #[test]
+fn help_groups_commands_by_plane() {
+    // RFC-010 Slice 2: `--help` clusters commands by plane (declaration order
+    // in the Command enum) and explains the planes in an after_help legend.
+    // Pinned lightly — the legend phrase + the cluster ordering — to avoid
+    // brittle full-text assertions on clap's help body.
+    let output = output_success(cli().arg("--help"));
+    let stdout = stdout_string(&output);
+
+    assert!(
+        stdout.contains("COMMANDS BY PLANE"),
+        "plane legend (after_help) missing from --help:\n{stdout}"
+    );
+
+    // The Commands list precedes the legend, so first occurrences sit in the
+    // list and must appear in plane order: a data verb, then a storage verb,
+    // then the control verb.
+    let pos = |needle: &str| {
+        stdout
+            .find(needle)
+            .unwrap_or_else(|| panic!("'{needle}' not found in --help:\n{stdout}"))
+    };
+    assert!(
+        pos("query") < pos("optimize"),
+        "data commands should be listed before storage commands"
+    );
+    assert!(
+        pos("optimize") < pos("cluster"),
+        "storage commands should be listed before the control command"
+    );
+}
+
+#[test]
 fn init_creates_graph_successfully_on_missing_local_directory() {
     let temp = tempdir().unwrap();
     let graph = graph_path(temp.path());

--- a/docs/user/cli-reference.md
+++ b/docs/user/cli-reference.md
@@ -43,6 +43,8 @@ These restrictions are enforced and reported, not silent:
 
 To maintain a server-backed graph, run the maintenance verbs from a host with storage access against the graph's storage URI (or `--target`), out-of-band from the serving process — there are no server routes for `optimize` / `repair` / `cleanup` by design.
 
+`omnigraph --help` lists commands **clustered by plane** (data → storage → control → session) with a plane legend at the bottom.
+
 ## Config surfaces
 
 Two config surfaces with single owners (RFC-007/RFC-008), plus a zero-config


### PR DESCRIPTION
Makes the planes RFC-010 Slice 1 declared **visible in `--help`**, and bumps clap to latest. Two commits.

## `chore(deps): bump clap to 4.6.1`
Workspace constraint `"4"` → `"4.6"` so the resolver picks up the 4.6 line. Minor bump, no API breakage; builds + all CLI suites pass.

## `feat(cli): group --help by plane`
clap can't print labeled heading rows between subcommand groups (verified against source — `help_heading` is args-only, `{subcommands}` is one flat block), so per the chosen **Option A**: cluster + legend.

- **Reorder the `Command` enum into plane bands** — clap lists subcommands in declaration order, so source order = help order (no magic `display_order` numbers; band comments for readers): data → storage/local-graph ops → control → session. Band placement matches `command_plane` (`lint`/`queries` are storage-plane — they reject `--server`), so the help grouping and the Slice-1 guard agree.
- **`after_help` legend** on `Cli` naming the planes (describes planes, not every command, so it doesn't drift).
- **Help polish:** hide the deprecated `ingest` from the list (still valid); trim the long `login`/`--as` descriptions to one line so columns don't blow up.

The behavioral source of truth for planes stays `planes::command_plane`; this ordering is its cosmetic counterpart — no second classification table.

### `--help` now reads
```
Commands:
  query mutate load branch snapshot export commit schema graphs   (data)
  init optimize repair cleanup lint queries                       (storage)
  cluster                                                          (control)
  policy embed login logout config version                        (session)
...
COMMANDS BY PLANE:  <legend>
```

### Known limitation (Option A)
The clusters are **unlabeled** in the list and the legend sits below `Options:` — clap can't put header rows between subcommands. Real in-list headers would need a custom help renderer (Option B), deliberately not taken here.

## Verification
`help_groups_commands_by_plane` pins the legend + cluster order; `cli_data`/`cli_schema_config`/`parity_matrix` green; full `cargo test --workspace --locked` → exit 0. Doc updated in `cli-reference.md` (same PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Reorders the `Command` enum into plane-banded declaration order so `--help` clusters commands by plane (data → storage → control → session), adds an `after_help` legend naming each plane, and bumps clap from 4.5 to 4.6.1. No behavioral changes: `command_plane` and `guard_addressing` in `planes.rs` are untouched.

- **Enum reorder + band comments** replace the old alphabetical/feature ordering; clap renders subcommands in declaration order, so source order _is_ help order with no `display_order` magic.
- **`after_help` legend** calls out mixed-plane commands (`schema [plan: storage]`, `queries [list: session]`) so the legend agrees with the runtime enforcement in `command_plane`.
- **Deprecation cleanup**: `ingest` gains `#[command(hide = true)]`; the `--as` flag doc trims to one line and links to `docs/user/policy.md`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are limited to help text presentation and a minor clap version bump with no behavioral impact.

The Command enum reorder is cosmetic: clap uses declaration order for display only, and command_plane / guard_addressing in planes.rs are unchanged, so runtime plane enforcement is unaffected. The after_help legend accurately reflects the mixed-plane commands. The clap 4.5 to 4.6 bump is a minor version with no API breakage; the transitive anstream/anstyle-parse major bumps are expected for this clap line.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/omnigraph-cli/src/cli.rs | Command enum reordered into four plane bands with band comments; after_help legend added; ingest hidden; --as doc trimmed. No logic changes. |
| crates/omnigraph-cli/tests/cli_schema_config.rs | New test pins after_help presence and data to storage to control ordering; lightly anchored by design per the PR description. |
| docs/user/cli-reference.md | Adds one sentence announcing clustered help. The Command planes section still lacks a Session-plane bullet (already flagged in a prior review). |
| Cargo.toml | Workspace clap constraint narrowed from 4 to 4.6 to pick up the 4.6 line; minor bump, no API breakage. |
| Cargo.lock | clap 4.5.58 to 4.6.1; transitive anstream 0.6 to 1.0 and anstyle-parse 0.2 to 1.0 (major bumps expected for this clap line). Lock is consistent with the Cargo.toml change. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    CLI["omnigraph --help"] --> DATA["Data plane\nquery, mutate, load, branch,\nsnapshot, export, commit,\nschema show/apply, graphs"]
    CLI --> STORAGE["Storage plane\ninit, optimize, repair,\ncleanup, lint, schema plan,\nqueries validate"]
    CLI --> CONTROL["Control plane\ncluster *"]
    CLI --> SESSION["Session plane\npolicy, embed, login,\nlogout, config, version"]
    DATA -->|"--server/--graph or URI/--target"| GC["GraphClient (embedded or remote)"]
    STORAGE -->|"URI/--target, no --server"| SD["Direct storage (file:// or s3://)"]
    CONTROL -->|"--config dir"| CD["Cluster directory"]
    SESSION -->|"no graph addressing"| LC["Local config and tooling"]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `docs/user/cli-reference.md`, line 31-46 ([link](https://github.com/modernrelay/omnigraph/blob/96335d1d7f79e8d9a4bea77db253c26afdea00e3/docs/user/cli-reference.md#L31-L46)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Session plane undocumented in the section the `after_help` sends users to**

   The `after_help` closes with "See the 'Command planes' section of the CLI reference for which flags apply where." That section currently has bullets only for Data, Storage/maintenance, and Control — Session plane (`policy`, `embed`, `login`, `logout`, `config`, `version`) is not described there. A user following the reference looking for Session-plane behavior will find nothing. A fourth bullet describing Session-plane commands and their characteristic (no graph addressing; local config only) is missing.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20docs%2Fuser%2Fcli-reference.md%0ALine%3A%2031-46%0A%0AComment%3A%0A**Session%20plane%20undocumented%20in%20the%20section%20the%20%60after_help%60%20sends%20users%20to**%0A%0AThe%20%60after_help%60%20closes%20with%20%22See%20the%20'Command%20planes'%20section%20of%20the%20CLI%20reference%20for%20which%20flags%20apply%20where.%22%20That%20section%20currently%20has%20bullets%20only%20for%20Data%2C%20Storage%2Fmaintenance%2C%20and%20Control%20%E2%80%94%20Session%20plane%20%28%60policy%60%2C%20%60embed%60%2C%20%60login%60%2C%20%60logout%60%2C%20%60config%60%2C%20%60version%60%29%20is%20not%20described%20there.%20A%20user%20following%20the%20reference%20looking%20for%20Session-plane%20behavior%20will%20find%20nothing.%20A%20fourth%20bullet%20describing%20Session-plane%20commands%20and%20their%20characteristic%20%28no%20graph%20addressing%3B%20local%20config%20only%29%20is%20missing.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modernrelay%2Fomnigraph&pr=220&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["feat(cli): qualify mixed-plane commands ..."](https://github.com/modernrelay/omnigraph/commit/203e419edc0483be0538244e1ad71db5fcca17fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37437661)</sub>

<!-- /greptile_comment -->