### PR TITLE
feat(cli)!: unify graph selection under --graph; --cluster is a global scope; remove --cluster-graph

### DIFF
--- a/crates/omnigraph-cli/src/cli.rs
+++ b/crates/omnigraph-cli/src/cli.rs
@@ -37,9 +37,11 @@ pub(crate) struct Cli {
     #[arg(long, global = true, value_name = "NAME|URL")]
     pub(crate) server: Option<String>,
 
-    /// Graph id on a multi-graph `--server` (appends `/graphs/<id>` to
-    /// the server url). Requires --server.
-    #[arg(long, global = true, value_name = "GRAPH_ID", requires = "server")]
+    /// Select a graph within a multi-graph scope: on a `--server` it appends
+    /// `/graphs/<id>` to the server url; on a `--cluster` it picks which
+    /// cluster graph to maintain. Rejected on a single-graph address (a
+    /// positional URI / `--store`).
+    #[arg(long, global = true, value_name = "GRAPH_ID")]
     pub(crate) graph: Option<String>,
 
     /// Select a named scope bundle (RFC-011) from `profiles:` in
@@ -55,6 +57,14 @@ pub(crate) struct Cli {
     /// server. Exclusive with a positional URI / `--server`.
     #[arg(long, global = true, value_name = "URI")]
     pub(crate) store: Option<String>,
+
+    /// Address a cluster-managed graph's storage for maintenance (RFC-011):
+    /// a cluster directory or storage-root URI — named via `clusters:` in
+    /// ~/.omnigraph/config.yaml, or a literal `file://`/`s3://` root. Pair
+    /// with `--graph <id>` to select the graph. Used by optimize / repair /
+    /// cleanup; exclusive with a positional URI / `--store` / `--server`.
+    #[arg(long, global = true, value_name = "DIR|URI")]
+    pub(crate) cluster: Option<String>,
 
     #[command(subcommand)]
     pub(crate) command: Command,
@@ -239,13 +249,6 @@ pub(crate) enum Command {
         uri: Option<String>,
         #[arg(long)]
         config: Option<PathBuf>,
-        /// Cluster directory or storage-root URI; with --cluster-graph, resolves
-        /// the graph's storage URI from the served cluster state.
-        #[arg(long, conflicts_with = "uri", requires = "cluster_graph")]
-        cluster: Option<String>,
-        /// Graph id within --cluster.
-        #[arg(long, requires = "cluster")]
-        cluster_graph: Option<String>,
         #[arg(long)]
         json: bool,
     },
@@ -255,13 +258,6 @@ pub(crate) enum Command {
         uri: Option<String>,
         #[arg(long)]
         config: Option<PathBuf>,
-        /// Cluster directory or storage-root URI; with --cluster-graph, resolves
-        /// the graph's storage URI from the served cluster state.
-        #[arg(long, conflicts_with = "uri", requires = "cluster_graph")]
-        cluster: Option<String>,
-        /// Graph id within --cluster.
-        #[arg(long, requires = "cluster")]
-        cluster_graph: Option<String>,
         /// Publish verified maintenance drift. Without this flag, repair only
         /// previews what it would do.
         #[arg(long)]
@@ -279,13 +275,6 @@ pub(crate) enum Command {
         uri: Option<String>,
         #[arg(long)]
         config: Option<PathBuf>,
-        /// Cluster directory or storage-root URI; with --cluster-graph, resolves
-        /// the graph's storage URI from the served cluster state.
-        #[arg(long, conflicts_with = "uri", requires = "cluster_graph")]
-        cluster: Option<String>,
-        /// Graph id within --cluster.
-        #[arg(long, requires = "cluster")]
-        cluster_graph: Option<String>,
         /// Number of recent versions to keep per table. Either `--keep` or
         /// `--older-than` (or both) must be set.
         #[arg(long)]

--- a/crates/omnigraph-cli/src/client.rs
+++ b/crates/omnigraph-cli/src/client.rs
@@ -100,7 +100,7 @@ impl GraphClient {
         let scope = crate::scope::resolve_scope(
             &crate::operator::load_operator_config()?,
             crate::planes::Capability::Any,
-            crate::scope::ScopeFlags { profile, store, server, graph, uri },
+            crate::scope::ScopeFlags { profile, store, server, cluster: None, graph, uri },
         )?;
         let (server, graph, uri) = (
             scope.server.as_deref(),
@@ -147,7 +147,7 @@ impl GraphClient {
         let scope = crate::scope::resolve_scope(
             &crate::operator::load_operator_config()?,
             crate::planes::Capability::Any,
-            crate::scope::ScopeFlags { profile, store, server, graph, uri },
+            crate::scope::ScopeFlags { profile, store, server, cluster: None, graph, uri },
         )?;
         let (server, graph, uri) = (
             scope.server.as_deref(),

--- a/crates/omnigraph-cli/src/helpers.rs
+++ b/crates/omnigraph-cli/src/helpers.rs
@@ -539,12 +539,49 @@ pub(crate) fn resolve_local_uri(
     Ok(resolve_local_graph(config, cli_uri, operation)?.uri)
 }
 
-/// Resolve a storage-plane verb's address to a direct storage URI (RFC-010
-/// Slice 3). `--cluster <dir|uri> --cluster-graph <id>` resolves the graph's
-/// storage URI from the **served cluster state** (the truth a `--cluster`
-/// server serves); otherwise the ordinary positional-URI path.
-/// clap enforces both-or-neither and exclusion with `uri`, so the mismatched
-/// arm is defensive.
+/// Resolve a maintenance verb's (optimize/repair/cleanup) address to a direct
+/// storage URI through the one RFC-011 scope path. Every primitive funnels
+/// here: a positional URI, `--store`, `--cluster <root> --graph <id>`, a
+/// `--profile` cluster binding, or operator defaults — all resolved at the
+/// `Direct` capability (so a server scope is rejected, a cluster scope is
+/// allowed), then mapped to a storage URI by `resolve_storage_uri`.
+pub(crate) async fn resolve_maintenance_uri(
+    config: &OmnigraphConfig,
+    profile: Option<&str>,
+    store: Option<&str>,
+    cluster: Option<&str>,
+    graph: Option<&str>,
+    cli_uri: Option<String>,
+    operation: &str,
+) -> Result<String> {
+    let scope = scope::resolve_scope(
+        &operator::load_operator_config()?,
+        planes::Capability::Direct,
+        scope::ScopeFlags {
+            profile,
+            store,
+            server: None,
+            cluster,
+            graph,
+            uri: cli_uri,
+        },
+    )?;
+    resolve_storage_uri(
+        config,
+        scope.uri,
+        scope.cluster.as_deref(),
+        scope.cluster_graph.as_deref(),
+        operation,
+    )
+    .await
+}
+
+/// Map a resolved direct address to a storage URI: a cluster scope
+/// (`--cluster <root> --graph <id>`, or a `--profile` cluster binding)
+/// resolves the graph's storage URI from the **served cluster state** (the
+/// truth a `--cluster` server serves); otherwise the ordinary positional-URI
+/// path. The scope resolver guarantees a cluster scope always carries a graph,
+/// so the mismatched arm is defensive.
 pub(crate) async fn resolve_storage_uri(
     config: &OmnigraphConfig,
     cli_uri: Option<String>,
@@ -555,7 +592,7 @@ pub(crate) async fn resolve_storage_uri(
     match (cluster, cluster_graph) {
         (Some(cluster), Some(graph_id)) => resolve_cluster_graph_uri(cluster, graph_id).await,
         (None, None) => resolve_local_uri(config, cli_uri, operation),
-        _ => bail!("--cluster and --cluster-graph must be given together"),
+        _ => bail!("internal error: a cluster scope was resolved without a graph id"),
     }
 }
 

--- a/crates/omnigraph-cli/src/main.rs
+++ b/crates/omnigraph-cli/src/main.rs
@@ -790,46 +790,18 @@ async fn main() -> Result<()> {
                 print_policy_explain(&decision, &actor, &request);
             }
         },
-        Command::Optimize {
-            uri,
-            config,
-            cluster,
-            cluster_graph,
-            json,
-        } => {
+        Command::Optimize { uri, config, json } => {
             let config = load_cli_config(config.as_ref())?;
-            let uri = if uri.is_some() || cluster.is_some() {
-                resolve_storage_uri(
-                    &config,
-                    uri,
-                    cluster.as_deref(),
-                    cluster_graph.as_deref(),
-                    "optimize",
-                )
-                .await?
-            } else {
-                // RFC-011: no explicit per-command address — consult the scope
-                // (a --profile cluster binding, --store, or operator defaults).
-                let scope = scope::resolve_scope(
-                    &operator::load_operator_config()?,
-                    planes::Capability::Direct,
-                    scope::ScopeFlags {
-                        profile: cli.profile.as_deref(),
-                        store: cli.store.as_deref(),
-                        server: None,
-                        graph: cli.graph.as_deref(),
-                        uri: None,
-                    },
-                )?;
-                resolve_storage_uri(
-                    &config,
-                    scope.uri,
-                    scope.cluster.as_deref(),
-                    scope.cluster_graph.as_deref(),
-                    "optimize",
-                )
-                .await?
-            };
+            let uri = resolve_maintenance_uri(
+                &config,
+                cli.profile.as_deref(),
+                cli.store.as_deref(),
+                cli.cluster.as_deref(),
+                cli.graph.as_deref(),
+                uri,
+                "optimize",
+            )
+            .await?;
             let db = Omnigraph::open(&uri).await?;
             let stats = db.optimize().await?;
             if json {
@@ -865,44 +837,21 @@ async fn main() -> Result<()> {
         Command::Repair {
             uri,
             config,
-            cluster,
-            cluster_graph,
             confirm,
             force,
             json,
         } => {
             let config = load_cli_config(config.as_ref())?;
-            let uri = if uri.is_some() || cluster.is_some() {
-                resolve_storage_uri(
-                    &config,
-                    uri,
-                    cluster.as_deref(),
-                    cluster_graph.as_deref(),
-                    "repair",
-                )
-                .await?
-            } else {
-                // RFC-011: no explicit per-command address — consult the scope.
-                let scope = scope::resolve_scope(
-                    &operator::load_operator_config()?,
-                    planes::Capability::Direct,
-                    scope::ScopeFlags {
-                        profile: cli.profile.as_deref(),
-                        store: cli.store.as_deref(),
-                        server: None,
-                        graph: cli.graph.as_deref(),
-                        uri: None,
-                    },
-                )?;
-                resolve_storage_uri(
-                    &config,
-                    scope.uri,
-                    scope.cluster.as_deref(),
-                    scope.cluster_graph.as_deref(),
-                    "repair",
-                )
-                .await?
-            };
+            let uri = resolve_maintenance_uri(
+                &config,
+                cli.profile.as_deref(),
+                cli.store.as_deref(),
+                cli.cluster.as_deref(),
+                cli.graph.as_deref(),
+                uri,
+                "repair",
+            )
+            .await?;
             let db = Omnigraph::open(&uri).await?;
             let stats = db
                 .repair(omnigraph::db::RepairOptions { confirm, force })
@@ -979,45 +928,22 @@ async fn main() -> Result<()> {
         Command::Cleanup {
             uri,
             config,
-            cluster,
-            cluster_graph,
             keep,
             older_than,
             confirm,
             json,
         } => {
             let config = load_cli_config(config.as_ref())?;
-            let uri = if uri.is_some() || cluster.is_some() {
-                resolve_storage_uri(
-                    &config,
-                    uri,
-                    cluster.as_deref(),
-                    cluster_graph.as_deref(),
-                    "cleanup",
-                )
-                .await?
-            } else {
-                // RFC-011: no explicit per-command address — consult the scope.
-                let scope = scope::resolve_scope(
-                    &operator::load_operator_config()?,
-                    planes::Capability::Direct,
-                    scope::ScopeFlags {
-                        profile: cli.profile.as_deref(),
-                        store: cli.store.as_deref(),
-                        server: None,
-                        graph: cli.graph.as_deref(),
-                        uri: None,
-                    },
-                )?;
-                resolve_storage_uri(
-                    &config,
-                    scope.uri,
-                    scope.cluster.as_deref(),
-                    scope.cluster_graph.as_deref(),
-                    "cleanup",
-                )
-                .await?
-            };
+            let uri = resolve_maintenance_uri(
+                &config,
+                cli.profile.as_deref(),
+                cli.store.as_deref(),
+                cli.cluster.as_deref(),
+                cli.graph.as_deref(),
+                uri,
+                "cleanup",
+            )
+            .await?;
 
             let older_than_dur = older_than.as_deref().map(parse_duration_arg).transpose()?;
 

--- a/crates/omnigraph-cli/src/planes.rs
+++ b/crates/omnigraph-cli/src/planes.rs
@@ -208,7 +208,7 @@ pub(crate) fn guard_addressing(cli: &Cli) -> Result<()> {
 
     if cli.server.is_some() && !capability.accepts_server_addressing() {
         bail!(
-            "`{label}` is a {} command; --server addresses a served graph and does not apply. {}",
+            "`{label}` is a {} command; --server addresses a served graph and does not apply.{}",
             capability.describe(),
             remediation(capability, &cli.command),
         );
@@ -216,7 +216,7 @@ pub(crate) fn guard_addressing(cli: &Cli) -> Result<()> {
     if cli.cluster.is_some() && !cluster_ok {
         bail!(
             "`{label}` is a {} command; --cluster addresses a cluster-managed graph for \
-             maintenance (optimize/repair/cleanup) and does not apply. {}",
+             maintenance (optimize/repair/cleanup) and does not apply.{}",
             capability.describe(),
             remediation(capability, &cli.command),
         );
@@ -224,7 +224,7 @@ pub(crate) fn guard_addressing(cli: &Cli) -> Result<()> {
     if cli.graph.is_some() && !(capability.accepts_server_addressing() || cluster_ok) {
         bail!(
             "`{label}` is a {} command; --graph selects a graph within a server or cluster \
-             scope and does not apply. {}",
+             scope and does not apply.{}",
             capability.describe(),
             remediation(capability, &cli.command),
         );
@@ -233,17 +233,20 @@ pub(crate) fn guard_addressing(cli: &Cli) -> Result<()> {
 }
 
 /// The "what to do instead" tail for a wrong-address error, by capability.
+/// Includes its own leading space when non-empty so the caller appends it
+/// directly — an empty tail (the served-addressing capabilities, which only
+/// reach this fn for a misplaced `--cluster`/`--graph`) leaves no trailing space.
 fn remediation(capability: Capability, cmd: &Command) -> &'static str {
     match capability {
         Capability::Direct => match cmd {
-            Command::Init { .. } => "Pass a storage URI.",
+            Command::Init { .. } => " Pass a storage URI.",
             Command::Optimize { .. } | Command::Repair { .. } | Command::Cleanup { .. } => {
-                "Pass a storage URI, or --cluster <dir> --graph <id>."
+                " Pass a storage URI, or --cluster <dir> --graph <id>."
             }
-            _ => "Pass a storage URI.",
+            _ => " Pass a storage URI.",
         },
-        Capability::Control => "It operates on a cluster (pass --config <dir>).",
-        Capability::Local => "It does not address a graph.",
+        Capability::Control => " It operates on a cluster (pass --config <dir>).",
+        Capability::Local => " It does not address a graph.",
         Capability::Any | Capability::Served => "",
     }
 }

--- a/crates/omnigraph-cli/src/planes.rs
+++ b/crates/omnigraph-cli/src/planes.rs
@@ -177,35 +177,75 @@ pub(crate) fn command_label(cmd: &Command) -> &'static str {
     }
 }
 
-/// Reject the data-plane addressing flags (`--server`/`--graph`) on any verb
-/// that does not live on the data plane. This replaces the old silent-ignore
-/// — e.g. `optimize --server prod` previously dropped `--server` and tried to
-/// resolve a default target, failing (if at all) with an unrelated message.
-/// Now it fails with one honest, declared error. RFC-010 Slice 1.
+/// The verbs that address an existing graph through a cluster scope
+/// (`--cluster <root> --graph <id>`): the storage-maintenance commands.
+/// `init` is storage-plane too but *creates* a graph (cluster graphs are born
+/// from `cluster apply`, not `init`), and `schema plan` / `lint` take a
+/// positional URI — none consume cluster addressing, so the guard rejects
+/// `--cluster`/`--graph` on them rather than silently dropping the flag.
+pub(crate) fn accepts_cluster_addressing(cmd: &Command) -> bool {
+    matches!(
+        cmd,
+        Command::Optimize { .. } | Command::Repair { .. } | Command::Cleanup { .. }
+    )
+}
+
+/// Reject a scope-addressing flag (`--server`/`--cluster`/`--graph`) on a verb
+/// that cannot consume it, rather than silently dropping it (the old behavior:
+/// e.g. `optimize --server prod` dropped `--server` and failed later with an
+/// unrelated message). Each flag has a distinct valid surface:
+/// - `--server` → served-graph scopes (`any`/`served`);
+/// - `--cluster` → the cluster-maintenance verbs (optimize/repair/cleanup);
+/// - `--graph` → any multi-graph scope: a served scope *or* a cluster one.
+/// RFC-010 Slice 1, generalized for RFC-011 cluster addressing.
 pub(crate) fn guard_addressing(cli: &Cli) -> Result<()> {
-    if cli.server.is_none() && cli.graph.is_none() {
+    if cli.server.is_none() && cli.cluster.is_none() && cli.graph.is_none() {
         return Ok(());
     }
     let capability = command_capability(&cli.command);
-    if capability.accepts_server_addressing() {
-        return Ok(());
-    }
     let label = command_label(&cli.command);
-    let how = match capability {
-        Capability::Direct => match cli.command {
+    let cluster_ok = accepts_cluster_addressing(&cli.command);
+
+    if cli.server.is_some() && !capability.accepts_server_addressing() {
+        bail!(
+            "`{label}` is a {} command; --server addresses a served graph and does not apply. {}",
+            capability.describe(),
+            remediation(capability, &cli.command),
+        );
+    }
+    if cli.cluster.is_some() && !cluster_ok {
+        bail!(
+            "`{label}` is a {} command; --cluster addresses a cluster-managed graph for \
+             maintenance (optimize/repair/cleanup) and does not apply. {}",
+            capability.describe(),
+            remediation(capability, &cli.command),
+        );
+    }
+    if cli.graph.is_some() && !(capability.accepts_server_addressing() || cluster_ok) {
+        bail!(
+            "`{label}` is a {} command; --graph selects a graph within a server or cluster \
+             scope and does not apply. {}",
+            capability.describe(),
+            remediation(capability, &cli.command),
+        );
+    }
+    Ok(())
+}
+
+/// The "what to do instead" tail for a wrong-address error, by capability.
+fn remediation(capability: Capability, cmd: &Command) -> &'static str {
+    match capability {
+        Capability::Direct => match cmd {
             Command::Init { .. } => "Pass a storage URI.",
-            _ => "Pass a storage URI, or --cluster <dir> --cluster-graph <id>.",
+            Command::Optimize { .. } | Command::Repair { .. } | Command::Cleanup { .. } => {
+                "Pass a storage URI, or --cluster <dir> --graph <id>."
+            }
+            _ => "Pass a storage URI.",
         },
         Capability::Control => "It operates on a cluster (pass --config <dir>).",
         Capability::Local => "It does not address a graph.",
-        Capability::Any | Capability::Served => {
-            unreachable!("served-addressing capabilities returned early")
-        }
-    };
-    bail!(
-        "`{label}` is a {} command; --server/--graph address a served graph and do not apply. {how}",
-        capability.describe()
-    );
+        Capability::Any | Capability::Served => "",
+    }
 }
 
 #[cfg(test)]

--- a/crates/omnigraph-cli/src/scope.rs
+++ b/crates/omnigraph-cli/src/scope.rs
@@ -42,6 +42,7 @@ pub(crate) struct ScopeFlags<'a> {
     pub(crate) profile: Option<&'a str>,
     pub(crate) store: Option<&'a str>,
     pub(crate) server: Option<&'a str>,
+    pub(crate) cluster: Option<&'a str>,
     pub(crate) graph: Option<&'a str>,
     pub(crate) uri: Option<String>,
 }
@@ -56,17 +57,49 @@ pub(crate) fn resolve_scope(
     capability: Capability,
     flags: ScopeFlags<'_>,
 ) -> Result<ResolvedScope> {
-    // `--store` is its own way to address a graph; combining it with a positional
-    // URI or `--server` is a contradiction, not a silent precedence.
-    if flags.store.is_some() && (flags.uri.is_some() || flags.server.is_some()) {
+    // At most one explicit scope primitive may address a command — a positional
+    // URI, `--store`, `--server`, or `--cluster` are mutually exclusive ways to
+    // name the graph. Combining them is a contradiction, not a silent precedence.
+    let primitives: Vec<&str> = [
+        flags.uri.as_deref().map(|_| "a positional URI"),
+        flags.store.map(|_| "--store"),
+        flags.server.map(|_| "--server"),
+        flags.cluster.map(|_| "--cluster"),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+    if primitives.len() > 1 {
         bail!(
-            "--store is exclusive with a positional URI and --server — pick one way to \
-             address the graph"
+            "{} are mutually exclusive — pick one way to address the graph",
+            primitives.join(" and ")
         );
     }
-    // 1. Any explicit address wins; reproduce today's behavior untouched.
-    //    `--store` is an explicit store URI — fold it into `uri`.
+
+    // 1a. `--cluster` is the cluster scope primitive (maintenance): resolve its
+    //     root + select the graph with `--graph`.
+    if let Some(cluster) = flags.cluster {
+        return scope_from_binding(
+            op,
+            capability,
+            ScopeBinding::Cluster(cluster.to_string()),
+            flags.graph.map(str::to_string),
+            "--cluster",
+        );
+    }
+
+    // 1b. Any other explicit address wins; reproduce today's behavior untouched.
+    //     `--store` is an explicit store URI — fold it into `uri`.
     if flags.uri.is_some() || flags.server.is_some() || flags.store.is_some() {
+        // `--graph` selects within a multi-graph scope; a bare positional URI /
+        // `--store` is already a single graph, so a stray `--graph` is an error
+        // rather than a silently-dropped flag.
+        if flags.graph.is_some() && flags.server.is_none() {
+            bail!(
+                "--graph selects a graph within a server or cluster scope; a positional \
+                 URI / --store is already a single graph"
+            );
+        }
         return Ok(ResolvedScope {
             server: flags.server.map(str::to_string),
             graph: flags.graph.map(str::to_string),
@@ -128,8 +161,8 @@ fn scope_from_binding(
             if capability == Capability::Direct {
                 bail!(
                     "this command needs direct storage access, but {source} resolves a \
-                     server scope; name storage explicitly with --store <uri> (or a \
-                     --cluster/--cluster-graph for a managed graph)"
+                     server scope; name storage explicitly with --store <uri> (or \
+                     --cluster <dir> --graph <id> for a managed graph)"
                 );
             }
             Ok(ResolvedScope {
@@ -146,21 +179,25 @@ fn scope_from_binding(
                      direct access"
                 );
             }
-            // A cluster binding is a config name (resolved against `clusters:`)
-            // or a literal root URI.
-            let root = if let Some(root) = op.cluster_root(&cluster) {
-                root.to_string()
-            } else if cluster.contains("://") {
-                cluster
-            } else {
+            // A cluster value is a config name (resolved against `clusters:`)
+            // or a literal root: an `s3://`/`file://` URI or a local cluster
+            // directory. Only a configured name is rewritten; anything else is
+            // passed through to the cluster-state resolver verbatim, so a bare
+            // directory path keeps working as it did for per-command `--cluster`.
+            let root = op
+                .cluster_root(&cluster)
+                .map(str::to_string)
+                .unwrap_or(cluster);
+            // A cluster holds many graphs; maintenance addresses one at a time.
+            let Some(graph) = graph else {
                 bail!(
-                    "unknown cluster '{cluster}' ({source}); define it under `clusters:` \
-                     in operator config, or use a literal root URI"
+                    "{source} resolves a cluster scope; pass --graph <id> to select which \
+                     graph to maintain"
                 );
             };
             Ok(ResolvedScope {
                 cluster: Some(root),
-                cluster_graph: graph,
+                cluster_graph: Some(graph),
                 ..Default::default()
             })
         }
@@ -192,6 +229,7 @@ mod tests {
             profile: None,
             store: None,
             server: None,
+            cluster: None,
             graph: None,
             uri: None,
         }
@@ -230,7 +268,7 @@ mod tests {
     }
 
     #[test]
-    fn store_is_exclusive_with_positional_uri_and_server() {
+    fn scope_primitives_are_mutually_exclusive() {
         let op = OperatorConfig::default();
         for flags in [
             ScopeFlags {
@@ -243,9 +281,93 @@ mod tests {
                 server: Some("prod"),
                 ..flags()
             },
+            ScopeFlags {
+                cluster: Some("./brain"),
+                uri: Some("file://other.omni".into()),
+                ..flags()
+            },
+            ScopeFlags {
+                cluster: Some("./brain"),
+                server: Some("prod"),
+                ..flags()
+            },
         ] {
-            let err = resolve_scope(&op, Capability::Any, flags).unwrap_err().to_string();
-            assert!(err.contains("--store is exclusive"), "{err}");
+            let err = resolve_scope(&op, Capability::Direct, flags)
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("mutually exclusive"), "{err}");
+        }
+    }
+
+    #[test]
+    fn cluster_flag_resolves_root_and_graph_for_maintenance() {
+        let op = cfg("clusters:\n  brain:\n    root: s3://acme/brain\n");
+        let scope = resolve_scope(
+            &op,
+            Capability::Direct,
+            ScopeFlags {
+                cluster: Some("brain"),
+                graph: Some("knowledge"),
+                ..flags()
+            },
+        )
+        .unwrap();
+        assert_eq!(scope.cluster.as_deref(), Some("s3://acme/brain"));
+        assert_eq!(scope.cluster_graph.as_deref(), Some("knowledge"));
+    }
+
+    #[test]
+    fn cluster_flag_accepts_a_literal_root_uri() {
+        let op = OperatorConfig::default();
+        let scope = resolve_scope(
+            &op,
+            Capability::Direct,
+            ScopeFlags {
+                cluster: Some("s3://bucket/clusters/brain"),
+                graph: Some("knowledge"),
+                ..flags()
+            },
+        )
+        .unwrap();
+        assert_eq!(scope.cluster.as_deref(), Some("s3://bucket/clusters/brain"));
+        assert_eq!(scope.cluster_graph.as_deref(), Some("knowledge"));
+    }
+
+    #[test]
+    fn cluster_scope_without_a_graph_is_a_loud_error() {
+        let op = cfg("clusters:\n  brain:\n    root: s3://acme/brain\n");
+        let err = resolve_scope(
+            &op,
+            Capability::Direct,
+            ScopeFlags {
+                cluster: Some("brain"),
+                ..flags()
+            },
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("--graph <id>"), "{err}");
+    }
+
+    #[test]
+    fn graph_on_a_bare_store_or_uri_is_rejected() {
+        let op = OperatorConfig::default();
+        for flags in [
+            ScopeFlags {
+                uri: Some("graph.omni".into()),
+                graph: Some("knowledge"),
+                ..flags()
+            },
+            ScopeFlags {
+                store: Some("s3://b/g.omni"),
+                graph: Some("knowledge"),
+                ..flags()
+            },
+        ] {
+            let err = resolve_scope(&op, Capability::Any, flags)
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("already a single graph"), "{err}");
         }
     }
 
@@ -292,6 +414,27 @@ mod tests {
         .unwrap();
         assert_eq!(scope.cluster.as_deref(), Some("s3://acme/brain"));
         assert_eq!(scope.cluster_graph.as_deref(), Some("knowledge"));
+    }
+
+    #[test]
+    fn profile_cluster_scope_with_graph_override() {
+        // The deferral closed by this slice: a `--graph` flag overrides a
+        // profile cluster's default_graph, exactly as it does for a server scope.
+        let op = cfg(
+            "clusters:\n  brain:\n    root: s3://acme/brain\nprofiles:\n  admin:\n    cluster: brain\n    default_graph: knowledge\n",
+        );
+        let scope = resolve_scope(
+            &op,
+            Capability::Direct,
+            ScopeFlags {
+                profile: Some("admin"),
+                graph: Some("archive"),
+                ..flags()
+            },
+        )
+        .unwrap();
+        assert_eq!(scope.cluster.as_deref(), Some("s3://acme/brain"));
+        assert_eq!(scope.cluster_graph.as_deref(), Some("archive")); // flag beats profile default
     }
 
     #[test]

--- a/crates/omnigraph-cli/tests/cli_cluster.rs
+++ b/crates/omnigraph-cli/tests/cli_cluster.rs
@@ -975,7 +975,7 @@ fn optimize_resolves_a_cluster_graph_by_id() {
             .arg("optimize")
             .arg("--cluster")
             .arg(temp.path())
-            .arg("--cluster-graph")
+            .arg("--graph")
             .arg("knowledge")
             .arg("--json"),
     );
@@ -994,7 +994,7 @@ fn optimize_unknown_cluster_graph_id_errors() {
             .arg("optimize")
             .arg("--cluster")
             .arg(temp.path())
-            .arg("--cluster-graph")
+            .arg("--graph")
             .arg("does-not-exist")
             .arg("--json"),
     );
@@ -1006,8 +1006,10 @@ fn optimize_unknown_cluster_graph_id_errors() {
 }
 
 #[test]
-fn cluster_flag_requires_cluster_graph() {
-    // clap enforces both-or-neither.
+fn cluster_without_graph_demands_a_graph_selector() {
+    // A cluster holds many graphs; `--cluster` alone can't pick one. The scope
+    // resolver demands `--graph <id>` (replacing the old `--cluster-graph`
+    // requirement) before it ever touches cluster state.
     let out = output_failure(
         cli()
             .arg("optimize")
@@ -1017,8 +1019,8 @@ fn cluster_flag_requires_cluster_graph() {
     );
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
-        stderr.contains("cluster-graph") || stderr.contains("required"),
-        "expected --cluster to require --cluster-graph; got: {stderr}"
+        stderr.contains("--graph <id>"),
+        "expected --cluster to demand --graph; got: {stderr}"
     );
 }
 
@@ -1076,7 +1078,7 @@ fn optimize_by_cluster_works_when_catalog_payloads_are_degraded() {
             .arg("optimize")
             .arg("--cluster")
             .arg(temp.path())
-            .arg("--cluster-graph")
+            .arg("--graph")
             .arg("knowledge")
             .arg("--json"),
     );

--- a/crates/omnigraph-cli/tests/cli_data.rs
+++ b/crates/omnigraph-cli/tests/cli_data.rs
@@ -172,6 +172,32 @@ fn optimize_with_server_flag_errors_wrong_plane() {
 }
 
 #[test]
+fn wrong_address_guard_message_has_no_trailing_space() {
+    // The remediation tail is empty for served-addressing capabilities, so a
+    // misplaced --cluster on a data verb must not leave "… does not apply. "
+    // with a dangling space (error text is observable contract). NO_COLOR keeps
+    // the assertion off ANSI styling.
+    let output = output_failure(
+        cli()
+            .env("NO_COLOR", "1")
+            .arg("query")
+            .arg("--cluster")
+            .arg("./brain")
+            .arg("-e")
+            .arg("query q { Person { id } }"),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("and does not apply."),
+        "expected the wrong-address message; got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("and does not apply. "),
+        "trailing space after the message; got: {stderr}"
+    );
+}
+
+#[test]
 fn graph_flag_on_a_positional_uri_errors() {
     // RFC-011: `--graph` selects within a multi-graph scope (a server or
     // cluster). A bare positional URI is already a single graph, so pairing it

--- a/crates/omnigraph-cli/tests/cli_data.rs
+++ b/crates/omnigraph-cli/tests/cli_data.rs
@@ -165,9 +165,34 @@ fn optimize_with_server_flag_errors_wrong_plane() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("`optimize` is a direct (storage-native) command")
-            && stderr.contains("--server/--graph address a served graph and do not apply")
-            && stderr.contains("Pass a storage URI, or --cluster <dir> --cluster-graph <id>."),
+            && stderr.contains("--server addresses a served graph and does not apply")
+            && stderr.contains("Pass a storage URI, or --cluster <dir> --graph <id>."),
         "wrong-capability guard message not found; got: {stderr}"
+    );
+}
+
+#[test]
+fn graph_flag_on_a_positional_uri_errors() {
+    // RFC-011: `--graph` selects within a multi-graph scope (a server or
+    // cluster). A bare positional URI is already a single graph, so pairing it
+    // with `--graph` is a loud error, not a silently-dropped flag. (The guard
+    // lets `--graph` reach a data verb; the scope resolver is what rejects it.)
+    let temp = tempdir().unwrap();
+    let graph = graph_path(temp.path());
+    init_graph(&graph);
+    let output = output_failure(
+        cli()
+            .arg("query")
+            .arg(&graph)
+            .arg("--graph")
+            .arg("knowledge")
+            .arg("-e")
+            .arg("query q { Person { id } }"),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("already a single graph"),
+        "expected --graph-on-positional-URI rejection; got: {stderr}"
     );
 }
 

--- a/crates/omnigraph-cli/tests/cli_schema_config.rs
+++ b/crates/omnigraph-cli/tests/cli_schema_config.rs
@@ -121,7 +121,7 @@ fn schema_plan_with_server_flag_errors_wrong_plane() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("`schema plan` is a direct (storage-native) command")
-            && stderr.contains("Pass a storage URI, or --cluster <dir> --cluster-graph <id>."),
+            && stderr.contains("Pass a storage URI."),
         "schema plan wrong-capability message not found; got: {stderr}"
     );
 }

--- a/docs/user/cli/reference.md
+++ b/docs/user/cli/reference.md
@@ -34,18 +34,18 @@ Every command declares the **capability** it needs — what it requires to reach
 
 - **`any`** — `query`, `mutate`, `load`, `ingest`, `branch *`, `snapshot`, `export`, `commit *`, `schema show`, `schema apply`. Run against a graph **served (via a server) or embedded (direct against a store)**: accept a positional `file://`/`s3://` URI, `--server <name|url>` (+ `--graph <id>` for multi-graph servers), `--store <uri>`, or `--profile <name>`. A remote server is addressed with `--server` — a positional `http(s)://` URI does **not** dispatch to one.
 - **`served`** — `graphs list`. Requires a server (accepts `--server` / `--profile`).
-- **`direct`** — `init`, `optimize`, `repair`, `cleanup`, `schema plan`, `queries validate`, `lint`. Need **direct storage access** (`file://` / `s3://`), never through a server. They accept a positional `URI`, but **not** `--server` / `--graph`, and a remote (`http(s)://`) URI is rejected. `optimize` / `repair` / `cleanup` also accept **`--cluster <dir|s3://…> --cluster-graph <id>`**, which resolves the graph's storage URI from the served cluster state (so you needn't know the `<storage>/graphs/<id>.omni` layout).
+- **`direct`** — `init`, `optimize`, `repair`, `cleanup`, `schema plan`, `queries validate`, `lint`. Need **direct storage access** (`file://` / `s3://`), never through a server. They accept a positional `URI`, but **not** `--server`, and a remote (`http(s)://`) URI is rejected. `optimize` / `repair` / `cleanup` additionally accept **`--cluster <dir|s3://…> --graph <id>`** (`--cluster` is a cluster directory or storage-root URI, named via `clusters:` in `~/.omnigraph/config.yaml` or a literal root), which resolves the graph's storage URI from the served cluster state (so you needn't know the `<storage>/graphs/<id>.omni` layout). `--graph` is the one graph selector across all scopes — on these three verbs it picks the cluster graph; on the other `direct` verbs it does not apply.
 - **`control`** — `cluster *`. Operates on a cluster directory via `--config <dir>`.
 - **`local`** — `policy *`, `embed`, `login`, `logout`, `config`, `version`, `queries list`. Address no graph.
 
 These restrictions are enforced and reported, not silent:
 
-- A served-graph flag (`--server` / `--graph`) on a verb that doesn't reach a graph through a server fails loudly, e.g.: ``optimize is a direct (storage-native) command; --server/--graph address a served graph and do not apply. Pass a storage URI, or --cluster <dir> --cluster-graph <id>.``
+- A scope flag on a verb that can't consume it fails loudly rather than being silently dropped — `--server` outside a served scope, `--cluster` outside the maintenance verbs, or `--graph` where no multi-graph scope applies, e.g.: ``optimize is a direct (storage-native) command; --server addresses a served graph and does not apply. Pass a storage URI, or --cluster <dir> --graph <id>.``
 - A `direct` verb pointed at a remote URI fails loudly, e.g.: ``optimize is a direct (storage-native) command and needs direct storage access; the resolved target is a remote server (https://…). Pass the graph's file:// or s3:// URI.``
 - A data verb pointed at a positional `http(s)://` URI fails loudly: ``a remote graph must be addressed with --server <url> — a positional (or --uri) http(s):// URL no longer dispatches to a server.``
 - `init` into an **established cluster's** storage layout (`<root>/graphs/<id>.omni` where `<root>` holds `__cluster/state.json`) is refused — graphs in a cluster are created by `cluster apply` (which records ledger / recovery / approvals), not `init`.
 
-To maintain a server-backed graph, run the `direct` verbs from a host with storage access against the graph's storage URI (a positional URI, or `--cluster … --cluster-graph …`), out-of-band from the serving process — there are no server routes for `optimize` / `repair` / `cleanup` by design.
+To maintain a server-backed graph, run the `direct` verbs from a host with storage access against the graph's storage URI (a positional URI, or `--cluster … --graph …`), out-of-band from the serving process — there are no server routes for `optimize` / `repair` / `cleanup` by design.
 
 `omnigraph --help` lists commands with a **capability legend** at the bottom (any / served / direct / control / local).
 
@@ -102,13 +102,14 @@ resolves its scope fresh, there is no sticky "current" mode.
 - `--store <uri>` addresses a single graph's storage directly (ad-hoc / break-glass).
 - A `cluster`-bound profile reaches `optimize` / `repair` / `cleanup` for a managed
   graph (resolving its storage root from `clusters:`), the same as
-  `--cluster <root> --cluster-graph <id>`.
+  `--cluster <root> --graph <id>`. A `--graph` flag overrides the profile's default.
 - A `server`-bound scope on a maintenance verb, or a `cluster`-bound scope on a
   data verb, is rejected with a message pointing at the right addressing.
 
-`--target` and the positional-`http(s)://`→remote dispatch have been **removed**;
-the remaining legacy surfaces (`--cluster-graph`, `omnigraph.yaml`'s `cli.graph`
-default) still work and an explicit address always wins.
+`--target`, `--cluster-graph`, and the positional-`http(s)://`→remote dispatch
+have been **removed** (`--graph` is now the one graph selector across server and
+cluster scopes); `omnigraph.yaml`'s `cli.graph` default still works and an
+explicit address always wins.
 
 #### Credentials keyed by server name
 

--- a/docs/user/clusters/index.md
+++ b/docs/user/clusters/index.md
@@ -258,10 +258,11 @@ operation — it runs out-of-band, with direct storage access, against the graph
 roots. Address a cluster graph by name instead of hand-typing its storage path:
 
 ```bash
-omnigraph optimize --cluster ./company-brain --cluster-graph knowledge
-omnigraph cleanup  --cluster ./company-brain --cluster-graph knowledge --keep 10 --confirm
-# --cluster also takes the storage-root URI directly (config-free):
-omnigraph optimize --cluster s3://bucket/clusters/company-brain --cluster-graph knowledge
+omnigraph optimize --cluster ./company-brain --graph knowledge
+omnigraph cleanup  --cluster ./company-brain --graph knowledge --keep 10 --confirm
+# --cluster also takes the storage-root URI directly (config-free), and a
+# `clusters:` name from ~/.omnigraph/config.yaml:
+omnigraph optimize --cluster s3://bucket/clusters/company-brain --graph knowledge
 ```
 
 The graph's storage URI is resolved from the **served cluster state** (the same

--- a/docs/user/operations/maintenance.md
+++ b/docs/user/operations/maintenance.md
@@ -1,6 +1,6 @@
 # Maintenance: Optimize, Repair & Cleanup
 
-**Addressing.** `optimize`, `repair`, and `cleanup` are **direct** (storage-native) CLI commands: they run with direct storage access against a positional `file://`/`s3://` URI or **`--cluster <dir|s3://…> --cluster-graph <id>`** (which resolves the graph's storage URI from the served cluster state, so you needn't know the `<storage>/graphs/<id>.omni` layout). They never run through a server, and reject `--server` / `--graph` or a remote (`http(s)://`) URI with a declared error. There are no server routes for them by design — to maintain a server-backed graph, run them out-of-band against the graph's storage URI. See the *Command capabilities* section of [cli-reference.md](../cli/reference.md).
+**Addressing.** `optimize`, `repair`, and `cleanup` are **direct** (storage-native) CLI commands: they run with direct storage access against a positional `file://`/`s3://` URI or **`--cluster <dir|s3://…> --graph <id>`** (which resolves the graph's storage URI from the served cluster state, so you needn't know the `<storage>/graphs/<id>.omni` layout). They never run through a server, and reject `--server` or a remote (`http(s)://`) URI with a declared error. There are no server routes for them by design — to maintain a server-backed graph, run them out-of-band against the graph's storage URI. See the *Command capabilities* section of [cli-reference.md](../cli/reference.md).
 
 ## `optimize` — non-destructive
 


### PR DESCRIPTION
## What

RFC-011: finishes "one `--graph` selector everywhere".

- **`--graph` is the single graph selector** across every multi-graph scope — drops `requires = "server"`, so it selects within a `--server`, a `--cluster`, or a `--profile` binding. On a single-graph address (positional URI / `--store`) it's a loud error, not a silently-dropped flag.
- **`--cluster` is promoted to a global scope primitive** (a cluster directory, storage-root URI, or `clusters:` name) alongside `--server`/`--store`/`--profile`. `optimize`/`repair`/`cleanup` now take `--cluster <root> --graph <id>`.
- **`--cluster-graph` is removed** (replacement ships in this PR — direct removal, consistent with #238).
- The bespoke maintenance-dispatch if/else collapses into the unified `resolve_scope` path (`resolve_maintenance_uri`).
- The wrong-address guard validates each scope flag against the verb it can consume (`--server`→served, `--cluster`→maintenance verbs, `--graph`→any multi-graph scope).

Closes the Slice-A deferrals for the global `--cluster` flag and the profile-cluster + `--graph` override.

## Tests

- Migrated `cli_cluster` maintenance-addressing tests to `--cluster … --graph`; new `scope.rs` unit tests (cluster primitive, exclusivity, no-graph error, `--graph`-on-bare-URI); guard-message updates.
- `cargo test --workspace --locked`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR finishes RFC-011's \"one `--graph` selector everywhere\": `--cluster` becomes a global scope primitive alongside `--server`/`--store`/`--profile`, the per-command `--cluster`/`--cluster-graph` args on `optimize`/`repair`/`cleanup` are removed, and `--graph` loses its clap-level `requires = \"server\"` in favour of a runtime guard. The bespoke maintenance if/else in `main.rs` collapses into a single `resolve_maintenance_uri` call.

- **`scope.rs`** adds `--cluster` as a mutual-exclusion primitive, rejects `--graph` on bare `--store`/URI, and threads the `graph` override through cluster bindings; the no-scope step-4 fallthrough still silently discards `--graph` when no companion scope is resolved.
- **`planes.rs`** splits `guard_addressing` into three independent flag checks with a `remediation()` helper, fixing the previously reported trailing-space issue.
- **`cli_cluster.rs` / `cli_data.rs`** tests cover the newly addressed cases (named-alias resolution, literal URI, no-graph error, `--graph`-on-bare-URI rejection, trailing-space guard).

<h3>Confidence Score: 4/5</h3>

The refactoring is clean and the addressed cases are well-tested, but the open concern from the prior review about --graph being silently dropped without a companion scope remains unresolved; maintenance commands (cleanup --confirm, repair --confirm) are on that code path.

The previous review identified a gap where --graph without --cluster passes guard_addressing for maintenance verbs (accepts_cluster_addressing returns true), then falls through to ResolvedScope::default() in resolve_scope step 4, silently discarding the flag and potentially operating on the wrong graph. That gap is still present.

crates/omnigraph-cli/src/scope.rs - step 4 of resolve_scope returns ResolvedScope::default() without checking whether flags.graph was set, which is the remaining unguarded path.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/omnigraph-cli/src/scope.rs | Core RFC-011 scope resolver: adds --cluster as a primitive, enforces mutual exclusion, rejects --graph on bare store/URI. The no-scope fallthrough (step 4) still silently drops --graph. |
| crates/omnigraph-cli/src/planes.rs | Guard refactored into three independent checks with a new remediation() helper. Trailing-space issue from prior review is fixed. |
| crates/omnigraph-cli/src/helpers.rs | Introduces resolve_maintenance_uri() that unifies the three maintenance verb address paths through resolve_scope. |
| crates/omnigraph-cli/src/main.rs | Optimize/Repair/Cleanup handlers simplified to single resolve_maintenance_uri() call; per-command cluster/cluster_graph bindings removed cleanly. |
| crates/omnigraph-cli/src/cli.rs | --graph loses requires=server (now a global selector); --cluster added as a global flag; per-command cluster/cluster_graph args removed. |
| crates/omnigraph-cli/tests/cli_data.rs | New tests: no-trailing-space guard message, --graph-on-positional-URI rejection, updated wrong-plane message assertions. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/omnigraph-cli/src/scope.rs`, line 143-146 ([link](https://github.com/modernrelay/omnigraph/blob/b50a2d87470ad05d2e9bac95d726e36798442616/crates/omnigraph-cli/src/scope.rs#L143-L146)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`--graph` silently dropped in the no-scope fallthrough**

   When no explicit primitive (`--cluster`, `--server`, `--store`, positional URI), no `--profile`, and no `defaults.server` is configured, `resolve_scope` returns `ResolvedScope::default()` — discarding `flags.graph` entirely. For maintenance verbs (`optimize`/`repair`/`cleanup`), `guard_addressing` lets `--graph` through (because `cluster_ok = true`), so a user running `omnigraph optimize --graph knowledge` (forgetting `--cluster`) will: ① pass the guard, ② have `graph` silently dropped by the scope resolver, ③ fall back to `resolve_cli_graph` → `config.cli_graph_name()` from legacy `omnigraph.yaml`, and potentially run `cleanup --confirm` on the wrong graph. Before this PR, clap's `requires = "server"` on `--graph` was the safety net; removing it without a compensating fallthrough check is the gap. Adding `if flags.graph.is_some() { bail!("--graph requires a scope …") }` before the final `Ok(ResolvedScope::default())` would close it.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fomnigraph-cli%2Fsrc%2Fscope.rs%0ALine%3A%20143-146%0A%0AComment%3A%0A**%60--graph%60%20silently%20dropped%20in%20the%20no-scope%20fallthrough**%0A%0AWhen%20no%20explicit%20primitive%20%28%60--cluster%60%2C%20%60--server%60%2C%20%60--store%60%2C%20positional%20URI%29%2C%20no%20%60--profile%60%2C%20and%20no%20%60defaults.server%60%20is%20configured%2C%20%60resolve_scope%60%20returns%20%60ResolvedScope%3A%3Adefault%28%29%60%20%E2%80%94%20discarding%20%60flags.graph%60%20entirely.%20For%20maintenance%20verbs%20%28%60optimize%60%2F%60repair%60%2F%60cleanup%60%29%2C%20%60guard_addressing%60%20lets%20%60--graph%60%20through%20%28because%20%60cluster_ok%20%3D%20true%60%29%2C%20so%20a%20user%20running%20%60omnigraph%20optimize%20--graph%20knowledge%60%20%28forgetting%20%60--cluster%60%29%20will%3A%20%E2%91%A0%20pass%20the%20guard%2C%20%E2%91%A1%20have%20%60graph%60%20silently%20dropped%20by%20the%20scope%20resolver%2C%20%E2%91%A2%20fall%20back%20to%20%60resolve_cli_graph%60%20%E2%86%92%20%60config.cli_graph_name%28%29%60%20from%20legacy%20%60omnigraph.yaml%60%2C%20and%20potentially%20run%20%60cleanup%20--confirm%60%20on%20the%20wrong%20graph.%20Before%20this%20PR%2C%20clap's%20%60requires%20%3D%20%22server%22%60%20on%20%60--graph%60%20was%20the%20safety%20net%3B%20removing%20it%20without%20a%20compensating%20fallthrough%20check%20is%20the%20gap.%20Adding%20%60if%20flags.graph.is_some%28%29%20%7B%20bail!%28%22--graph%20requires%20a%20scope%20%E2%80%A6%22%29%20%7D%60%20before%20the%20final%20%60Ok%28ResolvedScope%3A%3Adefault%28%29%29%60%20would%20close%20it.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modernrelay%2Fomnigraph&pr=241&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(cli): drop trailing space in wrong-a..."](https://github.com/modernrelay/omnigraph/commit/9e812881d19c4e7397fcf43557656f5940976f84) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37602974)</sub>

<!-- /greptile_comment -->