### PR TITLE
docs(rfc): RFC-011 review fixes — break-glass write safety + provisional maintenance capability

### DIFF
--- a/docs/dev/rfc-011-cli-refactoring.md
+++ b/docs/dev/rfc-011-cli-refactoring.md
@@ -48,7 +48,8 @@ three real entities; the mismatch is the whole problem, and `omnigraph.yaml` is
 the carrier:
 
 1. **`--target` straddles kinds.** It resolves through the legacy
-   `omnigraph.yaml` `graphs:` map (`config.rs::resolve_target_uri`), and that
+   `omnigraph.yaml` `graphs:` map
+   (`omnigraph-server/src/config.rs:459`, `resolve_target_uri`), and that
    `.uri` can be a **storage location** (`file`/`s3`) *or* a **remote server**
    (`http`). One flag, two access paths with different capability and trust
    models. The wrong-plane guard's storage-plane remote rejection
@@ -126,7 +127,7 @@ Every term is one concept. The rest of this RFC uses them precisely.
   inside the scope), **scope-scoped** (operates on the whole server/cluster
   scope), or **local** (does not resolve scope or graph).
 - **Actor** — the identity a write is attributed to: server-resolved from the
-  bearer token (served), or `--as` ?? `operator.actor` (direct).
+  bearer token (served), or `--as`, else `operator.actor` (direct).
 
 ### The relationships that prevent confusion
 
@@ -182,6 +183,14 @@ server**:
   local dev; a **remote `s3://`** store is break-glass. No catalog (named queries
   do not resolve — the ad-hoc lane).
 
+**Admins live in two scopes by design.** Because a scope binds exactly one
+entity, a maintainer **reads** through a server scope and **maintains** through a
+cluster scope — `query`/`mutate` against a cluster scope error (it is
+maintenance-only). This is the intended privilege boundary, at a known ergonomic
+cost: an admin alternates between their everyday server default and
+`--profile <admin>` / `--cluster` for maintenance. A combined admin scope is
+deferred (D5); Decision 11 (server-side maintenance) removes most of the need.
+
 A scope names **one** thing, so there is no independent `server`+`cluster` pair
 that could disagree (the audit's coherence hazard is gone by construction — the
 default is just a server). And the storage root lives only where it must:
@@ -216,8 +225,8 @@ The two access paths are genuinely different — not two transports for one thin
   writes* to storage until its handle refreshes). No storage credentials needed.
 - **Direct** (open the Lance storage in-process): a **privileged** path — it needs
   your own storage credentials, so only an admin/maintainer (or a local-dev file
-  store) takes it. Actor self-declared (`--as` ?? `operator.actor`), reads **live
-  storage HEAD**. There is **no server-side identity/auth gate** — but engine-level
+  store) takes it. Actor self-declared (`--as`, else `operator.actor`), reads
+  **live storage HEAD**. There is **no server-side identity/auth gate** — but engine-level
   Cedar policy *is* still enforced when the graph selection provides a policy
   (enforcement is engine-wide; embedded `_as` writers call the same `enforce`).
   "Direct" means "no HTTP boundary," not "unpoliced."
@@ -226,6 +235,16 @@ Because they differ in authority, freshness, and availability, a graph reached v
 a server and that graph's raw storage are **different things you name
 differently** — not one identity you flip. Making the access path a per-command
 toggle (`--via`) is the `--target` mistake in new clothes; it is rejected.
+
+**Break-glass is read-biased.** Direct `--store` access to a graph an
+`omnigraph-server` is actively serving is safe for **reads/inspection**. Direct
+*writes* to a server-active store are **not** generally safe — they are the
+multi-process-writer case the engine does not yet serialize across processes (see
+[invariants.md](invariants.md) → "Recovery is serialized against live writers
+in-process only"). Until a cross-process write lease lands, a direct write to a
+served graph requires quiescing the server first (or accepting the documented
+one-winner-CAS / staging-promotion race). The model lets you *name* the store; it
+does not make a concurrent foreign write safe.
 
 > **The access path follows from the scope and the verb.** A **server** scope →
 > served (data/catalog). A **cluster** scope → direct control, maintenance, and
@@ -255,11 +274,24 @@ The CLI validates through verb capability, not plane jargon:
 
 | Capability | Meaning | Examples |
 |---|---|---|
-| `any` | graph-scoped data; served via a server scope; direct only against a **store** scope (local dev / break-glass); **errors on a cluster scope** | `query`, `mutate`, `load`, `export`, branch reads, `schema show/apply` |
+| `any` | graph-scoped data; served via a server scope; direct only against a **store** scope (local dev / break-glass); **errors on a cluster scope** | `query`, `mutate`, `load`, `export`, branch reads, `schema show`/`apply`* |
 | `served` | requires an HTTP server; may be graph-scoped or scope-scoped | `graphs list`, `queries list` |
-| `direct` | graph-scoped storage-native or graph-backed validation; no server form exists | `init`, `optimize`, `repair`, `cleanup`, `schema plan`, graph-backed `lint` |
+| `direct` | graph-scoped storage-native or graph-backed validation; no server form exists | `init`, `optimize`†, `repair`†, `cleanup`†, `schema plan`, graph-backed `lint` |
 | `control` | cluster-scoped catalog/control-plane work; addresses the cluster, not a single raw store | `cluster *`, `queries validate` |
 | `local` | does not address a graph or scope | `config`, `profile`, `lint --query ... --schema ...` |
+
+**† Provisional (Decision 11).** `optimize`/`cleanup`/`repair` are `direct`
+*today*, but the committed direction (Decision 11) moves them to server-managed
+jobs. To avoid release-noting a CLI shape we intend to deprecate, RFC-011 ships
+the **addressing model** as the stable contract and treats these three verbs'
+`direct` capability as **provisional** — the privileged-direct examples in this
+RFC illustrate the rule, they are not a long-term contract for those specific
+verbs. `init`, `schema plan`, and graph-backed `lint` remain durably `direct`.
+
+**\* `schema apply` is `any` only for standalone graphs.** A cluster-managed
+graph rejects `schema apply` and points at `cluster apply` (Decision 10), so in a
+cluster deployment schema evolution is a control-plane act; the served
+`schema apply` path covers only non-cluster (standalone) served graphs.
 
 `any` does **not** mean "the user picks": the resolver picks from the scope.
 Internally the exhaustive `command_plane` match (`planes.rs`) stays as the drift
@@ -315,7 +347,10 @@ control/catalog check against the cluster-owned query definitions. A bare
    - `any` verb → **served** if the scope is a server; **direct** against a
      **store** scope (ad-hoc); on a **cluster** scope, error — cluster is
      maintenance-only, so use a server for data or `--store` for ad-hoc.
-7. Reject mismatches with an error naming the missing axis.
+7. Reject mismatches with an error naming the missing axis. A `--store` pointed at
+   a cluster root (or `--cluster` at a single `.omni` store) fails at open time
+   with a kind-mismatch error — the flag *declares* the entity; the CLI does not
+   re-infer it from what the URI turns out to contain.
 
 Good errors:
 
@@ -366,6 +401,23 @@ skip config and name it per command:
 cluster stays the source of truth for the managed catalog; tokens live in the
 keyed credential store, never in this file.
 
+**Worked resolution (Decision 6 — scope wholesale, prefs layered).** With flat
+defaults `{ server: prod, default_graph: knowledge, output: table }` and
+`profiles.staging = { server: staging, default_graph: knowledge }`, the command
+`omnigraph --profile staging query find_people --graph archive` resolves to:
+
+- **scope** = the `staging` server — taken *wholesale* from the profile; `prod` is
+  **not** merged in (no "server *and* server" per-key blending);
+- **graph** = `archive` — the explicit `--graph` flag beats the profile's
+  `default_graph`;
+- **output** = `table` — a non-scope preference, layered from flat defaults since
+  the profile sets none;
+- **access path** = served — server scope × `any` verb.
+
+Precedence is **explicit flag > profile > flat defaults**, but the entity binding
+(`server`/`cluster`/`store` + `default_graph`) never per-key merges across the
+scope dimension; only preferences (`output`, table layout) layer.
+
 ### Command shape
 
 Assume the everyday flat defaults: server `prod`, default graph `knowledge`.
@@ -385,7 +437,7 @@ Assume the everyday flat defaults: server `prod`, default graph `knowledge`.
 | Offline query lint | `omnigraph lint --query new.gq --schema schema.pg` | local |
 | Graph-backed query lint | `omnigraph lint --query new.gq --cluster s3://acme/clusters/brain --graph knowledge` | direct (privileged) |
 | Local dev, no server | `omnigraph query -e 'match { … } return { … }' --store graph.omni` | direct (local file) |
-| Break-glass: raw storage of a served graph | `omnigraph query --file find.gq --store s3://acme/clusters/brain/graphs/knowledge.omni` | direct (privileged, rare) |
+| Break-glass: **read** raw storage of a served graph | `omnigraph query -e 'match { … } return { … }' --store s3://acme/clusters/brain/graphs/knowledge.omni` | direct (privileged, rare; reads — see "Break-glass is read-biased") |
 
 Note what the everyday rows are: **all served.** `optimize` does *not* appear in
 the default-scope rows — from a server scope it errors and points you to name
@@ -468,8 +520,9 @@ staged and release-noted.
 
 ## Decisions
 
-The questions this RFC opened are resolved as follows. Two are explicitly
-deferred (see below); they do not block the model.
+The questions this RFC opened are resolved as follows. Numbers 5 and 8 are
+deferred below as D5/D8, so the list runs 1–4, 6, 7, 9–11; the two deferrals do
+not block the model.
 
 1. **Local-dev path → embedded `--store` scope.** Local dev runs the engine
    in-process against a `--store <file>` (or a store-scoped profile); `omnigraph
@@ -715,7 +768,7 @@ argv-shim → `lint`; `get` aliases `schema show`; `ingest` is hidden but runs.
 | Form | Looks up in | Resolves to | Source |
 |---|---|---|---|
 | `<URI>` / `--uri` | nothing (explicit) | the literal URI | — |
-| `--target <name>` | `omnigraph.yaml` `graphs:` | that graph's `uri` (local / S3 / **http**) | `config.rs::resolve_target_uri` |
+| `--target <name>` | `omnigraph.yaml` `graphs:` | that graph's `uri` (local / S3 / **http**) | `omnigraph-server/src/config.rs:459` |
 | `--server <name>` (+`--graph`) | `~/.omnigraph/config.yaml` `servers:` | a remote server URL | `helpers.rs::resolve_server_flag` |
 | `--cluster <dir\|s3> --cluster-graph <id>` | served cluster state | the graph's storage URI | `helpers.rs` (RFC-010 Slice 3) |
 


### PR DESCRIPTION
Applies the accepted review fixes to RFC-011. Docs only.

**Substantive**
- **Break-glass is read-biased** — direct `--store` *writes* to a server-active
  graph are the unsafe multi-process-writer case (`invariants.md` known gap), not
  just stale-read. Added the constraint; the break-glass example row is now a read.
- **Maintenance verbs marked provisional `direct`** — Decision 11 moves
  `optimize`/`cleanup`/`repair` server-side, so the RFC ships the addressing model
  as the stable contract and doesn't commit those verbs' direct CLI shape long-term
  (avoids Hyrum churn).
- **`schema apply` footnoted** — `any` only for standalone graphs; cluster graphs
  reject it (→ `cluster apply`, Decision 10).
- **Admins-live-in-two-scopes** promoted from Deferred into the Design body.
- **Worked profile-precedence trace** added (Decision 6).

**Minor** — `--as ?? …` → `--as, else …`; Decisions numbering note (5/8 deferred);
store/cluster mis-pointing fails at open time; `resolve_target_uri` cited precisely.

Verified: internal links resolve; `check-agents-md.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Applies a set of review-accepted doc fixes to RFC-011 (`docs/dev/rfc-011-cli-refactoring.md`). The changes are all documentation — no code is touched.

- **Break-glass write-safety**: adds an explicit \"Break-glass is read-biased\" section stating that direct `--store` writes to a server-active graph are unsafe (multi-process-writer race, per `invariants.md`); the Command Shape table example is updated to a read (`-e '...'`). Both citations were verified: `omnigraph-server/src/config.rs:459` starts `resolve_target_uri`, and `invariants.md` line 151 contains the exact quoted heading.
- **Provisional `direct` for maintenance verbs**: `optimize`/`cleanup`/`repair` are now marked `†` with a Decision 11 footnote clarifying they are not a long-term CLI contract, while `init`, `schema plan`, and graph-backed `lint` remain durably `direct`.
- **Minor prose and structural fixes**: `--as ?? …` → `--as, else …`; Decisions header now names the two deferred entries (5/8); \"Admins live in two scopes\" promoted from Deferred into the Design body; worked profile-precedence trace added; `schema apply` cluster-rejection footnoted; kind-mismatch error described at resolution step 7.

<h3>Confidence Score: 4/5</h3>

Documentation-only change; no code is modified. All internal citations check out. One minor table inconsistency is the only finding.

The diff is well-scoped and the substantive additions (break-glass safety constraint, provisional verb markers, admins-in-two-scopes section, worked trace) are accurate and consistent with the rest of the document. The one rough edge is that the Before/After table's "After" break-glass example still shows --file find.gq while the Command Shape table — updated in this very PR — now uses -e '...'; a reader following either table as a reference will see diverging forms for the same scenario.

docs/dev/rfc-011-cli-refactoring.md — specifically the Before/After table row for "Raw storage of a served graph" (the "After" column) which is inconsistent with the updated Command Shape break-glass example.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docs/dev/rfc-011-cli-refactoring.md | Docs-only RFC review fix: adds break-glass write-safety constraint, provisional capability markers for optimize/cleanup/repair, schema apply footnote, admins-in-two-scopes design paragraph, and a worked profile-precedence trace. All internal citations verified (config.rs:459 resolves to resolve_target_uri; invariants.md "Recovery is serialized…" exists at line 151). One minor inconsistency: the Before/After table's "After" break-glass example still shows --file find.gq while the updated Command Shape table now uses -e '...'. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Command issued] --> B{Verb capability?}
    B -- local --> C[Run without scope resolution]
    B -- any/served/direct/control --> D{Scope source?}
    D -- explicit primitive flag --> E[Use --store / --server / --cluster]
    D -- profile flag / OMNIGRAPH_PROFILE --> F[Load named profile]
    D -- neither --> G[Use operator flat defaults]
    E & F & G --> H{Scope kind × Verb capability}
    H -- server scope × any --> I[Served access]
    H -- server scope × direct --> J[Error: name storage explicitly]
    H -- store scope × any --> K[Direct ad-hoc access, no catalog]
    H -- cluster scope × any --> L[Error: cluster is maintenance-only]
    H -- cluster/store × direct --> M[Direct privileged access]
    H -- cluster × control --> N[Control-plane access]
    K -- s3:// store & write --> O[Unsafe: multi-process writer - see invariants.md]
    K -- s3:// store & read --> P[Break-glass inspection OK]
    M -- optimize/repair/cleanup --> Q[Provisional: moves server-side per Decision 11]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `docs/dev/rfc-011-cli-refactoring.md`, line 464 ([link](https://github.com/modernrelay/omnigraph/blob/3caea8a597b8ce2ab35f0e0814f6bfafe01cac5d/docs/dev/rfc-011-cli-refactoring.md#L464)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Before/After table break-glass "After" example diverges from Command Shape table**

   The "After" column here still shows `--file find.gq` as the break-glass form, but the Command Shape table (line 440, changed in this PR) now demonstrates break-glass with `-e 'match { … } return { … }'`. A reader consulting both tables to understand the expected break-glass invocation will see two different forms for the same scenario — one using a query file, one using an inline expression. The two forms are both valid reads, but having them disagree makes it harder to use the tables as canonical implementation reference. Aligning them (e.g. updating the "After" cell here to use the inline `-e '...'` form, consistent with the updated Command Shape row) would eliminate the ambiguity.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20docs%2Fdev%2Frfc-011-cli-refactoring.md%0ALine%3A%20464%0A%0AComment%3A%0A**Before%2FAfter%20table%20break-glass%20%22After%22%20example%20diverges%20from%20Command%20Shape%20table**%0A%0AThe%20%22After%22%20column%20here%20still%20shows%20%60--file%20find.gq%60%20as%20the%20break-glass%20form%2C%20but%20the%20Command%20Shape%20table%20%28line%20440%2C%20changed%20in%20this%20PR%29%20now%20demonstrates%20break-glass%20with%20%60-e%20'match%20%7B%20%E2%80%A6%20%7D%20return%20%7B%20%E2%80%A6%20%7D'%60.%20A%20reader%20consulting%20both%20tables%20to%20understand%20the%20expected%20break-glass%20invocation%20will%20see%20two%20different%20forms%20for%20the%20same%20scenario%20%E2%80%94%20one%20using%20a%20query%20file%2C%20one%20using%20an%20inline%20expression.%20The%20two%20forms%20are%20both%20valid%20reads%2C%20but%20having%20them%20disagree%20makes%20it%20harder%20to%20use%20the%20tables%20as%20canonical%20implementation%20reference.%20Aligning%20them%20%28e.g.%20updating%20the%20%22After%22%20cell%20here%20to%20use%20the%20inline%20%60-e%20'...'%60%20form%2C%20consistent%20with%20the%20updated%20Command%20Shape%20row%29%20would%20eliminate%20the%20ambiguity.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modernrelay%2Fomnigraph&pr=234&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fdev%2Frfc-011-cli-refactoring.md%3A464%0A**Before%2FAfter%20table%20break-glass%20%22After%22%20example%20diverges%20from%20Command%20Shape%20table**%0A%0AThe%20%22After%22%20column%20here%20still%20shows%20%60--file%20find.gq%60%20as%20the%20break-glass%20form%2C%20but%20the%20Command%20Shape%20table%20%28line%20440%2C%20changed%20in%20this%20PR%29%20now%20demonstrates%20break-glass%20with%20%60-e%20'match%20%7B%20%E2%80%A6%20%7D%20return%20%7B%20%E2%80%A6%20%7D'%60.%20A%20reader%20consulting%20both%20tables%20to%20understand%20the%20expected%20break-glass%20invocation%20will%20see%20two%20different%20forms%20for%20the%20same%20scenario%20%E2%80%94%20one%20using%20a%20query%20file%2C%20one%20using%20an%20inline%20expression.%20The%20two%20forms%20are%20both%20valid%20reads%2C%20but%20having%20them%20disagree%20makes%20it%20harder%20to%20use%20the%20tables%20as%20canonical%20implementation%20reference.%20Aligning%20them%20%28e.g.%20updating%20the%20%22After%22%20cell%20here%20to%20use%20the%20inline%20%60-e%20'...'%60%20form%2C%20consistent%20with%20the%20updated%20Command%20Shape%20row%29%20would%20eliminate%20the%20ambiguity.%0A%0A&repo=modernrelay%2Fomnigraph&pr=234&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(rfc): RFC-011 review fixes — break-..."](https://github.com/modernrelay/omnigraph/commit/3caea8a597b8ce2ab35f0e0814f6bfafe01cac5d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37515832)</sub>

<!-- /greptile_comment -->