### PR TITLE
feat(cli): --quiet/--yes globals; echo resolved write target; gate non-local destructive writes

### DIFF
--- a/crates/omnigraph-cli/src/cli.rs
+++ b/crates/omnigraph-cli/src/cli.rs
@@ -66,6 +66,18 @@ pub(crate) struct Cli {
     #[arg(long, global = true, value_name = "DIR|URI")]
     pub(crate) cluster: Option<String>,
 
+    /// Skip the confirmation prompt for a destructive write (`cleanup`,
+    /// overwrite `load`, `branch delete`) against a non-local scope (RFC-011
+    /// Decision 9). Without it, a non-local destructive write prompts on a TTY
+    /// and refuses (errors) when there is no TTY or `--json` is set.
+    #[arg(long, global = true)]
+    pub(crate) yes: bool,
+
+    /// Suppress the one-line resolved-write-target diagnostic that write
+    /// commands echo to stderr (RFC-011 Decision 9).
+    #[arg(long, global = true)]
+    pub(crate) quiet: bool,
+
     #[command(subcommand)]
     pub(crate) command: Command,
 }

--- a/crates/omnigraph-cli/src/helpers.rs
+++ b/crates/omnigraph-cli/src/helpers.rs
@@ -2,6 +2,8 @@
 //! remote HTTP, env/token handling, scaffolding (moved verbatim from
 //! main.rs in the modularization).
 
+use std::io::IsTerminal;
+
 use super::*;
 use crate::operator;
 
@@ -14,6 +16,59 @@ pub(crate) fn ensure_local_graph_parent(uri: &str) -> Result<()> {
 
 pub(crate) fn is_remote_uri(uri: &str) -> bool {
     uri.starts_with("http://") || uri.starts_with("https://")
+}
+
+/// Whether a resolved write target is *local* for the purposes of the RFC-011
+/// Decision 9 destructive-confirm gate: a bare path or a `file://` URI. Anything
+/// else carrying a scheme — `http(s)://` (served), `s3://` / `gs://` / … (object
+/// store) — is non-local and a destructive write against it requires explicit
+/// consent. Generalizes `is_remote_uri` (which only catches http(s)).
+pub(crate) fn uri_is_local(uri: &str) -> bool {
+    !uri.contains("://") || uri.starts_with("file://")
+}
+
+/// Echo the resolved write target + access path to stderr (RFC-011 Decision 9),
+/// unless `--quiet`. One line, e.g. `omnigraph load → file://g.omni (direct,
+/// local)`. stderr so `--json` consumers reading stdout are unaffected; the line
+/// legitimately differs embedded-vs-served (that visibility is the point).
+pub(crate) fn echo_write_target(quiet: bool, label: &str, uri: &str, served: bool) {
+    if quiet {
+        return;
+    }
+    let access = if served {
+        "served"
+    } else if uri_is_local(uri) {
+        "direct, local"
+    } else {
+        "direct, remote"
+    };
+    eprintln!("omnigraph {label} → {uri} ({access})");
+}
+
+/// Gate a destructive write (`cleanup`, overwrite `load`, `branch delete`)
+/// against a non-local scope (RFC-011 Decision 9). A local target needs no
+/// confirmation; otherwise `--yes` consents, an interactive TTY is prompted, and
+/// a non-TTY / `--json` run refuses rather than silently proceeding.
+pub(crate) fn confirm_destructive(label: &str, uri: &str, yes: bool, json: bool) -> Result<()> {
+    if uri_is_local(uri) || yes {
+        return Ok(());
+    }
+    if json || !std::io::stdin().is_terminal() {
+        bail!(
+            "refusing destructive `{label}` against non-local target {uri} without confirmation; \
+             pass --yes to confirm (an interactive TTY would be prompted instead)"
+        );
+    }
+    eprint!(
+        "About to run a destructive `{label}` against {uri} (not local). Type 'yes' to continue: "
+    );
+    io::stderr().flush()?;
+    let mut answer = String::new();
+    io::stdin().read_line(&mut answer)?;
+    match answer.trim().to_ascii_lowercase().as_str() {
+        "yes" | "y" => Ok(()),
+        _ => bail!("aborted: destructive `{label}` not confirmed"),
+    }
 }
 
 /// THE one way the CLI composes a remote request URL. Every remote call
@@ -1111,6 +1166,40 @@ pub(crate) fn rewrite_deprecated_argv(args: Vec<OsString>) -> Vec<OsString> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // RFC-011 Decision 9: locality classifier for the destructive-confirm gate.
+    #[test]
+    fn uri_is_local_truth_table() {
+        // Local: bare path or file://.
+        assert!(uri_is_local("graph.omni"));
+        assert!(uri_is_local("/abs/path/graph.omni"));
+        assert!(uri_is_local("file:///tmp/graph.omni"));
+        // Non-local: served or object-store schemes.
+        assert!(!uri_is_local("http://host/graphs/g"));
+        assert!(!uri_is_local("https://host/graphs/g"));
+        assert!(!uri_is_local("s3://bucket/graph.omni"));
+        assert!(!uri_is_local("gs://bucket/graph.omni"));
+    }
+
+    // RFC-011 Decision 9: a non-local destructive write with `--json` (the CI
+    // shape — also covers the no-TTY case, since tests run without a terminal)
+    // refuses rather than proceeding; a local one and an explicit `--yes` pass.
+    #[test]
+    fn confirm_destructive_refuses_non_local_without_consent() {
+        let err = confirm_destructive("cleanup", "s3://b/g.omni", false, true)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("--yes"), "{err}");
+    }
+
+    #[test]
+    fn confirm_destructive_allows_local_and_explicit_yes() {
+        // Local needs no confirmation, even with --json.
+        assert!(confirm_destructive("cleanup", "file:///tmp/g.omni", false, true).is_ok());
+        assert!(confirm_destructive("branch delete", "graph.omni", false, true).is_ok());
+        // --yes consents to a non-local target.
+        assert!(confirm_destructive("cleanup", "s3://b/g.omni", true, true).is_ok());
+    }
 
     // RFC-011 Decision 2: `--server` accepts a literal URL (value with `://`),
     // bypassing the operator-config registry — so no config / OMNIGRAPH_HOME is

--- a/crates/omnigraph-cli/src/main.rs
+++ b/crates/omnigraph-cli/src/main.rs
@@ -188,6 +188,10 @@ async fn main() -> Result<()> {
                 cli.store.as_deref(),
             )?;
             let branch = resolve_branch(&config, branch, None, "main");
+            if matches!(mode, CliLoadMode::Overwrite) {
+                confirm_destructive("load --mode overwrite", client.uri(), cli.yes, json)?;
+            }
+            echo_write_target(cli.quiet, "load", client.uri(), client.is_remote());
             let payload = client
                 .load(&branch, from.as_deref(), &data.to_string_lossy(), mode)
                 .await?;
@@ -223,6 +227,7 @@ async fn main() -> Result<()> {
             )?;
             let branch = resolve_branch(&config, branch, None, "main");
             let from = resolve_branch(&config, from, None, "main");
+            echo_write_target(cli.quiet, "ingest", client.uri(), client.is_remote());
             let payload = client
                 .ingest(&branch, &from, &data.to_string_lossy(), mode)
                 .await?;
@@ -251,6 +256,7 @@ async fn main() -> Result<()> {
                     cli.store.as_deref(),
                 )?;
                 let from = resolve_branch(&config, from, None, "main");
+                echo_write_target(cli.quiet, "branch create", client.uri(), client.is_remote());
                 let payload = client.branch_create_from(&from, &name).await?;
                 if json {
                     print_json(&payload)?;
@@ -297,6 +303,8 @@ async fn main() -> Result<()> {
                     cli.profile.as_deref(),
                     cli.store.as_deref(),
                 )?;
+                confirm_destructive("branch delete", client.uri(), cli.yes, json)?;
+                echo_write_target(cli.quiet, "branch delete", client.uri(), client.is_remote());
                 let payload = client.branch_delete(&name).await?;
                 if json {
                     print_json(&payload)?;
@@ -322,6 +330,7 @@ async fn main() -> Result<()> {
                     cli.store.as_deref(),
                 )?;
                 let into = resolve_branch(&config, into, None, "main");
+                echo_write_target(cli.quiet, "branch merge", client.uri(), client.is_remote());
                 let payload = client.branch_merge(&source, &into).await?;
                 if json {
                     print_json(&payload)?;
@@ -440,6 +449,7 @@ async fn main() -> Result<()> {
                     (!registry.is_empty()).then_some(registry)
                 };
                 let label = client.selected().unwrap_or(client.uri()).to_string();
+                echo_write_target(cli.quiet, "schema apply", client.uri(), client.is_remote());
                 let output = client
                     .apply_schema(&schema_source, allow_data_loss, |catalog| {
                         if let Some(registry) = registry.as_ref() {
@@ -802,6 +812,7 @@ async fn main() -> Result<()> {
                 "optimize",
             )
             .await?;
+            echo_write_target(cli.quiet, "optimize", &uri, false);
             let db = Omnigraph::open(&uri).await?;
             let stats = db.optimize().await?;
             if json {
@@ -852,6 +863,7 @@ async fn main() -> Result<()> {
                 "repair",
             )
             .await?;
+            echo_write_target(cli.quiet, "repair", &uri, false);
             let db = Omnigraph::open(&uri).await?;
             let stats = db
                 .repair(omnigraph::db::RepairOptions { confirm, force })
@@ -967,6 +979,11 @@ async fn main() -> Result<()> {
                 );
                 return Ok(());
             }
+            // Past the preview gate: a real destructive run. Against a non-local
+            // scope this additionally requires --yes (or an interactive yes), so
+            // `cleanup --confirm s3://…` in CI refuses rather than destroying.
+            confirm_destructive("cleanup", &uri, cli.yes, json)?;
+            echo_write_target(cli.quiet, "cleanup", &uri, false);
 
             let options = omnigraph::db::CleanupPolicyOptions {
                 keep_versions: keep,

--- a/crates/omnigraph-cli/tests/cli_data.rs
+++ b/crates/omnigraph-cli/tests/cli_data.rs
@@ -1565,6 +1565,160 @@ fn branch_delete_rejects_main() {
     assert!(stderr.contains("cannot delete branch 'main'"));
 }
 
+// ── RFC-011 Decision 9: write diagnostics + non-local destructive-confirm ──
+
+#[test]
+fn write_echoes_resolved_target_to_stderr() {
+    // Every write echoes its resolved target + access path to stderr; --json
+    // (stdout) is unaffected. A local load → "(direct, local)".
+    let temp = tempdir().unwrap();
+    let graph = graph_path(temp.path());
+    init_graph(&graph);
+    let data = fixture("test.jsonl");
+    let output = output_success(
+        cli()
+            .arg("load")
+            .arg("--mode")
+            .arg("append")
+            .arg("--data")
+            .arg(&data)
+            .arg(&graph)
+            .arg("--json"),
+    );
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("omnigraph load →") && stderr.contains("(direct, local)"),
+        "missing write-target echo; stderr: {stderr}"
+    );
+    // stdout still parses as JSON — the echo went to stderr.
+    let _: Value = serde_json::from_slice(&output.stdout).unwrap();
+}
+
+#[test]
+fn quiet_suppresses_the_write_target_echo() {
+    let temp = tempdir().unwrap();
+    let graph = graph_path(temp.path());
+    init_graph(&graph);
+    let data = fixture("test.jsonl");
+    let output = output_success(
+        cli()
+            .arg("--quiet")
+            .arg("load")
+            .arg("--mode")
+            .arg("append")
+            .arg("--data")
+            .arg(&data)
+            .arg(&graph),
+    );
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        !stderr.contains("omnigraph load →"),
+        "--quiet should suppress the echo; stderr: {stderr}"
+    );
+}
+
+#[test]
+fn branch_delete_against_non_local_scope_refuses_without_yes() {
+    // No bucket needed: the confirm gate fires before the graph is opened.
+    let output = output_failure(
+        cli()
+            .arg("branch")
+            .arg("delete")
+            .arg("--store")
+            .arg("s3://fake-bucket/g.omni")
+            .arg("feature")
+            .arg("--json"),
+    );
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("refusing destructive `branch delete`") && stderr.contains("--yes"),
+        "expected a non-local destructive refusal; stderr: {stderr}"
+    );
+}
+
+#[test]
+fn branch_delete_against_non_local_scope_passes_gate_with_yes() {
+    // With --yes the gate is bypassed; the command then fails for an unrelated
+    // reason (the fake bucket can't be opened), so the refusal must be ABSENT.
+    let output = output_failure(
+        cli()
+            .arg("branch")
+            .arg("delete")
+            .arg("--store")
+            .arg("s3://fake-bucket/g.omni")
+            .arg("feature")
+            .arg("--yes")
+            .arg("--json"),
+    );
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        !stderr.contains("refusing destructive"),
+        "--yes should bypass the confirm gate; stderr: {stderr}"
+    );
+}
+
+#[test]
+fn overwrite_load_against_non_local_scope_refuses_without_yes() {
+    let output = output_failure(
+        cli()
+            .arg("load")
+            .arg("--mode")
+            .arg("overwrite")
+            .arg("--data")
+            .arg(fixture("test.jsonl"))
+            .arg("--store")
+            .arg("s3://fake-bucket/g.omni")
+            .arg("--json"),
+    );
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("refusing destructive `load --mode overwrite`"),
+        "expected a non-local overwrite refusal; stderr: {stderr}"
+    );
+}
+
+#[test]
+fn cleanup_against_non_local_scope_refuses_without_yes() {
+    // Past the --confirm preview gate, a non-local cleanup still needs --yes.
+    let output = output_failure(
+        cli()
+            .arg("cleanup")
+            .arg("--store")
+            .arg("s3://fake-bucket/g.omni")
+            .arg("--keep")
+            .arg("5")
+            .arg("--confirm")
+            .arg("--json"),
+    );
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("refusing destructive `cleanup`"),
+        "expected a non-local cleanup refusal; stderr: {stderr}"
+    );
+}
+
+#[test]
+fn cleanup_against_local_scope_executes_with_confirm() {
+    // Local cleanup needs no --yes; --confirm alone executes (and echoes).
+    let temp = tempdir().unwrap();
+    let graph = graph_path(temp.path());
+    init_graph(&graph);
+    load_fixture(&graph);
+    let output = output_success(
+        cli()
+            .arg("cleanup")
+            .arg("--keep")
+            .arg("1")
+            .arg("--confirm")
+            .arg(&graph)
+            .arg("--json"),
+    );
+    let payload: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(payload["tables"].as_array().is_some(), "{payload}");
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("omnigraph cleanup →"), "stderr: {stderr}");
+}
+
 #[test]
 fn branch_merge_defaults_target_to_main() {
     let temp = tempdir().unwrap();

--- a/crates/omnigraph-cli/tests/parity_matrix.rs
+++ b/crates/omnigraph-cli/tests/parity_matrix.rs
@@ -142,7 +142,10 @@ fn parity_branch_create_delete() {
     let (l, r) = p.run(&["branch", "create", "--from", "main", "parity-branch", "--json"],
     );
     assert_parity("branch create", &l, &r);
-    let (l, r) = p.run(&["branch", "delete", "parity-branch", "--json"],
+    // `branch delete` is destructive: the served (remote) arm is non-local and
+    // requires consent (RFC-011 Decision 9), so the row passes `--yes` to test
+    // the operation itself, not the safety gate. The local arm ignores `--yes`.
+    let (l, r) = p.run(&["branch", "delete", "parity-branch", "--yes", "--json"],
     );
     assert_parity("branch delete", &l, &r);
 }

--- a/crates/omnigraph-cli/tests/system_remote.rs
+++ b/crates/omnigraph-cli/tests/system_remote.rs
@@ -550,6 +550,8 @@ fn remote_branch_delete_removes_branch() {
             .arg("--config")
             .arg(&config)
             .arg("feature")
+            // Served target is non-local → destructive-confirm gate (RFC-011 D9).
+            .arg("--yes")
             .arg("--json"),
     ));
     assert_eq!(deleted["name"], "feature");

--- a/docs/user/cli/reference.md
+++ b/docs/user/cli/reference.md
@@ -23,7 +23,7 @@ Top-level command families and subcommands. Graph-targeting commands accept a po
 | `cluster validate \| plan \| apply \| approve \| status \| refresh \| import \| force-unlock` | declarative cluster control plane. `validate` checks a local `cluster.yaml` folder and referenced schema/query/policy files; `plan` diffs it against local JSON state at `__cluster/state.json`, annotates dispositions, and embeds real schema-migration previews; `apply` converges the cluster — stored-query/policy catalog writes (content-addressed under `__cluster/resources/`), graph creates, schema updates (soft drops only; `--as` records the actor), and graph deletes behind a digest-bound approval from `cluster approve <resource> --as <actor>` (`apply`/`approve` default the actor from the per-operator `omnigraph.yaml`'s `cli.actor` when `--as` is omitted; nothing else in that file affects cluster commands); what apply converges is what an `omnigraph-server --cluster <dir>` deployment serves on its next restart (omnigraph.yaml deployments are unaffected); `status` reads the state ledger; `refresh`/`import` explicitly update local JSON state from read-only graph observations; `force-unlock <LOCK_ID>` manually removes a held local state lock by exact id |
 | `optimize` | non-destructive Lance compaction (skips tables with `Blob` columns or uncovered drift; `--json` reports `skipped`) |
 | `repair [--confirm] [--force]` | preview or explicitly publish uncovered manifest/head drift. `--confirm` heals verified maintenance drift and exits non-zero if suspicious/unverifiable drift is refused; `--force --confirm` publishes suspicious/unverifiable drift after operator review |
-| `cleanup --keep N --older-than 7d --confirm` | destructive version GC |
+| `cleanup --keep N --older-than 7d --confirm` | destructive version GC (`--confirm` to execute; also needs `--yes` against a non-local `s3://` target — see *Write diagnostics & destructive confirmation*) |
 | `embed` | offline JSONL embedding pipeline |
 | `policy validate \| test \| explain` | Cedar tooling. Selects `cli.graph`, else `server.graph`, else top-level `policy.file` |
 | `version` / `-v` | print `omnigraph 0.3.x` |
@@ -48,6 +48,15 @@ These restrictions are enforced and reported, not silent:
 To maintain a server-backed graph, run the `direct` verbs from a host with storage access against the graph's storage URI (a positional URI, or `--cluster … --graph …`), out-of-band from the serving process — there are no server routes for `optimize` / `repair` / `cleanup` by design.
 
 `omnigraph --help` lists commands with a **capability legend** at the bottom (any / served / direct / control / local).
+
+## Write diagnostics & destructive confirmation
+
+Two global flags make writes self-documenting and guard the dangerous ones (RFC-011 Decision 9):
+
+- **Every write echoes its resolved target to stderr** — `omnigraph load → s3://acme/brain/graphs/knowledge.omni (direct, remote)` — so you catch a scope that resolved somewhere unexpected (e.g. *prod*) before it lands. Applies to `load`, `ingest`, `mutate`, `branch create|delete|merge`, `schema apply`, `optimize`, `repair`, `cleanup`. The line is stderr, so `--json` consumers reading stdout are unaffected; suppress it with **`--quiet`**.
+- **Destructive writes against a non-local scope require confirmation.** `cleanup`, overwrite `load` (`--mode overwrite`), and `branch delete` proceed freely against a local (`file://`) graph, but when the resolved target is **not local** (a served `http(s)://` graph or an `s3://` store/cluster) they require explicit consent: pass **`--yes`** to confirm, an interactive terminal is prompted, and a non-interactive run (no TTY, or `--json`) **refuses with an error** rather than silently destroying. `cleanup` still also requires its existing `--confirm` (preview→execute); `--yes` is the additional non-local consent.
+
+A "local" target is a bare path or a `file://` URI; `http(s)://`, `s3://`, and other object-store schemes are non-local.
 
 ## Config surfaces
 

--- a/docs/user/clusters/index.md
+++ b/docs/user/clusters/index.md
@@ -271,6 +271,12 @@ not resolvable. Run these from a host with storage access — there are no serve
 routes for them. Conversely, **`init` refuses** a cluster-managed path: graphs in
 a cluster are created by `cluster apply`, not by hand.
 
+Against an **`s3://`-backed cluster** the resolved graph storage is non-local, so a
+destructive `cleanup` additionally requires **`--yes`** (an interactive prompt
+otherwise, refusal without a TTY) on top of `--confirm` — see [cli-reference.md](../cli/reference.md)'s
+*Write diagnostics & destructive confirmation*. Every maintenance run also echoes
+its resolved target to stderr (suppress with `--quiet`).
+
 ## What the control plane does not do (yet)
 
 - **No hot reload** — applied changes serve on the next restart.

--- a/docs/user/operations/maintenance.md
+++ b/docs/user/operations/maintenance.md
@@ -34,6 +34,7 @@
   backstop, so it does as much as it can and converges on re-run. The CLI reports
   any failed tables; rerun `cleanup` to retry them.
 - CLI guards with `--confirm`; without it, prints a preview line.
+- **Non-local consent (RFC-011 D9).** Against a non-local target (an `s3://` store/cluster), `cleanup` additionally requires `--yes` on top of `--confirm`: a TTY is prompted, and a non-interactive run (no TTY, or `--json`) refuses rather than destroying. A local (`file://`) target needs only `--confirm`. The same `--yes` gate applies to overwrite `load` and `branch delete`; every maintenance run echoes its resolved target to stderr (suppress with `--quiet`).
 - **Recovery floor:** `--keep < 3` may garbage-collect versions that crash recovery needs as a rollback target. Default `--keep 10` is safe.
 - **Orphaned-branch reconciliation:** before the version GC, cleanup reclaims any per-table or commit-graph branch absent from the manifest branch list. These orphans arise when a `branch_delete` flips the manifest authority but a downstream best-effort reclaim does not complete (see [branches-commits.md](../branching/index.md)). The reconciler is idempotent (it no-ops once nothing is orphaned), runs regardless of the `keep_versions` / `older_than` values (those gate version GC only), and never reclaims `main` or system-branch forks. Reclaimed forks are logged.
 


### PR DESCRIPTION
## What

RFC-011 **Decision 9** — write diagnostics + destructive-write safety. (Supersedes #242, which auto-closed when its stacked base `rfc-011/unify-graph-selector` merged via #241; rebased onto `main`.)

- **Every write echoes its resolved target + access path to stderr** — `omnigraph load → <uri> (direct, local | direct, remote | served)` — for `load`/`ingest`/`mutate`/`branch create|delete|merge`/`schema apply`/`optimize`/`repair`/`cleanup`. stderr-only, so `--json` stdout is untouched; suppress with the new global `--quiet`.
- **Destructive writes against a non-local scope require consent.** `cleanup`, overwrite `load`, and `branch delete` against an `http(s)://` server or `s3://` store/cluster require the new global `--yes`, an interactive TTY prompt, or — for a non-TTY / `--json` run — a hard refusal instead of silently proceeding. Local (`file://`) writes are unaffected. `cleanup` keeps `--confirm` (preview→execute); `--yes` is the additional non-local consent.

Helpers (`uri_is_local`, `echo_write_target`, `confirm_destructive`) in `helpers.rs`; the gate uses `std::io::IsTerminal` (no new dependency).

## Breaking

`cleanup` / overwrite-`load` / `branch delete` against a remote/`s3://` target with `--json` (or any non-TTY context) previously executed; they now **refuse** unless `--yes` is passed. CI scripts that destroy remote data must add `--yes`.

## Tests

- 3 helper unit tests + 8 integration tests (refuse/bypass/echo/quiet/local-executes).
- The one legitimate parity divergence (served `branch delete` now needs `--yes`) fixed by passing `--yes` in the parity + `system_remote` rows — they test the operation, not the gate.
- `cargo test --workspace --locked`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements RFC-011 Decision 9: every write command now echoes its resolved target and access path to stderr, and three destructive write operations (`cleanup`, `load --mode overwrite`, `branch delete`) against non-local scopes require explicit consent via `--yes`, an interactive TTY prompt, or refuse in non-TTY/`--json` contexts. Two new global flags (`--yes`, `--quiet`) and three centralized helpers (`uri_is_local`, `echo_write_target`, `confirm_destructive`) back this behavior.

- **Write diagnostics**: `echo_write_target` is wired into eight of the nine documented commands; `mutate` is listed in both the PR description and `docs/user/cli/reference.md` as echoing its target, but the `Command::Mutate` handler was not instrumented.
- **Destructive-confirm gate**: `confirm_destructive` is correctly placed before the actual operations for `cleanup`, overwrite `load`, and `branch delete`; `--yes` bypasses the gate, `--json`/no-TTY refuses, and interactive TTY prompts; unit tests and integration tests cover all three paths.
- **AGENTS.md quick-reference**: two example commands (`load --mode overwrite s3://…` and `cleanup --confirm s3://…`) are now stale — they omit the required `--yes` and will refuse in non-interactive contexts, contradicting the codebase's own maintenance-contract rule that docs must be updated in the same PR.

<h3>Confidence Score: 3/5</h3>

The destructive-confirm gate and write-target echo are correctly implemented for all but one command; the missing instrumentation on `mutate` and stale AGENTS.md examples should be fixed before merge.

The `mutate` command was explicitly included in the spec and docs but has no `echo_write_target` call — operators running mutations against remote graphs won't see the diagnostic that the feature promises. Separately, the AGENTS.md quick-reference retains two example invocations (`load --mode overwrite s3://…` and `cleanup --confirm s3://…`) that now fail without `--yes` in non-TTY/CI contexts; AGENTS.md is the always-loaded agent context file, so stale examples there cause generated commands to break in automation. Both are present defects introduced by this PR, not speculative future risk.

`crates/omnigraph-cli/src/main.rs` (missing `echo_write_target` in `Command::Mutate`) and `AGENTS.md` (two quick-reference examples missing `--yes`).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/omnigraph-cli/src/helpers.rs | Adds `uri_is_local`, `echo_write_target`, and `confirm_destructive` helpers with matching unit tests; logic is correct and well-guarded. |
| crates/omnigraph-cli/src/main.rs | Instruments write commands with echo and destructive-confirm gates — `mutate` is listed in the spec but was not instrumented, causing a doc/behavior mismatch. |
| crates/omnigraph-cli/src/cli.rs | Adds `--yes` and `--quiet` as global CLI flags with correct `global = true` and clear docstrings. |
| crates/omnigraph-cli/tests/cli_data.rs | Adds 8 integration tests covering echo, quiet-suppression, refuse/bypass gates for cleanup/load/branch-delete; coverage is thorough for what was instrumented. |
| crates/omnigraph-cli/tests/parity_matrix.rs | Correctly threads `--yes` through the `branch delete` parity row to bypass the new gate while still testing the operation itself. |
| crates/omnigraph-cli/tests/system_remote.rs | Adds `--yes` to `remote_branch_delete_removes_branch` to unblock the served-target destructive-confirm gate; minimal, targeted fix. |
| AGENTS.md | Quick-reference examples for `load --mode overwrite s3://…` and `cleanup --confirm s3://…` are now stale — both will refuse in non-TTY contexts without the new `--yes` flag. |
| docs/user/cli/reference.md | New 'Write diagnostics & destructive confirmation' section accurately describes behavior, but the spec listing `mutate` as echoing conflicts with the code. |
| docs/user/clusters/index.md | Adds a short note on `--yes` requirement for S3-backed cluster cleanup with a link to the CLI reference; accurate and appropriately brief. |
| docs/user/operations/maintenance.md | Adds a one-liner non-local consent note under the cleanup section; accurate and consistent with implementation. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CLI write command invoked] --> B{Destructive?\ncleanup / load overwrite / branch delete}
    B -- No --> E[echo_write_target]
    B -- Yes --> C{uri_is_local OR --yes?}
    C -- Yes --> E
    C -- No --> D{--json OR\nnot is_terminal?}
    D -- Yes --> ERR[bail! refusing destructive write]
    D -- No --> PROMPT[eprint! interactive prompt\nread stdin]
    PROMPT --> ANS{answer == yes/y?}
    ANS -- Yes --> E
    ANS -- No --> ABORT[bail! aborted]
    E --> F{--quiet?}
    F -- Yes --> G[proceed with operation]
    F -- No --> ECHO[eprintln! omnigraph label → uri access]
    ECHO --> G
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/omnigraph-cli/src/main.rs`, line 750-757 ([link](https://github.com/modernrelay/omnigraph/blob/a4f8c140911d57d1cbe950876985c634786a8939/crates/omnigraph-cli/src/main.rs#L750-L757)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`mutate` missing `echo_write_target` call**

   The PR description and the updated `docs/user/cli/reference.md` both state that write-target echoing "Applies to `load`, `ingest`, `mutate`, `branch create|delete|merge`, `schema apply`, `optimize`, `repair`, `cleanup`." The code adds `echo_write_target` to every one of those — except `mutate`. Every `Command::Mutate` invocation runs `client.mutate(...)` and returns without ever calling `echo_write_target`, so operators running mutations against a remote or S3-backed graph get no resolved-target diagnostic even though the docs promise one. This is the only handler listed in the spec that was not instrumented.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fomnigraph-cli%2Fsrc%2Fmain.rs%0ALine%3A%20750-757%0A%0AComment%3A%0A**%60mutate%60%20missing%20%60echo_write_target%60%20call**%0A%0AThe%20PR%20description%20and%20the%20updated%20%60docs%2Fuser%2Fcli%2Freference.md%60%20both%20state%20that%20write-target%20echoing%20%22Applies%20to%20%60load%60%2C%20%60ingest%60%2C%20%60mutate%60%2C%20%60branch%20create%7Cdelete%7Cmerge%60%2C%20%60schema%20apply%60%2C%20%60optimize%60%2C%20%60repair%60%2C%20%60cleanup%60.%22%20The%20code%20adds%20%60echo_write_target%60%20to%20every%20one%20of%20those%20%E2%80%94%20except%20%60mutate%60.%20Every%20%60Command%3A%3AMutate%60%20invocation%20runs%20%60client.mutate%28...%29%60%20and%20returns%20without%20ever%20calling%20%60echo_write_target%60%2C%20so%20operators%20running%20mutations%20against%20a%20remote%20or%20S3-backed%20graph%20get%20no%20resolved-target%20diagnostic%20even%20though%20the%20docs%20promise%20one.%20This%20is%20the%20only%20handler%20listed%20in%20the%20spec%20that%20was%20not%20instrumented.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modernrelay%2Fomnigraph&pr=243&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fomnigraph-cli%2Fsrc%2Fmain.rs%3A750-757%0A**%60mutate%60%20missing%20%60echo_write_target%60%20call**%0A%0AThe%20PR%20description%20and%20the%20updated%20%60docs%2Fuser%2Fcli%2Freference.md%60%20both%20state%20that%20write-target%20echoing%20%22Applies%20to%20%60load%60%2C%20%60ingest%60%2C%20%60mutate%60%2C%20%60branch%20create%7Cdelete%7Cmerge%60%2C%20%60schema%20apply%60%2C%20%60optimize%60%2C%20%60repair%60%2C%20%60cleanup%60.%22%20The%20code%20adds%20%60echo_write_target%60%20to%20every%20one%20of%20those%20%E2%80%94%20except%20%60mutate%60.%20Every%20%60Command%3A%3AMutate%60%20invocation%20runs%20%60client.mutate%28...%29%60%20and%20returns%20without%20ever%20calling%20%60echo_write_target%60%2C%20so%20operators%20running%20mutations%20against%20a%20remote%20or%20S3-backed%20graph%20get%20no%20resolved-target%20diagnostic%20even%20though%20the%20docs%20promise%20one.%20This%20is%20the%20only%20handler%20listed%20in%20the%20spec%20that%20was%20not%20instrumented.%0A%0A&repo=modernrelay%2Fomnigraph&pr=243&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(cli): document --yes/--quiet, write..."](https://github.com/modernrelay/omnigraph/commit/a4f8c140911d57d1cbe950876985c634786a8939) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37605456)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=59169be6-01cf-4bae-80fc-604b6a708098))
- Context used - CLAUDE.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=fba7c581-edb6-48b3-90ce-1db695f47e8b))

<!-- /greptile_comment -->