### PR TITLE
feat(cli): alias subcommand; remove --alias flag (RFC-011 D4)

### DIFF
--- a/crates/omnigraph-cli/src/cli.rs
+++ b/crates/omnigraph-cli/src/cli.rs
@@ -99,12 +99,10 @@ pub(crate) enum Command {
         legacy_uri: Option<String>,
         #[arg(long)]
         config: Option<PathBuf>,
-        #[arg(long, conflicts_with_all = ["query", "query_string"])]
-        alias: Option<String>,
-        #[arg(long, conflicts_with_all = ["alias", "query_string"])]
+        #[arg(long, conflicts_with = "query_string")]
         query: Option<PathBuf>,
-        /// Inline GQ source — alternative to `--query <path>` and `--alias <name>`.
-        #[arg(short = 'e', long = "query-string", value_name = "GQ", conflicts_with_all = ["query", "alias"])]
+        /// Inline GQ source — alternative to `--query <path>`.
+        #[arg(short = 'e', long = "query-string", value_name = "GQ", conflicts_with = "query")]
         query_string: Option<String>,
         #[arg(long)]
         name: Option<String>,
@@ -118,8 +116,6 @@ pub(crate) enum Command {
         format: Option<ReadOutputFormat>,
         #[arg(long, conflicts_with = "format")]
         json: bool,
-        #[arg()]
-        alias_args: Vec<String>,
     },
     /// Execute a graph mutation query against a branch.
     ///
@@ -135,12 +131,10 @@ pub(crate) enum Command {
         legacy_uri: Option<String>,
         #[arg(long)]
         config: Option<PathBuf>,
-        #[arg(long, conflicts_with_all = ["query", "query_string"])]
-        alias: Option<String>,
-        #[arg(long, conflicts_with_all = ["alias", "query_string"])]
+        #[arg(long, conflicts_with = "query_string")]
         query: Option<PathBuf>,
-        /// Inline GQ source — alternative to `--query <path>` and `--alias <name>`.
-        #[arg(short = 'e', long = "query-string", value_name = "GQ", conflicts_with_all = ["query", "alias"])]
+        /// Inline GQ source — alternative to `--query <path>`.
+        #[arg(short = 'e', long = "query-string", value_name = "GQ", conflicts_with = "query")]
         query_string: Option<String>,
         #[arg(long)]
         name: Option<String>,
@@ -150,8 +144,28 @@ pub(crate) enum Command {
         branch: Option<String>,
         #[arg(long)]
         json: bool,
-        #[arg()]
-        alias_args: Vec<String>,
+    },
+    /// Invoke an operator alias (RFC-011 Decision 4).
+    ///
+    /// An alias is a personal binding under `aliases:` in
+    /// ~/.omnigraph/config.yaml — name → (server, graph, stored-query name,
+    /// default params). `omnigraph alias <name> [args]` invokes the bound
+    /// stored query on its server. Living in its own namespace, an alias can
+    /// never shadow or be shadowed by a built-in verb. Replaces the removed
+    /// `--alias` flag on `query`/`mutate`.
+    Alias {
+        /// Alias name (a key under `aliases:` in ~/.omnigraph/config.yaml).
+        name: String,
+        /// Positional args bound to the alias's declared `args` params, in order.
+        args: Vec<String>,
+        #[arg(long)]
+        config: Option<PathBuf>,
+        #[command(flatten)]
+        params: ParamsArgs,
+        #[arg(long, conflicts_with = "json")]
+        format: Option<ReadOutputFormat>,
+        #[arg(long, conflicts_with = "format")]
+        json: bool,
     },
     /// Load data into a graph (local or remote)
     Load {

--- a/crates/omnigraph-cli/src/helpers.rs
+++ b/crates/omnigraph-cli/src/helpers.rs
@@ -729,44 +729,6 @@ pub(crate) fn parse_alias_value(value: &str) -> Value {
     serde_json::from_str(value).unwrap_or_else(|_| Value::String(value.to_string()))
 }
 
-pub(crate) fn merged_params_json(
-    alias_name: Option<&str>,
-    alias_arg_names: &[String],
-    alias_arg_values: &[String],
-    explicit: Option<Value>,
-) -> Result<Option<Value>> {
-    if alias_arg_values.len() > alias_arg_names.len() {
-        let alias = alias_name.unwrap_or("<alias>");
-        bail!(
-            "alias '{}' expects at most {} args but got {}",
-            alias,
-            alias_arg_names.len(),
-            alias_arg_values.len()
-        );
-    }
-
-    let mut merged = serde_json::Map::new();
-    for (arg_name, arg_value) in alias_arg_names.iter().zip(alias_arg_values.iter()) {
-        merged.insert(arg_name.clone(), parse_alias_value(arg_value));
-    }
-
-    match explicit {
-        Some(Value::Object(object)) => {
-            for (key, value) in object {
-                merged.insert(key, value);
-            }
-        }
-        Some(_) => bail!("params JSON must be an object"),
-        None => {}
-    }
-
-    if merged.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(Value::Object(merged)))
-    }
-}
-
 /// The format cascade (RFC-007 §D3): `--json` > `--format` > alias format >
 /// legacy `cli.output_format` (RFC-008 window) > operator `defaults.output`
 /// > table.
@@ -790,43 +752,6 @@ pub(crate) fn resolve_read_format(
         .unwrap_or_default()
 }
 
-pub(crate) fn resolve_alias<'a>(
-    config: &'a OmnigraphConfig,
-    alias_name: Option<&'a str>,
-    expected: AliasCommand,
-) -> Result<Option<(&'a str, &'a omnigraph_server::AliasConfig)>> {
-    let Some(alias_name) = alias_name else {
-        return Ok(None);
-    };
-    let alias = config.alias(alias_name)?;
-    if alias.command != expected {
-        bail!(
-            "alias '{}' is a {:?} alias, not a {:?} alias",
-            alias_name,
-            alias.command,
-            expected
-        );
-    }
-    Ok(Some((alias_name, alias)))
-}
-
-pub(crate) fn normalize_legacy_alias_uri(
-    uri: Option<String>,
-    target_available: bool,
-    alias_name: Option<&str>,
-    mut alias_args: Vec<String>,
-) -> (Option<String>, Vec<String>) {
-    let Some(candidate) = uri else {
-        return (None, alias_args);
-    };
-
-    if alias_name.is_some() && target_available {
-        alias_args.insert(0, candidate);
-        return (None, alias_args);
-    }
-
-    (Some(candidate), alias_args)
-}
 
 
 pub(crate) fn read_target_from_cli(branch: Option<String>, snapshot: Option<String>) -> ReadTarget {

--- a/crates/omnigraph-cli/src/main.rs
+++ b/crates/omnigraph-cli/src/main.rs
@@ -28,7 +28,7 @@ use omnigraph_api_types::{
 };
 use omnigraph_server::queries::{QueryRegistry, check, format_check_breakages};
 use omnigraph_server::{
-    AliasCommand, OmnigraphConfig, PolicyAction, PolicyDecision, PolicyEngine, PolicyRequest,
+    OmnigraphConfig, PolicyAction, PolicyDecision, PolicyEngine, PolicyRequest,
     PolicyTestConfig, ReadOutputFormat, graph_resource_id_for_selection, load_config,
 };
 use reqwest::Method;
@@ -569,7 +569,6 @@ async fn main() -> Result<()> {
             uri,
             legacy_uri,
             config,
-            alias,
             query,
             query_string,
             name,
@@ -578,188 +577,98 @@ async fn main() -> Result<()> {
             snapshot,
             format,
             json,
-            alias_args,
         } => {
-            if alias.is_none() && query.is_none() && query_string.is_none() {
-                bail!("exactly one of --query, --query-string, or --alias must be provided");
+            if query.is_none() && query_string.is_none() {
+                bail!("provide a query: --query <file> or -e '<inline gq>'");
             }
 
             let config = load_cli_config(config.as_ref())?;
-            // Operator aliases (RFC-007 PR 3): pure bindings to stored
-            // queries. A legacy file-alias with the same name wins during
-            // the RFC-008 window (with a warning); an alias name found
-            // only in the operator layer takes the invoke path here.
-            if let Some(alias_name) = alias.as_deref() {
-                let operator_config = crate::operator::load_operator_config()?;
-                if let Some(operator_alias) = operator_config.aliases.get(alias_name) {
-                    if config.alias(alias_name).is_ok() {
-                        eprintln!(
-                            "warning: alias '{alias_name}' is defined in both omnigraph.yaml (legacy, wins during the deprecation window) and the operator config; the legacy definition applies"
-                        );
-                    } else {
-                        // The hidden legacy-uri positional swallows the first
-                        // bare arg; an operator alias always knows its target,
-                        // so reclaim it as the first positional param.
-                        let (_, alias_args) = normalize_legacy_alias_uri(
-                            legacy_uri.clone(),
-                            true,
-                            Some(alias_name),
-                            alias_args.clone(),
-                        );
-                        let output = execute_operator_alias(
-                            &http_client,
-                            &config,
-                            alias_name,
-                            operator_alias,
-                            &alias_args,
-                            load_params_json(&params)?,
-                        )
-                        .await?;
-                        let format =
-                            resolve_read_format(&config, format, json, operator_alias.format);
-                        print_read_output(&output, format, &config)?;
-                        return Ok(());
-                    }
-                }
-            }
-            let alias = resolve_alias(&config, alias.as_deref(), AliasCommand::Read)?;
-            let alias_name = alias.as_ref().map(|(name, _)| *name);
-            let alias_config = alias.as_ref().map(|(_, alias)| *alias);
-            let alias_graph = alias_config.and_then(|alias| alias.graph.as_deref());
-            let target_available = alias_graph.is_some() || config.cli_graph_name().is_some();
-            let (legacy_uri, alias_args) =
-                normalize_legacy_alias_uri(legacy_uri, target_available, alias_name, alias_args);
-            // `--target` is gone; resolve an alias's legacy `graph` name to its
-            // URI (a positional URI still wins).
-            let uri = match uri.or(legacy_uri) {
-                Some(uri) => Some(uri),
-                None => match alias_graph {
-                    Some(name) => Some(config.resolve_target_uri(None, Some(name), None)?),
-                    None => None,
-                },
-            };
             let client = client::GraphClient::resolve(
                 &config,
                 cli.server.as_deref(),
                 cli.graph.as_deref(),
-                uri,
+                uri.or(legacy_uri),
                 cli.profile.as_deref(),
                 cli.store.as_deref(),
             )?;
-            let query_source = resolve_query_source(
-                &config,
-                query.as_ref(),
-                query_string.as_deref(),
-                alias_config.map(|a| a.query.as_str()),
-            )?;
-            let params_json = merged_params_json(
-                alias_name,
-                alias_config
-                    .map(|alias| alias.args.as_slice())
-                    .unwrap_or(&[]),
-                &alias_args,
-                load_params_json(&params)?,
-            )?;
-            let target = resolve_read_target(
-                &config,
-                branch,
-                snapshot,
-                alias_config.and_then(|alias| alias.branch.clone()),
-            )?;
-            let query_name = name.or_else(|| alias_config.and_then(|alias| alias.name.clone()));
+            let query_source =
+                resolve_query_source(&config, query.as_ref(), query_string.as_deref(), None)?;
+            let params_json = load_params_json(&params)?;
+            let target = resolve_read_target(&config, branch, snapshot, None)?;
             let output = client
-                .query(
-                    target,
-                    &query_source,
-                    query_name.as_deref(),
-                    params_json.as_ref(),
-                )
+                .query(target, &query_source, name.as_deref(), params_json.as_ref())
                 .await?;
-            let format = resolve_read_format(
-                &config,
-                format,
-                json,
-                alias_config.and_then(|alias| alias.format),
-            );
+            let format = resolve_read_format(&config, format, json, None);
             print_read_output(&output, format, &config)?;
         }
         Command::Mutate {
             uri,
             legacy_uri,
             config,
-            alias,
             query,
             query_string,
             name,
             params,
             branch,
             json,
-            alias_args,
         } => {
-            if alias.is_none() && query.is_none() && query_string.is_none() {
-                bail!("exactly one of --query, --query-string, or --alias must be provided");
+            if query.is_none() && query_string.is_none() {
+                bail!("provide a mutation query: --query <file> or -e '<inline gq>'");
             }
 
             let config = load_cli_config(config.as_ref())?;
-            let alias = resolve_alias(&config, alias.as_deref(), AliasCommand::Change)?;
-            let alias_name = alias.as_ref().map(|(name, _)| *name);
-            let alias_config = alias.as_ref().map(|(_, alias)| *alias);
-            let alias_graph = alias_config.and_then(|alias| alias.graph.as_deref());
-            let target_available = alias_graph.is_some() || config.cli_graph_name().is_some();
-            let (legacy_uri, alias_args) =
-                normalize_legacy_alias_uri(legacy_uri, target_available, alias_name, alias_args);
-            // `--target` is gone; resolve an alias's legacy `graph` name to its
-            // URI (a positional URI still wins).
-            let uri = match uri.or(legacy_uri) {
-                Some(uri) => Some(uri),
-                None => match alias_graph {
-                    Some(name) => Some(config.resolve_target_uri(None, Some(name), None)?),
-                    None => None,
-                },
-            };
             let client = client::GraphClient::resolve_with_policy(
                 &config,
                 cli.server.as_deref(),
                 cli.graph.as_deref(),
-                uri,
+                uri.or(legacy_uri),
                 cli.as_actor.as_deref(),
                 cli.profile.as_deref(),
                 cli.store.as_deref(),
             )?;
-            let query_source = resolve_query_source(
-                &config,
-                query.as_ref(),
-                query_string.as_deref(),
-                alias_config.map(|a| a.query.as_str()),
-            )?;
-            let params_json = merged_params_json(
-                alias_name,
-                alias_config
-                    .map(|alias| alias.args.as_slice())
-                    .unwrap_or(&[]),
-                &alias_args,
-                load_params_json(&params)?,
-            )?;
-            let branch = resolve_branch(
-                &config,
-                branch,
-                alias_config.and_then(|alias| alias.branch.clone()),
-                "main",
-            );
-            let query_name = name.or_else(|| alias_config.and_then(|alias| alias.name.clone()));
+            let query_source =
+                resolve_query_source(&config, query.as_ref(), query_string.as_deref(), None)?;
+            let params_json = load_params_json(&params)?;
+            let branch = resolve_branch(&config, branch, None, "main");
             let output = client
-                .mutate(
-                    &branch,
-                    &query_source,
-                    query_name.as_deref(),
-                    params_json.as_ref(),
-                )
+                .mutate(&branch, &query_source, name.as_deref(), params_json.as_ref())
                 .await?;
             if json {
                 print_json(&output)?;
             } else {
                 print_change_human(&output);
             }
+        }
+        Command::Alias {
+            name,
+            args,
+            config,
+            params,
+            format,
+            json,
+        } => {
+            let config = load_cli_config(config.as_ref())?;
+            let operator_config = crate::operator::load_operator_config()?;
+            let Some(operator_alias) = operator_config.aliases.get(&name) else {
+                let defined: Vec<&str> =
+                    operator_config.aliases.keys().map(String::as_str).collect();
+                bail!(
+                    "unknown alias '{name}'; defined aliases: [{}] \
+                     (add it under `aliases:` in ~/.omnigraph/config.yaml)",
+                    defined.join(", ")
+                );
+            };
+            let output = execute_operator_alias(
+                &http_client,
+                &config,
+                &name,
+                operator_alias,
+                &args,
+                load_params_json(&params)?,
+            )
+            .await?;
+            let format = resolve_read_format(&config, format, json, operator_alias.format);
+            print_read_output(&output, format, &config)?;
         }
         Command::Policy { command } => match command {
             PolicyCommand::Validate { config } => {

--- a/crates/omnigraph-cli/src/planes.rs
+++ b/crates/omnigraph-cli/src/planes.rs
@@ -106,6 +106,7 @@ pub(crate) fn command_plane(cmd: &Command) -> Plane {
     match cmd {
         Command::Query { .. }
         | Command::Mutate { .. }
+        | Command::Alias { .. }
         | Command::Load { .. }
         | Command::Ingest { .. }
         | Command::Branch { .. }
@@ -168,6 +169,7 @@ pub(crate) fn command_label(cmd: &Command) -> &'static str {
         Command::Commit { .. } => "commit",
         Command::Query { .. } => "query",
         Command::Mutate { .. } => "mutate",
+        Command::Alias { .. } => "alias",
         Command::Policy { .. } => "policy",
         Command::Optimize { .. } => "optimize",
         Command::Repair { .. } => "repair",

--- a/crates/omnigraph-cli/tests/cli_data.rs
+++ b/crates/omnigraph-cli/tests/cli_data.rs
@@ -505,10 +505,9 @@ query list_people() {
 
 #[test]
 fn deprecated_read_and_change_subcommands_emit_warnings() {
-    // Both subcommands require `--query`/`--query-string`/`--alias`, so
-    // invoking them with no args will exit non-zero. That's fine --
-    // we only care that the deprecation warning is printed before the
-    // argument-required error.
+    // Both subcommands require `--query`/`--query-string`, so invoking them
+    // with no args will exit non-zero. That's fine -- we only care that the
+    // deprecation warning is printed before the argument-required error.
     let output = cli().arg("read").output().unwrap();
     let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(

--- a/crates/omnigraph-cli/tests/cli_queries.rs
+++ b/crates/omnigraph-cli/tests/cli_queries.rs
@@ -2,7 +2,6 @@
 //! Moved verbatim from tests/cli.rs in the modularization.
 
 
-use serde_json::Value;
 use tempfile::tempdir;
 
 mod support;
@@ -57,141 +56,42 @@ query list_people() {
     assert_eq!(stdout_string(&lint_output), stdout_string(&check_output));
 }
 
+// Legacy `omnigraph.yaml` `aliases:` invoked via the `--alias` flag were
+// removed in RFC-011 D4 — operator aliases now live under `omnigraph alias
+// <name>` (the happy path is covered by system_local's operator-alias e2e).
+// The legacy file-alias path has no CLI entry point.
+
 #[test]
-fn read_alias_from_yaml_config_runs_with_kv_output() {
-    let temp = tempdir().unwrap();
-    let graph = graph_path(temp.path());
-    let config = temp.path().join("omnigraph.yaml");
-    let query = temp.path().join("aliases.gq");
-    init_graph(&graph);
-    load_fixture(&graph);
-    write_query_file(
-        &query,
-        &std::fs::read_to_string(fixture("test.gq")).unwrap(),
+fn alias_flag_is_removed_from_query() {
+    // RFC-011 D4: `--alias` no longer exists on query/mutate; use `alias <name>`.
+    let output = output_failure(cli().arg("query").arg("--alias").arg("who"));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unexpected argument") && stderr.contains("--alias"),
+        "expected clap to reject --alias on query; got: {stderr}"
     );
-    write_config(
-        &config,
-        &format!(
-            "{}aliases:\n  owner:\n    command: read\n    query: aliases.gq\n    name: get_person\n    args: [name]\n    format: kv\n",
-            local_yaml_config(&graph)
-        ),
-    );
-
-    let output = output_success(
-        cli()
-            .arg("read")
-            .arg("--config")
-            .arg(&config)
-            .arg("--alias")
-            .arg("owner")
-            .arg("Alice"),
-    );
-    let stdout = stdout_string(&output);
-
-    assert!(stdout.contains("row 1"));
-    assert!(stdout.contains("p.name: Alice"));
 }
 
 #[test]
-fn read_alias_uses_alias_target_without_cli_default_and_accepts_url_like_arg() {
-    let temp = tempdir().unwrap();
-    let graph = graph_path(temp.path());
-    let config = temp.path().join("omnigraph.yaml");
-    let query = temp.path().join("aliases.gq");
-    let data = temp.path().join("url-like.jsonl");
-    init_graph(&graph);
-    write_jsonl(
-        &data,
-        r#"{"type":"Person","data":{"name":"https://example.com","age":30}}"#,
-    );
-    output_success(
+fn alias_unknown_name_errors_listing_defined() {
+    // Hermetic: an unknown alias fails before any network, listing defined ones.
+    let home = tempdir().unwrap();
+    std::fs::write(
+        home.path().join("config.yaml"),
+        "servers:\n  dev:\n    url: https://x\naliases:\n  who:\n    server: dev\n    query: find_person\n",
+    )
+    .unwrap();
+    let output = output_failure(
         cli()
-            .arg("load")
-            .arg("--mode")
-            .arg("overwrite")
-            .arg("--data")
-            .arg(&data)
-            .arg(&graph),
+            .env("OMNIGRAPH_HOME", home.path())
+            .arg("alias")
+            .arg("nope"),
     );
-    write_query_file(
-        &query,
-        &std::fs::read_to_string(fixture("test.gq")).unwrap(),
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unknown alias 'nope'") && stderr.contains("who"),
+        "expected an unknown-alias error listing defined aliases; got: {stderr}"
     );
-    write_config(
-        &config,
-        &format!(
-            "graphs:\n  local:\n    uri: '{}'\nquery:\n  roots:\n    - .\npolicy: {{}}\naliases:\n  owner:\n    command: read\n    query: aliases.gq\n    name: get_person\n    args: [name]\n    graph: local\n    format: kv\n",
-            graph.to_string_lossy()
-        ),
-    );
-
-    let output = output_success(
-        cli()
-            .arg("read")
-            .arg("--config")
-            .arg(&config)
-            .arg("--alias")
-            .arg("owner")
-            .arg("https://example.com"),
-    );
-    let stdout = stdout_string(&output);
-
-    assert!(stdout.contains("row 1"));
-    assert!(stdout.contains("p.name: https://example.com"));
-}
-
-#[test]
-fn change_alias_from_yaml_config_persists_changes() {
-    let temp = tempdir().unwrap();
-    let graph = graph_path(temp.path());
-    let config = temp.path().join("omnigraph.yaml");
-    let query = temp.path().join("mutations.gq");
-    init_graph(&graph);
-    load_fixture(&graph);
-    write_query_file(
-        &query,
-        r#"
-query insert_person($name: String, $age: I32) {
-    insert Person { name: $name, age: $age }
-}
-"#,
-    );
-    write_config(
-        &config,
-        &format!(
-            "{}aliases:\n  add_person:\n    command: change\n    query: mutations.gq\n    name: insert_person\n    args: [name, age]\n",
-            local_yaml_config(&graph)
-        ),
-    );
-
-    let output = output_success(
-        cli()
-            .arg("change")
-            .arg("--config")
-            .arg(&config)
-            .arg("--alias")
-            .arg("add_person")
-            .arg("Eve")
-            .arg("29")
-            .arg("--json"),
-    );
-    let payload: Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(payload["affected_nodes"], 1);
-
-    let verify = output_success(
-        cli()
-            .arg("read")
-            .arg(&graph)
-            .arg("--query")
-            .arg(fixture("test.gq"))
-            .arg("--name")
-            .arg("get_person")
-            .arg("--params")
-            .arg(r#"{"name":"Eve"}"#)
-            .arg("--json"),
-    );
-    let verify_payload: Value = serde_json::from_slice(&verify.stdout).unwrap();
-    assert_eq!(verify_payload["row_count"], 1);
 }
 
 #[test]

--- a/crates/omnigraph-cli/tests/system_local.rs
+++ b/crates/omnigraph-cli/tests/system_local.rs
@@ -2480,12 +2480,11 @@ fn local_cli_operator_alias_and_server_flag_invoke_stored_query() {
         .unwrap();
     }
 
-    // The operator alias: name + positional arg, nothing else — server,
+    // The operator alias (RFC-011 D4): `alias <name> [args]` — server,
     // graph, stored query, and token all resolve from the operator layer.
     let output = cli()
         .env("OMNIGRAPH_HOME", operator_home.path())
-        .arg("query")
-        .arg("--alias")
+        .arg("alias")
         .arg("who")
         .arg("Alice")
         .arg("--json")

--- a/docs/user/cli/index.md
+++ b/docs/user/cli/index.md
@@ -30,8 +30,9 @@ omnigraph mutate --uri graph.omni \
   --params '{"name":"Inline","age":42}'
 ```
 
-`-e` is mutually exclusive with `--query <path>` and `--alias <name>`; exactly
-one of the three must be provided. The inline source travels through the same
+`-e` is mutually exclusive with `--query <path>`; exactly one of the two must be
+provided. (Operator aliases moved to their own `omnigraph alias <name>`
+subcommand — RFC-011 D4.) The inline source travels through the same
 parser, lint, params binding, and commit machinery as a file-based query —
 only the source loader changes.
 

--- a/docs/user/cli/reference.md
+++ b/docs/user/cli/reference.md
@@ -11,8 +11,9 @@ Top-level command families and subcommands. Graph-targeting commands accept a po
 | `init` | `--schema <pg>` → initialize a graph (no longer scaffolds `omnigraph.yaml`; start cluster configs from the [cluster.md](../clusters/index.md) quick-start or `config migrate`) |
 | `load` | bulk load a branch, local or remote (`--mode overwrite\|append\|merge` is **required** — overwrite is destructive, so there is no default). Without `--from` the target branch must exist; `--from <base>` forks a missing `--branch` from `<base>` first |
 | `ingest` | deprecated alias of `load --from <base>` (defaults: `--from main --mode merge`); prints a one-line warning to stderr |
-| `query` (alias: `read`) | run named read query; source via `--query <path>`, `-e`/`--query-string <GQ>`, or `--alias <name>` (exactly one). `read` is the deprecated previous name and prints a one-line warning to stderr |
-| `mutate` (alias: `change`) | run mutation query; same `--query` / `-e` / `--alias` mutual-exclusion as `query`. `change` is the deprecated previous name and prints a one-line warning to stderr |
+| `query` (alias: `read`) | run a read query; source via `--query <path>` or `-e`/`--query-string <GQ>`. `read` is the deprecated previous name and prints a one-line warning to stderr |
+| `mutate` (alias: `change`) | run a mutation query; same `--query` / `-e` source as `query`. `change` is the deprecated previous name and prints a one-line warning to stderr |
+| `alias <name> [args]` | invoke an operator alias — a personal binding (under `aliases:` in `~/.omnigraph/config.yaml`) to a stored query on a named server (RFC-011 D4; replaces the removed `--alias` flag) |
 | `snapshot` | print current snapshot (per-table version + row count) |
 | `export` | dump to JSONL on stdout (`--type T`, `--table K` filters) |
 | `branch create \| list \| delete \| merge` | branching ops |
@@ -146,10 +147,12 @@ aliases:
     format: table
 ```
 
-`omnigraph query --alias triage 2026-06-01` invokes
+`omnigraph alias triage 2026-06-01` invokes
 `POST <server>/graphs/spike/queries/weekly_triage` with the keyed
-credential. A legacy `omnigraph.yaml` alias with the same name wins during
-the deprecation window (with a warning).
+credential. Aliases live in their own `alias` namespace (RFC-011 Decision 4),
+so an alias can never shadow — or be shadowed by — a built-in verb. (The old
+`--alias <name>` flag on `query`/`mutate` was removed; legacy `omnigraph.yaml`
+`aliases:` no longer have a CLI entry point.)
 
 A remote command whose URL prefix-matches an operator server's `url` (the
 `gh` host model — no flags needed) resolves its token through:
@@ -199,14 +202,11 @@ query:
   roots: [<dir>, …]   # search path for .gq files
 auth:
   env_file: .env.omni
-aliases:
-  <alias>:
-    # accepted values: `read` / `query` (read alias), `change` / `mutate`
-    # (write alias). `query` and `mutate` are recommended; `read` and
-    # `change` remain accepted forever for back-compat.
-    command: read|change|query|mutate
-    query: <path-to-.gq>
-    name: <query-name>
+aliases:                          # legacy file-aliases — parsed but no longer
+  <alias>:                        # reachable from the CLI (RFC-011 D4 removed
+    command: read|change|query|mutate   # the `--alias` flag). Use operator
+    query: <path-to-.gq>                # aliases (`~/.omnigraph/config.yaml`
+    name: <query-name>                  # `aliases:`) via `omnigraph alias <name>`.
     args: [<positional-name>, …]
     graph: <name>
     branch: <name>


### PR DESCRIPTION
## What

RFC-011 **Decision 4** — operator aliases move from the `--alias <name>` flag (on `query`/`mutate`) to a dedicated **`omnigraph alias <name> [args]`** subcommand. Living in its own namespace, an alias can never shadow — or be shadowed by — a built-in verb.

- `omnigraph alias <name> [args]` looks up the operator alias in `~/.omnigraph/config.yaml` and runs the existing `execute_operator_alias` path (POST `/queries/{name}` on the bound server with the keyed credential). Unknown name → loud error listing the defined aliases.
- Removing `--alias` lets the `query`/`mutate` arms shed the legacy alias machinery (`resolve_alias`, `normalize_legacy_alias_uri`, `merged_params_json`, the operator/legacy branches) — **net −156 lines**.

## Breaking

- `query --alias <name>` / `mutate --alias <name>` are removed; use `omnigraph alias <name>`.
- Legacy `omnigraph.yaml` `aliases:` (the file-alias `command`/`query`/`name` form) lose their only CLI entry point (the block still parses; the omnigraph.yaml excision is a later slice).

## Tests

- `alias <unknown>` lists defined aliases; `query --alias` → clap "unexpected argument"; the operator-alias e2e (`system_local`) migrated to `alias who Alice`; legacy file-alias tests removed.
- `cargo test --workspace --locked`: green (61 suites, 0 failures).

First of three sequenced RFC-011 invocation slices (D4 → D7 → D3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements RFC-011 Decision 4: operator aliases move from `--alias <name>` on `query`/`mutate` to a dedicated `omnigraph alias <name> [args]` subcommand, removing 156 lines of legacy alias machinery (`resolve_alias`, `normalize_legacy_alias_uri`, `merged_params_json`) in the process. Legacy `omnigraph.yaml` file-based aliases lose their CLI entry point entirely (deferred excision is a later slice).

- `cli.rs` gains a new `Alias { name, args, config, params, format, json }` variant; `--alias` and `alias_args` are removed from `Query` and `Mutate`.
- `main.rs` adds a `Command::Alias` arm that looks up the operator config, fails loudly with a sorted alias list on an unknown name, and delegates to the existing `execute_operator_alias` path.
- Docs (`docs/user/cli/index.md`, `docs/user/cli/reference.md`) are updated in-tree; the operator-alias e2e test in `system_local.rs` is migrated to the new syntax.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the primary codebase; the only gap is stale CLI examples in the related cookbooks repo that can be cleaned up in a follow-on.

The code change is clean and well-tested: arity validation is preserved in `execute_operator_alias`, operator-config lookup correctly respects `OMNIGRAPH_HOME`, alias keys iterate in sorted order via `BTreeMap`, and the e2e test in `system_local.rs` exercises the full happy path. The two findings are a missing symmetric clap-rejection test for `mutate --alias` and a stale operator-alias invocation in the related `omnigraph-cookbooks` repo that is directly actionable now.

`crates/omnigraph-cli/tests/cli_queries.rs` is missing the `mutate --alias` rejection test; `omnigraph-cookbooks/skills/omnigraph-best-practices/references/server-policy.md` contains a stale operator-alias example that could be updated in this PR.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/omnigraph-cli/src/cli.rs | Removes `--alias`/`alias_args` from `Query` and `Mutate` variants; adds a new `Alias { name, args, config, params, format, json }` subcommand with clean clap annotations. Conflict declarations correctly simplified. |
| crates/omnigraph-cli/src/helpers.rs | Removes `merged_params_json`, `resolve_alias`, and `normalize_legacy_alias_uri` — all dead-code after the `--alias` flag removal. Arity validation preserved in the unchanged `execute_operator_alias`. |
| crates/omnigraph-cli/src/main.rs | Query and Mutate arms simplified to require only `--query`/`-e`; new `Command::Alias` arm looks up operator config, fails loudly with sorted alias list on unknown name, then delegates to `execute_operator_alias`. Logic is clean. |
| crates/omnigraph-cli/src/planes.rs | Adds `Command::Alias` to `command_plane` (data plane) and `command_label` (returns `"alias"`). Minimal and correct. |
| crates/omnigraph-cli/tests/cli_queries.rs | Three legacy alias tests removed; two new tests added. Missing a symmetric rejection test for `mutate --alias`. |
| crates/omnigraph-cli/tests/system_local.rs | Operator-alias e2e test migrated from `query --alias who Alice` to `alias who Alice`. Mechanical and correct. |
| docs/user/cli/reference.md | Reference table and config-schema section updated to reflect removal of `--alias` and addition of `alias <name> [args]` subcommand. |
| docs/user/cli/index.md | Quick-start prose updated to drop the `--alias` mention and point to the new subcommand. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[omnigraph CLI] --> B{subcommand?}
    B -->|alias| C[Command::Alias]
    B -->|query| D[Command::Query]
    B -->|mutate| E[Command::Mutate]

    C --> F[load_cli_config]
    C --> G[load_operator_config]
    G --> H{alias name found?}
    H -->|no| I["bail! with sorted alias list\n(BTreeMap keys)"]
    H -->|yes| J[execute_operator_alias]
    J --> K["resolve_server_flag(alias.server)"]
    K --> L["POST {server}/queries/{alias.query}"]
    L --> M[resolve_read_format + print_read_output]

    D --> N["require --query or -e\nbail if neither"]
    D --> O[GraphClient.query]

    E --> P["require --query or -e\nbail if neither"]
    E --> Q[GraphClient.mutate]

    style I fill:#f88,color:#000
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/omnigraph-cli/tests/cli_queries.rs`, line 563-575 ([link](https://github.com/modernrelay/omnigraph/blob/a3556352a3eb006014298b6a7d1f0cfc39375442/crates/omnigraph-cli/tests/cli_queries.rs#L563-L575)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Missing symmetrical rejection test for `mutate`**

   The test verifies that `query --alias` is rejected by clap, but there's no equivalent check that `mutate --alias` is also rejected. Both variants had `--alias` removed in `cli.rs`, so the symmetry should be tested. If a future merge conflict or revert accidentally restores the field only on `Mutate`, this gap would let it slip past CI undetected.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fomnigraph-cli%2Ftests%2Fcli_queries.rs%0ALine%3A%20563-575%0A%0AComment%3A%0A**Missing%20symmetrical%20rejection%20test%20for%20%60mutate%60**%0A%0AThe%20test%20verifies%20that%20%60query%20--alias%60%20is%20rejected%20by%20clap%2C%20but%20there's%20no%20equivalent%20check%20that%20%60mutate%20--alias%60%20is%20also%20rejected.%20Both%20variants%20had%20%60--alias%60%20removed%20in%20%60cli.rs%60%2C%20so%20the%20symmetry%20should%20be%20tested.%20If%20a%20future%20merge%20conflict%20or%20revert%20accidentally%20restores%20the%20field%20only%20on%20%60Mutate%60%2C%20this%20gap%20would%20let%20it%20slip%20past%20CI%20undetected.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modernrelay%2Fomnigraph&pr=244&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fomnigraph-cli%2Ftests%2Fcli_queries.rs%3A563-575%0A**Missing%20symmetrical%20rejection%20test%20for%20%60mutate%60**%0A%0AThe%20test%20verifies%20that%20%60query%20--alias%60%20is%20rejected%20by%20clap%2C%20but%20there's%20no%20equivalent%20check%20that%20%60mutate%20--alias%60%20is%20also%20rejected.%20Both%20variants%20had%20%60--alias%60%20removed%20in%20%60cli.rs%60%2C%20so%20the%20symmetry%20should%20be%20tested.%20If%20a%20future%20merge%20conflict%20or%20revert%20accidentally%20restores%20the%20field%20only%20on%20%60Mutate%60%2C%20this%20gap%20would%20let%20it%20slip%20past%20CI%20undetected.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fomnigraph-cli%2Fsrc%2Fmain.rs%3A642-671%0A**Stale%20operator-alias%20examples%20in%20%60omnigraph-cookbooks%60%20will%20silently%20break%20users**%0A%0AThe%20%60omnigraph-cookbooks%60%20repo%20has%20a%20large%20number%20of%20shell%20examples%20using%20%60omnigraph%20query%20--alias%20%3Cname%3E%60%20or%20%60omnigraph%20mutate%20--alias%20%3Cname%3E%60%20that%20will%20fail%20with%20a%20clap%20error%20after%20this%20PR%20ships.%0A%0AMost%20are%20file-based%20%28%60omnigraph.yaml%60%29%20aliases%20whose%20migration%20trails%20the%20later%20excision%20slice.%20However%20%5B%60omnigraph-best-practices%2Freferences%2Fserver-policy.md%3A59%60%5D%28https%3A%2F%2Fgithub.com%2Fmodernrelay%2Fomnigraph-cookbooks%2Fblob%2FHEAD%2Fskills%2Fomnigraph-best-practices%2Freferences%2Fserver-policy.md%29%20contains%20%60omnigraph%20query%20--server%20remote%20--graph%20spike%20--alias%20signal%20sig-foo%60%20%E2%80%94%20an%20**operator%20alias**%20invocation%20%28it%20uses%20%60--server%60%29%20that%20is%20directly%20actionable%20now%20and%20should%20become%20%60omnigraph%20alias%20signal%20sig-foo%60.%0A%0A&repo=modernrelay%2Fomnigraph&pr=244&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(cli): document the alias subcommand..."](https://github.com/modernrelay/omnigraph/commit/a3556352a3eb006014298b6a7d1f0cfc39375442) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37611434)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=59169be6-01cf-4bae-80fc-604b6a708098))
- Context used - CLAUDE.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=fba7c581-edb6-48b3-90ce-1db695f47e8b))

<!-- /greptile_comment -->