### PR TITLE
fix(engine): v1→v2 migration verifies the unenforced PK is object_id (Greptile follow-up)

### DIFF
--- a/crates/omnigraph/src/db/manifest/migrations.rs
+++ b/crates/omnigraph/src/db/manifest/migrations.rs
@@ -123,16 +123,36 @@ pub(super) async fn migrate_internal_schema(dataset: &mut Dataset) -> Result<()>
 /// (Fresh graphs bake the PK into `manifest_schema()` at init and never run
 /// this migration; only genuine pre-v0.4.0 graphs do.)
 async fn migrate_v1_to_v2(dataset: &mut Dataset) -> Result<()> {
-    if dataset.schema().unenforced_primary_key().is_empty() {
-        dataset
-            .update_field_metadata()
-            .update(
-                "object_id",
-                [(OBJECT_ID_PK_KEY.to_string(), "true".to_string())],
-            )
-            .map_err(|e| OmniError::Lance(e.to_string()))?
-            .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+    // The guard is over the *specific* field, not just "any PK is set": skipping
+    // when `object_id` is already the PK is the idempotent crash-recovery path,
+    // but a manifest whose PK is some *other* field has the wrong CAS key — and
+    // Lance 7 won't let us change it. Refuse loudly rather than silently leave
+    // merge-insert conflict detection keyed on the wrong column.
+    let pk_fields: Vec<&str> = dataset
+        .schema()
+        .unenforced_primary_key()
+        .iter()
+        .map(|field| field.name.as_str())
+        .collect();
+    match pk_fields.as_slice() {
+        ["object_id"] => {} // already migrated (or a crash re-entry) — idempotent no-op
+        [] => {
+            dataset
+                .update_field_metadata()
+                .update(
+                    "object_id",
+                    [(OBJECT_ID_PK_KEY.to_string(), "true".to_string())],
+                )
+                .map_err(|e| OmniError::Lance(e.to_string()))?
+                .await
+                .map_err(|e| OmniError::Lance(e.to_string()))?;
+        }
+        other => {
+            return Err(OmniError::manifest_internal(format!(
+                "__manifest unenforced primary key is {other:?}, expected [\"object_id\"]; \
+                 refusing to migrate a manifest with an unexpected CAS key"
+            )));
+        }
     }
     set_stamp(dataset, 2).await
 }


### PR DESCRIPTION
Greptile follow-up on #236. The Lance-7 migration fix guarded the PK field-set with
`unenforced_primary_key().is_empty()`, which skips the set whenever *any* field is
the PK. If a field other than `object_id` ever carried the unenforced PK
(corruption / tooling error), the migration would silently skip and leave
merge-insert row-level CAS keyed on the wrong column — and Lance 7 forbids changing
the PK afterward, making it permanent.

Match on the specific PK field instead:
- `["object_id"]` → idempotent no-op (the crash-recovery re-entry the original fix targets);
- `[]` → set it (the genuine pre-v0.4.0 first migration);
- anything else → refuse loudly with a clear error.

Defensive by construction — Lance won't let a fresh graph reach the error branch, so
it isn't separately testable, but the change is correct. The idempotent path stays
covered by `test_publish_migrates_pre_stamp_manifest_to_current_version`.

Verification: `cargo test -p omnigraph-engine --lib db::manifest` (53) + `--test
recovery` (19) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This follow-up to #236 tightens the v1→v2 manifest migration guard from a generic `unenforced_primary_key().is_empty()` check to an exact match on the specific `"object_id"` field, preventing a silent no-op when corruption or tooling error left a *different* field carrying the unenforced PK — an unrecoverable state because Lance 7 forbids changing the PK once set.

- Replaces `is_empty()` with a three-way `match` on `pk_fields.as_slice()`: `["object_id"]` is the idempotent crash-recovery no-op; `[]` triggers the genuine PK annotation write; any other slice returns a loud, descriptive error rather than silently leaving merge-insert CAS keyed on the wrong column.
- The `set_stamp(dataset, 2)` call sits outside the match and is correctly reached only from the first two arms (the `other` arm returns `Err` early), so both the no-op and genuine migration paths converge on stamping to v2.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a tightly-scoped defensive guard on a migration path that was already correct in the common case, and it cannot make things worse for any currently-reachable dataset state.

The three-way match correctly handles all observable states: the idempotent crash-recovery path, the genuine pre-v0.4.0 first-migration path, and the impossible-but-defended corruption case that returns Err early. The set_stamp call is correctly placed outside the match and unreachable from the error arm. Lifetimes are sound and the untestable error branch is justified by Lance's own PK-immutability enforcement.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/omnigraph/src/db/manifest/migrations.rs | The v1→v2 migration guard is replaced with a precise three-way match on the exact PK field name; logic, lifetimes, and control flow are all correct. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[migrate_v1_to_v2 called\nstamp == 1] --> B[collect pk_fields from\nunenforced_primary_key]
    B --> C{match pk_fields.as_slice}
    C -->|'object_id'| D[no-op\ncrash re-entry recovery path]
    C -->|empty slice| E[update_field_metadata\nannotate object_id as unenforced PK]
    C -->|anything else| F[return Err\nOmniError::manifest_internal\nrefuses corrupt CAS key]
    D --> G[set_stamp dataset 2]
    E --> G
    F --> H[caller sees error\nopen-for-write aborts]
    G --> I[stamp written to v2\nmigration complete]
```

<sub>Reviews (1): Last reviewed commit: ["fix(engine): v1→v2 migration verifies th..."](https://github.com/modernrelay/omnigraph/commit/92adcd0cfd2087ea0960cd9c829cf3c9ba21e3aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37535202)</sub>

<!-- /greptile_comment -->