### PR TITLE
feat: canonical POST /load, deprecate /ingest (RFC-009 Phase 5)

### DIFF
--- a/crates/omnigraph-cli/src/client.rs
+++ b/crates/omnigraph-cli/src/client.rs
@@ -304,10 +304,13 @@ impl GraphClient {
                 token,
             } => {
                 let data = std::fs::read_to_string(data)?;
+                // RFC-009 Phase 5: the canonical `load` verb targets the
+                // canonical `/load` route (the deprecated `ingest` verb below
+                // still rides `/ingest`).
                 let output = remote_json::<IngestOutput>(
                     http,
                     Method::POST,
-                    remote_url(base_url, "/ingest"),
+                    remote_url(base_url, "/load"),
                     Some(serde_json::to_value(IngestRequest {
                         branch: Some(branch.to_string()),
                         from: from.map(ToOwned::to_owned),

--- a/crates/omnigraph-cli/tests/parity_matrix.rs
+++ b/crates/omnigraph-cli/tests/parity_matrix.rs
@@ -265,9 +265,9 @@ fn parity_errors_share_exit_codes() {
 //
 // - `graphs list`: server-only today; becomes Both-capability when the
 //   embedded arm enumerates the cluster catalog (RFC-009 open Q3, answered).
-// - `ingest`: deprecated alias of load; the remote `load` arm itself rides
-//   the deprecated /ingest route today (RFC-009 Phase 5 flips it to /load —
-//   this matrix's `parity_load` row is where that flip becomes visible).
+// - `ingest`: deprecated alias of load; its remote arm rides the deprecated
+//   /ingest route. The canonical `load` verb targets `/load` (RFC-009 Phase 5,
+//   landed) — `parity_load` exercises it on the remote arm.
 // - `init`, `optimize`, `repair`, `cleanup`, `cluster *`: storage-plane by
 //   design (must work with the server down); Phase 4 declares this.
 #[allow(dead_code)]

--- a/crates/omnigraph-server/src/handlers.rs
+++ b/crates/omnigraph-server/src/handlers.rs
@@ -1183,46 +1183,22 @@ pub(crate) async fn server_schema_apply(
     Ok(Json(schema_apply_output(handle.uri.as_str(), result)))
 }
 
-#[utoipa::path(
-    post,
-    path = "/ingest",
-    tag = "mutations",
-    operation_id = "ingest",
-    request_body = IngestRequest,
-    responses(
-        (status = 200, description = "Ingest results", body = IngestOutput),
-        (status = 400, description = "Bad request", body = ErrorOutput),
-        (status = 401, description = "Unauthorized", body = ErrorOutput),
-        (status = 403, description = "Forbidden", body = ErrorOutput),
-        (status = 429, description = "Per-actor admission cap exceeded; honor `Retry-After` header", body = ErrorOutput),
-    ),
-    security(("bearer_token" = [])),
-)]
-/// Bulk-load NDJSON data into a branch.
-///
-/// `data` is NDJSON with one record per line. `mode` controls behavior on
-/// existing rows: `merge` upserts by id (default), `append` blindly inserts,
-/// `overwrite` replaces table contents. Branch creation is opt-in by
-/// presence of `from`: with `from` set, a missing `branch` is created from
-/// it; without `from`, `branch` must already exist — a missing branch is a
-/// 404, never an implicit fork. **Destructive** when `mode` is `overwrite`
-/// or when the load produces conflicting writes.
-pub(crate) async fn server_ingest(
-    State(state): State<AppState>,
-    Extension(handle): Extension<Arc<GraphHandle>>,
-    actor: Option<Extension<ResolvedActor>>,
-    Json(request): Json<IngestRequest>,
-) -> std::result::Result<Json<IngestOutput>, ApiError> {
+/// Shared body for `POST /load` (canonical) and `POST /ingest` (deprecated):
+/// branch-exists / fork-if-`from` check, Cedar authorization, admission, the
+/// bulk `load_as`, and the `IngestOutput` mapping.
+async fn run_ingest(
+    state: AppState,
+    handle: Arc<GraphHandle>,
+    actor: Option<&ResolvedActor>,
+    request: IngestRequest,
+) -> std::result::Result<IngestOutput, ApiError> {
     let branch = request.branch.unwrap_or_else(|| "main".to_string());
     let from = request.from;
     let mode = request.mode.unwrap_or(omnigraph::loader::LoadMode::Merge);
     let actor_arc = actor
-        .as_ref()
-        .map(|Extension(actor)| Arc::clone(&actor.actor_id))
+        .map(|actor| Arc::clone(&actor.actor_id))
         .unwrap_or_else(|| Arc::<str>::from("anonymous"));
-    let actor_id = actor
-        .as_ref()
-        .map(|Extension(actor)| actor.actor_id.as_ref());
+    let actor_id = actor.map(|actor| actor.actor_id.as_ref());
 
     let branch_exists = {
         let db = &handle.engine;
@@ -1244,7 +1220,7 @@ pub(crate) async fn server_ingest(
                 )));
             }
             Some(from) => authorize_request(
-                actor.as_ref().map(|Extension(actor)| actor),
+                actor,
                 handle.policy.as_deref(),
                 PolicyRequest {
                     action: PolicyAction::BranchCreate,
@@ -1255,7 +1231,7 @@ pub(crate) async fn server_ingest(
         }
     }
     authorize_request(
-        actor.as_ref().map(|Extension(actor)| actor),
+        actor,
         handle.policy.as_deref(),
         PolicyRequest {
             action: PolicyAction::Change,
@@ -1276,12 +1252,98 @@ pub(crate) async fn server_ingest(
             .map_err(ApiError::from_omni)?
     };
 
-    Ok(Json(ingest_output(
+    Ok(ingest_output(
         handle.uri.as_str(),
         &result,
         mode,
         actor_id.map(str::to_string),
-    )))
+    ))
+}
+
+#[utoipa::path(
+    post,
+    path = "/load",
+    tag = "mutations",
+    operation_id = "load",
+    request_body = IngestRequest,
+    responses(
+        (status = 200, description = "Load results", body = IngestOutput),
+        (status = 400, description = "Bad request", body = ErrorOutput),
+        (status = 401, description = "Unauthorized", body = ErrorOutput),
+        (status = 403, description = "Forbidden", body = ErrorOutput),
+        (status = 429, description = "Per-actor admission cap exceeded; honor `Retry-After` header", body = ErrorOutput),
+    ),
+    security(("bearer_token" = [])),
+)]
+/// Bulk-load NDJSON data into a branch (canonical load endpoint).
+///
+/// `data` is NDJSON with one record per line. `mode` controls behavior on
+/// existing rows: `merge` upserts by id (default), `append` blindly inserts,
+/// `overwrite` replaces table contents. Branch creation is opt-in by
+/// presence of `from`: with `from` set, a missing `branch` is created from
+/// it; without `from`, `branch` must already exist — a missing branch is a
+/// 404, never an implicit fork. **Destructive** when `mode` is `overwrite`
+/// or when the load produces conflicting writes.
+///
+/// The legacy `POST /ingest` route has identical semantics and is kept as a
+/// deprecated alias.
+pub(crate) async fn server_load(
+    State(state): State<AppState>,
+    Extension(handle): Extension<Arc<GraphHandle>>,
+    actor: Option<Extension<ResolvedActor>>,
+    Json(request): Json<IngestRequest>,
+) -> std::result::Result<Json<IngestOutput>, ApiError> {
+    Ok(Json(
+        run_ingest(
+            state,
+            handle,
+            actor.as_ref().map(|Extension(actor)| actor),
+            request,
+        )
+        .await?,
+    ))
+}
+
+#[utoipa::path(
+    post,
+    path = "/ingest",
+    tag = "mutations",
+    operation_id = "ingest",
+    request_body = IngestRequest,
+    responses(
+        (status = 200, description = "Load results (response includes `Deprecation: true` + `Link: </load>; rel=\"successor-version\"`)", body = IngestOutput),
+        (status = 400, description = "Bad request", body = ErrorOutput),
+        (status = 401, description = "Unauthorized", body = ErrorOutput),
+        (status = 403, description = "Forbidden", body = ErrorOutput),
+        (status = 429, description = "Per-actor admission cap exceeded; honor `Retry-After` header", body = ErrorOutput),
+    ),
+    security(("bearer_token" = [])),
+)]
+#[deprecated(note = "use POST /load instead; /ingest is kept indefinitely for back-compat")]
+/// **Deprecated** — use [`POST /load`](#tag/mutations/operation/load) instead.
+///
+/// Bulk-load NDJSON data into a branch. Behavior is unchanged; the route is
+/// kept indefinitely for back-compat. New integrations should target
+/// `POST /load`, which has identical semantics. Responses from this route
+/// include `Deprecation: true` and `Link: </load>; rel="successor-version"`
+/// headers per RFC 9745 / RFC 8288 so SDKs and proxies can surface the signal.
+pub(crate) async fn server_ingest(
+    State(state): State<AppState>,
+    Extension(handle): Extension<Arc<GraphHandle>>,
+    actor: Option<Extension<ResolvedActor>>,
+    Json(request): Json<IngestRequest>,
+) -> std::result::Result<([(HeaderName, HeaderValue); 2], Json<IngestOutput>), ApiError> {
+    let output = run_ingest(
+        state,
+        handle,
+        actor.as_ref().map(|Extension(actor)| actor),
+        request,
+    )
+    .await?;
+    Ok((
+        deprecation_headers("</load>; rel=\"successor-version\""),
+        Json(output),
+    ))
 }
 
 #[utoipa::path(

--- a/crates/omnigraph-server/src/lib.rs
+++ b/crates/omnigraph-server/src/lib.rs
@@ -107,7 +107,10 @@ fn hash_bearer_token(token: &str) -> BearerTokenHash {
         handlers::server_invoke_query,
         handlers::server_schema_apply,
         handlers::server_schema_get,
-        handlers::server_ingest,
+        handlers::server_load,
+        // deprecated; the #[deprecated] attribute on the handler surfaces as
+        // `deprecated: true` on the OpenAPI operation.
+        #[allow(deprecated)] handlers::server_ingest,
         handlers::server_branch_list,
         handlers::server_branch_create,
         handlers::server_branch_delete,
@@ -935,8 +938,19 @@ pub fn build_app(state: AppState) -> Router {
         .route("/schema", get(server_schema_get))
         .route("/schema/apply", post(server_schema_apply))
         .route(
+            "/load",
+            post(server_load).layer(DefaultBodyLimit::max(INGEST_REQUEST_BODY_LIMIT_BYTES)),
+        )
+        // /ingest is the deprecated alias of /load; its handler carries
+        // #[deprecated] (OpenAPI operation flagged) and emits RFC 9745
+        // Deprecation + RFC 8288 Link headers. Suppress the call-site warning.
+        .route(
             "/ingest",
-            post(server_ingest).layer(DefaultBodyLimit::max(INGEST_REQUEST_BODY_LIMIT_BYTES)),
+            post({
+                #[allow(deprecated)]
+                server_ingest
+            })
+            .layer(DefaultBodyLimit::max(INGEST_REQUEST_BODY_LIMIT_BYTES)),
         )
         .route(
             "/branches",

--- a/crates/omnigraph-server/tests/data_routes.rs
+++ b/crates/omnigraph-server/tests/data_routes.rs
@@ -621,6 +621,83 @@ async fn change_endpoint_emits_deprecation_headers() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn load_endpoint_loads_into_existing_branch() {
+    // Canonical bulk-load endpoint (RFC-009 Phase 5). Same wire shape as
+    // /ingest, no deprecation signal.
+    let (_temp, app) = app_for_loaded_graph().await;
+    let request = IngestRequest {
+        branch: Some("main".to_string()),
+        from: None,
+        mode: Some(LoadMode::Merge),
+        data: r#"{"type":"Person","data":{"name":"Loaded","age":7}}"#.to_string(),
+    };
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/load")
+                .method(Method::POST)
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&request).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response.headers().get("deprecation").is_none(),
+        "POST /load must not advertise itself as deprecated"
+    );
+    let body_bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body: Value = serde_json::from_slice(&body_bytes).unwrap();
+    assert_eq!(body["branch"], "main");
+    assert_eq!(body["tables"][0]["table_key"], "node:Person");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn ingest_endpoint_emits_deprecation_headers() {
+    // `/ingest` is the deprecated alias of `/load` (RFC-009 Phase 5): flagged
+    // at runtime per RFC 9745 (`Deprecation: true`) + RFC 8288 (`Link: </load>;
+    // rel="successor-version"`). The OpenAPI side is covered by
+    // `openapi_ingest_is_deprecated` in tests/openapi.rs.
+    let (_temp, app) = app_for_loaded_graph().await;
+    let request = IngestRequest {
+        branch: Some("main".to_string()),
+        from: None,
+        mode: Some(LoadMode::Merge),
+        data: r#"{"type":"Person","data":{"name":"Legacyer","age":33}}"#.to_string(),
+    };
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/ingest")
+                .method(Method::POST)
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&request).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get("deprecation")
+            .and_then(|v| v.to_str().ok()),
+        Some("true"),
+        "POST /ingest must advertise `Deprecation: true` (RFC 9745)"
+    );
+    assert_eq!(
+        response.headers().get("link").and_then(|v| v.to_str().ok()),
+        Some("</load>; rel=\"successor-version\""),
+        "POST /ingest must point at /load via `Link` rel=successor-version (RFC 8288)"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn read_endpoint_emits_deprecation_headers() {
     // `/read` is kept indefinitely for byte-stable back-compat but flagged
     // at runtime per RFC 9745 + RFC 8288. Successor is `/query`.

--- a/crates/omnigraph-server/tests/openapi.rs
+++ b/crates/omnigraph-server/tests/openapi.rs
@@ -172,6 +172,7 @@ const EXPECTED_PATHS: &[&str] = &[
     "/queries/{name}",
     "/schema",
     "/schema/apply",
+    "/load",
     "/ingest",
     "/branches",
     "/branches/{branch}",
@@ -298,6 +299,32 @@ fn openapi_mutate_is_not_deprecated() {
 fn openapi_ingest_is_post() {
     let doc = openapi_json();
     assert!(doc["paths"]["/ingest"]["post"].is_object());
+}
+
+#[test]
+fn openapi_load_is_not_deprecated() {
+    // RFC-009 Phase 5: /load is the canonical bulk-load endpoint.
+    let doc = openapi_json();
+    assert!(doc["paths"]["/load"]["post"].is_object());
+    let deprecated = doc["paths"]["/load"]["post"]
+        .get("deprecated")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    assert!(
+        !deprecated,
+        "/load is the canonical load endpoint and must not be deprecated"
+    );
+}
+
+#[test]
+fn openapi_ingest_is_deprecated() {
+    // RFC-009 Phase 5: /ingest is now the deprecated alias of /load.
+    let doc = openapi_json();
+    assert_eq!(
+        doc["paths"]["/ingest"]["post"]["deprecated"],
+        serde_json::Value::Bool(true),
+        "/ingest must be flagged deprecated now that /load is canonical"
+    );
 }
 
 #[test]
@@ -705,6 +732,7 @@ fn protected_endpoints_reference_bearer_token_security() {
         ("/schema/apply", "post"),
         ("/queries", "get"),
         ("/queries/{name}", "post"),
+        ("/load", "post"),
         ("/ingest", "post"),
         ("/export", "post"),
         ("/snapshot", "get"),

--- a/docs/dev/rfc-009-unify-access-paths.md
+++ b/docs/dev/rfc-009-unify-access-paths.md
@@ -161,15 +161,20 @@ and cluster commands must work with the server down) explicit in code.
 "Server" targets include operator-config named servers (RFC-007), not only
 literal `http(s)://` URIs.
 
-### Phase 5 — Route alignment
+### Phase 5 — Route alignment (landed)
 
-Add a canonical `/load` endpoint (the handler already exists behind the
-`/ingest` shim); point `RemoteClient` at it; keep `/ingest` on its existing
-deprecation path. While here, check whether the server uses `utoipa-axum`'s
-router-coupled registration (`OpenApiRouter`/`routes!`); if it hand-mounts
-routes beside `#[utoipa::path]` annotations, prefer migrating registration so
-path annotations and mount points are the same declaration (the modularization
-already hit one orphaned-attribute incident of exactly this class).
+Added a canonical `POST /load` (shared `run_ingest` body; the deprecated
+`/ingest` is now a thin alias carrying `#[deprecated]` + RFC 9745/8288
+`Deprecation`/`Link: </load>` headers, exactly mirroring `/mutate`↔`/change`)
+and pointed the CLI's remote `load` arm at it; `/ingest` stays on its
+deprecation path. `/load` reuses `IngestRequest`/`IngestOutput` (as canonical
+`/mutate` reuses `Change*`); a DTO rename is a separate change.
+
+Registration finding: the server **hand-mounts** routes (`.route(...)`) beside a
+manual `#[openapi(paths(...))]` list, not `utoipa-axum`'s `OpenApiRouter`/
+`routes!`. This PR followed the existing manual pattern (one `.route` + one
+`paths(...)` entry + the `#[utoipa::path]` annotation) rather than migrating
+registration — the migration is a worthwhile but orthogonal cleanup, deferred.
 
 ## Non-goals
 

--- a/docs/user/server.md
+++ b/docs/user/server.md
@@ -56,7 +56,8 @@ Per-graph endpoints — same body shape across modes; URLs differ:
 | POST | `/queries/{name}` | `/graphs/{id}/queries/{name}` | bearer + `invoke_query` (+ `change` for a stored mutation) | invoke a named query from the `queries:` registry; deny == 404 | `server_invoke_query` |
 | GET | `/schema` | `/graphs/{id}/schema` | bearer + `read` | get current `.pg` source | `server_schema_get` |
 | POST | `/schema/apply` | `/graphs/{id}/schema/apply` | bearer + `schema_apply` (target=`main`) | migrate | `server_schema_apply` |
-| POST | `/ingest` | `/graphs/{id}/ingest` | bearer + `branch_create` (only when `from` is set and the branch is created) + `change` | bulk load; branch creation is opt-in via `from` — without it a missing `branch` is a 404, never an implicit fork | `server_ingest` (32 MB body limit) |
+| POST | `/load` | `/graphs/{id}/load` | bearer + `branch_create` (only when `from` is set and the branch is created) + `change` | bulk load (canonical); branch creation is opt-in via `from` — without it a missing `branch` is a 404, never an implicit fork | `server_load` (32 MB body limit) |
+| POST | `/ingest` | `/graphs/{id}/ingest` | bearer + `branch_create` (only when `from` is set and the branch is created) + `change` | **deprecated** alias of `/load` (carries `Deprecation: true` + `Link: </load>; rel="successor-version"`) | `server_ingest` (32 MB body limit) |
 | GET | `/branches` | `/graphs/{id}/branches` | bearer + `read` | list branches | `server_branch_list` |
 | POST | `/branches` | `/graphs/{id}/branches` | bearer + `branch_create` | create | `server_branch_create` |
 | DELETE | `/branches/{branch}` | `/graphs/{id}/branches/{branch}` | bearer + `branch_delete` | delete | `server_branch_delete` |

--- a/openapi.json
+++ b/openapi.json
@@ -670,8 +670,8 @@
         "tags": [
           "mutations"
         ],
-        "summary": "Bulk-load NDJSON data into a branch.",
-        "description": "`data` is NDJSON with one record per line. `mode` controls behavior on\nexisting rows: `merge` upserts by id (default), `append` blindly inserts,\n`overwrite` replaces table contents. Branch creation is opt-in by\npresence of `from`: with `from` set, a missing `branch` is created from\nit; without `from`, `branch` must already exist — a missing branch is a\n404, never an implicit fork. **Destructive** when `mode` is `overwrite`\nor when the load produces conflicting writes.",
+        "summary": "**Deprecated** — use [`POST /load`](#tag/mutations/operation/load) instead.",
+        "description": "Bulk-load NDJSON data into a branch. Behavior is unchanged; the route is\nkept indefinitely for back-compat. New integrations should target\n`POST /load`, which has identical semantics. Responses from this route\ninclude `Deprecation: true` and `Link: </load>; rel=\"successor-version\"`\nheaders per RFC 9745 / RFC 8288 so SDKs and proxies can surface the signal.",
         "operationId": "ingest",
         "requestBody": {
           "content": {
@@ -685,7 +685,85 @@
         },
         "responses": {
           "200": {
-            "description": "Ingest results",
+            "description": "Load results (response includes `Deprecation: true` + `Link: </load>; rel=\"successor-version\"`)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IngestOutput"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOutput"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOutput"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOutput"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Per-actor admission cap exceeded; honor `Retry-After` header",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOutput"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": true,
+        "security": [
+          {
+            "bearer_token": []
+          }
+        ]
+      }
+    },
+    "/load": {
+      "post": {
+        "tags": [
+          "mutations"
+        ],
+        "summary": "Bulk-load NDJSON data into a branch (canonical load endpoint).",
+        "description": "`data` is NDJSON with one record per line. `mode` controls behavior on\nexisting rows: `merge` upserts by id (default), `append` blindly inserts,\n`overwrite` replaces table contents. Branch creation is opt-in by\npresence of `from`: with `from` set, a missing `branch` is created from\nit; without `from`, `branch` must already exist — a missing branch is a\n404, never an implicit fork. **Destructive** when `mode` is `overwrite`\nor when the load produces conflicting writes.\n\nThe legacy `POST /ingest` route has identical semantics and is kept as a\ndeprecated alias.",
+        "operationId": "load",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IngestRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Load results",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
The last RFC-009 item — **completes RFC-009**. The CLI's non-deprecated `load` verb rode the deprecated `/ingest` route, so `/ingest`'s eventual removal would silently break it. This adds a canonical `/load`, mirroring the shipped `/mutate`↔`/change` and `/query`↔`/read` deprecation pattern exactly.

## `feat(server): canonical POST /load, deprecate /ingest`
- Extract `server_ingest`'s body into a shared **`run_ingest`** (branch-exists / fork-if-`from`, Cedar auth, admission, `load_as`, `IngestOutput` mapping).
- **`server_load`** (canonical) → `run_ingest`, `Json<IngestOutput>`.
- **`server_ingest`** (deprecated) → `run_ingest` + `#[deprecated]` + RFC 9745/8288 `Deprecation: true` / `Link: </load>; rel="successor-version"` headers.
- Router mounts `/load` (same 32 MB body limit) beside `/ingest`; OpenAPI `paths(...)` gains `server_load` and flags `server_ingest` deprecated. `openapi.json` regenerated.

`/load` reuses `IngestRequest`/`IngestOutput` — exactly as canonical `/mutate` reuses `Change*`. A DTO rename is a separate, larger change (out of scope).

## `feat(cli): point remote load at /load`
`GraphClient::load`'s remote arm now POSTs `/load`; the deprecated `ingest` verb keeps riding `/ingest`. `parity_load` exercises `/load` (its documented flip).

## Verification
OpenAPI drift test regenerated + strict-passes; new assertions (`/load` present + not-deprecated + bearer-secured, `/ingest` deprecated); data-route `/load` happy-path + `/ingest` deprecation-header tests; existing `/ingest` tests stay green (shim unchanged); `parity_load` green; full `cargo test --workspace --locked` → exit 0. Docs: server.md endpoint table; RFC-009 Phase 5 marked landed (incl. the hand-mount-vs-`utoipa-axum` registration finding — followed the existing manual pattern, migration deferred as orthogonal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes RFC-009 Phase 5 by introducing a canonical `POST /load` endpoint alongside the now-deprecated `POST /ingest`, mirroring the existing `/mutate`↔`/change` and `/query`↔`/read` pattern exactly. The implementation is clean: shared logic is extracted into `run_ingest`, the canonical `server_load` wraps it with a plain `Json` return, and the deprecated `server_ingest` wraps it with RFC 9745 `Deprecation: true` / RFC 8288 `Link:` headers.

- **Server**: `run_ingest` factored out; `server_load` (canonical) and `server_ingest` (deprecated shim) both delegate to it; router mounts `/load` with the same 32 MB body limit; `openapi.json` regenerated with `/load` added and `/ingest` flagged `deprecated: true`.
- **CLI**: `GraphClient::load`'s remote arm now POSTs `/load`; the deprecated `ingest` verb keeps riding `/ingest`; `parity_load` exercises the flip.
- **Tests**: new `load_endpoint_loads_into_existing_branch`, `ingest_endpoint_emits_deprecation_headers`, `openapi_load_is_not_deprecated`, and `openapi_ingest_is_deprecated` assertions; existing `/ingest` tests stay green.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the core server change is a clean extraction with shared logic behind both routes, all auth/admission/body-limit invariants preserved, and full test coverage for the happy path, deprecation headers, and OpenAPI flags.

The Rust-side changes are correct and well-tested. The one gap is that the TypeScript SDK in omnigraph-ts still hardcodes `/ingest` with no `load()` method and a stale `spec/openapi.json`; SDK consumers will silently receive `Deprecation` headers without a canonical upgrade path from the SDK until a companion PR lands there. Since `/ingest` is kept indefinitely the migration is non-breaking, but the SDK follow-up is the expected completion of this work.

No files in this PR need special attention; the companion update needed is in `modernrelay/omnigraph-ts` (regenerate SDK types from the new `openapi.json` and add a `load()` method).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/omnigraph-server/src/handlers.rs | Extracts shared `run_ingest` helper, adds canonical `server_load`, demotes `server_ingest` to a deprecated shim with RFC 9745/8288 headers — mirrors the existing `/mutate`↔`/change` pattern exactly. |
| crates/omnigraph-server/src/lib.rs | Mounts `/load` with the same 32 MB body limit as `/ingest`; adds `server_load` to the OpenAPI paths list and keeps `server_ingest` with `#[allow(deprecated)]` at both call sites. |
| crates/omnigraph-cli/src/client.rs | Redirects the canonical `load` verb's remote arm from `/ingest` to `/load`; deprecated `ingest` verb keeps targeting `/ingest`. |
| crates/omnigraph-server/tests/data_routes.rs | Adds `load_endpoint_loads_into_existing_branch` (no deprecation header) and `ingest_endpoint_emits_deprecation_headers` (RFC 9745 + RFC 8288) tests; coverage is complete and well-structured. |
| crates/omnigraph-server/tests/openapi.rs | Adds `/load` to `EXPECTED_PATHS`, adds `openapi_load_is_not_deprecated` and `openapi_ingest_is_deprecated` tests, and adds `/load` to the bearer-security assertion set. |
| openapi.json | Regenerated artifact: `/ingest` gains `deprecated: true` and updated description; new `/load` operation added with identical request/response shapes. |
| crates/omnigraph-cli/tests/parity_matrix.rs | Comment-only update to reflect that `/load` is now live; no functional change. |
| docs/dev/rfc-009-unify-access-paths.md | Phase 5 marked as landed; documents the hand-mount vs. `utoipa-axum` registration finding and defers migration as orthogonal. |
| docs/user/server.md | Endpoint table updated: `/load` row added as canonical, `/ingest` row updated with deprecated marker and header description. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as CLI load verb
    participant CLI2 as CLI ingest verb
    participant SL as POST /load server_load
    participant SI as POST /ingest server_ingest
    participant RI as run_ingest
    participant Engine as GraphHandle Engine

    CLI->>SL: POST /load (RFC-009 Phase 5)
    SL->>RI: run_ingest(state, handle, actor, request)
    RI->>Engine: branch_list / authorize / try_admit / load_as
    Engine-->>RI: LoadResult
    RI-->>SL: IngestOutput
    SL-->>CLI: 200 JSON no deprecation headers

    CLI2->>SI: POST /ingest deprecated alias
    SI->>RI: run_ingest(state, handle, actor, request)
    RI->>Engine: branch_list / authorize / try_admit / load_as
    Engine-->>RI: LoadResult
    RI-->>SI: IngestOutput
    SI-->>CLI2: 200 JSON + Deprecation true + Link rel successor-version
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fomnigraph-server%2Fsrc%2Fhandlers.rs%3A1330-1347%0A**TypeScript%20SDK%20still%20targets%20%60%2Fingest%60%20with%20no%20%60%2Fload%60%20method**%0A%0A%5B%60omnigraph-ts%60's%20%60client.ts%60%5D%28https%3A%2F%2Fgithub.com%2Fmodernrelay%2Fomnigraph-ts%2Fblob%2FHEAD%2Fpackages%2Fsdk%2Fsrc%2Fclient.ts%29%20hardcodes%20%60POST%20%2Fingest%60%20in%20its%20%60ingest%28%29%60%20method%2C%20and%20the%20SDK%20has%20no%20%60load%28%29%60%20method%20for%20%60POST%20%2Fload%60.%20Starting%20with%20this%20deployment%2C%20every%20%60ingest%28%29%60%20call%20the%20SDK%20makes%20will%20receive%20%60Deprecation%3A%20true%60%20and%20%60Link%3A%20%3C%2Fload%3E%3B%20rel%3D%22successor-version%22%60%20response%20headers%20with%20no%20corresponding%20canonical%20path%20for%20SDK%20consumers%20to%20migrate%20to.%20The%20%5B%60spec%2Fopenapi.json%60%5D%28https%3A%2F%2Fgithub.com%2Fmodernrelay%2Fomnigraph-ts%2Fblob%2FHEAD%2Fspec%2Fopenapi.json%29%20pinned%20in%20that%20repo%20also%20predates%20this%20change%20and%20won't%20reflect%20the%20deprecation%20or%20the%20new%20%60%2Fload%60%20operation.%20Since%20%60%2Fingest%60%20is%20kept%20indefinitely%20this%20isn't%20blocking%2C%20but%20a%20companion%20PR%20to%20regenerate%20the%20SDK%20types%20and%20add%20a%20%60load%28%29%60%20method%20is%20the%20intended%20completion%20of%20this%20migration%20for%20TypeScript%20consumers.%0A%0A&repo=modernrelay%2Fomnigraph&pr=222&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(cli): point remote load at /load (R..."](https://github.com/modernrelay/omnigraph/commit/867ce37cb398cbcb1a8bf7cee291742e2316325c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37446176)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->