### PR TITLE
feat(cli): defaults.store — a zero-flag local default scope (RFC-011)

### DIFF
--- a/crates/omnigraph-cli/src/operator.rs
+++ b/crates/omnigraph-cli/src/operator.rs
@@ -18,7 +18,7 @@ use std::env;
 use std::path::{Path, PathBuf};
 
 use color_eyre::Result;
-use color_eyre::eyre::eyre;
+use color_eyre::eyre::{bail, eyre};
 use serde::Deserialize;
 
 use omnigraph_server::config::ReadOutputFormat;
@@ -108,8 +108,14 @@ pub(crate) struct OperatorDefaults {
     pub(crate) table_cell_layout: Option<omnigraph_server::config::TableCellLayout>,
     /// Default server scope (RFC-011): the everyday addressing when no
     /// `--profile` / primitive / legacy address is given. Names an entry
-    /// under `servers:`.
+    /// under `servers:`. Mutually exclusive with `store` — a scope binds one
+    /// entity.
     pub(crate) server: Option<String>,
+    /// Default **store** scope (RFC-011): a `file://` / `s3://` graph storage
+    /// URI used as the zero-flag local default for graph commands when no
+    /// `--profile` / primitive address is given. The local-dev counterpart of
+    /// `server`; mutually exclusive with it.
+    pub(crate) store: Option<String>,
     /// Default graph selected within a server/cluster scope when no
     /// `--graph` is passed (RFC-011).
     pub(crate) default_graph: Option<String>,
@@ -202,9 +208,27 @@ impl OperatorConfig {
         self.defaults.server.as_deref()
     }
 
+    /// The flat-default store scope URI, if set (RFC-011) — the zero-flag
+    /// local-dev default.
+    pub(crate) fn default_store(&self) -> Option<&str> {
+        self.defaults.store.as_deref()
+    }
+
     /// The flat-default graph within a server/cluster scope, if set (RFC-011).
     pub(crate) fn default_graph(&self) -> Option<&str> {
         self.defaults.default_graph.as_deref()
+    }
+
+    /// A scope binds one entity (Decision 6): `defaults.server` and
+    /// `defaults.store` are mutually exclusive.
+    fn validate_defaults(&self) -> Result<()> {
+        if self.defaults.server.is_some() && self.defaults.store.is_some() {
+            bail!(
+                "operator config `defaults` sets both `server` and `store` — a default scope \
+                 binds one entity; keep one (use a `profile` if you need both)"
+            );
+        }
+        Ok(())
     }
 }
 
@@ -282,6 +306,7 @@ pub(crate) fn load_operator_config_at(path: &Path) -> Result<OperatorConfig> {
     for warning in config.unknown_key_warnings() {
         eprintln!("warning: {warning} in operator config '{}'", path.display());
     }
+    config.validate_defaults()?;
     Ok(config)
 }
 
@@ -558,6 +583,29 @@ mod tests {
         let config = load_operator_config_at(&path).unwrap();
         assert_eq!(config.actor(), Some("act-andrew"));
         assert_eq!(config.output(), Some(ReadOutputFormat::Json));
+    }
+
+    #[test]
+    fn defaults_store_parses_and_is_accessible() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        fs::write(&path, "defaults:\n  store: file:///tmp/dev.omni\n").unwrap();
+        let config = load_operator_config_at(&path).unwrap();
+        assert_eq!(config.default_store(), Some("file:///tmp/dev.omni"));
+        assert_eq!(config.default_server(), None);
+    }
+
+    #[test]
+    fn defaults_server_and_store_together_is_a_loud_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        fs::write(
+            &path,
+            "defaults:\n  server: prod\n  store: file:///tmp/dev.omni\n",
+        )
+        .unwrap();
+        let err = load_operator_config_at(&path).unwrap_err().to_string();
+        assert!(err.contains("binds one entity"), "{err}");
     }
 
     #[test]

--- a/crates/omnigraph-cli/src/operator.rs
+++ b/crates/omnigraph-cli/src/operator.rs
@@ -220,12 +220,20 @@ impl OperatorConfig {
     }
 
     /// A scope binds one entity (Decision 6): `defaults.server` and
-    /// `defaults.store` are mutually exclusive.
+    /// `defaults.store` are mutually exclusive, and a `store` (already a single
+    /// graph) cannot carry a `default_graph`. Both are refused loudly rather
+    /// than silently dropped.
     fn validate_defaults(&self) -> Result<()> {
         if self.defaults.server.is_some() && self.defaults.store.is_some() {
             bail!(
                 "operator config `defaults` sets both `server` and `store` — a default scope \
                  binds one entity; keep one (use a `profile` if you need both)"
+            );
+        }
+        if self.defaults.store.is_some() && self.defaults.default_graph.is_some() {
+            bail!(
+                "operator config `defaults` sets both `store` and `default_graph` — a store is \
+                 already a single graph; drop `default_graph` (it applies only to a server/cluster scope)"
             );
         }
         Ok(())
@@ -606,6 +614,19 @@ mod tests {
         .unwrap();
         let err = load_operator_config_at(&path).unwrap_err().to_string();
         assert!(err.contains("binds one entity"), "{err}");
+    }
+
+    #[test]
+    fn defaults_store_with_default_graph_is_a_loud_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.yaml");
+        fs::write(
+            &path,
+            "defaults:\n  store: file:///tmp/dev.omni\n  default_graph: knowledge\n",
+        )
+        .unwrap();
+        let err = load_operator_config_at(&path).unwrap_err().to_string();
+        assert!(err.contains("already a single graph"), "{err}");
     }
 
     #[test]

--- a/crates/omnigraph-cli/src/scope.rs
+++ b/crates/omnigraph-cli/src/scope.rs
@@ -140,6 +140,18 @@ pub(crate) fn resolve_scope(
         );
     }
 
+    // 3b. Flat default store scope — the zero-flag local-dev default (RFC-011).
+    //     Mutually exclusive with `defaults.server` (enforced at config load).
+    if let Some(store) = op.default_store() {
+        return scope_from_binding(
+            op,
+            capability,
+            ScopeBinding::Store(store.to_string()),
+            flags.graph.map(str::to_string),
+            "operator defaults",
+        );
+    }
+
     // 4. Nothing resolved — leave the tuple empty; downstream falls through to
     //    today's behavior (legacy `cli.graph` default or a no-address error).
     Ok(ResolvedScope::default())
@@ -371,6 +383,34 @@ mod tests {
                 .to_string();
             assert!(err.contains("already a single graph"), "{err}");
         }
+    }
+
+    #[test]
+    fn flat_default_store_drives_local_verbs() {
+        // RFC-011: `defaults.store` is the zero-flag local default — no flags,
+        // no profile → the store URI resolves as the (single-graph) store scope.
+        let op = cfg("defaults:\n  store: file:///tmp/dev.omni\n");
+        let scope = resolve_scope(&op, Capability::Any, flags()).unwrap();
+        assert_eq!(scope.uri.as_deref(), Some("file:///tmp/dev.omni"));
+        assert_eq!(scope.server, None);
+    }
+
+    #[test]
+    fn flat_default_store_rejects_graph() {
+        // A store is already a single graph, so `--graph` against a default
+        // store is a loud error.
+        let op = cfg("defaults:\n  store: file:///tmp/dev.omni\n");
+        let err = resolve_scope(
+            &op,
+            Capability::Any,
+            ScopeFlags {
+                graph: Some("knowledge"),
+                ..flags()
+            },
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("does not apply to a store scope"), "{err}");
     }
 
     #[test]

--- a/docs/user/cli/reference.md
+++ b/docs/user/cli/reference.md
@@ -84,7 +84,10 @@ servers:                # operator-owned endpoints; names key the credentials
     url: https://graph.example.com     # no tokens in this file, ever
 defaults:
   output: table         # read format default, below --json/--format/alias/legacy
-  server: prod          # the everyday scope when no address is given (RFC-011)
+  server: prod          # the everyday SERVED scope when no address is given (RFC-011)
+  # store: file:///data/dev.omni   # OR a zero-flag LOCAL default (mutually
+  #                                #   exclusive with `server`); the local-dev
+  #                                #   counterpart of `server`
   default_graph: knowledge   # graph selected in a server/cluster scope
 clusters:               # admin-only: managed-cluster storage roots (RFC-011).
   brain:                #   the ONLY place a storage root lives in this file.
@@ -105,9 +108,11 @@ graph in it; the served-vs-direct access path is derived from the scope, not
 toggled. The scope comes from one of (highest precedence first): an explicit
 address (a positional URI, `--server`, or `--store <uri>`); a named
 `--profile <name>` (or `$OMNIGRAPH_PROFILE`); or the flat `defaults.server` +
-`defaults.default_graph`. A **profile** binds exactly one of `server` / `cluster`
-/ `store` plus an optional default graph — config data, not state: every command
-resolves its scope fresh, there is no sticky "current" mode.
+`defaults.default_graph` (a served default) **or** `defaults.store` (a zero-flag
+*local* default — mutually exclusive with `defaults.server`). A **profile** binds
+exactly one of `server` / `cluster` / `store` plus an optional default graph —
+config data, not state: every command resolves its scope fresh, there is no
+sticky "current" mode.
 
 - `--store <uri>` addresses a single graph's storage directly (ad-hoc / break-glass).
 - A `cluster`-bound profile reaches `optimize` / `repair` / `cleanup` for a managed


### PR DESCRIPTION
## What

Operator config gains **`defaults.store`** — a `file://`/`s3://` graph storage URI used as the zero-flag **local** default, symmetric with the existing `defaults.server` + `default_graph` (the served default). With no `--profile`/primitive address, a graph command resolves the default store as a single-graph store scope.

- Mutually exclusive with `defaults.server` (a default scope binds one entity — rejected at config load).
- `scope.rs` gains a flat-default-store branch (step 3b), after the default-server branch.

## Why

This is the enabler for the **omnigraph.yaml excision** (first of that phased sequence): removing the legacy `cli.graph` drops the zero-flag *local* default graph. `defaults.store` restores it on the operator-config side **before** the removal, so local-dev keeps a no-flags default.

## Tests
- `operator.rs`: `defaults.store` parses; `server`+`store` together errors.
- `scope.rs`: flat default store drives local verbs; `--graph` against a default store is rejected.
- `cargo test --workspace --locked`: green (61 suites, 0 failures).

Additive and non-breaking. First step of the phased `omnigraph.yaml` excision (PR 0 of 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `defaults.store` to the operator config, giving the CLI a zero-flag local-dev default scope symmetric with the existing `defaults.server`. A `store` URI is already a single graph, so `defaults.store` and `defaults.server` are mutually exclusive, as is `defaults.store` + `defaults.default_graph`; both combinations are rejected loudly by the new `validate_defaults` method.

- **`operator.rs`**: adds `OperatorDefaults.store`, `OperatorConfig::default_store()`, and `validate_defaults()` (called from `load_operator_config_at`); three new unit tests cover parse-and-access, server+store conflict, and store+default_graph conflict.
- **`scope.rs`**: step 3b is inserted between the flat default-server branch and the fallthrough, routing a configured `defaults.store` through `scope_from_binding(Store)`, which already rejects a stray `--graph`; two new unit tests cover the happy path and the `--graph`-rejection path.
- **`docs/user/cli/reference.md`**: the config block and scope-resolution prose are updated to document the new field and its mutual-exclusivity constraint.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is purely additive, all mutual-exclusivity constraints are enforced loudly at load time, and the scope resolution chain correctly delegates to existing Store-scope machinery.

The new defaults.store field and step 3b are well-contained, the two conflict rules are validated at load_operator_config_at before anything can use them, and the scope_from_binding(Store) path already handles the --graph rejection for every other caller. No existing behavior is changed.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/omnigraph-cli/src/operator.rs | Adds store field to OperatorDefaults, default_store() accessor, and validate_defaults() called at load time; all three new tests cover the key error paths. |
| crates/omnigraph-cli/src/scope.rs | Step 3b correctly routes a configured defaults.store through scope_from_binding(Store), which enforces the no---graph invariant; two new unit tests exercise both the happy path and the error path. |
| docs/user/cli/reference.md | Adds commented-out store: example and updates the scope-resolution prose to describe defaults.store and its mutual-exclusivity with defaults.server. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[resolve_scope] --> B{Explicit primitive?}
    B -->|cluster flag| C[scope_from_binding Cluster]
    B -->|uri/store/server| D{graph + non-server?}
    D -->|yes| E[error: single graph already]
    D -->|no| F[ResolvedScope passthrough]
    B -->|none| G{profile or env?}
    G -->|yes| H[lookup profile binding]
    G -->|no| I{defaults.server set?}
    I -->|yes| J[scope_from_binding Server]
    I -->|no| K{defaults.store set? NEW}
    K -->|yes| L[scope_from_binding Store]
    L --> M{graph flag passed?}
    M -->|yes| N[error: graph does not apply to store]
    M -->|no| O[ResolvedScope uri = store URI]
    K -->|no| P[ResolvedScope default - legacy fallthrough]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/omnigraph-cli/src/scope.rs`, line 50-54 ([link](https://github.com/modernrelay/omnigraph/blob/662bfbb9364bc7e6ed469e792a699ede9d06a8ef/crates/omnigraph-cli/src/scope.rs#L50-L54)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `resolve_scope` doc comment still lists only steps 1–4 but the implementation now has a distinct step 3b. A reader consulting the doc comment alone would not know that `defaults.store` is checked before reaching step 4.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fomnigraph-cli%2Fsrc%2Fscope.rs%0ALine%3A%2050-54%0A%0AComment%3A%0AThe%20%60resolve_scope%60%20doc%20comment%20still%20lists%20only%20steps%201%E2%80%934%20but%20the%20implementation%20now%20has%20a%20distinct%20step%203b.%20A%20reader%20consulting%20the%20doc%20comment%20alone%20would%20not%20know%20that%20%60defaults.store%60%20is%20checked%20before%20reaching%20step%204.%0A%0A%60%60%60suggestion%0A%2F%2F%2F%20Resolve%20the%20scope%20for%20a%20command%20with%20%60capability%60.%20Precedence%20%28RFC-011%29%3A%0A%2F%2F%2F%201.%20explicit%20primitive%20address%20%28%60uri%60%2F%60--server%60%2F%60--store%60%29%20%E2%86%92%20passthrough%3B%0A%2F%2F%2F%202.%20%60--profile%60%20%2F%20%60OMNIGRAPH_PROFILE%60%3B%0A%2F%2F%2F%203.%20flat%20%60defaults.server%60%20%2B%20%60defaults.default_graph%60%20%28served%20default%29%3B%0A%2F%2F%2F%203b.%20flat%20%60defaults.store%60%20%28zero-flag%20local-dev%20default%3B%20mutually%20exclusive%0A%2F%2F%2F%20%20%20%20%20with%20%60defaults.server%60%2C%20enforced%20at%20config%20load%29%3B%0A%2F%2F%2F%204.%20nothing%20%E2%80%94%20downstream%20behaves%20as%20today.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modernrelay%2Fomnigraph&pr=249&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(cli): reject defaults.store + defaul..."](https://github.com/modernrelay/omnigraph/commit/37735187e523e1fd53a159092780e8a56108e0b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37630759)</sub>

<!-- /greptile_comment -->