### PR TITLE
feat(cli): no-default-graph errors list candidate graphs (RFC-011 D7)

### DIFF
--- a/crates/omnigraph-cli/src/client.rs
+++ b/crates/omnigraph-cli/src/client.rs
@@ -42,7 +42,7 @@ use crate::helpers::{
     ResolvedCliGraph, apply_bearer_token, apply_server_flag, build_http_client, is_remote_uri,
     legacy_change_request_body, open_local_db_with_policy, query_params_from_json,
     remote_json, remote_url, resolve_cli_actor, resolve_cli_graph, resolve_remote_bearer_token,
-    select_named_query,
+    resolve_server_flag, select_named_query,
 };
 use crate::output::{LoadOutput, load_output_from_result, load_output_from_tables};
 use omnigraph_server::config::OmnigraphConfig;
@@ -66,6 +66,43 @@ pub(crate) enum GraphClient {
     },
 }
 
+/// RFC-011 Decision 7: a server scope that selects no graph (no `--graph`, no
+/// `default_graph`) must not silently fall through to the bare server URL when
+/// the server is multi-graph. Best-effort probe `GET /graphs`: a populated list
+/// forces `--graph` (listing the candidates); a single-graph/flat server (405),
+/// a policy-gated `/graphs`, or an unreachable server all proceed — the bare URL
+/// is then correct, or the real request surfaces the failure. Only fires on the
+/// no-graph path, so a `--graph`/`default_graph` happy path does no extra I/O.
+async fn require_graph_for_multi_graph_server(
+    config: &OmnigraphConfig,
+    scope: &crate::scope::ResolvedScope,
+) -> Result<()> {
+    let (Some(server), None) = (scope.server.as_deref(), scope.graph.as_deref()) else {
+        return Ok(());
+    };
+    let Some(base) = resolve_server_flag(Some(server), None)? else {
+        return Ok(());
+    };
+    let token = resolve_remote_bearer_token(config, Some(&base))?;
+    let probe = GraphClient::Remote {
+        http: build_http_client()?,
+        base_url: base,
+        token,
+    };
+    if let Ok(resp) = probe.list_graphs().await {
+        if !resp.graphs.is_empty() {
+            let ids: Vec<&str> = resp.graphs.iter().map(|g| g.graph_id.as_str()).collect();
+            bail!(
+                "server scope '{server}' has {} graphs: [{}]; pass --graph <id> to select one \
+                 (or set `default_graph` in your operator config)",
+                ids.len(),
+                ids.join(", ")
+            );
+        }
+    }
+    Ok(())
+}
+
 /// A remote graph must be addressed with `--server` (RFC-011): a positional or
 /// `--uri` `http(s)://` URL no longer auto-dispatches to a server. A remote URL
 /// produced by a server scope (`via_server`) is fine.
@@ -86,7 +123,7 @@ impl GraphClient {
     /// fork. Mirrors the read verbs' current preamble (`resolve_uri`
     /// path, not the policy-bearing `resolve_cli_graph`). Used by reads
     /// and `query` (which opens without policy, like the reads).
-    pub(crate) fn resolve(
+    pub(crate) async fn resolve(
         config: &OmnigraphConfig,
         server: Option<&str>,
         graph: Option<&str>,
@@ -102,6 +139,7 @@ impl GraphClient {
             crate::planes::Capability::Any,
             crate::scope::ScopeFlags { profile, store, server, cluster: None, graph, uri },
         )?;
+        require_graph_for_multi_graph_server(config, &scope).await?;
         let (server, graph, uri) = (
             scope.server.as_deref(),
             scope.graph.as_deref(),
@@ -133,7 +171,7 @@ impl GraphClient {
     /// resolved up front. The embedded arm then opens WITH policy. The
     /// resolution order matches the write arms exactly: server flag →
     /// bearer token → graph.
-    pub(crate) fn resolve_with_policy(
+    pub(crate) async fn resolve_with_policy(
         config: &OmnigraphConfig,
         server: Option<&str>,
         graph: Option<&str>,
@@ -149,6 +187,7 @@ impl GraphClient {
             crate::planes::Capability::Any,
             crate::scope::ScopeFlags { profile, store, server, cluster: None, graph, uri },
         )?;
+        require_graph_for_multi_graph_server(config, &scope).await?;
         let (server, graph, uri) = (
             scope.server.as_deref(),
             scope.graph.as_deref(),

--- a/crates/omnigraph-cli/src/client.rs
+++ b/crates/omnigraph-cli/src/client.rs
@@ -93,9 +93,10 @@ async fn require_graph_for_multi_graph_server(
         if !resp.graphs.is_empty() {
             let ids: Vec<&str> = resp.graphs.iter().map(|g| g.graph_id.as_str()).collect();
             bail!(
-                "server scope '{server}' has {} graphs: [{}]; pass --graph <id> to select one \
+                "server scope '{server}' has {} {}: [{}]; pass --graph <id> to select one \
                  (or set `default_graph` in your operator config)",
                 ids.len(),
+                if ids.len() == 1 { "graph" } else { "graphs" },
                 ids.join(", ")
             );
         }

--- a/crates/omnigraph-cli/src/helpers.rs
+++ b/crates/omnigraph-cli/src/helpers.rs
@@ -632,11 +632,12 @@ pub(crate) async fn resolve_maintenance_uri(
 }
 
 /// Map a resolved direct address to a storage URI: a cluster scope
-/// (`--cluster <root> --graph <id>`, or a `--profile` cluster binding)
-/// resolves the graph's storage URI from the **served cluster state** (the
-/// truth a `--cluster` server serves); otherwise the ordinary positional-URI
-/// path. The scope resolver guarantees a cluster scope always carries a graph,
-/// so the mismatched arm is defensive.
+/// (`--cluster <root> --graph <id>`, or a `--profile` cluster binding) resolves
+/// the graph's storage URI from the **served cluster state**; otherwise the
+/// ordinary positional-URI path. When a cluster scope carries no graph
+/// selection (RFC-011 D7), enumerate the catalog: a sole graph is used
+/// automatically, otherwise error and list the candidates so the operator can
+/// pass `--graph <id>`.
 pub(crate) async fn resolve_storage_uri(
     config: &OmnigraphConfig,
     cli_uri: Option<String>,
@@ -646,8 +647,32 @@ pub(crate) async fn resolve_storage_uri(
 ) -> Result<String> {
     match (cluster, cluster_graph) {
         (Some(cluster), Some(graph_id)) => resolve_cluster_graph_uri(cluster, graph_id).await,
+        (Some(cluster), None) => {
+            let graph_id = resolve_sole_cluster_graph(cluster).await?;
+            resolve_cluster_graph_uri(cluster, &graph_id).await
+        }
         (None, None) => resolve_local_uri(config, cli_uri, operation),
-        _ => bail!("internal error: a cluster scope was resolved without a graph id"),
+        (None, Some(_)) => {
+            bail!("internal error: a graph was selected without a cluster scope")
+        }
+    }
+}
+
+/// Pick the graph for a cluster scope that has no `--graph`/`default_graph`
+/// (RFC-011 D7): exactly one applied graph → use it; zero → error; more than
+/// one → error and list the candidates. Never auto-picks among several.
+async fn resolve_sole_cluster_graph(cluster: &str) -> Result<String> {
+    let ids = omnigraph_cluster::cluster_graph_ids(cluster)
+        .await
+        .map_err(|diagnostic| color_eyre::eyre::eyre!("{}", diagnostic.message))?;
+    match ids.as_slice() {
+        [only] => Ok(only.clone()),
+        [] => bail!("cluster `{cluster}` has no applied graphs; run `cluster apply` first"),
+        many => bail!(
+            "cluster `{cluster}` has {} graphs: [{}]; pass --graph <id> to select one",
+            many.len(),
+            many.join(", ")
+        ),
     }
 }
 

--- a/crates/omnigraph-cli/src/main.rs
+++ b/crates/omnigraph-cli/src/main.rs
@@ -186,7 +186,8 @@ async fn main() -> Result<()> {
                 cli.as_actor.as_deref(),
                 cli.profile.as_deref(),
                 cli.store.as_deref(),
-            )?;
+            )
+            .await?;
             let branch = resolve_branch(&config, branch, None, "main");
             if matches!(mode, CliLoadMode::Overwrite) {
                 confirm_destructive("load --mode overwrite", client.uri(), cli.yes, json)?;
@@ -224,7 +225,8 @@ async fn main() -> Result<()> {
                 cli.as_actor.as_deref(),
                 cli.profile.as_deref(),
                 cli.store.as_deref(),
-            )?;
+            )
+            .await?;
             let branch = resolve_branch(&config, branch, None, "main");
             let from = resolve_branch(&config, from, None, "main");
             echo_write_target(cli.quiet, "ingest", client.uri(), client.is_remote());
@@ -254,7 +256,8 @@ async fn main() -> Result<()> {
                     cli.as_actor.as_deref(),
                     cli.profile.as_deref(),
                     cli.store.as_deref(),
-                )?;
+                )
+                .await?;
                 let from = resolve_branch(&config, from, None, "main");
                 echo_write_target(cli.quiet, "branch create", client.uri(), client.is_remote());
                 let payload = client.branch_create_from(&from, &name).await?;
@@ -277,7 +280,8 @@ async fn main() -> Result<()> {
                     uri,
                     cli.profile.as_deref(),
                     cli.store.as_deref(),
-                )?;
+                )
+                .await?;
                 let payload = client.branch_list().await?;
                 if json {
                     print_json(&payload)?;
@@ -302,7 +306,8 @@ async fn main() -> Result<()> {
                     cli.as_actor.as_deref(),
                     cli.profile.as_deref(),
                     cli.store.as_deref(),
-                )?;
+                )
+                .await?;
                 confirm_destructive("branch delete", client.uri(), cli.yes, json)?;
                 echo_write_target(cli.quiet, "branch delete", client.uri(), client.is_remote());
                 let payload = client.branch_delete(&name).await?;
@@ -328,7 +333,8 @@ async fn main() -> Result<()> {
                     cli.as_actor.as_deref(),
                     cli.profile.as_deref(),
                     cli.store.as_deref(),
-                )?;
+                )
+                .await?;
                 let into = resolve_branch(&config, into, None, "main");
                 echo_write_target(cli.quiet, "branch merge", client.uri(), client.is_remote());
                 let payload = client.branch_merge(&source, &into).await?;
@@ -359,7 +365,8 @@ async fn main() -> Result<()> {
                     uri,
                     cli.profile.as_deref(),
                     cli.store.as_deref(),
-                )?;
+                )
+                .await?;
                 let payload = client.list_commits(branch.as_deref()).await?;
                 if json {
                     print_json(&payload)?;
@@ -381,7 +388,8 @@ async fn main() -> Result<()> {
                     uri,
                     cli.profile.as_deref(),
                     cli.store.as_deref(),
-                )?;
+                )
+                .await?;
                 let commit = client.get_commit(&commit_id).await?;
                 if json {
                     print_json(&commit)?;
@@ -436,7 +444,8 @@ async fn main() -> Result<()> {
                     cli.as_actor.as_deref(),
                     cli.profile.as_deref(),
                     cli.store.as_deref(),
-                )?;
+                )
+                .await?;
                 let schema_source = fs::read_to_string(&schema)?;
                 // The stored-query registry check is an embedded-only concern
                 // (the remote arm ignores the validator — the server runs its
@@ -477,7 +486,8 @@ async fn main() -> Result<()> {
                     uri,
                     cli.profile.as_deref(),
                     cli.store.as_deref(),
-                )?;
+                )
+                .await?;
                 let output = client.schema_source().await?;
                 if json {
                     print_json(&output)?;
@@ -528,7 +538,8 @@ async fn main() -> Result<()> {
                 uri,
                 cli.profile.as_deref(),
                 cli.store.as_deref(),
-            )?;
+            )
+            .await?;
             let branch = resolve_branch(&config, branch, None, "main");
             let payload = client.snapshot(&branch).await?;
             if json {
@@ -553,7 +564,8 @@ async fn main() -> Result<()> {
                 uri,
                 cli.profile.as_deref(),
                 cli.store.as_deref(),
-            )?;
+            )
+            .await?;
             let branch = resolve_branch(&config, branch, None, "main");
             if jsonl {
                 eprintln!("warning: --jsonl is deprecated; `omnigraph export` always emits JSONL");
@@ -590,7 +602,8 @@ async fn main() -> Result<()> {
                 uri.or(legacy_uri),
                 cli.profile.as_deref(),
                 cli.store.as_deref(),
-            )?;
+            )
+            .await?;
             let query_source =
                 resolve_query_source(&config, query.as_ref(), query_string.as_deref(), None)?;
             let params_json = load_params_json(&params)?;
@@ -625,7 +638,8 @@ async fn main() -> Result<()> {
                 cli.as_actor.as_deref(),
                 cli.profile.as_deref(),
                 cli.store.as_deref(),
-            )?;
+            )
+            .await?;
             let query_source =
                 resolve_query_source(&config, query.as_ref(), query_string.as_deref(), None)?;
             let params_json = load_params_json(&params)?;
@@ -1005,7 +1019,8 @@ async fn main() -> Result<()> {
                     uri,
                     cli.profile.as_deref(),
                     cli.store.as_deref(),
-                )?;
+                )
+                .await?;
                 let payload = client.list_graphs().await?;
                 if json {
                     print_json(&payload)?;

--- a/crates/omnigraph-cli/src/scope.rs
+++ b/crates/omnigraph-cli/src/scope.rs
@@ -189,15 +189,13 @@ fn scope_from_binding(
                 .map(str::to_string)
                 .unwrap_or(cluster);
             // A cluster holds many graphs; maintenance addresses one at a time.
-            let Some(graph) = graph else {
-                bail!(
-                    "{source} resolves a cluster scope; pass --graph <id> to select which \
-                     graph to maintain"
-                );
-            };
+            // When no `--graph`/`default_graph` is given, leave `cluster_graph`
+            // empty and defer to the async storage-URI resolver (RFC-011 D7),
+            // which enumerates the catalog: auto-use a sole graph, else error
+            // and list the candidates.
             Ok(ResolvedScope {
                 cluster: Some(root),
-                cluster_graph: Some(graph),
+                cluster_graph: graph,
                 ..Default::default()
             })
         }
@@ -334,9 +332,13 @@ mod tests {
     }
 
     #[test]
-    fn cluster_scope_without_a_graph_is_a_loud_error() {
+    fn cluster_scope_without_a_graph_defers_to_catalog_enumeration() {
+        // RFC-011 D7: with no `--graph`/`default_graph`, resolution no longer
+        // bails here — it resolves the cluster root and leaves `cluster_graph`
+        // empty, deferring to the async storage-URI resolver (which enumerates
+        // the catalog: auto-use a sole graph, else error listing candidates).
         let op = cfg("clusters:\n  brain:\n    root: s3://acme/brain\n");
-        let err = resolve_scope(
+        let scope = resolve_scope(
             &op,
             Capability::Direct,
             ScopeFlags {
@@ -344,9 +346,9 @@ mod tests {
                 ..flags()
             },
         )
-        .unwrap_err()
-        .to_string();
-        assert!(err.contains("--graph <id>"), "{err}");
+        .unwrap();
+        assert_eq!(scope.cluster.as_deref(), Some("s3://acme/brain"));
+        assert_eq!(scope.cluster_graph, None);
     }
 
     #[test]

--- a/crates/omnigraph-cli/tests/cli_cluster.rs
+++ b/crates/omnigraph-cli/tests/cli_cluster.rs
@@ -1006,21 +1006,80 @@ fn optimize_unknown_cluster_graph_id_errors() {
 }
 
 #[test]
-fn cluster_without_graph_demands_a_graph_selector() {
-    // A cluster holds many graphs; `--cluster` alone can't pick one. The scope
-    // resolver demands `--graph <id>` (replacing the old `--cluster-graph`
-    // requirement) before it ever touches cluster state.
+fn optimize_auto_uses_the_sole_cluster_graph() {
+    // RFC-011 D7: a cluster with exactly one applied graph needs no --graph —
+    // the resolver enumerates the catalog and uses the only candidate.
+    let temp = applied_knowledge_cluster();
+    let out = output_success(
+        cli()
+            .arg("optimize")
+            .arg("--cluster")
+            .arg(temp.path())
+            .arg("--json"),
+    );
+    assert!(
+        parse_stdout_json(&out)["tables"].as_array().is_some(),
+        "optimize should auto-resolve the sole cluster graph"
+    );
+}
+
+/// Stand up an applied cluster with two graphs (`knowledge`, `archive`).
+fn applied_two_graph_cluster() -> tempfile::TempDir {
+    let temp = tempdir().unwrap();
+    let root = temp.path();
+    fs::write(
+        root.join("people.pg"),
+        "node Person {\n  name: String @key\n  age: I32?\n}\n",
+    )
+    .unwrap();
+    fs::write(root.join("base.policy.yaml"), "rules: []\n").unwrap();
+    fs::write(
+        root.join("cluster.yaml"),
+        r#"
+version: 1
+metadata:
+  name: two-graph
+state:
+  backend: cluster
+  lock: true
+graphs:
+  knowledge:
+    schema: ./people.pg
+  archive:
+    schema: ./people.pg
+policies:
+  base:
+    file: ./base.policy.yaml
+    applies_to: [knowledge, archive]
+"#,
+    )
+    .unwrap();
+    init_named_cluster_graph(root, "knowledge", "people.pg");
+    init_named_cluster_graph(root, "archive", "people.pg");
+    assert_eq!(cluster_json(root, "import")["ok"], true);
+    assert_eq!(cluster_json(root, "apply")["converged"], true);
+    temp
+}
+
+#[test]
+fn optimize_on_multi_graph_cluster_without_graph_lists_candidates() {
+    // RFC-011 D7: >1 graph and no --graph → error naming every candidate,
+    // never an auto-pick.
+    let temp = applied_two_graph_cluster();
     let out = output_failure(
         cli()
             .arg("optimize")
             .arg("--cluster")
-            .arg(".")
+            .arg(temp.path())
             .arg("--json"),
     );
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
-        stderr.contains("--graph <id>"),
-        "expected --cluster to demand --graph; got: {stderr}"
+        stderr.contains("2 graphs")
+            && stderr.contains("archive")
+            && stderr.contains("knowledge")
+            && stderr.contains("--graph <id>"),
+        "expected a candidate-listing error; got: {stderr}"
     );
 }
 

--- a/crates/omnigraph-cli/tests/system_remote.rs
+++ b/crates/omnigraph-cli/tests/system_remote.rs
@@ -1136,5 +1136,27 @@ auth:
         .collect();
     assert_eq!(ids, vec!["alpha"]);
 
+    // RFC-011 D7: addressing the multi-graph server via `--server <url>` with no
+    // `--graph` errors and lists the candidate graphs (the resolver probes
+    // GET /graphs; the default-env token authorizes it).
+    let no_graph = cli()
+        .env("OMNIGRAPH_BEARER_TOKEN", "admin-token")
+        .arg("query")
+        .arg("--server")
+        .arg(&server.base_url)
+        .arg("-e")
+        .arg("query q { match { $p: Person { name: \"x\" } } return { $p.name } }")
+        .output()
+        .unwrap();
+    assert!(
+        !no_graph.status.success(),
+        "multi-graph server with no --graph must error"
+    );
+    let stderr = String::from_utf8_lossy(&no_graph.stderr);
+    assert!(
+        stderr.contains("alpha") && stderr.contains("--graph <id>"),
+        "expected a candidate-listing error naming alpha; got: {stderr}"
+    );
+
     drop(server);
 }

--- a/crates/omnigraph-cluster/src/lib.rs
+++ b/crates/omnigraph-cluster/src/lib.rs
@@ -28,7 +28,7 @@ mod store;
 use store::{ClusterStore, StateLockGuard, StateSnapshot};
 pub use types::*;
 use types::*;
-pub use serve::{ServingGraph, ServingPolicy, ServingQuery, ServingSnapshot, cluster_root_for_graph_uri, read_serving_snapshot, read_serving_snapshot_from_storage, resolve_graph_storage_uri};
+pub use serve::{ServingGraph, ServingPolicy, ServingQuery, ServingSnapshot, cluster_graph_ids, cluster_root_for_graph_uri, read_serving_snapshot, read_serving_snapshot_from_storage, resolve_graph_storage_uri};
 use config::{QueriesDecl, observe_declared_graphs, validate_cluster_header, future_field_diagnostics, initial_import_state, observe_live_graph, preview_schema_migration, state_resource_digests, graph_address, policy_address, query_address, schema_address, load_desired, normalize_policy_target, parse_cluster_config, resolve_config_path, resolve_query_decls, validate_id, validate_query_source};
 use diff::{FailedGraphOrigin, ResourceKind, append_policy_binding_changes, approved_resources, classify_changes, compute_approvals, compute_blast_radius, demote_dependents_of_failed_graphs, diff_resources, resource_kind};
 use sweep::{mark_approvals_consumed, record_approval_consumed, sweep_recovery_sidecars, tombstone_graph_subtree, warn_pending_recovery_sidecars};

--- a/crates/omnigraph-cluster/src/serve.rs
+++ b/crates/omnigraph-cluster/src/serve.rs
@@ -112,28 +112,13 @@ pub async fn cluster_root_for_graph_uri(graph_uri: &str) -> Option<String> {
 /// `cluster` is a config directory or a storage-root URI (`s3://…`, config-free),
 /// mirroring the server's `--cluster` dispatch.
 pub async fn resolve_graph_storage_uri(cluster: &str, graph_id: &str) -> Result<String, Diagnostic> {
-    let backend = if cluster.contains("://") {
-        ClusterStore::for_storage_root(cluster)?
-    } else {
-        ClusterStore::for_config_dir(Path::new(cluster))
-    };
+    let backend = open_cluster_backend(cluster)?;
     let mut observations = backend.observations();
     let snapshot = backend.read_state(&mut observations).await?;
-    let state = snapshot.state.ok_or_else(|| {
-        Diagnostic::error(
-            "cluster_state_missing",
-            CLUSTER_STATE_FILE,
-            format!("cluster `{cluster}` has no applied state; run `cluster apply` first"),
-        )
-    })?;
+    let state = snapshot.state.ok_or_else(|| missing_state_diagnostic(cluster))?;
     let address = format!("graph.{graph_id}");
     if !state.applied_revision.resources.contains_key(&address) {
-        let applied: Vec<&str> = state
-            .applied_revision
-            .resources
-            .keys()
-            .filter_map(|a| a.strip_prefix("graph."))
-            .collect();
+        let applied = applied_graph_ids(&state);
         return Err(Diagnostic::error(
             "graph_not_applied",
             address,
@@ -145,6 +130,46 @@ pub async fn resolve_graph_storage_uri(cluster: &str, graph_id: &str) -> Result<
         ));
     }
     Ok(backend.graph_root(graph_id))
+}
+
+/// List the graph ids applied in a cluster's served state (sorted). Reads the
+/// ledger only — no catalog validation — like `resolve_graph_storage_uri`, so
+/// it works on a degraded cluster. Used to enumerate candidates when no
+/// `--graph` is selected (RFC-011 Decision 7).
+pub async fn cluster_graph_ids(cluster: &str) -> Result<Vec<String>, Diagnostic> {
+    let backend = open_cluster_backend(cluster)?;
+    let mut observations = backend.observations();
+    let snapshot = backend.read_state(&mut observations).await?;
+    let state = snapshot.state.ok_or_else(|| missing_state_diagnostic(cluster))?;
+    Ok(applied_graph_ids(&state))
+}
+
+fn open_cluster_backend(cluster: &str) -> Result<ClusterStore, Diagnostic> {
+    if cluster.contains("://") {
+        ClusterStore::for_storage_root(cluster)
+    } else {
+        Ok(ClusterStore::for_config_dir(Path::new(cluster)))
+    }
+}
+
+fn missing_state_diagnostic(cluster: &str) -> Diagnostic {
+    Diagnostic::error(
+        "cluster_state_missing",
+        CLUSTER_STATE_FILE,
+        format!("cluster `{cluster}` has no applied state; run `cluster apply` first"),
+    )
+}
+
+fn applied_graph_ids(state: &crate::types::ClusterState) -> Vec<String> {
+    let mut ids: Vec<String> = state
+        .applied_revision
+        .resources
+        .keys()
+        .filter_map(|a| a.strip_prefix("graph."))
+        .map(str::to_string)
+        .collect();
+    ids.sort();
+    ids
 }
 
 /// Split `<root>/graphs/<id>.omni` → `<root>`, gating on the exact cluster

--- a/docs/user/cli/reference.md
+++ b/docs/user/cli/reference.md
@@ -115,6 +115,13 @@ resolves its scope fresh, there is no sticky "current" mode.
   `--cluster <root> --graph <id>`. A `--graph` flag overrides the profile's default.
 - A `server`-bound scope on a maintenance verb, or a `cluster`-bound scope on a
   data verb, is rejected with a message pointing at the right addressing.
+- **No graph selected (RFC-011 D7).** When a server or cluster scope has no
+  `--graph` and no `default_graph`: a scope with exactly **one** graph uses it
+  automatically; a scope with **several** errors and **lists the candidates** so
+  you can pass `--graph <id>` — it never silently picks. For a cluster the
+  candidates come from the served catalog; for a multi-graph server they come
+  from a best-effort `GET /graphs` (a single-graph / flat server, or one whose
+  `/graphs` is policy-gated, just uses its bare URL as before).
 
 `--target`, `--cluster-graph`, and the positional-`http(s)://`→remote dispatch
 have been **removed** (`--graph` is now the one graph selector across server and

--- a/docs/user/cli/reference.md
+++ b/docs/user/cli/reference.md
@@ -115,13 +115,14 @@ resolves its scope fresh, there is no sticky "current" mode.
   `--cluster <root> --graph <id>`. A `--graph` flag overrides the profile's default.
 - A `server`-bound scope on a maintenance verb, or a `cluster`-bound scope on a
   data verb, is rejected with a message pointing at the right addressing.
-- **No graph selected (RFC-011 D7).** When a server or cluster scope has no
-  `--graph` and no `default_graph`: a scope with exactly **one** graph uses it
-  automatically; a scope with **several** errors and **lists the candidates** so
-  you can pass `--graph <id>` — it never silently picks. For a cluster the
-  candidates come from the served catalog; for a multi-graph server they come
-  from a best-effort `GET /graphs` (a single-graph / flat server, or one whose
-  `/graphs` is policy-gated, just uses its bare URL as before).
+- **No graph selected (RFC-011 D7).** When a scope has no `--graph` and no
+  `default_graph`, the CLI never silently picks:
+  - **Cluster scope** — exactly **one** applied graph is used automatically;
+    **several** errors and lists the candidates (from the served catalog).
+  - **Server scope** — a multi-graph server (any non-empty `GET /graphs`, even a
+    single entry) errors and lists the candidates: you must pass `--graph <id>`.
+    A single-graph / flat server (405 on `/graphs`), or one whose `/graphs` is
+    policy-gated or unreachable, uses its bare URL as before.
 
 `--target`, `--cluster-graph`, and the positional-`http(s)://`→remote dispatch
 have been **removed** (`--graph` is now the one graph selector across server and

--- a/docs/user/clusters/index.md
+++ b/docs/user/clusters/index.md
@@ -271,6 +271,10 @@ not resolvable. Run these from a host with storage access — there are no serve
 routes for them. Conversely, **`init` refuses** a cluster-managed path: graphs in
 a cluster are created by `cluster apply`, not by hand.
 
+If the cluster has exactly **one** applied graph you can omit `--graph` — it is
+used automatically. With **several**, omitting `--graph` errors and lists the
+candidates (RFC-011 D7); it never picks one for you.
+
 Against an **`s3://`-backed cluster** the resolved graph storage is non-local, so a
 destructive `cleanup` additionally requires **`--yes`** (an interactive prompt
 otherwise, refusal without a TTY) on top of `--confirm` — see [cli-reference.md](../cli/reference.md)'s


### PR DESCRIPTION
## What

RFC-011 **Decision 7** — a graph-scoped verb that resolves a server or cluster scope with no `--graph` and no `default_graph` no longer fails obscurely or picks silently:

- **Cluster scope** — the async storage-URI resolver enumerates the served catalog (new `omnigraph_cluster::cluster_graph_ids`, factored out of `resolve_graph_storage_uri`). Exactly one graph → used automatically; zero → error; several → error listing the candidates for `--graph <id>`.
- **Server scope** — `GraphClient::resolve`/`resolve_with_policy` become `async` and, **only on the no-graph path**, best-effort probe `GET /graphs`. A populated list forces `--graph` (naming the candidates); a single-graph/flat server (405 on `/graphs`), a policy-gated `/graphs`, or an unreachable server proceed on the bare URL as before. No extra I/O when a graph is already selected.

`scope_from_binding` stops bailing on a cluster scope without a graph — it leaves `cluster_graph` empty and defers to the enumerating resolver.

## Tests

- `optimize --cluster <1-graph>` (no `--graph`) auto-uses it; `--cluster <2-graph>` lists `archive, knowledge` and demands `--graph`; the scope unit test asserts the deferral.
- Server path covered by the (loopback-gated) `system_remote` multi-graph test: `query --server <url>` with no `--graph` errors naming `alpha`.
- `cargo test --workspace --locked`: green (61 suites, 0 failures).

Second of three sequenced RFC-011 invocation slices (D4 ✅ #244 → **D7** → D3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements RFC-011 Decision 7: when a graph-scoped CLI verb is invoked with no `--graph` and no `default_graph`, the CLI now fails explicitly and names the candidate graphs instead of silently proceeding or failing obscurely. Cluster scopes auto-select the sole applied graph; server scopes probe `GET /graphs` and always require an explicit selection if any graphs are found.

- **Cluster path** — `scope_from_binding` stops bailing on a missing graph; `resolve_storage_uri` gains a `(Some(cluster), None)` arm that calls the new `resolve_sole_cluster_graph`, which enumerates the catalog via the new public `cluster_graph_ids` symbol. Exactly one graph is used automatically; any other count errors with candidates listed.
- **Server path** — `GraphClient::resolve` and `resolve_with_policy` become `async` and gain a best-effort `GET /graphs` pre-check (`require_graph_for_multi_graph_server`); a non-empty response forces `--graph`, while 405 / auth failure / unreachable server proceeds on the bare URL. All call sites in `main.rs` are updated to `.await?`.

<h3>Confidence Score: 4/5</h3>

The cluster and write-verb server paths work correctly, but `graphs list --server <url>` is broken on any multi-graph server when no graph is pre-configured — the new guard fires before the command can run, and no test exercises that specific invocation.

The core RFC-011 D7 logic (cluster enumeration, server probe, scope deferral) is sound and well-tested. The issue is that `require_graph_for_multi_graph_server` is injected unconditionally into `GraphClient::resolve`, which is shared with `graphs list`. A user running `omnigraph graphs list --server http://multi-graph-server` with no `--graph` and no operator-config default will now get a "pass --graph <id>" error — a regression from the previous behaviour where the command succeeded and printed the list. The existing test suite avoids this path because the `graphs list` tests pass `--config` with `cli.graph` set, leaving `scope.server = None` so the guard short-circuits.

crates/omnigraph-cli/src/client.rs — the `require_graph_for_multi_graph_server` guard needs to be bypassed (or not injected) for `graphs list`; crates/omnigraph-cli/tests/system_remote.rs — a test for `graphs list --server <url>` on a multi-graph server without a pre-configured graph is missing.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/omnigraph-cli/src/client.rs | Adds `require_graph_for_multi_graph_server` (probes GET /graphs on no-graph server scopes) and makes `resolve`/`resolve_with_policy` async; the guard is correctly scoped for write/read verbs but is also applied to `graphs list`, which breaks that command on multi-graph servers when no graph is pre-configured. |
| crates/omnigraph-cli/src/helpers.rs | Updates `resolve_storage_uri` to handle cluster scope with no graph by enumerating the catalog (auto-use sole graph, else error with candidates); refactoring is clean but the `(Some, None)` arm reads cluster state twice. |
| crates/omnigraph-cli/src/scope.rs | Removes the eager cluster-without-graph bail, leaving `cluster_graph` empty and deferring to the async resolver; the scope test is correctly updated to assert the deferral rather than the old error. |
| crates/omnigraph-cluster/src/serve.rs | Factors out `open_cluster_backend`, `missing_state_diagnostic`, and `applied_graph_ids` helpers; adds the new public `cluster_graph_ids` function; refactoring is clean and the sort on IDs ensures deterministic output. |
| crates/omnigraph-cli/src/main.rs | Mechanical `.await?` additions to all `GraphClient::resolve` and `resolve_with_policy` call sites; the `graphs list` call site gains the async await but does not bypass the new graph-check guard, which is the root of the regression. |
| crates/omnigraph-cli/tests/system_remote.rs | Adds a loopback-gated test for `query --server <url>` (no `--graph`) on a multi-graph server; validates the error message names the candidate graph. Does not cover `graphs list --server <url>` without a pre-configured graph. |
| crates/omnigraph-cluster/src/lib.rs | Re-exports the new `cluster_graph_ids` symbol from `serve`; straightforward pub use addition. |
| docs/user/cli/reference.md | Adds the RFC-011 D7 "no graph selected" section; the server-scope bullet correctly notes any non-empty GET /graphs list forces --graph, consistent with the implementation. |
| docs/user/clusters/index.md | Adds the one-graph auto-use / many-graph error note for cluster maintenance; accurate and concise. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CLI verb invoked] --> B{scope has --graph\nor default_graph?}
    B -- Yes --> Z[Proceed normally\nno extra I/O]
    B -- No --> C{scope type?}
    C -- Cluster --> D[cluster_graph_ids\nread state ledger]
    D --> E{count?}
    E -- 0 --> F[Error: no applied graphs\nrun cluster apply]
    E -- 1 --> G[Auto-use sole graph\nresolve_cluster_graph_uri]
    E -- many --> H[Error: N graphs: a, b\npass --graph id]
    C -- Server --> I[GET /graphs probe]
    I --> J{response?}
    J -- empty list --> K[Proceed on bare URL]
    J -- 405 / auth fail\n/ unreachable --> K
    J -- non-empty list --> L[Error: N graphs: a\npass --graph id]
    G --> Z2[Proceed]
    K --> Z2
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fomnigraph-cli%2Fsrc%2Fclient.rs%3A76-104%0A**%60graphs%20list%20--server%60%20broken%20on%20multi-graph%20servers**%0A%0A%60require_graph_for_multi_graph_server%60%20is%20injected%20into%20%60GraphClient%3A%3Aresolve%60%2C%20which%20is%20also%20the%20factory%20used%20by%20%60graphs%20list%60%20%28see%20%60main.rs%60%20lines%201015%E2%80%931022%29.%20When%20a%20user%20runs%20%60omnigraph%20graphs%20list%20--server%20http%3A%2F%2Fmy-server%60%20without%20%60--graph%60%20or%20a%20config-provided%20default%20graph%2C%20%60scope.server%20%3D%20Some%28...%29%60%20and%20%60scope.graph%20%3D%20None%60%2C%20so%20the%20guard%20fires%20and%20returns%20%22has%20N%20graphs%3A%20%5B...%5D%3B%20pass%20--graph%20%3Cid%3E%22%20%E2%80%94%20the%20command%20fails%20instead%20of%20printing%20the%20list.%20This%20is%20a%20catch-22%3A%20%60graphs%20list%60%20is%20the%20discovery%20command%20for%20users%20who%20don't%20yet%20know%20the%20graph%20names.%0A%0AThe%20existing%20passing%20test%20avoids%20this%20path%20because%20it%20passes%20%60--config%60%20with%20%60cli.graph%3A%20dev%60%2C%20leaving%20%60scope.server%20%3D%20None%60%20so%20the%20guard%20short-circuits.%20No%20test%20exercises%20%60graphs%20list%20--server%20%3Curl%3E%60%20on%20a%20multi-graph%20server%20without%20a%20pre-known%20graph%2C%20so%20this%20regression%20is%20not%20caught%20by%20the%20current%20suite.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fomnigraph-cli%2Fsrc%2Fhelpers.rs%3A648-658%0A**Double%20cluster%20state%20read%20in%20the%20auto-use-single-graph%20path**%0A%0A%60resolve_storage_uri%60%20handles%20the%20%60%28Some%28cluster%29%2C%20None%29%60%20arm%20by%20first%20calling%20%60resolve_sole_cluster_graph%60%20%28which%20calls%20%60cluster_graph_ids%60%20%E2%86%92%20%60ClusterStore%3A%3Aread_state%60%29%20and%20then%20calling%20%60resolve_cluster_graph_uri%60%20%28which%20calls%20%60resolve_graph_storage_uri%60%20%E2%86%92%20%60ClusterStore%3A%3Aread_state%60%20again%29.%20On%20a%20local%20filesystem%20cluster%20this%20is%20cheap%2C%20but%20against%20an%20S3-backed%20cluster%20it%20incurs%20two%20ledger%20round%20trips%20for%20what%20is%20logically%20a%20single%20lookup.%20The%20%60%28Some%28cluster%29%2C%20Some%28graph_id%29%29%60%20arm%20pays%20only%20one%20read.%0A%0A&repo=modernrelay%2Fomnigraph&pr=245&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(cli): correct no-graph server messag..."](https://github.com/modernrelay/omnigraph/commit/8f2aec92aa47849d5bc7d82e072a6eea62bbb3d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37614768)</sub>

<!-- /greptile_comment -->