### PR TITLE
fix(cli): unify remote URL builder, fix branch delete //branches 404

### DIFF
--- a/crates/omnigraph-cli/src/client.rs
+++ b/crates/omnigraph-cli/src/client.rs
@@ -40,7 +40,7 @@ use serde_json::Value;
 use crate::cli::CliLoadMode;
 use crate::helpers::{
     ResolvedCliGraph, apply_bearer_token, apply_server_flag, build_http_client, is_remote_uri,
-    legacy_change_request_body, open_local_db_with_policy, query_params_from_json, remote_branch_url,
+    legacy_change_request_body, open_local_db_with_policy, query_params_from_json,
     remote_json, remote_url, resolve_cli_actor, resolve_cli_graph, resolve_remote_bearer_token,
     select_named_query,
 };
@@ -173,7 +173,7 @@ impl GraphClient {
                 remote_json(
                     http,
                     Method::GET,
-                    remote_url(base_url, "/branches"),
+                    remote_url(base_url, &["branches"], &[])?,
                     None,
                     token.as_deref(),
                 )
@@ -198,7 +198,7 @@ impl GraphClient {
                 remote_json(
                     http,
                     Method::GET,
-                    format!("{}?branch={}", remote_url(base_url, "/snapshot"), branch),
+                    remote_url(base_url, &["snapshot"], &[("branch", branch)])?,
                     None,
                     token.as_deref(),
                 )
@@ -222,7 +222,7 @@ impl GraphClient {
                 remote_json(
                     http,
                     Method::GET,
-                    remote_url(base_url, "/schema"),
+                    remote_url(base_url, &["schema"], &[])?,
                     None,
                     token.as_deref(),
                 )
@@ -245,8 +245,8 @@ impl GraphClient {
                 token,
             } => {
                 let url = match branch {
-                    Some(branch) => format!("{}?branch={}", remote_url(base_url, "/commits"), branch),
-                    None => remote_url(base_url, "/commits"),
+                    Some(branch) => remote_url(base_url, &["commits"], &[("branch", branch)])?,
+                    None => remote_url(base_url, &["commits"], &[])?,
                 };
                 remote_json(http, Method::GET, url, None, token.as_deref()).await
             }
@@ -273,7 +273,7 @@ impl GraphClient {
                 remote_json(
                     http,
                     Method::GET,
-                    remote_url(base_url, &format!("/commits/{commit_id}")),
+                    remote_url(base_url, &["commits", commit_id], &[])?,
                     None,
                     token.as_deref(),
                 )
@@ -310,7 +310,7 @@ impl GraphClient {
                 let output = remote_json::<IngestOutput>(
                     http,
                     Method::POST,
-                    remote_url(base_url, "/load"),
+                    remote_url(base_url, &["load"], &[])?,
                     Some(serde_json::to_value(IngestRequest {
                         branch: Some(branch.to_string()),
                         from: from.map(ToOwned::to_owned),
@@ -354,7 +354,7 @@ impl GraphClient {
                 remote_json(
                     http,
                     Method::POST,
-                    remote_url(base_url, "/ingest"),
+                    remote_url(base_url, &["ingest"], &[])?,
                     Some(serde_json::to_value(IngestRequest {
                         branch: Some(branch.to_string()),
                         from: Some(from.to_string()),
@@ -393,7 +393,7 @@ impl GraphClient {
                 remote_json(
                     http,
                     Method::POST,
-                    remote_url(base_url, "/change"),
+                    remote_url(base_url, &["change"], &[])?,
                     Some(legacy_change_request_body(
                         query_source,
                         query_name,
@@ -446,7 +446,7 @@ impl GraphClient {
                 remote_json(
                     http,
                     Method::POST,
-                    remote_url(base_url, "/read"),
+                    remote_url(base_url, &["read"], &[])?,
                     Some(serde_json::to_value(ReadRequest {
                         query_source: query_source.to_string(),
                         query_name: query_name.map(ToOwned::to_owned),
@@ -484,7 +484,7 @@ impl GraphClient {
                 remote_json(
                     http,
                     Method::POST,
-                    remote_url(base_url, "/branches"),
+                    remote_url(base_url, &["branches"], &[])?,
                     Some(serde_json::to_value(BranchCreateRequest {
                         from: Some(from.to_string()),
                         name: name.to_string(),
@@ -518,7 +518,7 @@ impl GraphClient {
                 remote_json(
                     http,
                     Method::DELETE,
-                    remote_branch_url(base_url, name)?,
+                    remote_url(base_url, &["branches", name], &[])?,
                     None,
                     token.as_deref(),
                 )
@@ -547,7 +547,7 @@ impl GraphClient {
                 remote_json(
                     http,
                     Method::POST,
-                    remote_url(base_url, "/branches/merge"),
+                    remote_url(base_url, &["branches", "merge"], &[])?,
                     Some(serde_json::to_value(BranchMergeRequest {
                         source: source.to_string(),
                         target: Some(into.to_string()),
@@ -598,7 +598,7 @@ impl GraphClient {
                 remote_json::<SchemaApplyOutput>(
                     http,
                     Method::POST,
-                    remote_url(base_url, "/schema/apply"),
+                    remote_url(base_url, &["schema", "apply"], &[])?,
                     Some(serde_json::to_value(SchemaApplyRequest {
                         schema_source: schema_source.to_string(),
                         allow_data_loss,
@@ -642,7 +642,7 @@ impl GraphClient {
                 token,
             } => {
                 let request = apply_bearer_token(
-                    http.request(Method::POST, remote_url(base_url, "/export")),
+                    http.request(Method::POST, remote_url(base_url, &["export"], &[])?),
                     token.as_deref(),
                 )
                 .json(&ExportRequest {
@@ -690,7 +690,7 @@ impl GraphClient {
                 remote_json(
                     http,
                     Method::GET,
-                    remote_url(base_url, "/graphs"),
+                    remote_url(base_url, &["graphs"], &[])?,
                     None,
                     token.as_deref(),
                 )

--- a/crates/omnigraph-cli/src/helpers.rs
+++ b/crates/omnigraph-cli/src/helpers.rs
@@ -1059,3 +1059,27 @@ pub(crate) fn rewrite_deprecated_argv(args: Vec<OsString>) -> Vec<OsString> {
     }
     args
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Regression for the `branch delete` 404: over a multi-graph
+    // `--server`/`--graph` target the composed URL must be exactly
+    // `<base>/branches/<name>` with no empty `//` segment. An empty segment
+    // misses the `/graphs/{graph_id}/branches/{branch}` route and 404s.
+    //
+    // This FAILS against the current `remote_branch_url`, which parses the base
+    // with a manually appended trailing slash and so emits
+    // `…/graphs/p9-os//branches/tmpbranch`. The fix (a unified, structured URL
+    // builder) turns it green.
+    #[test]
+    fn remote_branch_url_multi_graph_base_has_no_double_slash() {
+        let url = remote_branch_url("http://host/graphs/p9-os", "tmpbranch").unwrap();
+        assert_eq!(url, "http://host/graphs/p9-os/branches/tmpbranch");
+        assert!(
+            !url.contains("//branches"),
+            "double slash before branches: {url}"
+        );
+    }
+}

--- a/crates/omnigraph-cli/src/helpers.rs
+++ b/crates/omnigraph-cli/src/helpers.rs
@@ -16,15 +16,41 @@ pub(crate) fn is_remote_uri(uri: &str) -> bool {
     uri.starts_with("http://") || uri.starts_with("https://")
 }
 
-pub(crate) fn remote_url(base: &str, path: &str) -> String {
-    format!("{}{}", base.trim_end_matches('/'), path)
-}
-
-pub(crate) fn remote_branch_url(base: &str, branch: &str) -> Result<String> {
-    let mut url = reqwest::Url::parse(&format!("{}/", base.trim_end_matches('/')))?;
+/// THE one way the CLI composes a remote request URL. Every remote call
+/// routes through here so URL assembly has a single mechanism instead of
+/// per-callsite string interpolation.
+///
+/// - `base` is the resolved server root (single-graph) or `…/graphs/{id}`
+///   (multi-graph).
+/// - `segments` are appended as individual percent-encoded path segments, so
+///   a dynamic component (branch name, commit id, query name) is always one
+///   safe segment — e.g. a branch `etl/zendesk/run-1` becomes `%2F`-escaped.
+/// - `query` pairs are percent-encoded values.
+///
+/// Trailing-slash normalization happens exactly once via `pop_if_empty`:
+/// `Url::parse` normalizes a path-less base (`http://host`) to a single empty
+/// trailing segment, and a `…/graphs/{id}/` base keeps its own. `extend`
+/// appends *after* the last segment, so without dropping a trailing empty one
+/// the join emits `…/graphs/{id}//branches/{name}` — the empty `//` segment
+/// misses the route and 404s. Because callers pass structured segments rather
+/// than a pre-joined string, neither a stray `//` nor an un-encoded dynamic
+/// component is representable here.
+pub(crate) fn remote_url(
+    base: &str,
+    segments: &[&str],
+    query: &[(&str, &str)],
+) -> Result<String> {
+    let mut url = reqwest::Url::parse(base.trim_end_matches('/'))?;
     url.path_segments_mut()
         .map_err(|_| color_eyre::eyre::eyre!("invalid remote base url"))?
-        .extend(["branches", branch]);
+        .pop_if_empty()
+        .extend(segments);
+    if !query.is_empty() {
+        let mut pairs = url.query_pairs_mut();
+        for (key, value) in query {
+            pairs.append_pair(key, value);
+        }
+    }
     Ok(url.to_string())
 }
 
@@ -340,7 +366,7 @@ pub(crate) async fn execute_operator_alias(
     remote_json(
         client,
         Method::POST,
-        remote_url(&uri, &format!("/queries/{}", alias.query)),
+        remote_url(&uri, &["queries", &alias.query], &[])?,
         body,
         bearer_token.as_deref(),
     )
@@ -1064,22 +1090,66 @@ pub(crate) fn rewrite_deprecated_argv(args: Vec<OsString>) -> Vec<OsString> {
 mod tests {
     use super::*;
 
-    // Regression for the `branch delete` 404: over a multi-graph
-    // `--server`/`--graph` target the composed URL must be exactly
-    // `<base>/branches/<name>` with no empty `//` segment. An empty segment
-    // misses the `/graphs/{graph_id}/branches/{branch}` route and 404s.
-    //
-    // This FAILS against the current `remote_branch_url`, which parses the base
-    // with a manually appended trailing slash and so emits
-    // `…/graphs/p9-os//branches/tmpbranch`. The fix (a unified, structured URL
-    // builder) turns it green.
+    // `branch delete` interpolates the branch into the URL path. The composed
+    // path must be exactly `<base-path>/branches/<name>` with no empty `//`
+    // segment — an empty segment misses the
+    // `/graphs/{graph_id}/branches/{branch}` route and 404s.
     #[test]
-    fn remote_branch_url_multi_graph_base_has_no_double_slash() {
-        let url = remote_branch_url("http://host/graphs/p9-os", "tmpbranch").unwrap();
+    fn remote_url_multi_graph_base_has_no_double_slash() {
+        let url = remote_url("http://host/graphs/p9-os", &["branches", "tmpbranch"], &[]).unwrap();
         assert_eq!(url, "http://host/graphs/p9-os/branches/tmpbranch");
         assert!(
             !url.contains("//branches"),
             "double slash before branches: {url}"
+        );
+    }
+
+    #[test]
+    fn remote_url_single_graph_base_has_no_double_slash() {
+        let url = remote_url("http://host", &["branches", "tmpbranch"], &[]).unwrap();
+        assert_eq!(url, "http://host/branches/tmpbranch");
+    }
+
+    #[test]
+    fn remote_url_tolerates_trailing_slash_on_base() {
+        let url = remote_url("http://host/graphs/p9-os/", &["branches", "tmpbranch"], &[]).unwrap();
+        assert_eq!(url, "http://host/graphs/p9-os/branches/tmpbranch");
+    }
+
+    #[test]
+    fn remote_url_encodes_slashes_in_path_segment() {
+        let url = remote_url(
+            "http://host/graphs/p9-os",
+            &["branches", "etl/zendesk/run-1"],
+            &[],
+        )
+        .unwrap();
+        assert_eq!(
+            url,
+            "http://host/graphs/p9-os/branches/etl%2Fzendesk%2Frun-1"
+        );
+    }
+
+    // Sibling cases the unified builder closes by construction: a dynamic
+    // commit id in the path, and a branch name carried as a query value, are
+    // both percent-encoded instead of interpolated raw.
+    #[test]
+    fn remote_url_encodes_dynamic_path_segment_for_commits() {
+        let url = remote_url("http://host/graphs/p9-os", &["commits", "a/b c"], &[]).unwrap();
+        assert_eq!(url, "http://host/graphs/p9-os/commits/a%2Fb%20c");
+    }
+
+    #[test]
+    fn remote_url_encodes_query_values() {
+        let url = remote_url(
+            "http://host/graphs/p9-os",
+            &["snapshot"],
+            &[("branch", "feature&x=1")],
+        )
+        .unwrap();
+        assert_eq!(
+            url,
+            "http://host/graphs/p9-os/snapshot?branch=feature%26x%3D1"
         );
     }
 }


### PR DESCRIPTION
## What & why

`omnigraph branch delete` over an HTTP `--server`/`--graph` target composed its URL with a manually appended trailing slash, so the path-segment join emitted an empty `//` segment (`/graphs/{id}//branches/{name}`) that missed the route and returned 404; the server endpoint itself was fine. This replaces the two divergent URL helpers with one structured `remote_url(base, segments, query)` builder that every remote call routes through, so trailing-slash normalization and per-segment / per-value percent-encoding live in one place and the bug class (stray `//`, un-encoded dynamic components) is closed by construction.

## Backing issue / RFC

- [x] Fixes an **accepted** issue: Closes #232

## Checklist

- [x] Change is focused (one logical change)
- [x] Tests added/updated for behavior changes (or N/A)
- [x] Public docs updated if user-facing surface changed (or N/A) — N/A: fixes broken behavior to match the documented CLI surface; no flag/endpoint change
- [x] Reviewed against [docs/dev/invariants.md](../blob/main/docs/dev/invariants.md) — no Hard Invariant weakened, no deny-list item hit (or justified)

## Notes for reviewers

The fix also closes two previously latent siblings of the same class: a commit id interpolated raw into the path (`get_commit`) and a branch name interpolated raw into the query string (`list_commits`/`snapshot`) are now percent-encoded.

Coverage is boundary-matched: the defect is CLI URL composition (a pure function), so it is covered by 6 `remote_url` unit tests — multi-graph/single-graph/trailing-slash bases asserting no `//`, slash-in-name path encoding, and the latent commit-id and query-value cases. The server route is already covered by the `boot_settings` `DELETE /graphs/{id}/branches/{branch}` oneshot, and branch-delete logic by the embedded `local_cli_branch_delete_enforces_engine_layer_policy` test, so no new spawned-server e2e was added.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only HTTP URL composition with no server or storage changes; behavior is narrowed to correct routing and encoding, backed by targeted unit tests.
> 
> **Overview**
> Fixes **remote `branch delete` (and similar) 404s** when the CLI targets a multi-graph server base like `…/graphs/{id}`: URL assembly no longer produces an empty `//` path segment before `branches/{name}`.
> 
> The CLI now has **one `remote_url(base, segments, query)` builder** (via `reqwest::Url` with `pop_if_empty` + segment extend) instead of separate string-concat and branch-specific helpers. **All remote HTTP call sites** in `GraphClient` (and operator alias query POSTs) go through it, with `?` propagation on URL build failure.
> 
> **Dynamic pieces are encoded by construction**: branch/commit/query names as path segments (e.g. slashes in branch names), and branch names in query strings for snapshot/commits, instead of raw `format!` interpolation.
> 
> Adds **six unit tests** on `remote_url` for no double-slash joins, trailing-slash bases, and path/query encoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e88808918a46b709e0f982851f6ba50d0f11da63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a 404 on `branch delete` over an HTTP server target by replacing two divergent URL-building helpers with a single `remote_url(base, segments, query)` builder that routes every remote call through one code path. The double-slash bug was caused by `remote_branch_url` appending a literal `/` before calling `Url::path_segments_mut().extend(…)`, which left a trailing empty segment that produced `…/graphs/{id}//branches/{name}`.

- **Core fix**: The new builder calls `pop_if_empty()` on the path segments before `extend(segments)`, eliminating the stray empty segment by construction rather than by per-callsite string hygiene.
- **Latent bug closure**: Commit IDs interpolated raw into paths (`get_commit`) and branch names interpolated raw into query strings (`list_commits`, `snapshot`) are now percent-encoded automatically via the structured segment and query-pair API.
- **Test coverage**: Six focused unit tests for `remote_url` verify multi-graph/single-graph bases, trailing-slash tolerance, and slash/special-char encoding for both path segments and query values.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a pure URL construction refactor with no behavioral change except the fix itself; both helpers were pub(crate) so there is no external API surface to break.

The bug fix is mechanically correct: pop_if_empty() removes the trailing empty path segment before extend appends the new ones, which is precisely what was causing the double-slash 404. All 16 call-sites in client.rs migrate cleanly to the new signature, and the six unit tests directly pin the fixed invariant plus the latent encoding cases. No cross-crate API surface is affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/omnigraph-cli/src/helpers.rs | Replaces old string-concatenation remote_url and the broken remote_branch_url with a single reqwest::Url-based builder that uses pop_if_empty() + extend(segments) for correct slash handling and per-segment percent-encoding; adds 6 unit tests that directly pin the bug fix and latent encoding cases. |
| crates/omnigraph-cli/src/client.rs | Mechanical migration of all 16 remote call-sites to the new remote_url(base, &[...], &[])? signature; removes import of remote_branch_url; the branch-delete path now routes through the fixed builder. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["remote_url(base, segments, query)"] --> B["trim_end_matches('/') on base"]
    B --> C["Url::parse(trimmed_base)"]
    C -->|"cannot-be-a-base URL"| ERR["Err: invalid remote base url"]
    C -->|"valid URL"| D["path_segments_mut()"]
    D --> E["pop_if_empty()\n(removes trailing empty segment,\ne.g. from http://host/ or …/graphs/id/)"]
    E --> F["extend(segments)\n(each segment is percent-encoded,\ne.g. etl/zendesk → etl%2Fzendesk)"]
    F --> G{"query.is_empty()?"}
    G -->|"No"| H["query_pairs_mut()\n.append_pair(key, value)\n(both key & value percent-encoded)"]
    G -->|"Yes"| I["Ok(url.to_string())"]
    H --> I
```

<sub>Reviews (4): Last reviewed commit: ["fix(cli): unify remote URL builder, clos..."](https://github.com/modernrelay/omnigraph/commit/e88808918a46b709e0f982851f6ba50d0f11da63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37501187)</sub>

<!-- /greptile_comment -->