### PR TITLE
feat(cli)!: remove legacy data-plane addressing (--target, positional http→remote, --as-on-served)

### DIFF
--- a/crates/omnigraph-cli/src/cli.rs
+++ b/crates/omnigraph-cli/src/cli.rs
@@ -31,10 +31,10 @@ pub(crate) struct Cli {
     #[arg(long = "as", global = true, value_name = "ACTOR")]
     pub(crate) as_actor: Option<String>,
 
-    /// Target an operator-defined server by name (RFC-007): resolves to
-    /// its `url` from `servers:` in ~/.omnigraph/config.yaml. Exclusive
-    /// with a positional URI or `--target`.
-    #[arg(long, global = true, value_name = "NAME")]
+    /// Address a server by name (resolves to its `url` from `servers:` in
+    /// ~/.omnigraph/config.yaml) or by a literal `http(s)://` URL. Exclusive
+    /// with a positional URI.
+    #[arg(long, global = true, value_name = "NAME|URL")]
     pub(crate) server: Option<String>,
 
     /// Graph id on a multi-graph `--server` (appends `/graphs/<id>` to
@@ -52,7 +52,7 @@ pub(crate) struct Cli {
 
     /// Address a single graph's storage directly (RFC-011): a `file://` /
     /// `s3://` store URI. Explicit, ad-hoc direct access — bypasses any
-    /// server. Exclusive with a positional URI / `--target` / `--server`.
+    /// server. Exclusive with a positional URI / `--server`.
     #[arg(long, global = true, value_name = "URI")]
     pub(crate) store: Option<String>,
 
@@ -75,8 +75,6 @@ pub(crate) enum Command {
         uri: Option<String>,
         #[arg(hide = true)]
         legacy_uri: Option<String>,
-        #[arg(long)]
-        target: Option<String>,
         #[arg(long)]
         config: Option<PathBuf>,
         #[arg(long, conflicts_with_all = ["query", "query_string"])]
@@ -114,8 +112,6 @@ pub(crate) enum Command {
         #[arg(hide = true)]
         legacy_uri: Option<String>,
         #[arg(long)]
-        target: Option<String>,
-        #[arg(long)]
         config: Option<PathBuf>,
         #[arg(long, conflicts_with_all = ["query", "query_string"])]
         alias: Option<String>,
@@ -140,8 +136,6 @@ pub(crate) enum Command {
         /// Graph URI
         uri: Option<String>,
         #[arg(long)]
-        target: Option<String>,
-        #[arg(long)]
         config: Option<PathBuf>,
         #[arg(long)]
         data: PathBuf,
@@ -165,8 +159,6 @@ pub(crate) enum Command {
         /// Graph URI
         uri: Option<String>,
         #[arg(long)]
-        target: Option<String>,
-        #[arg(long)]
         config: Option<PathBuf>,
         #[arg(long)]
         data: PathBuf,
@@ -189,8 +181,6 @@ pub(crate) enum Command {
         /// Graph URI
         uri: Option<String>,
         #[arg(long)]
-        target: Option<String>,
-        #[arg(long)]
         config: Option<PathBuf>,
         #[arg(long)]
         branch: Option<String>,
@@ -201,8 +191,6 @@ pub(crate) enum Command {
     Export {
         /// Graph URI
         uri: Option<String>,
-        #[arg(long)]
-        target: Option<String>,
         #[arg(long)]
         config: Option<PathBuf>,
         #[arg(long)]
@@ -250,12 +238,10 @@ pub(crate) enum Command {
         /// Graph URI
         uri: Option<String>,
         #[arg(long)]
-        target: Option<String>,
-        #[arg(long)]
         config: Option<PathBuf>,
         /// Cluster directory or storage-root URI; with --cluster-graph, resolves
         /// the graph's storage URI from the served cluster state.
-        #[arg(long, conflicts_with_all = ["uri", "target"], requires = "cluster_graph")]
+        #[arg(long, conflicts_with = "uri", requires = "cluster_graph")]
         cluster: Option<String>,
         /// Graph id within --cluster.
         #[arg(long, requires = "cluster")]
@@ -268,12 +254,10 @@ pub(crate) enum Command {
         /// Graph URI
         uri: Option<String>,
         #[arg(long)]
-        target: Option<String>,
-        #[arg(long)]
         config: Option<PathBuf>,
         /// Cluster directory or storage-root URI; with --cluster-graph, resolves
         /// the graph's storage URI from the served cluster state.
-        #[arg(long, conflicts_with_all = ["uri", "target"], requires = "cluster_graph")]
+        #[arg(long, conflicts_with = "uri", requires = "cluster_graph")]
         cluster: Option<String>,
         /// Graph id within --cluster.
         #[arg(long, requires = "cluster")]
@@ -294,12 +278,10 @@ pub(crate) enum Command {
         /// Graph URI
         uri: Option<String>,
         #[arg(long)]
-        target: Option<String>,
-        #[arg(long)]
         config: Option<PathBuf>,
         /// Cluster directory or storage-root URI; with --cluster-graph, resolves
         /// the graph's storage URI from the served cluster state.
-        #[arg(long, conflicts_with_all = ["uri", "target"], requires = "cluster_graph")]
+        #[arg(long, conflicts_with = "uri", requires = "cluster_graph")]
         cluster: Option<String>,
         /// Graph id within --cluster.
         #[arg(long, requires = "cluster")]
@@ -332,8 +314,6 @@ pub(crate) enum Command {
     Lint {
         /// Graph URI
         uri: Option<String>,
-        #[arg(long)]
-        target: Option<String>,
         #[arg(long)]
         config: Option<PathBuf>,
         #[arg(long)]
@@ -489,8 +469,6 @@ pub(crate) enum GraphsCommand {
         #[arg(long)]
         uri: Option<String>,
         #[arg(long)]
-        target: Option<String>,
-        #[arg(long)]
         config: Option<PathBuf>,
         #[arg(long)]
         json: bool,
@@ -505,8 +483,6 @@ pub(crate) enum BranchCommand {
         #[arg(long)]
         uri: Option<String>,
         #[arg(long)]
-        target: Option<String>,
-        #[arg(long)]
         config: Option<PathBuf>,
         #[arg(long)]
         from: Option<String>,
@@ -520,8 +496,6 @@ pub(crate) enum BranchCommand {
         #[arg(long)]
         uri: Option<String>,
         #[arg(long)]
-        target: Option<String>,
-        #[arg(long)]
         config: Option<PathBuf>,
         #[arg(long)]
         json: bool,
@@ -531,8 +505,6 @@ pub(crate) enum BranchCommand {
         /// Graph URI
         #[arg(long)]
         uri: Option<String>,
-        #[arg(long)]
-        target: Option<String>,
         #[arg(long)]
         config: Option<PathBuf>,
         name: String,
@@ -544,8 +516,6 @@ pub(crate) enum BranchCommand {
         /// Graph URI
         #[arg(long)]
         uri: Option<String>,
-        #[arg(long)]
-        target: Option<String>,
         #[arg(long)]
         config: Option<PathBuf>,
         source: String,
@@ -563,8 +533,6 @@ pub(crate) enum SchemaCommand {
         /// Graph URI
         uri: Option<String>,
         #[arg(long)]
-        target: Option<String>,
-        #[arg(long)]
         config: Option<PathBuf>,
         #[arg(long)]
         schema: PathBuf,
@@ -580,8 +548,6 @@ pub(crate) enum SchemaCommand {
     Apply {
         /// Graph URI
         uri: Option<String>,
-        #[arg(long)]
-        target: Option<String>,
         #[arg(long)]
         config: Option<PathBuf>,
         #[arg(long)]
@@ -606,8 +572,6 @@ pub(crate) enum SchemaCommand {
         /// Graph URI
         uri: Option<String>,
         #[arg(long)]
-        target: Option<String>,
-        #[arg(long)]
         config: Option<PathBuf>,
         #[arg(long)]
         json: bool,
@@ -622,8 +586,6 @@ pub(crate) enum CommitCommand {
         /// Graph URI
         uri: Option<String>,
         #[arg(long)]
-        target: Option<String>,
-        #[arg(long)]
         config: Option<PathBuf>,
         #[arg(long)]
         branch: Option<String>,
@@ -635,8 +597,6 @@ pub(crate) enum CommitCommand {
         /// Graph URI
         #[arg(long)]
         uri: Option<String>,
-        #[arg(long)]
-        target: Option<String>,
         #[arg(long)]
         config: Option<PathBuf>,
         commit_id: String,
@@ -684,16 +644,12 @@ pub(crate) enum QueriesCommand {
         /// Graph URI
         uri: Option<String>,
         #[arg(long)]
-        target: Option<String>,
-        #[arg(long)]
         config: Option<PathBuf>,
         #[arg(long)]
         json: bool,
     },
     /// List the registered stored queries (name, MCP exposure, params).
     List {
-        #[arg(long)]
-        target: Option<String>,
         #[arg(long)]
         config: Option<PathBuf>,
         #[arg(long)]

--- a/crates/omnigraph-cli/src/client.rs
+++ b/crates/omnigraph-cli/src/client.rs
@@ -147,6 +147,15 @@ impl GraphClient {
         let token = resolve_remote_bearer_token(config, uri.as_deref(), target)?;
         let resolved = resolve_cli_graph(config, uri, target)?;
         if resolved.is_remote {
+            // A served write resolves the actor server-side from the bearer
+            // token; `--as` cannot set identity here and is rejected.
+            if cli_as.is_some() {
+                bail!(
+                    "`--as` is not allowed on a served write — the server resolves the actor \
+                     from the bearer token. Remove `--as`, or run the write directly against \
+                     storage with `--store <uri>`."
+                );
+            }
             Ok(GraphClient::Remote {
                 http: build_http_client()?,
                 base_url: resolved.uri,

--- a/crates/omnigraph-cli/src/client.rs
+++ b/crates/omnigraph-cli/src/client.rs
@@ -66,6 +66,19 @@ pub(crate) enum GraphClient {
     },
 }
 
+/// A remote graph must be addressed with `--server` (RFC-011): a positional or
+/// `--uri` `http(s)://` URL no longer auto-dispatches to a server. A remote URL
+/// produced by a server scope (`via_server`) is fine.
+fn reject_positional_remote(via_server: bool, uri: &str) -> Result<()> {
+    if !via_server && is_remote_uri(uri) {
+        bail!(
+            "a remote graph must be addressed with `--server <url>` — a positional \
+             (or `--uri`) http(s):// URL no longer dispatches to a server"
+        );
+    }
+    Ok(())
+}
+
 impl GraphClient {
     /// Resolve the addressing (positional URI / `--target` / `--server`)
     /// and credential once, then pick the variant by URI scheme — the
@@ -96,9 +109,11 @@ impl GraphClient {
             scope.uri,
             scope.target.as_deref(),
         );
+        let via_server = server.is_some();
         let uri = apply_server_flag(server, graph, uri, target)?;
         let token = resolve_remote_bearer_token(config, uri.as_deref(), target)?;
         let uri = crate::helpers::resolve_uri(config, uri, target)?;
+        reject_positional_remote(via_server, &uri)?;
         if is_remote_uri(&uri) {
             Ok(GraphClient::Remote {
                 http: build_http_client()?,
@@ -143,9 +158,11 @@ impl GraphClient {
             scope.uri,
             scope.target.as_deref(),
         );
+        let via_server = server.is_some();
         let uri = apply_server_flag(server, graph, uri, target)?;
         let token = resolve_remote_bearer_token(config, uri.as_deref(), target)?;
         let resolved = resolve_cli_graph(config, uri, target)?;
+        reject_positional_remote(via_server, &resolved.uri)?;
         if resolved.is_remote {
             // A served write resolves the actor server-side from the bearer
             // token; `--as` cannot set identity here and is rejected.

--- a/crates/omnigraph-cli/src/client.rs
+++ b/crates/omnigraph-cli/src/client.rs
@@ -91,28 +91,26 @@ impl GraphClient {
         server: Option<&str>,
         graph: Option<&str>,
         uri: Option<String>,
-        target: Option<&str>,
         profile: Option<&str>,
         store: Option<&str>,
     ) -> Result<Self> {
         // RFC-011: a scope (profile / --store / operator defaults) may stand in
-        // for omitted addressing. The explicit branch passes server/graph/uri/
-        // target straight through, so existing invocations are unchanged.
+        // for omitted addressing. The explicit branch passes server/graph/uri
+        // straight through, so existing invocations are unchanged.
         let scope = crate::scope::resolve_scope(
             &crate::operator::load_operator_config()?,
             crate::planes::Capability::Any,
-            crate::scope::ScopeFlags { profile, store, server, graph, uri, target },
+            crate::scope::ScopeFlags { profile, store, server, graph, uri },
         )?;
-        let (server, graph, uri, target) = (
+        let (server, graph, uri) = (
             scope.server.as_deref(),
             scope.graph.as_deref(),
             scope.uri,
-            scope.target.as_deref(),
         );
         let via_server = server.is_some();
-        let uri = apply_server_flag(server, graph, uri, target)?;
-        let token = resolve_remote_bearer_token(config, uri.as_deref(), target)?;
-        let uri = crate::helpers::resolve_uri(config, uri, target)?;
+        let uri = apply_server_flag(server, graph, uri)?;
+        let token = resolve_remote_bearer_token(config, uri.as_deref())?;
+        let uri = crate::helpers::resolve_uri(config, uri)?;
         reject_positional_remote(via_server, &uri)?;
         if is_remote_uri(&uri) {
             Ok(GraphClient::Remote {
@@ -140,7 +138,6 @@ impl GraphClient {
         server: Option<&str>,
         graph: Option<&str>,
         uri: Option<String>,
-        target: Option<&str>,
         cli_as: Option<&str>,
         profile: Option<&str>,
         store: Option<&str>,
@@ -150,18 +147,17 @@ impl GraphClient {
         let scope = crate::scope::resolve_scope(
             &crate::operator::load_operator_config()?,
             crate::planes::Capability::Any,
-            crate::scope::ScopeFlags { profile, store, server, graph, uri, target },
+            crate::scope::ScopeFlags { profile, store, server, graph, uri },
         )?;
-        let (server, graph, uri, target) = (
+        let (server, graph, uri) = (
             scope.server.as_deref(),
             scope.graph.as_deref(),
             scope.uri,
-            scope.target.as_deref(),
         );
         let via_server = server.is_some();
-        let uri = apply_server_flag(server, graph, uri, target)?;
-        let token = resolve_remote_bearer_token(config, uri.as_deref(), target)?;
-        let resolved = resolve_cli_graph(config, uri, target)?;
+        let uri = apply_server_flag(server, graph, uri)?;
+        let token = resolve_remote_bearer_token(config, uri.as_deref())?;
+        let resolved = resolve_cli_graph(config, uri)?;
         reject_positional_remote(via_server, &resolved.uri)?;
         if resolved.is_remote {
             // A served write resolves the actor server-side from the bearer

--- a/crates/omnigraph-cli/src/helpers.rs
+++ b/crates/omnigraph-cli/src/helpers.rs
@@ -303,19 +303,26 @@ pub(crate) fn resolve_server_flag(
     let Some(server) = server else {
         return Ok(None);
     };
-    let operator_config = operator::load_operator_config()?;
-    let Some(entry) = operator_config.servers.get(server) else {
-        let known = operator_config
-            .servers
-            .keys()
-            .map(String::as_str)
-            .collect::<Vec<_>>()
-            .join(", ");
-        color_eyre::eyre::bail!(
-            "unknown server '{server}' — servers defined in the operator config: [{known}] (add it under servers: in ~/.omnigraph/config.yaml)"
-        );
+    // RFC-011 Decision 2: a value containing `://` is a literal base URL
+    // (bypasses the operator-config registry); otherwise it is a config name.
+    let base_url = if server.contains("://") {
+        server.to_string()
+    } else {
+        let operator_config = operator::load_operator_config()?;
+        let Some(entry) = operator_config.servers.get(server) else {
+            let known = operator_config
+                .servers
+                .keys()
+                .map(String::as_str)
+                .collect::<Vec<_>>()
+                .join(", ");
+            color_eyre::eyre::bail!(
+                "unknown server '{server}' — servers defined in the operator config: [{known}] (add it under servers: in ~/.omnigraph/config.yaml)"
+            );
+        };
+        entry.url.clone()
     };
-    let base = entry.url.trim_end_matches('/');
+    let base = base_url.trim_end_matches('/');
     Ok(Some(match graph {
         Some(graph) => format!("{base}/graphs/{graph}"),
         None => base.to_string(),
@@ -1089,6 +1096,22 @@ pub(crate) fn rewrite_deprecated_argv(args: Vec<OsString>) -> Vec<OsString> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // RFC-011 Decision 2: `--server` accepts a literal URL (value with `://`),
+    // bypassing the operator-config registry — so no config / OMNIGRAPH_HOME is
+    // read on this path (hermetic).
+    #[test]
+    fn server_flag_accepts_a_literal_url() {
+        assert_eq!(
+            resolve_server_flag(Some("https://graph.example.com"), None).unwrap(),
+            Some("https://graph.example.com".to_string())
+        );
+        // trailing slash trimmed; `--graph` appends the multi-graph path.
+        assert_eq!(
+            resolve_server_flag(Some("https://graph.example.com/"), Some("knowledge")).unwrap(),
+            Some("https://graph.example.com/graphs/knowledge".to_string())
+        );
+    }
 
     // `branch delete` interpolates the branch into the URL path. The composed
     // path must be exactly `<base-path>/branches/<name>` with no empty `//`

--- a/crates/omnigraph-cli/src/helpers.rs
+++ b/crates/omnigraph-cli/src/helpers.rs
@@ -245,8 +245,9 @@ pub(crate) fn normalize_policy_graph_uri(uri: &str) -> Result<String> {
 pub(crate) fn resolve_remote_bearer_token(
     config: &OmnigraphConfig,
     explicit_uri: Option<&str>,
-    explicit_target: Option<&str>,
 ) -> Result<Option<String>> {
+    // `--target` is gone; the legacy explicit-target name is always None.
+    let explicit_target: Option<&str> = None;
     // The keyed hop (RFC-007 §D4, gh-host model): when the effective remote
     // URL belongs to an operator-defined server, that server's keyed chain
     // applies first — OMNIGRAPH_TOKEN_<NAME> env, then the 0600 credentials
@@ -343,7 +344,7 @@ pub(crate) async fn execute_operator_alias(
 ) -> Result<ReadOutput> {
     let uri = resolve_server_flag(Some(&alias.server), alias.graph.as_deref())?
         .expect("server name is present");
-    let bearer_token = resolve_remote_bearer_token(config, Some(&uri), None)?;
+    let bearer_token = resolve_remote_bearer_token(config, Some(&uri))?;
 
     let mut params = serde_json::Map::new();
     for (key, value) in &alias.params {
@@ -386,14 +387,13 @@ pub(crate) fn apply_server_flag(
     server: Option<&str>,
     graph: Option<&str>,
     uri: Option<String>,
-    target: Option<&str>,
 ) -> Result<Option<String>> {
     if server.is_none() {
         return Ok(uri);
     }
-    if uri.is_some() || target.is_some() {
+    if uri.is_some() {
         color_eyre::eyre::bail!(
-            "--server is exclusive with a positional URI and --target — pick one way to address the graph"
+            "--server is exclusive with a positional URI — pick one way to address the graph"
         );
     }
     resolve_server_flag(server, graph)
@@ -455,28 +455,23 @@ pub(crate) async fn remote_json<T: DeserializeOwned>(
     Ok(serde_json::from_str(&text)?)
 }
 
-pub(crate) fn resolve_uri(
-    config: &OmnigraphConfig,
-    cli_uri: Option<String>,
-    cli_target: Option<&str>,
-) -> Result<String> {
-    config.resolve_target_uri(cli_uri, cli_target, config.cli_graph_name())
+pub(crate) fn resolve_uri(config: &OmnigraphConfig, cli_uri: Option<String>) -> Result<String> {
+    // `--target` is gone; the second arg (the legacy explicit-target name) is
+    // always None. A bare command still falls back to `cli.graph` (the third arg).
+    config.resolve_target_uri(cli_uri, None, config.cli_graph_name())
 }
 
 pub(crate) fn resolve_cli_graph(
     config: &OmnigraphConfig,
     cli_uri: Option<String>,
-    cli_target: Option<&str>,
 ) -> Result<ResolvedCliGraph> {
     let selected = if cli_uri.is_some() {
         None
     } else {
-        cli_target
-            .map(str::to_string)
-            .or_else(|| config.cli_graph_name().map(str::to_string))
+        config.cli_graph_name().map(str::to_string)
     };
     config.resolve_graph_selection(selected.as_deref())?;
-    let uri = resolve_uri(config, cli_uri, cli_target)?;
+    let uri = resolve_uri(config, cli_uri)?;
     let normalized_uri = normalize_policy_graph_uri(&uri)?;
     let graph_id = graph_resource_id_for_selection(selected.as_deref(), &normalized_uri);
     Ok(ResolvedCliGraph {
@@ -491,10 +486,9 @@ pub(crate) fn resolve_cli_graph(
 pub(crate) fn resolve_local_graph(
     config: &OmnigraphConfig,
     cli_uri: Option<String>,
-    cli_target: Option<&str>,
     operation: &str,
 ) -> Result<ResolvedCliGraph> {
-    let graph = resolve_cli_graph(config, cli_uri, cli_target)?;
+    let graph = resolve_cli_graph(config, cli_uri)?;
     if graph.is_remote {
         bail!(
             "`{}` is a direct (storage-native) command and needs direct storage \
@@ -540,29 +534,27 @@ pub(crate) fn parse_duration_arg(s: &str) -> Result<std::time::Duration> {
 pub(crate) fn resolve_local_uri(
     config: &OmnigraphConfig,
     cli_uri: Option<String>,
-    cli_target: Option<&str>,
     operation: &str,
 ) -> Result<String> {
-    Ok(resolve_local_graph(config, cli_uri, cli_target, operation)?.uri)
+    Ok(resolve_local_graph(config, cli_uri, operation)?.uri)
 }
 
-/// Resolve a storage-plane verb's target to a direct storage URI (RFC-010
+/// Resolve a storage-plane verb's address to a direct storage URI (RFC-010
 /// Slice 3). `--cluster <dir|uri> --cluster-graph <id>` resolves the graph's
 /// storage URI from the **served cluster state** (the truth a `--cluster`
-/// server serves); otherwise the ordinary positional-URI / `--target` path.
-/// clap enforces both-or-neither and exclusion with `uri`/`--target`, so the
-/// mismatched arm is defensive.
+/// server serves); otherwise the ordinary positional-URI path.
+/// clap enforces both-or-neither and exclusion with `uri`, so the mismatched
+/// arm is defensive.
 pub(crate) async fn resolve_storage_uri(
     config: &OmnigraphConfig,
     cli_uri: Option<String>,
-    cli_target: Option<&str>,
     cluster: Option<&str>,
     cluster_graph: Option<&str>,
     operation: &str,
 ) -> Result<String> {
     match (cluster, cluster_graph) {
         (Some(cluster), Some(graph_id)) => resolve_cluster_graph_uri(cluster, graph_id).await,
-        (None, None) => resolve_local_uri(config, cli_uri, cli_target, operation),
+        (None, None) => resolve_local_uri(config, cli_uri, operation),
         _ => bail!("--cluster and --cluster-graph must be given together"),
     }
 }
@@ -793,7 +785,6 @@ pub(crate) fn query_params_from_json(
 pub(crate) async fn execute_query_lint(
     config: &OmnigraphConfig,
     cli_uri: Option<String>,
-    cli_target: Option<&str>,
     schema_path: Option<&PathBuf>,
     query_path: &PathBuf,
 ) -> Result<QueryLintOutput> {
@@ -815,13 +806,12 @@ pub(crate) async fn execute_query_lint(
         ));
     }
 
-    let has_graph_target =
-        cli_uri.is_some() || cli_target.is_some() || config.cli_graph_name().is_some();
+    let has_graph_target = cli_uri.is_some() || config.cli_graph_name().is_some();
     if !has_graph_target {
         bail!("lint requires --schema <schema.pg> or a resolvable graph target");
     }
 
-    let uri = resolve_local_uri(config, cli_uri, cli_target, "lint")?;
+    let uri = resolve_local_uri(config, cli_uri, "lint")?;
     let db = Omnigraph::open(&uri).await?;
     Ok(lint_query_file(
         &db.catalog(),
@@ -834,10 +824,9 @@ pub(crate) async fn execute_query_lint(
 pub(crate) fn resolve_selected_graph(
     config: &OmnigraphConfig,
     cli_uri: Option<String>,
-    cli_target: Option<&str>,
     operation: &str,
 ) -> Result<(String, Option<String>)> {
-    let graph = resolve_local_graph(config, cli_uri, cli_target, operation)?;
+    let graph = resolve_local_graph(config, cli_uri, operation)?;
     Ok((graph.uri, graph.selected))
 }
 
@@ -867,11 +856,8 @@ pub(crate) fn graph_query_registry_names(config: &OmnigraphConfig) -> Vec<&str> 
 
 pub(crate) fn resolve_registry_selection_for_list(
     config: &OmnigraphConfig,
-    target: Option<&str>,
 ) -> Result<Option<String>> {
-    let selected = target
-        .map(str::to_string)
-        .or_else(|| config.cli_graph_name().map(str::to_string));
+    let selected = config.cli_graph_name().map(str::to_string);
     if let Some(name) = selected.as_deref() {
         config.resolve_graph_selection(Some(name))?;
         return Ok(selected);
@@ -887,10 +873,9 @@ pub(crate) fn resolve_registry_selection_for_list(
     }
 
     bail!(
-        "stored-query registries are configured for graph{} {} but no graph was selected. Pass `--target {}` or set `cli.graph`.",
+        "stored-query registries are configured for graph{} {} but no graph was selected. Pass a positional URI or set `cli.graph`.",
         if graph_names.len() == 1 { "" } else { "s" },
         graph_names.join(", "),
-        graph_names[0],
     )
 }
 
@@ -910,15 +895,12 @@ pub(crate) fn validate_registry_for_catalog(
 
 pub(crate) async fn execute_queries_validate(
     uri: Option<String>,
-    target: Option<String>,
     config_path: Option<&PathBuf>,
     json: bool,
 ) -> Result<()> {
     let config = load_cli_config(config_path)?;
-    // One selection drives both the schema URI and the registry, so a
-    // positional URI and a `--target` can't validate different graphs.
-    let (uri, selected) =
-        resolve_selected_graph(&config, uri, target.as_deref(), "queries validate")?;
+    // One selection drives both the schema URI and the registry.
+    let (uri, selected) = resolve_selected_graph(&config, uri, "queries validate")?;
     let registry = load_registry_or_report(&config, selected.as_deref())?;
     let db = Omnigraph::open(&uri).await?;
     let report = check(&registry, &db.catalog());
@@ -968,13 +950,9 @@ pub(crate) async fn execute_queries_validate(
     Ok(())
 }
 
-pub(crate) fn execute_queries_list(
-    target: Option<String>,
-    config_path: Option<&PathBuf>,
-    json: bool,
-) -> Result<()> {
+pub(crate) fn execute_queries_list(config_path: Option<&PathBuf>, json: bool) -> Result<()> {
     let config = load_cli_config(config_path)?;
-    let selected = resolve_registry_selection_for_list(&config, target.as_deref())?;
+    let selected = resolve_registry_selection_for_list(&config)?;
     let registry = load_registry_or_report(&config, selected.as_deref())?;
 
     let output = QueriesListOutput {

--- a/crates/omnigraph-cli/src/main.rs
+++ b/crates/omnigraph-cli/src/main.rs
@@ -170,7 +170,6 @@ async fn main() -> Result<()> {
         }
         Command::Load {
             uri,
-            target,
             config,
             data,
             branch,
@@ -184,7 +183,6 @@ async fn main() -> Result<()> {
                 cli.server.as_deref(),
                 cli.graph.as_deref(),
                 uri,
-                target.as_deref(),
                 cli.as_actor.as_deref(),
                 cli.profile.as_deref(),
                 cli.store.as_deref(),
@@ -201,7 +199,6 @@ async fn main() -> Result<()> {
         }
         Command::Ingest {
             uri,
-            target,
             config,
             data,
             branch,
@@ -220,7 +217,6 @@ async fn main() -> Result<()> {
                 cli.server.as_deref(),
                 cli.graph.as_deref(),
                 uri,
-                target.as_deref(),
                 cli.as_actor.as_deref(),
                 cli.profile.as_deref(),
                 cli.store.as_deref(),
@@ -239,7 +235,6 @@ async fn main() -> Result<()> {
         Command::Branch { command } => match command {
             BranchCommand::Create {
                 uri,
-                target,
                 config,
                 from,
                 name,
@@ -251,7 +246,6 @@ async fn main() -> Result<()> {
                     cli.server.as_deref(),
                     cli.graph.as_deref(),
                     uri,
-                    target.as_deref(),
                     cli.as_actor.as_deref(),
                     cli.profile.as_deref(),
                     cli.store.as_deref(),
@@ -266,7 +260,6 @@ async fn main() -> Result<()> {
             }
             BranchCommand::List {
                 uri,
-                target,
                 config,
                 json,
             } => {
@@ -276,7 +269,6 @@ async fn main() -> Result<()> {
                     cli.server.as_deref(),
                     cli.graph.as_deref(),
                     uri,
-                    target.as_deref(),
                     cli.profile.as_deref(),
                     cli.store.as_deref(),
                 )?;
@@ -291,7 +283,6 @@ async fn main() -> Result<()> {
             }
             BranchCommand::Delete {
                 uri,
-                target,
                 config,
                 name,
                 json,
@@ -302,7 +293,6 @@ async fn main() -> Result<()> {
                     cli.server.as_deref(),
                     cli.graph.as_deref(),
                     uri,
-                    target.as_deref(),
                     cli.as_actor.as_deref(),
                     cli.profile.as_deref(),
                     cli.store.as_deref(),
@@ -316,7 +306,6 @@ async fn main() -> Result<()> {
             }
             BranchCommand::Merge {
                 uri,
-                target,
                 config,
                 source,
                 into,
@@ -328,7 +317,6 @@ async fn main() -> Result<()> {
                     cli.server.as_deref(),
                     cli.graph.as_deref(),
                     uri,
-                    target.as_deref(),
                     cli.as_actor.as_deref(),
                     cli.profile.as_deref(),
                     cli.store.as_deref(),
@@ -350,7 +338,6 @@ async fn main() -> Result<()> {
         Command::Commit { command } => match command {
             CommitCommand::List {
                 uri,
-                target,
                 config,
                 branch,
                 json,
@@ -361,7 +348,6 @@ async fn main() -> Result<()> {
                     cli.server.as_deref(),
                     cli.graph.as_deref(),
                     uri,
-                    target.as_deref(),
                     cli.profile.as_deref(),
                     cli.store.as_deref(),
                 )?;
@@ -374,7 +360,6 @@ async fn main() -> Result<()> {
             }
             CommitCommand::Show {
                 uri,
-                target,
                 config,
                 commit_id,
                 json,
@@ -385,7 +370,6 @@ async fn main() -> Result<()> {
                     cli.server.as_deref(),
                     cli.graph.as_deref(),
                     uri,
-                    target.as_deref(),
                     cli.profile.as_deref(),
                     cli.store.as_deref(),
                 )?;
@@ -400,14 +384,13 @@ async fn main() -> Result<()> {
         Command::Schema { command } => match command {
             SchemaCommand::Plan {
                 uri,
-                target,
                 config,
                 schema,
                 json,
                 allow_data_loss,
             } => {
                 let config = load_cli_config(config.as_ref())?;
-                let uri = resolve_local_uri(&config, uri, target.as_deref(), "schema plan")?;
+                let uri = resolve_local_uri(&config, uri, "schema plan")?;
                 let schema_source = fs::read_to_string(&schema)?;
                 let db = Omnigraph::open(&uri).await?;
                 let plan = db
@@ -430,7 +413,6 @@ async fn main() -> Result<()> {
             }
             SchemaCommand::Apply {
                 uri,
-                target,
                 config,
                 schema,
                 json,
@@ -442,7 +424,6 @@ async fn main() -> Result<()> {
                     cli.server.as_deref(),
                     cli.graph.as_deref(),
                     uri,
-                    target.as_deref(),
                     cli.as_actor.as_deref(),
                     cli.profile.as_deref(),
                     cli.store.as_deref(),
@@ -475,7 +456,6 @@ async fn main() -> Result<()> {
             }
             SchemaCommand::Show {
                 uri,
-                target,
                 config,
                 json,
             } => {
@@ -485,7 +465,6 @@ async fn main() -> Result<()> {
                     cli.server.as_deref(),
                     cli.graph.as_deref(),
                     uri,
-                    target.as_deref(),
                     cli.profile.as_deref(),
                     cli.store.as_deref(),
                 )?;
@@ -499,7 +478,6 @@ async fn main() -> Result<()> {
         },
         Command::Lint {
             uri,
-            target,
             config,
             query,
             schema,
@@ -507,30 +485,27 @@ async fn main() -> Result<()> {
         } => {
             let config = load_cli_config(config.as_ref())?;
             let output =
-                execute_query_lint(&config, uri, target.as_deref(), schema.as_ref(), &query)
+                execute_query_lint(&config, uri, schema.as_ref(), &query)
                     .await?;
             finish_query_lint(&output, json)?;
         }
         Command::Queries { command } => match command {
             QueriesCommand::Validate {
                 uri,
-                target,
                 config,
                 json,
             } => {
-                execute_queries_validate(uri, target, config.as_ref(), json).await?;
+                execute_queries_validate(uri, config.as_ref(), json).await?;
             }
             QueriesCommand::List {
-                target,
                 config,
                 json,
             } => {
-                execute_queries_list(target, config.as_ref(), json)?;
+                execute_queries_list(config.as_ref(), json)?;
             }
         },
         Command::Snapshot {
             uri,
-            target,
             config,
             branch,
             json,
@@ -541,7 +516,6 @@ async fn main() -> Result<()> {
                 cli.server.as_deref(),
                 cli.graph.as_deref(),
                 uri,
-                target.as_deref(),
                 cli.profile.as_deref(),
                 cli.store.as_deref(),
             )?;
@@ -555,7 +529,6 @@ async fn main() -> Result<()> {
         }
         Command::Export {
             uri,
-            target,
             config,
             branch,
             jsonl,
@@ -568,7 +541,6 @@ async fn main() -> Result<()> {
                 cli.server.as_deref(),
                 cli.graph.as_deref(),
                 uri,
-                target.as_deref(),
                 cli.profile.as_deref(),
                 cli.store.as_deref(),
             )?;
@@ -586,7 +558,6 @@ async fn main() -> Result<()> {
         Command::Query {
             uri,
             legacy_uri,
-            target,
             config,
             alias,
             query,
@@ -644,23 +615,24 @@ async fn main() -> Result<()> {
             let alias = resolve_alias(&config, alias.as_deref(), AliasCommand::Read)?;
             let alias_name = alias.as_ref().map(|(name, _)| *name);
             let alias_config = alias.as_ref().map(|(_, alias)| *alias);
-            let target_available = target.is_some()
-                || alias_config
-                    .and_then(|alias| alias.graph.as_deref())
-                    .is_some()
-                || config.cli_graph_name().is_some();
+            let alias_graph = alias_config.and_then(|alias| alias.graph.as_deref());
+            let target_available = alias_graph.is_some() || config.cli_graph_name().is_some();
             let (legacy_uri, alias_args) =
                 normalize_legacy_alias_uri(legacy_uri, target_available, alias_name, alias_args);
-            let uri = uri.or(legacy_uri);
-            let target_name = target
-                .as_deref()
-                .or_else(|| alias_config.and_then(|alias| alias.graph.as_deref()));
+            // `--target` is gone; resolve an alias's legacy `graph` name to its
+            // URI (a positional URI still wins).
+            let uri = match uri.or(legacy_uri) {
+                Some(uri) => Some(uri),
+                None => match alias_graph {
+                    Some(name) => Some(config.resolve_target_uri(None, Some(name), None)?),
+                    None => None,
+                },
+            };
             let client = client::GraphClient::resolve(
                 &config,
                 cli.server.as_deref(),
                 cli.graph.as_deref(),
                 uri,
-                target_name,
                 cli.profile.as_deref(),
                 cli.store.as_deref(),
             )?;
@@ -704,7 +676,6 @@ async fn main() -> Result<()> {
         Command::Mutate {
             uri,
             legacy_uri,
-            target,
             config,
             alias,
             query,
@@ -723,23 +694,24 @@ async fn main() -> Result<()> {
             let alias = resolve_alias(&config, alias.as_deref(), AliasCommand::Change)?;
             let alias_name = alias.as_ref().map(|(name, _)| *name);
             let alias_config = alias.as_ref().map(|(_, alias)| *alias);
-            let target_available = target.is_some()
-                || alias_config
-                    .and_then(|alias| alias.graph.as_deref())
-                    .is_some()
-                || config.cli_graph_name().is_some();
+            let alias_graph = alias_config.and_then(|alias| alias.graph.as_deref());
+            let target_available = alias_graph.is_some() || config.cli_graph_name().is_some();
             let (legacy_uri, alias_args) =
                 normalize_legacy_alias_uri(legacy_uri, target_available, alias_name, alias_args);
-            let uri = uri.or(legacy_uri);
-            let target_name = target
-                .as_deref()
-                .or_else(|| alias_config.and_then(|alias| alias.graph.as_deref()));
+            // `--target` is gone; resolve an alias's legacy `graph` name to its
+            // URI (a positional URI still wins).
+            let uri = match uri.or(legacy_uri) {
+                Some(uri) => Some(uri),
+                None => match alias_graph {
+                    Some(name) => Some(config.resolve_target_uri(None, Some(name), None)?),
+                    None => None,
+                },
+            };
             let client = client::GraphClient::resolve_with_policy(
                 &config,
                 cli.server.as_deref(),
                 cli.graph.as_deref(),
                 uri,
-                target_name,
                 cli.as_actor.as_deref(),
                 cli.profile.as_deref(),
                 cli.store.as_deref(),
@@ -820,18 +792,16 @@ async fn main() -> Result<()> {
         },
         Command::Optimize {
             uri,
-            target,
             config,
             cluster,
             cluster_graph,
             json,
         } => {
             let config = load_cli_config(config.as_ref())?;
-            let uri = if uri.is_some() || target.is_some() || cluster.is_some() {
+            let uri = if uri.is_some() || cluster.is_some() {
                 resolve_storage_uri(
                     &config,
                     uri,
-                    target.as_deref(),
                     cluster.as_deref(),
                     cluster_graph.as_deref(),
                     "optimize",
@@ -849,13 +819,11 @@ async fn main() -> Result<()> {
                         server: None,
                         graph: cli.graph.as_deref(),
                         uri: None,
-                        target: None,
                     },
                 )?;
                 resolve_storage_uri(
                     &config,
                     scope.uri,
-                    scope.target.as_deref(),
                     scope.cluster.as_deref(),
                     scope.cluster_graph.as_deref(),
                     "optimize",
@@ -896,7 +864,6 @@ async fn main() -> Result<()> {
         }
         Command::Repair {
             uri,
-            target,
             config,
             cluster,
             cluster_graph,
@@ -905,11 +872,10 @@ async fn main() -> Result<()> {
             json,
         } => {
             let config = load_cli_config(config.as_ref())?;
-            let uri = if uri.is_some() || target.is_some() || cluster.is_some() {
+            let uri = if uri.is_some() || cluster.is_some() {
                 resolve_storage_uri(
                     &config,
                     uri,
-                    target.as_deref(),
                     cluster.as_deref(),
                     cluster_graph.as_deref(),
                     "repair",
@@ -926,13 +892,11 @@ async fn main() -> Result<()> {
                         server: None,
                         graph: cli.graph.as_deref(),
                         uri: None,
-                        target: None,
                     },
                 )?;
                 resolve_storage_uri(
                     &config,
                     scope.uri,
-                    scope.target.as_deref(),
                     scope.cluster.as_deref(),
                     scope.cluster_graph.as_deref(),
                     "repair",
@@ -1014,7 +978,6 @@ async fn main() -> Result<()> {
         }
         Command::Cleanup {
             uri,
-            target,
             config,
             cluster,
             cluster_graph,
@@ -1024,11 +987,10 @@ async fn main() -> Result<()> {
             json,
         } => {
             let config = load_cli_config(config.as_ref())?;
-            let uri = if uri.is_some() || target.is_some() || cluster.is_some() {
+            let uri = if uri.is_some() || cluster.is_some() {
                 resolve_storage_uri(
                     &config,
                     uri,
-                    target.as_deref(),
                     cluster.as_deref(),
                     cluster_graph.as_deref(),
                     "cleanup",
@@ -1045,13 +1007,11 @@ async fn main() -> Result<()> {
                         server: None,
                         graph: cli.graph.as_deref(),
                         uri: None,
-                        target: None,
                     },
                 )?;
                 resolve_storage_uri(
                     &config,
                     scope.uri,
-                    scope.target.as_deref(),
                     scope.cluster.as_deref(),
                     scope.cluster_graph.as_deref(),
                     "cleanup",
@@ -1182,7 +1142,6 @@ async fn main() -> Result<()> {
         Command::Graphs { command } => match command {
             GraphsCommand::List {
                 uri,
-                target,
                 config,
                 json,
             } => {
@@ -1192,7 +1151,6 @@ async fn main() -> Result<()> {
                     cli.server.as_deref(),
                     cli.graph.as_deref(),
                     uri,
-                    target.as_deref(),
                     cli.profile.as_deref(),
                     cli.store.as_deref(),
                 )?;

--- a/crates/omnigraph-cli/src/main_tests.rs
+++ b/crates/omnigraph-cli/src/main_tests.rs
@@ -209,13 +209,7 @@ cli:
         let config = load_config(Some(&config_path)).unwrap();
 
         assert_eq!(
-            resolve_remote_bearer_token(&config, None, Some("demo"))
-                .unwrap()
-                .as_deref(),
-            Some("scoped-token")
-        );
-        assert_eq!(
-            resolve_remote_bearer_token(&config, Some("https://override.example.com"), None)
+            resolve_remote_bearer_token(&config, Some("https://override.example.com"))
                 .unwrap()
                 .as_deref(),
             Some("global-token")
@@ -369,12 +363,16 @@ graphs:
     uri: s3://bucket/prod-graph/
     policy:
       file: ./prod-policy.yaml
+cli:
+  graph: prod
 "#,
         )
         .unwrap();
 
         let config = load_config(Some(&config_path)).unwrap();
-        let graph = resolve_cli_graph(&config, None, Some("prod")).unwrap();
+        // `--target` is removed; the `cli.graph` default drives the same
+        // graph-key (not project name / URI) selection.
+        let graph = resolve_cli_graph(&config, None).unwrap();
         assert_eq!(graph.selected(), Some("prod"));
         assert_eq!(graph.graph_id, "prod");
         assert_eq!(graph.uri, "s3://bucket/prod-graph/");
@@ -405,7 +403,6 @@ cli:
         let local_graph = resolve_cli_graph(
             &config,
             Some(format!("file://{}", local_graph_path.display())),
-            None,
         )
         .unwrap();
         assert_eq!(local_graph.selected(), None);
@@ -418,7 +415,6 @@ cli:
         let s3_graph = resolve_cli_graph(
             &config,
             Some("s3://bucket/anonymous-graph/".to_string()),
-            None,
         )
         .unwrap();
         assert_eq!(s3_graph.selected(), None);

--- a/crates/omnigraph-cli/src/migrate.rs
+++ b/crates/omnigraph-cli/src/migrate.rs
@@ -66,7 +66,7 @@ pub(crate) fn build_report(config: &OmnigraphConfig, source: &Path) -> MigrateRe
     if config.cli.graph.is_some() {
         dropped.push(DroppedKey {
             key: "cli.graph".into(),
-            reason: "no operator default-target yet — address graphs explicitly via --target/--server (RFC-002 locator territory)".into(),
+            reason: "address graphs explicitly via --store/--server, or set defaults.default_graph in the operator config".into(),
         });
     }
     if config.cli.branch.is_some() {

--- a/crates/omnigraph-cli/src/planes.rs
+++ b/crates/omnigraph-cli/src/planes.rs
@@ -232,6 +232,9 @@ mod tests {
         let cap = |args: &[&str]| {
             command_capability(&Cli::try_parse_from(args).unwrap().command)
         };
+        // The one Data→Served refinement — if the `graphs` guard were deleted,
+        // every other assertion here would still pass.
+        assert_eq!(cap(&["omnigraph", "graphs", "list"]), Capability::Served);
         assert_eq!(cap(&["omnigraph", "optimize", "graph.omni"]), Capability::Direct);
         assert_eq!(cap(&["omnigraph", "schema", "plan", "--schema", "s.pg", "graph.omni"]), Capability::Direct);
         assert_eq!(cap(&["omnigraph", "cluster", "status", "--config", "."]), Capability::Control);

--- a/crates/omnigraph-cli/src/planes.rs
+++ b/crates/omnigraph-cli/src/planes.rs
@@ -192,11 +192,9 @@ pub(crate) fn guard_addressing(cli: &Cli) -> Result<()> {
     }
     let label = command_label(&cli.command);
     let how = match capability {
-        // `init` is the one direct verb with no `--target` today (it takes a
-        // required positional URI), so its remediation drops the `--target` half.
         Capability::Direct => match cli.command {
             Command::Init { .. } => "Pass a storage URI.",
-            _ => "Use --target <name>, a storage URI, or --cluster <dir> --cluster-graph <id>.",
+            _ => "Pass a storage URI, or --cluster <dir> --cluster-graph <id>.",
         },
         Capability::Control => "It operates on a cluster (pass --config <dir>).",
         Capability::Local => "It does not address a graph.",

--- a/crates/omnigraph-cli/src/scope.rs
+++ b/crates/omnigraph-cli/src/scope.rs
@@ -32,24 +32,22 @@ pub(crate) struct ResolvedScope {
     pub(crate) server: Option<String>,
     pub(crate) graph: Option<String>,
     pub(crate) uri: Option<String>,
-    pub(crate) target: Option<String>,
     pub(crate) cluster: Option<String>,
     pub(crate) cluster_graph: Option<String>,
 }
 
 /// The raw addressing inputs for one command: the global scope flags plus the
-/// command's own positional/`--target` address.
+/// command's own positional URI.
 pub(crate) struct ScopeFlags<'a> {
     pub(crate) profile: Option<&'a str>,
     pub(crate) store: Option<&'a str>,
     pub(crate) server: Option<&'a str>,
     pub(crate) graph: Option<&'a str>,
     pub(crate) uri: Option<String>,
-    pub(crate) target: Option<&'a str>,
 }
 
 /// Resolve the scope for a command with `capability`. Precedence (RFC-011):
-/// 1. explicit legacy/primitive address (`uri`/`target`/`--server`/`--store`) → passthrough;
+/// 1. explicit primitive address (`uri`/`--server`/`--store`) → passthrough;
 /// 2. `--profile` / `OMNIGRAPH_PROFILE`;
 /// 3. flat `defaults.server` + `defaults.default_graph`;
 /// 4. nothing — downstream behaves as today.
@@ -60,13 +58,11 @@ pub(crate) fn resolve_scope(
 ) -> Result<ResolvedScope> {
     // 1. Any explicit address wins; reproduce today's behavior untouched.
     //    `--store` is an explicit store URI — fold it into `uri`.
-    if flags.uri.is_some() || flags.target.is_some() || flags.server.is_some() || flags.store.is_some()
-    {
+    if flags.uri.is_some() || flags.server.is_some() || flags.store.is_some() {
         return Ok(ResolvedScope {
             server: flags.server.map(str::to_string),
             graph: flags.graph.map(str::to_string),
             uri: flags.store.map(str::to_string).or(flags.uri),
-            target: flags.target.map(str::to_string),
             ..Default::default()
         });
     }
@@ -190,7 +186,6 @@ mod tests {
             server: None,
             graph: None,
             uri: None,
-            target: None,
         }
     }
 

--- a/crates/omnigraph-cli/src/scope.rs
+++ b/crates/omnigraph-cli/src/scope.rs
@@ -56,6 +56,14 @@ pub(crate) fn resolve_scope(
     capability: Capability,
     flags: ScopeFlags<'_>,
 ) -> Result<ResolvedScope> {
+    // `--store` is its own way to address a graph; combining it with a positional
+    // URI or `--server` is a contradiction, not a silent precedence.
+    if flags.store.is_some() && (flags.uri.is_some() || flags.server.is_some()) {
+        bail!(
+            "--store is exclusive with a positional URI and --server — pick one way to \
+             address the graph"
+        );
+    }
     // 1. Any explicit address wins; reproduce today's behavior untouched.
     //    `--store` is an explicit store URI — fold it into `uri`.
     if flags.uri.is_some() || flags.server.is_some() || flags.store.is_some() {
@@ -219,6 +227,26 @@ mod tests {
         )
         .unwrap();
         assert_eq!(scope.uri.as_deref(), Some("s3://b/g.omni"));
+    }
+
+    #[test]
+    fn store_is_exclusive_with_positional_uri_and_server() {
+        let op = OperatorConfig::default();
+        for flags in [
+            ScopeFlags {
+                store: Some("s3://b/g.omni"),
+                uri: Some("file://other.omni".into()),
+                ..flags()
+            },
+            ScopeFlags {
+                store: Some("s3://b/g.omni"),
+                server: Some("prod"),
+                ..flags()
+            },
+        ] {
+            let err = resolve_scope(&op, Capability::Any, flags).unwrap_err().to_string();
+            assert!(err.contains("--store is exclusive"), "{err}");
+        }
     }
 
     #[test]

--- a/crates/omnigraph-cli/tests/cli_data.rs
+++ b/crates/omnigraph-cli/tests/cli_data.rs
@@ -1280,6 +1280,24 @@ fn read_supports_inline_query_string() {
 }
 
 #[test]
+fn positional_http_uri_on_a_data_verb_is_rejected() {
+    // RFC-011: a positional/`--uri` http(s):// URL no longer dispatches to a
+    // remote server — that requires `--server <url>`.
+    let output = output_failure(
+        cli()
+            .arg("query")
+            .arg("http://127.0.0.1:1")
+            .arg("-e")
+            .arg("query q() { match { $p: Person { } } return { $p } }"),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("must be addressed with `--server <url>`"),
+        "expected positional-remote rejection; got: {stderr}"
+    );
+}
+
+#[test]
 fn as_on_a_served_write_is_rejected() {
     // RFC-011: a served write resolves the actor from the bearer token, so --as
     // cannot set identity. It errors while building the remote client — before

--- a/crates/omnigraph-cli/tests/cli_data.rs
+++ b/crates/omnigraph-cli/tests/cli_data.rs
@@ -166,7 +166,7 @@ fn optimize_with_server_flag_errors_wrong_plane() {
     assert!(
         stderr.contains("`optimize` is a direct (storage-native) command")
             && stderr.contains("--server/--graph address a served graph and do not apply")
-            && stderr.contains("Use --target <name>, a storage URI, or --cluster <dir> --cluster-graph <id>."),
+            && stderr.contains("Pass a storage URI, or --cluster <dir> --cluster-graph <id>."),
         "wrong-capability guard message not found; got: {stderr}"
     );
 }

--- a/crates/omnigraph-cli/tests/cli_data.rs
+++ b/crates/omnigraph-cli/tests/cli_data.rs
@@ -1280,6 +1280,30 @@ fn read_supports_inline_query_string() {
 }
 
 #[test]
+fn as_on_a_served_write_is_rejected() {
+    // RFC-011: a served write resolves the actor from the bearer token, so --as
+    // cannot set identity. It errors while building the remote client — before
+    // any HTTP call, so no server is needed.
+    let output = output_failure(
+        cli()
+            .arg("mutate")
+            .arg("--server")
+            .arg("http://127.0.0.1:1")
+            .arg("--as")
+            .arg("act-nope")
+            .arg("-e")
+            .arg("query add($name: String) { insert Person { name: $name } }")
+            .arg("--params")
+            .arg(r#"{"name":"X"}"#),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("`--as` is not allowed on a served write"),
+        "expected --as-served rejection; got: {stderr}"
+    );
+}
+
+#[test]
 fn change_supports_inline_query_string() {
     let temp = tempdir().unwrap();
     let repo = graph_path(temp.path());

--- a/crates/omnigraph-cli/tests/cli_queries.rs
+++ b/crates/omnigraph-cli/tests/cli_queries.rs
@@ -323,7 +323,7 @@ fn queries_list_requires_graph_selection_for_per_graph_only_registries() {
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("local") && stderr.contains("--target local"),
+        stderr.contains("local") && stderr.contains("set `cli.graph`"),
         "error must name the graph and give a concrete selection hint; stderr:\n{stderr}"
     );
 }
@@ -357,12 +357,12 @@ fn queries_list_without_graph_selection_lists_top_level_registry() {
 }
 
 #[test]
-fn queries_list_unknown_target_errors() {
+fn queries_list_unknown_cli_graph_errors() {
     // `queries list` opens no graph URI, so unknown-graph validation can't ride
     // along on URI resolution the way it does for every other command. An
-    // unknown `--target` must still error (naming the graph) instead of
-    // silently falling back to the top-level registry and showing the wrong
-    // (or empty) catalog.
+    // unknown `cli.graph` selection must still error (naming the graph) instead
+    // of silently falling back to the top-level registry and showing the wrong
+    // (or empty) catalog. (`--target` was removed; `cli.graph` drives selection.)
     let graph = SystemGraph::loaded();
     graph.write_query(
         "find_person.gq",
@@ -370,21 +370,12 @@ fn queries_list_unknown_target_errors() {
     );
     let config = graph.write_config(
         "omnigraph.yaml",
-        &queries_test_config(
-            &graph.path().to_string_lossy(),
-            "find_person",
-            "find_person.gq",
+        &format!(
+            "graphs:\n  local:\n    uri: '{}'\n    queries:\n      find_person:\n        file: ./find_person.gq\ncli:\n  graph: nonexistent\npolicy: {{}}\n",
+            graph.path().to_string_lossy().replace('\'', "''"),
         ),
     );
-    let output = output_failure(
-        cli()
-            .arg("queries")
-            .arg("list")
-            .arg("--target")
-            .arg("nonexistent")
-            .arg("--config")
-            .arg(&config),
-    );
+    let output = output_failure(cli().arg("queries").arg("list").arg("--config").arg(&config));
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("nonexistent"),

--- a/crates/omnigraph-cli/tests/cli_schema_config.rs
+++ b/crates/omnigraph-cli/tests/cli_schema_config.rs
@@ -121,7 +121,7 @@ fn schema_plan_with_server_flag_errors_wrong_plane() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("`schema plan` is a direct (storage-native) command")
-            && stderr.contains("Use --target <name>, a storage URI, or --cluster <dir> --cluster-graph <id>."),
+            && stderr.contains("Pass a storage URI, or --cluster <dir> --cluster-graph <id>."),
         "schema plan wrong-capability message not found; got: {stderr}"
     );
 }

--- a/crates/omnigraph-cli/tests/support/mod.rs
+++ b/crates/omnigraph-cli/tests/support/mod.rs
@@ -831,8 +831,18 @@ pub fn run_both_with_config(
     server_url: &str,
     args: &[&str],
 ) -> (std::process::Output, std::process::Output) {
+    // Address both arms with GLOBAL flags (`--store` / `--server`) appended after
+    // the verb + its args, so the address is placed correctly regardless of
+    // subcommand nesting (a positional graph only works for top-level verbs;
+    // `schema show <graph>` etc. need the global flag). Local = embedded store,
+    // remote = served.
     let mut local = cli();
-    local.arg(args[0]).arg(local_graph).args(&args[1..]).arg("--as").arg(PARITY_ACTOR);
+    local
+        .args(args)
+        .arg("--store")
+        .arg(local_graph)
+        .arg("--as")
+        .arg(PARITY_ACTOR);
     if let Some(config) = local_config {
         local.arg("--config").arg(config);
     }
@@ -841,9 +851,9 @@ pub fn run_both_with_config(
     let mut remote = cli();
     remote
         .env("OMNIGRAPH_BEARER_TOKEN", PARITY_TOKEN)
-        .arg(args[0])
-        .arg(server_url)
-        .args(&args[1..]);
+        .args(args)
+        .arg("--server")
+        .arg(server_url);
     let remote_out = remote.output().unwrap();
     (local_out, remote_out)
 }

--- a/crates/omnigraph-cli/tests/system_local.rs
+++ b/crates/omnigraph-cli/tests/system_local.rs
@@ -2339,6 +2339,7 @@ fn local_cli_keyed_credentials_authenticate_url_matched_server() {
         }
         command
             .arg("read")
+            .arg("--server")
             .arg(&server.base_url)
             .arg("--query")
             .arg(fixture("test.gq"))

--- a/docs/user/cli/index.md
+++ b/docs/user/cli/index.md
@@ -60,14 +60,16 @@ Read through the HTTP API:
 
 ```bash
 omnigraph query \
-  --target http://127.0.0.1:8080 \
+  --server http://127.0.0.1:8080 \
   --query queries.gq \
   --name get_person \
   --params '{"name":"Alice"}'
 ```
 
-If the server requires auth, set `OMNIGRAPH_SERVER_BEARER_TOKEN` on the server
-and configure the matching `bearer_token_env` in `omnigraph.yaml`.
+A server is addressed with `--server` (a name from `~/.omnigraph/config.yaml` or a
+literal URL); a positional `http(s)://` URI is rejected. If the server requires
+auth, set its bearer token and `omnigraph login <server>` (or
+`OMNIGRAPH_BEARER_TOKEN`).
 
 ## Multi-graph servers (v0.6.0+)
 

--- a/docs/user/cli/reference.md
+++ b/docs/user/cli/reference.md
@@ -2,7 +2,7 @@
 
 A reference for the `omnigraph` binary's command surface and `omnigraph.yaml` schema. For a quick-start guide, see [cli.md](index.md).
 
-Top-level command families and subcommands. Graph-targeting commands accept a positional `URI`, `--uri`, a `--target <name>` resolved against `omnigraph.yaml`, `--server <name>` (an operator-defined server from `~/.omnigraph/config.yaml`, optionally with `--graph <id>` for multi-graph servers; exclusive with the other forms), `--store <uri>` (a single graph's storage directly), or `--profile <name>` / `$OMNIGRAPH_PROFILE` (a named scope bundle; see [Scopes & profiles](#scopes--profiles-rfc-011)); `cluster` commands use `--config <dir>`.
+Top-level command families and subcommands. Graph-targeting commands accept a positional `file://`/`s3://` URI, `--server <name|url>` (an operator-defined server from `~/.omnigraph/config.yaml` by name, or a literal `http(s)://` URL, optionally with `--graph <id>` for multi-graph servers; exclusive with a positional URI), `--store <uri>` (a single graph's storage directly), or `--profile <name>` / `$OMNIGRAPH_PROFILE` (a named scope bundle; see [Scopes & profiles](#scopes--profiles-rfc-011)); `cluster` commands use `--config <dir>`. A remote server is addressed only with `--server` — a positional `http(s)://` URI is rejected.
 
 ## Top-level commands
 
@@ -32,19 +32,20 @@ Top-level command families and subcommands. Graph-targeting commands accept a po
 
 Every command declares the **capability** it needs — what it requires to reach a graph — which determines the addressing flags that apply:
 
-- **`any`** — `query`, `mutate`, `load`, `ingest`, `branch *`, `snapshot`, `export`, `commit *`, `schema show`, `schema apply`. Run against a graph **served (via a server) or embedded (direct against a store)**: accept a positional `URI` / `--target` / `--server` (+ `--graph` for multi-graph servers) / `--store` / `--profile`.
+- **`any`** — `query`, `mutate`, `load`, `ingest`, `branch *`, `snapshot`, `export`, `commit *`, `schema show`, `schema apply`. Run against a graph **served (via a server) or embedded (direct against a store)**: accept a positional `file://`/`s3://` URI, `--server <name|url>` (+ `--graph <id>` for multi-graph servers), `--store <uri>`, or `--profile <name>`. A remote server is addressed with `--server` — a positional `http(s)://` URI does **not** dispatch to one.
 - **`served`** — `graphs list`. Requires a server (accepts `--server` / `--profile`).
-- **`direct`** — `init`, `optimize`, `repair`, `cleanup`, `schema plan`, `queries validate`, `lint`. Need **direct storage access** (`file://` / `s3://`), never through a server. They accept a positional `URI` or `--target`, but **not** `--server` / `--graph`, and a `--target` that resolves to a remote (`http(s)://`) server is rejected. (`init` takes only a positional `URI` today — no `--target`.) `optimize` / `repair` / `cleanup` also accept **`--cluster <dir|s3://…> --cluster-graph <id>`**, which resolves the graph's storage URI from the served cluster state (so you needn't know the `<storage>/graphs/<id>.omni` layout).
+- **`direct`** — `init`, `optimize`, `repair`, `cleanup`, `schema plan`, `queries validate`, `lint`. Need **direct storage access** (`file://` / `s3://`), never through a server. They accept a positional `URI`, but **not** `--server` / `--graph`, and a remote (`http(s)://`) URI is rejected. `optimize` / `repair` / `cleanup` also accept **`--cluster <dir|s3://…> --cluster-graph <id>`**, which resolves the graph's storage URI from the served cluster state (so you needn't know the `<storage>/graphs/<id>.omni` layout).
 - **`control`** — `cluster *`. Operates on a cluster directory via `--config <dir>`.
 - **`local`** — `policy *`, `embed`, `login`, `logout`, `config`, `version`, `queries list`. Address no graph.
 
 These restrictions are enforced and reported, not silent:
 
-- A served-graph flag (`--server` / `--graph`) on a verb that doesn't reach a graph through a server fails loudly, e.g.: ``optimize is a direct (storage-native) command; --server/--graph address a served graph and do not apply. Use --target <name>, a storage URI, or --cluster <dir> --cluster-graph <id>.``
-- A `direct` verb pointed at a remote target fails loudly, e.g.: ``optimize is a direct (storage-native) command and needs direct storage access; the resolved target is a remote server (https://…). Pass the graph's file:// or s3:// URI.``
+- A served-graph flag (`--server` / `--graph`) on a verb that doesn't reach a graph through a server fails loudly, e.g.: ``optimize is a direct (storage-native) command; --server/--graph address a served graph and do not apply. Pass a storage URI, or --cluster <dir> --cluster-graph <id>.``
+- A `direct` verb pointed at a remote URI fails loudly, e.g.: ``optimize is a direct (storage-native) command and needs direct storage access; the resolved target is a remote server (https://…). Pass the graph's file:// or s3:// URI.``
+- A data verb pointed at a positional `http(s)://` URI fails loudly: ``a remote graph must be addressed with --server <url> — a positional (or --uri) http(s):// URL no longer dispatches to a server.``
 - `init` into an **established cluster's** storage layout (`<root>/graphs/<id>.omni` where `<root>` holds `__cluster/state.json`) is refused — graphs in a cluster are created by `cluster apply` (which records ledger / recovery / approvals), not `init`.
 
-To maintain a server-backed graph, run the `direct` verbs from a host with storage access against the graph's storage URI (`--target`, or `--cluster … --cluster-graph …`), out-of-band from the serving process — there are no server routes for `optimize` / `repair` / `cleanup` by design.
+To maintain a server-backed graph, run the `direct` verbs from a host with storage access against the graph's storage URI (a positional URI, or `--cluster … --cluster-graph …`), out-of-band from the serving process — there are no server routes for `optimize` / `repair` / `cleanup` by design.
 
 `omnigraph --help` lists commands with a **capability legend** at the bottom (any / served / direct / control / local).
 
@@ -92,7 +93,7 @@ newer CLI works on an older one). `$OMNIGRAPH_CONFIG=<path>` stands in for
 A command resolves a **scope** — a server, a cluster, or a store — then selects a
 graph in it; the served-vs-direct access path is derived from the scope, not
 toggled. The scope comes from one of (highest precedence first): an explicit
-address (a positional URI, `--target`, `--server`, or `--store <uri>`); a named
+address (a positional URI, `--server`, or `--store <uri>`); a named
 `--profile <name>` (or `$OMNIGRAPH_PROFILE`); or the flat `defaults.server` +
 `defaults.default_graph`. A **profile** binds exactly one of `server` / `cluster`
 / `store` plus an optional default graph — config data, not state: every command
@@ -105,9 +106,9 @@ resolves its scope fresh, there is no sticky "current" mode.
 - A `server`-bound scope on a maintenance verb, or a `cluster`-bound scope on a
   data verb, is rejected with a message pointing at the right addressing.
 
-This model **coexists** with the legacy addressing (`--uri` / `--target` /
-`--cluster-graph` / `omnigraph.yaml`) — nothing is removed yet; an explicit legacy
-address always wins.
+`--target` and the positional-`http(s)://`→remote dispatch have been **removed**;
+the remaining legacy surfaces (`--cluster-graph`, `omnigraph.yaml`'s `cli.graph`
+default) still work and an explicit address always wins.
 
 #### Credentials keyed by server name
 

--- a/docs/user/clusters/config.md
+++ b/docs/user/clusters/config.md
@@ -51,9 +51,9 @@ The exact contract:
   implicit current-directory search runs (mode-inference rule 0). Boot from
   cluster state XOR `omnigraph.yaml`, never a merge.
 - **The other direction is ergonomics, not coupling**: a per-operator
-  `omnigraph.yaml` may point `graphs.<name>.uri` at a cluster's derived root
-  (`company-brain/graphs/knowledge.omni`) so data-plane commands can use
-  `--target <name>` — an ordinary local path, no special handling.
+  data-plane commands address a cluster graph by its derived storage root
+  (`company-brain/graphs/knowledge.omni`) with `--store <uri>` — an ordinary
+  local path, no special handling.
 
 ## Supported `cluster.yaml`
 

--- a/docs/user/clusters/index.md
+++ b/docs/user/clusters/index.md
@@ -246,10 +246,10 @@ with an in-flight apply.
   human step by design — keep `cluster approve` out of automation.
 - **`omnigraph.yaml` still has a job**: per-operator settings — your
   `cli.actor` default for `--as`, CLI defaults, credentials, and data-plane
-  ergonomics (point `graphs.<name>.uri` at a derived root like
-  `company-brain/graphs/knowledge.omni` to use `--target <name>` for
-  loads). It just no longer describes the deployment — a server boots from
-  one source or the other, never a merge of both.
+  ergonomics (address a cluster graph by its derived root like
+  `company-brain/graphs/knowledge.omni` with `--store` for loads). It just no
+  longer describes the deployment — a server boots from one source or the
+  other, never a merge of both.
 
 ## 7. Maintaining a cluster graph
 

--- a/docs/user/operations/maintenance.md
+++ b/docs/user/operations/maintenance.md
@@ -1,6 +1,6 @@
 # Maintenance: Optimize, Repair & Cleanup
 
-**Addressing.** `optimize`, `repair`, and `cleanup` are **direct** (storage-native) CLI commands: they run with direct storage access against a positional `URI`, `--target`, or **`--cluster <dir|s3://…> --cluster-graph <id>`** (which resolves the graph's storage URI from the served cluster state, so you needn't know the `<storage>/graphs/<id>.omni` layout). They never run through a server, and reject `--server` / `--graph` or a `--target` that resolves to a remote (`http(s)://`) URL with a declared error. There are no server routes for them by design — to maintain a server-backed graph, run them out-of-band against the graph's storage URI. See the *Command capabilities* section of [cli-reference.md](../cli/reference.md).
+**Addressing.** `optimize`, `repair`, and `cleanup` are **direct** (storage-native) CLI commands: they run with direct storage access against a positional `file://`/`s3://` URI or **`--cluster <dir|s3://…> --cluster-graph <id>`** (which resolves the graph's storage URI from the served cluster state, so you needn't know the `<storage>/graphs/<id>.omni` layout). They never run through a server, and reject `--server` / `--graph` or a remote (`http(s)://`) URI with a declared error. There are no server routes for them by design — to maintain a server-backed graph, run them out-of-band against the graph's storage URI. See the *Command capabilities* section of [cli-reference.md](../cli/reference.md).
 
 ## `optimize` — non-destructive
 

--- a/docs/user/operations/policy.md
+++ b/docs/user/operations/policy.md
@@ -105,7 +105,7 @@ is validated/tested/explained as the anonymous policy.
 - `omnigraph policy validate` — parse + count actors, exit 1 on parse error.
 - `omnigraph policy test` — run cases in `policy.tests.yaml`, exit 1 on any expectation mismatch.
 - `omnigraph policy explain --actor … --action … [--branch …] [--target-branch …]` — show decision and matched rule.
-- `omnigraph --as <ACTOR> <subcommand>` — set the actor for the duration of one invocation. Effective for `change`, `load` (and its deprecated `ingest` alias), `branch create|delete|merge`, and `schema apply` against local URIs. No-op against remote HTTP URIs (actor is bearer-token-resolved server-side).
+- `omnigraph --as <ACTOR> <subcommand>` — set the actor for the duration of one invocation. Effective for `change`, `load` (and its deprecated `ingest` alias), `branch create|delete|merge`, and `schema apply` against a direct (`--store`) graph. **Rejected** on a served write (`--server`): the actor is bearer-token-resolved server-side, so `--as` can't set it there.
 
 ## Enforcement
 

--- a/docs/user/search/indexes.md
+++ b/docs/user/search/indexes.md
@@ -23,7 +23,7 @@ list/`Blob` columns → none.
 > **Coverage and cost.** Each indexed column adds index files and build time, and
 > an index only covers the fragments it was built over. Rows appended after the
 > index was built (e.g. by `ingest --mode merge`) are scanned unindexed until a
-> reindex extends coverage; see [maintenance](maintenance.md) → `optimize`.
+> reindex extends coverage; see [maintenance](../operations/maintenance.md) → `optimize`.
 
 ## L2 — OmniGraph orchestration
 


### PR DESCRIPTION
Removes the legacy data-plane addressing surfaces outright (the warn stage was
skipped per request — acceptable for this pre-1.0 CLI). Replacements all ship:
`--store` / `--profile` / `--server <name|url>`.

**Breaking changes**
- **`--target <name>` removed.** Address graphs with a positional URI, `--store`,
  `--profile`, or `--server`. The parameter is threaded out of the whole resolver
  chain (~11 helpers, both `GraphClient` factories, `ScopeFlags`/`ResolvedScope`).
  The `omnigraph.yaml` `cli.graph` default is **kept** (separable — its removal
  belongs to the eventual file excision), and the **server's** own `--target` boot
  flag is untouched.
- **A positional `http(s)://` URI no longer dispatches to a server** — use
  `--server <url>` (now accepts a literal URL). Storage verbs keep their existing
  remote-URI hard error (separate path).
- **`--as` on a served write is a hard error** (was a silent no-op; the server
  resolves the actor from the bearer token).

**Commits** (each keeps the suite green):
1. `--server` accepts a literal URL (enabler).
2. Parity harness → global `--store`/`--server` — this **fixed a latent bug**: the
   nested-verb parity tests (schema/branch/commit) were passing *vacuously* (both
   arms failed identically on a mis-placed positional address); they now actually
   compare embedded vs remote.
3. `--as`-on-served error.
4. Remove positional-`http`→remote dispatch.
5. Remove `--target` (the wide thread-out; net −132 lines).
6. Docs.

**Verification**
- `omnigraph-cli` suite: **228 green** (named-target tests rewritten onto
  `cli.graph`; positional-URI tests unchanged; new tests for the 3 removals).
- `cargo test --workspace --locked`: **1405 passed, 0 failed**.

**Deferred** (own slices): `--cluster-graph` + the `--graph`-on-maintenance
generalization; the `omnigraph.yaml` file + `cli.graph` removal; `--alias` → `alias`
namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes three legacy data-plane addressing surfaces from the CLI: the `--target <name>` flag (excised from all 11 command variants and the full resolver chain), positional `http(s)://` URI dispatch to a server, and the silent no-op of `--as` on a served write (now a hard error). The replacement surfaces (`--server <name|url>`, `--store`, `--profile`) were already shipped.

- **`--target` removal** is a wide mechanical thread-out across `cli.rs`, `client.rs`, `helpers.rs`, `main.rs`, and `scope.rs` (net \u2212132 lines); `ScopeFlags`/`ResolvedScope` lose the field, and all 11 command destructures are updated consistently.
- **`--server` gains literal-URL support** \u2014 `resolve_server_flag` short-circuits on `://` to bypass the operator-config registry; the existing URL-based keyed-token hop still resolves credentials correctly via URL matching.
- **Parity-test latent bug fixed** \u2014 `run_both_with_config` was placing the positional address at position 1, making nested-verb parity tests pass vacuously; it now uses `--store`/`--server` global flags.

<h3>Confidence Score: 4/5</h3>

The thread-out is mechanically complete and all 228 CLI tests pass; the one user-visible defect is a misleading error message, not a wrong code path.

The `resolve_registry_selection_for_list` error message tells users to 'Pass a positional URI' for `queries list`, a command that accepts no URI — anyone who hits this error with an unconfigured `cli.graph` will follow advice that clap immediately rejects, leaving them stuck. Everything else in the change is well-implemented and covered by new tests.

crates/omnigraph-cli/src/helpers.rs — the `resolve_registry_selection_for_list` error message; crates/omnigraph-cli/tests/cli_queries.rs — assertion looseness on the updated error text.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/omnigraph-cli/src/helpers.rs | Core resolver helpers — `--target` threaded out of all resolution paths; `resolve_server_flag` gains literal-URL support; `reject_positional_remote` added. One issue: the `queries list` error message says 'Pass a positional URI' which that command cannot accept. |
| crates/omnigraph-cli/src/cli.rs | `--target` removed from every command variant (11 sites); `--cluster` conflicts-with updated; `--server` value_name updated to NAME|URL. Mechanical and complete. |
| crates/omnigraph-cli/src/client.rs | Both `GraphClient` factories drop `target` parameter; `reject_positional_remote` injected correctly; `--as`-on-served-write error added inside `resolve_with_policy` gated on `is_remote`. Logic is sound. |
| crates/omnigraph-cli/src/scope.rs | `target` removed from `ScopeFlags` and `ResolvedScope`; new `--store`-exclusive guard added; unit tests for the new exclusion added. Clean. |
| crates/omnigraph-cli/src/main.rs | `--target` destructured and forwarded removed at all call sites; alias graph-name-to-URI resolution lifted inline for both `Query` and `Mutate`. Large but mechanical. |
| crates/omnigraph-cli/tests/support/mod.rs | `run_both_with_config` now uses `--store`/`--server` global flags, fixing the vacuous-parity-test latent bug. Correct and well-commented. |
| crates/omnigraph-cli/tests/cli_data.rs | Two new integration tests: positional http:// URI rejection and `--as`-on-served-write rejection. Both test the right error strings without requiring a running server. |
| crates/omnigraph-cli/tests/cli_queries.rs | Test rewritten to use `cli.graph: nonexistent` config; assertion checks updated but slightly looser than the old ones. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CLI invocation] --> B{Address source?}
    B -->|--server name| C[resolve_server_flag: name lookup]
    B -->|--server https://url| D[resolve_server_flag: literal URL bypass]
    B -->|--store s3://uri| E[scope: fold into uri slot]
    B -->|positional file or s3 URI| G[resolve_uri]
    B -->|positional http URI| ERR1[reject_positional_remote error]
    C --> H[apply_server_flag resolved URL]
    D --> H
    E --> G
    G --> I{is_remote?}
    H --> J[resolve_remote_bearer_token]
    J --> I
    I -->|yes via_server false| ERR1
    I -->|yes via_server true| K{write client?}
    I -->|no| M[Local Omnigraph open]
    K -->|--as present| ERR2[--as not allowed on served write]
    K -->|--as absent| L[GraphClient Remote HTTP]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `crates/omnigraph-cli/src/helpers.rs`, line 249-267 ([link](https://github.com/modernrelay/omnigraph/blob/8872f2eae9b2567f260b47b38cd80ea59b02b39d/crates/omnigraph-cli/src/helpers.rs#L249-L267)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Dead variable leaves two call sites unreachable**

   `explicit_target` is hardcoded to `None` but is still passed to both `effective_remote_url` (line 257) and `config.graph_bearer_token_env` (line 267). The branches inside those functions that act on `Some(target)` are now permanently dead. The keyed-hop lookup at lines 258–263 correctly fills the gap via URL matching, so there is no functional regression — but leaving the `None` placeholder as a local variable instead of cleaning up the callers means the dead branches will persist and confuse future readers.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fomnigraph-cli%2Fsrc%2Fhelpers.rs%0ALine%3A%20249-267%0A%0AComment%3A%0A**Dead%20variable%20leaves%20two%20call%20sites%20unreachable**%0A%0A%60explicit_target%60%20is%20hardcoded%20to%20%60None%60%20but%20is%20still%20passed%20to%20both%20%60effective_remote_url%60%20%28line%20257%29%20and%20%60config.graph_bearer_token_env%60%20%28line%20267%29.%20The%20branches%20inside%20those%20functions%20that%20act%20on%20%60Some%28target%29%60%20are%20now%20permanently%20dead.%20The%20keyed-hop%20lookup%20at%20lines%20258%E2%80%93263%20correctly%20fills%20the%20gap%20via%20URL%20matching%2C%20so%20there%20is%20no%20functional%20regression%20%E2%80%94%20but%20leaving%20the%20%60None%60%20placeholder%20as%20a%20local%20variable%20instead%20of%20cleaning%20up%20the%20callers%20means%20the%20dead%20branches%20will%20persist%20and%20confuse%20future%20readers.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modernrelay%2Fomnigraph&pr=238&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>


2. `crates/omnigraph-cli/tests/cli_queries.rs`, line 323-330 ([link](https://github.com/modernrelay/omnigraph/blob/8872f2eae9b2567f260b47b38cd80ea59b02b39d/crates/omnigraph-cli/tests/cli_queries.rs#L323-L330)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Test assertion may pass vacuously after the error-message change**

   The assertion checks `stderr.contains("local") && stderr.contains("set \`cli.graph\`")`. Both strings are present in the new error message so the test is green — but it no longer validates the "concrete selection hint" the comment promises. A tighter check (e.g., also asserting `contains("top-level")` or the config-file key) would guard against accidental message regressions.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fomnigraph-cli%2Ftests%2Fcli_queries.rs%0ALine%3A%20323-330%0A%0AComment%3A%0A**Test%20assertion%20may%20pass%20vacuously%20after%20the%20error-message%20change**%0A%0AThe%20assertion%20checks%20%60stderr.contains%28%22local%22%29%20%26%26%20stderr.contains%28%22set%20%5C%60cli.graph%5C%60%22%29%60.%20Both%20strings%20are%20present%20in%20the%20new%20error%20message%20so%20the%20test%20is%20green%20%E2%80%94%20but%20it%20no%20longer%20validates%20the%20%22concrete%20selection%20hint%22%20the%20comment%20promises.%20A%20tighter%20check%20%28e.g.%2C%20also%20asserting%20%60contains%28%22top-level%22%29%60%20or%20the%20config-file%20key%29%20would%20guard%20against%20accidental%20message%20regressions.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modernrelay%2Fomnigraph&pr=238&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>


3. `crates/omnigraph-cli/src/helpers.rs`, line 303-330 ([link](https://github.com/modernrelay/omnigraph/blob/8872f2eae9b2567f260b47b38cd80ea59b02b39d/crates/omnigraph-cli/src/helpers.rs#L303-L330)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Cross-repo cookbook skill docs still document the removed `--target` flag**

   The [omnigraph-cookbooks skill reference](https://github.com/modernrelay/omnigraph-cookbooks/blob/HEAD/skills/omnigraph-best-practices/references/commands.md) (line 183) lists "`--target <name>`" as step 3 of graph targeting, and the [stored-queries reference](https://github.com/modernrelay/omnigraph-cookbooks/blob/HEAD/skills/omnigraph-best-practices/references/stored-queries.md) (line 49) still advises `--target <graph>` for `queries list`. Agents consuming those skill files will suggest `--target` to users, who will get a parse error. Per the AGENTS.md maintenance contract, a companion PR or issue tracking the cookbook update is warranted.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fomnigraph-cli%2Fsrc%2Fhelpers.rs%0ALine%3A%20303-330%0A%0AComment%3A%0A**Cross-repo%20cookbook%20skill%20docs%20still%20document%20the%20removed%20%60--target%60%20flag**%0A%0AThe%20%5Bomnigraph-cookbooks%20skill%20reference%5D%28https%3A%2F%2Fgithub.com%2Fmodernrelay%2Fomnigraph-cookbooks%2Fblob%2FHEAD%2Fskills%2Fomnigraph-best-practices%2Freferences%2Fcommands.md%29%20%28line%20183%29%20lists%20%22%60--target%20%3Cname%3E%60%22%20as%20step%203%20of%20graph%20targeting%2C%20and%20the%20%5Bstored-queries%20reference%5D%28https%3A%2F%2Fgithub.com%2Fmodernrelay%2Fomnigraph-cookbooks%2Fblob%2FHEAD%2Fskills%2Fomnigraph-best-practices%2Freferences%2Fstored-queries.md%29%20%28line%2049%29%20still%20advises%20%60--target%20%3Cgraph%3E%60%20for%20%60queries%20list%60.%20Agents%20consuming%20those%20skill%20files%20will%20suggest%20%60--target%60%20to%20users%2C%20who%20will%20get%20a%20parse%20error.%20Per%20the%20AGENTS.md%20maintenance%20contract%2C%20a%20companion%20PR%20or%20issue%20tracking%20the%20cookbook%20update%20is%20warranted.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modernrelay%2Fomnigraph&pr=238&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Fomnigraph-cli%2Fsrc%2Fhelpers.rs%3A875-879%0A**Misleading%20error%20guidance%20for%20%60queries%20list%60**%0A%0AThe%20error%20message%20tells%20the%20user%20to%20%22Pass%20a%20positional%20URI%2C%22%20but%20%60QueriesCommand%3A%3AList%60%20has%20no%20%60uri%60%20field%20%E2%80%94%20it%20accepts%20only%20%60--config%60%20and%20%60--json%60.%20A%20user%20who%20hits%20this%20error%20%28graphs%20configured%20with%20per-graph%20registries%2C%20no%20%60cli.graph%60%20set%29%20will%20try%20to%20add%20a%20positional%20URI%20and%20find%20it%20rejected%20by%20clap.%20The%20only%20working%20remedy%20is%20to%20set%20%60cli.graph%60%20in%20the%20config%20%28or%20add%20a%20top-level%20%60queries%3A%60%20block%29%2C%20but%20the%20message%20does%20not%20say%20that.%0A%0A%60%60%60suggestion%0A%20%20%20%20bail!%28%0A%20%20%20%20%20%20%20%20%22stored-query%20registries%20are%20configured%20for%20graph%7B%7D%20%7B%7D%20but%20no%20graph%20was%20selected.%20%5C%0A%20%20%20%20%20%20%20%20%20Set%20%60cli.graph%60%20in%20your%20config%2C%20or%20add%20a%20top-level%20%60queries%3A%60%20block.%22%2C%0A%20%20%20%20%20%20%20%20if%20graph_names.len%28%29%20%3D%3D%201%20%7B%20%22%22%20%7D%20else%20%7B%20%22s%22%20%7D%2C%0A%20%20%20%20%20%20%20%20graph_names.join%28%22%2C%20%22%29%2C%0A%20%20%20%20%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Fomnigraph-cli%2Fsrc%2Fhelpers.rs%3A249-267%0A**Dead%20variable%20leaves%20two%20call%20sites%20unreachable**%0A%0A%60explicit_target%60%20is%20hardcoded%20to%20%60None%60%20but%20is%20still%20passed%20to%20both%20%60effective_remote_url%60%20%28line%20257%29%20and%20%60config.graph_bearer_token_env%60%20%28line%20267%29.%20The%20branches%20inside%20those%20functions%20that%20act%20on%20%60Some%28target%29%60%20are%20now%20permanently%20dead.%20The%20keyed-hop%20lookup%20at%20lines%20258%E2%80%93263%20correctly%20fills%20the%20gap%20via%20URL%20matching%2C%20so%20there%20is%20no%20functional%20regression%20%E2%80%94%20but%20leaving%20the%20%60None%60%20placeholder%20as%20a%20local%20variable%20instead%20of%20cleaning%20up%20the%20callers%20means%20the%20dead%20branches%20will%20persist%20and%20confuse%20future%20readers.%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Fomnigraph-cli%2Ftests%2Fcli_queries.rs%3A323-330%0A**Test%20assertion%20may%20pass%20vacuously%20after%20the%20error-message%20change**%0A%0AThe%20assertion%20checks%20%60stderr.contains%28%22local%22%29%20%26%26%20stderr.contains%28%22set%20%5C%60cli.graph%5C%60%22%29%60.%20Both%20strings%20are%20present%20in%20the%20new%20error%20message%20so%20the%20test%20is%20green%20%E2%80%94%20but%20it%20no%20longer%20validates%20the%20%22concrete%20selection%20hint%22%20the%20comment%20promises.%20A%20tighter%20check%20%28e.g.%2C%20also%20asserting%20%60contains%28%22top-level%22%29%60%20or%20the%20config-file%20key%29%20would%20guard%20against%20accidental%20message%20regressions.%0A%0A%23%23%23%20Issue%204%20of%204%0Acrates%2Fomnigraph-cli%2Fsrc%2Fhelpers.rs%3A303-330%0A**Cross-repo%20cookbook%20skill%20docs%20still%20document%20the%20removed%20%60--target%60%20flag**%0A%0AThe%20%5Bomnigraph-cookbooks%20skill%20reference%5D%28https%3A%2F%2Fgithub.com%2Fmodernrelay%2Fomnigraph-cookbooks%2Fblob%2FHEAD%2Fskills%2Fomnigraph-best-practices%2Freferences%2Fcommands.md%29%20%28line%20183%29%20lists%20%22%60--target%20%3Cname%3E%60%22%20as%20step%203%20of%20graph%20targeting%2C%20and%20the%20%5Bstored-queries%20reference%5D%28https%3A%2F%2Fgithub.com%2Fmodernrelay%2Fomnigraph-cookbooks%2Fblob%2FHEAD%2Fskills%2Fomnigraph-best-practices%2Freferences%2Fstored-queries.md%29%20%28line%2049%29%20still%20advises%20%60--target%20%3Cgraph%3E%60%20for%20%60queries%20list%60.%20Agents%20consuming%20those%20skill%20files%20will%20suggest%20%60--target%60%20to%20users%2C%20who%20will%20get%20a%20parse%20error.%20Per%20the%20AGENTS.md%20maintenance%20contract%2C%20a%20companion%20PR%20or%20issue%20tracking%20the%20cookbook%20update%20is%20warranted.%0A%0A&repo=modernrelay%2Fomnigraph&pr=238&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): --store is loudly exclusive wi..."](https://github.com/modernrelay/omnigraph/commit/8872f2eae9b2567f260b47b38cd80ea59b02b39d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37534763)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->