### PR TITLE
feat(cli): add read-only profile list / profile show (RFC-011 D8)

### DIFF
--- a/crates/omnigraph-cli/src/cli.rs
+++ b/crates/omnigraph-cli/src/cli.rs
@@ -352,8 +352,30 @@ pub(crate) enum Command {
         #[arg(long)]
         json: bool,
     },
+    /// Inspect the scope profiles in ~/.omnigraph/config.yaml (read-only).
+    Profile {
+        #[command(subcommand)]
+        command: ProfileCommand,
+    },
     /// Print the CLI version
     Version,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum ProfileCommand {
+    /// List the profiles defined in ~/.omnigraph/config.yaml.
+    List {
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show a profile's resolved scope. With no name, shows the active
+    /// (`$OMNIGRAPH_PROFILE`) profile, else the flat operator defaults.
+    Show {
+        /// Profile name (optional).
+        name: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Debug, Subcommand)]

--- a/crates/omnigraph-cli/src/main.rs
+++ b/crates/omnigraph-cli/src/main.rs
@@ -94,6 +94,95 @@ async fn main() -> Result<()> {
             let path = crate::operator::remove_credential(&name)?;
             finish_logout(&name, &path, json)?;
         }
+        Command::Profile { command } => {
+            use crate::operator::ScopeBinding;
+            let op = crate::operator::load_operator_config()?;
+            let active = std::env::var(scope::PROFILE_ENV)
+                .ok()
+                .filter(|s| !s.is_empty());
+            match command {
+                ProfileCommand::List { json } => {
+                    let items: Vec<ProfileListItem> = op
+                        .profiles
+                        .iter()
+                        .map(|(name, profile)| {
+                            let binding = match profile.binding(name) {
+                                Ok(ScopeBinding::Server(s)) => format!("server: {s}"),
+                                Ok(ScopeBinding::Cluster(c)) => format!("cluster: {c}"),
+                                Ok(ScopeBinding::Store(u)) => format!("store: {u}"),
+                                Err(e) => format!("invalid: {e}"),
+                            };
+                            ProfileListItem {
+                                name: name.clone(),
+                                binding,
+                                default_graph: profile.default_graph.clone(),
+                                active: active.as_deref() == Some(name.as_str()),
+                            }
+                        })
+                        .collect();
+                    print_profile_list(&items, json)?;
+                }
+                ProfileCommand::Show { name, json } => {
+                    let detail = match name.or(active) {
+                        Some(name) => {
+                            let profile = op.profile(&name).ok_or_else(|| {
+                                color_eyre::eyre::eyre!(
+                                    "unknown profile '{name}' (not defined under `profiles:`)"
+                                )
+                            })?;
+                            let (kind, target, endpoint) = match profile.binding(&name)? {
+                                ScopeBinding::Server(s) => {
+                                    let endpoint = op.servers.get(&s).map(|sv| sv.url.clone());
+                                    ("server", Some(s), endpoint)
+                                }
+                                ScopeBinding::Cluster(c) => {
+                                    let endpoint = op.cluster_root(&c).map(str::to_string);
+                                    ("cluster", Some(c), endpoint)
+                                }
+                                ScopeBinding::Store(u) => ("store", Some(u.clone()), Some(u)),
+                            };
+                            ProfileDetail {
+                                name,
+                                scope_kind: kind.to_string(),
+                                target,
+                                endpoint,
+                                default_graph: profile
+                                    .default_graph
+                                    .clone()
+                                    .or_else(|| op.default_graph().map(str::to_string)),
+                                output_format: op
+                                    .output()
+                                    .and_then(|f| f.to_possible_value())
+                                    .map(|v| v.get_name().to_string()),
+                            }
+                        }
+                        // No name and no active profile: the flat operator defaults.
+                        None => {
+                            let (kind, target, endpoint) = if let Some(s) = op.default_server() {
+                                let endpoint = op.servers.get(s).map(|sv| sv.url.clone());
+                                ("server", Some(s.to_string()), endpoint)
+                            } else if let Some(u) = op.default_store() {
+                                ("store", Some(u.to_string()), Some(u.to_string()))
+                            } else {
+                                ("none", None, None)
+                            };
+                            ProfileDetail {
+                                name: "(defaults)".to_string(),
+                                scope_kind: kind.to_string(),
+                                target,
+                                endpoint,
+                                default_graph: op.default_graph().map(str::to_string),
+                                output_format: op
+                                    .output()
+                                    .and_then(|f| f.to_possible_value())
+                                    .map(|v| v.get_name().to_string()),
+                            }
+                        }
+                    };
+                    print_profile_detail(&detail, json)?;
+                }
+            }
+        }
         Command::Version => {
             println!("omnigraph {}", env!("CARGO_PKG_VERSION"));
         }

--- a/crates/omnigraph-cli/src/operator.rs
+++ b/crates/omnigraph-cli/src/operator.rs
@@ -91,8 +91,7 @@ pub(crate) struct OperatorServer {
 #[derive(Debug, Default, Deserialize)]
 pub(crate) struct OperatorIdentity {
     /// Default actor for every `--as` cascade (CLI direct-engine writes and
-    /// cluster commands alike): `--as` > legacy config actor (RFC-008
-    /// window) > this > none.
+    /// cluster commands alike): `--as` > this > none.
     pub(crate) actor: Option<String>,
     #[serde(flatten)]
     unknown: serde_yaml::Mapping,

--- a/crates/omnigraph-cli/src/output.rs
+++ b/crates/omnigraph-cli/src/output.rs
@@ -887,6 +887,75 @@ pub(crate) fn finish_logout(
     Ok(())
 }
 
+#[derive(Debug, Serialize)]
+pub(crate) struct ProfileListItem {
+    pub(crate) name: String,
+    /// `server: <n>` / `cluster: <n>` / `store: <uri>` / `invalid: <reason>`.
+    pub(crate) binding: String,
+    pub(crate) default_graph: Option<String>,
+    pub(crate) active: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ProfileDetail {
+    /// Profile name, or `(defaults)` for the no-name flat-defaults view.
+    pub(crate) name: String,
+    /// `server` | `cluster` | `store` | `none`.
+    pub(crate) scope_kind: String,
+    /// The bound server/cluster name, or the store URI.
+    pub(crate) target: Option<String>,
+    /// Resolved endpoint: a server's URL / a cluster's root / the store URI;
+    /// `None` if a named server/cluster isn't defined in this config.
+    pub(crate) endpoint: Option<String>,
+    pub(crate) default_graph: Option<String>,
+    pub(crate) output_format: Option<String>,
+}
+
+pub(crate) fn print_profile_list(items: &[ProfileListItem], json: bool) -> Result<()> {
+    if json {
+        return print_json(&items);
+    }
+    if items.is_empty() {
+        println!("no profiles defined in the operator config");
+        return Ok(());
+    }
+    for item in items {
+        let active = if item.active { " (active)" } else { "" };
+        let graph = item
+            .default_graph
+            .as_deref()
+            .map(|g| format!(" · graph: {g}"))
+            .unwrap_or_default();
+        println!("{}{active}  {}{graph}", item.name, item.binding);
+    }
+    Ok(())
+}
+
+pub(crate) fn print_profile_detail(detail: &ProfileDetail, json: bool) -> Result<()> {
+    if json {
+        return print_json(detail);
+    }
+    println!("profile: {}", detail.name);
+    let target = detail
+        .target
+        .as_deref()
+        .map(|t| format!(" {t}"))
+        .unwrap_or_default();
+    println!("  scope:   {}{target}", detail.scope_kind);
+    if let Some(endpoint) = &detail.endpoint {
+        println!("  endpoint: {endpoint}");
+    } else if matches!(detail.scope_kind.as_str(), "server" | "cluster") {
+        println!("  endpoint: (undefined — name not in this config)");
+    }
+    if let Some(graph) = &detail.default_graph {
+        println!("  default graph: {graph}");
+    }
+    if let Some(format) = &detail.output_format {
+        println!("  output: {format}");
+    }
+    Ok(())
+}
+
 /// Table prefs cascade (RFC-011): operator defaults.table_* > built-in.
 pub(crate) fn resolve_table_render_options() -> ReadRenderOptions {
     let operator = crate::operator::load_operator_config().unwrap_or_default();

--- a/crates/omnigraph-cli/src/planes.rs
+++ b/crates/omnigraph-cli/src/planes.rs
@@ -132,6 +132,7 @@ pub(crate) fn command_plane(cmd: &Command) -> Plane {
         Command::Embed(_)
         | Command::Login { .. }
         | Command::Logout { .. }
+        | Command::Profile { .. }
         | Command::Version => Plane::Session,
     }
 }
@@ -143,6 +144,7 @@ pub(crate) fn command_label(cmd: &Command) -> &'static str {
         Command::Version => "version",
         Command::Login { .. } => "login",
         Command::Logout { .. } => "logout",
+        Command::Profile { .. } => "profile",
         Command::Embed(_) => "embed",
         Command::Init { .. } => "init",
         Command::Load { .. } => "load",

--- a/crates/omnigraph-cli/tests/cli_data.rs
+++ b/crates/omnigraph-cli/tests/cli_data.rs
@@ -2069,3 +2069,143 @@ fn cli_fails_for_invalid_merge_requests() {
             .contains("distinct source and target")
     );
 }
+
+/// RFC-011 Decision 8: `profile list` / `profile show` inspect the operator
+/// config's profiles read-only. Hermetic via OMNIGRAPH_HOME.
+fn profile_home() -> tempfile::TempDir {
+    let home = tempdir().unwrap();
+    std::fs::write(
+        home.path().join("config.yaml"),
+        "operator:\n  actor: act-andrew\n\
+         defaults:\n  output: json\n  server: prod\n  default_graph: knowledge\n\
+         servers:\n  prod:\n    url: https://graph.example.com\n\
+         clusters:\n  brain:\n    root: s3://acme/clusters/brain\n\
+         profiles:\n\
+         \x20 staging:\n    server: prod\n    default_graph: kb\n\
+         \x20 brain-admin:\n    cluster: brain\n\
+         \x20 localdev:\n    store: file:///data/dev.omni\n\
+         \x20 broken:\n    server: a\n    store: b\n",
+    )
+    .unwrap();
+    home
+}
+
+#[test]
+fn profile_list_names_each_profile_with_its_binding_and_marks_active() {
+    let home = profile_home();
+    let out = output_success(
+        cli()
+            .env("OMNIGRAPH_HOME", home.path())
+            .env("OMNIGRAPH_PROFILE", "staging")
+            .arg("profile")
+            .arg("list"),
+    );
+    let stdout = stdout_string(&out);
+    assert!(stdout.contains("staging (active)"), "{stdout}");
+    assert!(stdout.contains("server: prod"), "{stdout}");
+    assert!(stdout.contains("cluster: brain"), "{stdout}");
+    assert!(stdout.contains("store: file:///data/dev.omni"), "{stdout}");
+    // A malformed (two-scope) profile is reported, not a hard failure.
+    assert!(stdout.contains("broken") && stdout.contains("invalid:"), "{stdout}");
+}
+
+#[test]
+fn profile_list_json_shape() {
+    let home = profile_home();
+    let out = output_success(
+        cli()
+            .env("OMNIGRAPH_HOME", home.path())
+            .arg("profile")
+            .arg("list")
+            .arg("--json"),
+    );
+    let items: Value = serde_json::from_slice(&out.stdout).unwrap();
+    let brain = items
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|p| p["name"] == "brain-admin")
+        .unwrap();
+    assert_eq!(brain["binding"], "cluster: brain");
+    assert_eq!(brain["active"], false);
+}
+
+#[test]
+fn profile_show_resolves_named_scope_endpoints() {
+    let home = profile_home();
+    // A cluster profile resolves its root.
+    let cluster = output_success(
+        cli()
+            .env("OMNIGRAPH_HOME", home.path())
+            .arg("profile")
+            .arg("show")
+            .arg("brain-admin"),
+    );
+    let cs = stdout_string(&cluster);
+    assert!(cs.contains("scope:   cluster brain"), "{cs}");
+    assert!(cs.contains("endpoint: s3://acme/clusters/brain"), "{cs}");
+
+    // A store profile shows its URI as the endpoint.
+    let store = output_success(
+        cli()
+            .env("OMNIGRAPH_HOME", home.path())
+            .arg("profile")
+            .arg("show")
+            .arg("localdev")
+            .arg("--json"),
+    );
+    let detail: Value = serde_json::from_slice(&store.stdout).unwrap();
+    assert_eq!(detail["scope_kind"], "store");
+    assert_eq!(detail["endpoint"], "file:///data/dev.omni");
+}
+
+#[test]
+fn profile_show_without_name_falls_back_to_flat_defaults() {
+    let home = profile_home();
+    let out = output_success(
+        cli()
+            .env("OMNIGRAPH_HOME", home.path())
+            .arg("profile")
+            .arg("show")
+            .arg("--json"),
+    );
+    let detail: Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(detail["name"], "(defaults)");
+    assert_eq!(detail["scope_kind"], "server");
+    assert_eq!(detail["endpoint"], "https://graph.example.com");
+    assert_eq!(detail["default_graph"], "knowledge");
+}
+
+#[test]
+fn profile_show_without_name_uses_active_env_profile() {
+    let home = profile_home();
+    let out = output_success(
+        cli()
+            .env("OMNIGRAPH_HOME", home.path())
+            .env("OMNIGRAPH_PROFILE", "brain-admin")
+            .arg("profile")
+            .arg("show")
+            .arg("--json"),
+    );
+    let detail: Value = serde_json::from_slice(&out.stdout).unwrap();
+    // No name arg, but $OMNIGRAPH_PROFILE selects brain-admin (not the flat defaults).
+    assert_eq!(detail["name"], "brain-admin");
+    assert_eq!(detail["scope_kind"], "cluster");
+    assert_eq!(detail["endpoint"], "s3://acme/clusters/brain");
+    // output_format renders as the canonical lowercase value name.
+    assert_eq!(detail["output_format"], "json");
+}
+
+#[test]
+fn profile_show_unknown_name_errors() {
+    let home = profile_home();
+    let out = output_failure(
+        cli()
+            .env("OMNIGRAPH_HOME", home.path())
+            .arg("profile")
+            .arg("show")
+            .arg("nope"),
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("unknown profile 'nope'"), "{stderr}");
+}

--- a/docs/dev/rfc-011-cli-refactoring.md
+++ b/docs/dev/rfc-011-cli-refactoring.md
@@ -1,6 +1,9 @@
 # RFC-011: CLI refactoring — one addressing & config model
 
-**Status:** Proposed
+**Status:** Accepted — implemented (the `omnigraph.yaml` excision landed as
+#250/#251/#252; D1–D4, D6, D7, D9, D10 shipped). Two items remain: **D11**
+(server-side maintenance jobs) is gated on the bulk-data-plane RFC #219; **D5**
+(combined admin scope) stays deferred by design.
 **Date:** 2026-06-14
 **Audience:** CLI/server maintainers
 **Builds on:** [rfc-007-operator-config.md](rfc-007-operator-config.md)
@@ -526,10 +529,9 @@ Non-blocking; settle when convenient.
   server scope and maintain via `--cluster`. A `deployments: { … }` object
   (server + cluster validated coherent, referenced by a profile) is revisited only
   if admin ergonomics demand it — and Decision 11 largely removes the need.
-- **D8 — the `profile` command surface.** `profile list` / `profile show`
-  (read-only inspection) are additive diagnostics, shippable anytime; they don't
-  touch the grammar or resolution. The *no sticky `profile use`* constraint holds
-  regardless — it is a design principle, not a command.
+- **D8 — the `profile` command surface.** *Shipped:* `profile list` / `profile
+  show [<name>]` (read-only inspection). The *no sticky `profile use`* constraint
+  holds — it is a design principle, not a command.
 
 ## Safety
 

--- a/docs/user/cli/reference.md
+++ b/docs/user/cli/reference.md
@@ -26,6 +26,7 @@ Top-level command families and subcommands. Graph-targeting commands accept a po
 | `cleanup --keep N --older-than 7d --confirm` | destructive version GC (`--confirm` to execute; also needs `--yes` against a non-local `s3://` target — see *Write diagnostics & destructive confirmation*) |
 | `embed` | offline JSONL embedding pipeline |
 | `policy validate \| test \| explain` | Cedar tooling against a cluster's applied policies (`--cluster <dir>`; `--graph <id>` picks a graph's bundle when several apply). `test` takes `--tests <file>`; `explain` takes `--actor`/`--action`/`--branch`/`--target-branch` |
+| `profile list \| show [<name>]` | read-only inspection of `~/.omnigraph/config.yaml` profiles. `list` shows each profile's binding (server/cluster/store) + default graph and marks the `$OMNIGRAPH_PROFILE`-active one; `show` resolves one profile's scope (endpoint + default graph), defaulting to the active profile, else the flat operator defaults |
 | `version` / `-v` | print `omnigraph 0.3.x` |
 
 ## Command capabilities
@@ -106,7 +107,8 @@ address (a positional URI, `--server`, or `--store <uri>`); a named
 *local* default — mutually exclusive with `defaults.server`). A **profile** binds
 exactly one of `server` / `cluster` / `store` plus an optional default graph —
 config data, not state: every command resolves its scope fresh, there is no
-sticky "current" mode.
+sticky "current" mode. Inspect what is defined with `omnigraph profile list` and
+`omnigraph profile show [<name>]` (read-only).
 
 - `--store <uri>` addresses a single graph's storage directly (ad-hoc / break-glass).
 - A `cluster`-bound profile reaches `optimize` / `repair` / `cleanup` for a managed


### PR DESCRIPTION
## What

RFC-011 **Decision 8**: read-only inspection of the per-operator `~/.omnigraph/config.yaml` scope profiles. Purely additive — no grammar or resolution changes.

- **`profile list [--json]`** — every profile with its binding (`server: <n>` / `cluster: <n>` / `store: <uri>`) and default graph; marks the `$OMNIGRAPH_PROFILE`-active one. A malformed (zero/two-scope) profile is reported as `invalid: <reason>`, not a hard failure.
- **`profile show [<name>] [--json]`** — one profile's resolved scope: binding kind + target, resolved endpoint (a server's URL / a cluster's root / the store URI), default graph, output format. With no name, shows the active profile, else the flat operator defaults.

Both are `local` (Session plane) — operator-config only, no addressing flags.

## Design note
Display reads `OperatorProfile::binding()` + the same `servers`/`clusters` lookups the scope resolver uses, **not** `scope::resolve_scope` — the resolver is capability-gated (a cluster profile is rejected under `Any`, a server under `Direct`), so no single capability can render all three binding kinds. Reading the binding directly is honest about what a profile binds and reuses the real accessors.

## Tests (`cli_data.rs`)
`profile list` names + binding summaries + active marker + `invalid:` for a malformed profile; `--json` shape; `profile show` resolves cluster root + store URI endpoints; no-name → flat defaults; unknown name → error.

## Also
- RFC-011 bookkeeping: `Status: Proposed → Accepted`; D8 marked shipped; D11 noted as gated on the bulk-data-plane RFC #219; D5 deferred.
- Dropped a stale "legacy config actor (RFC-008 window)" comment in `operator.rs` (the legacy actor is gone).

## Verification
- `cargo test --workspace --locked` green: **61 suites, 1387 passed, 0 failed**.
- `cargo build -p omnigraph-server --features aws` green; `scripts/check-agents-md.sh` clean (except pre-existing untracked scratch docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements RFC-011 Decision 8: two read-only CLI commands — `profile list` and `profile show [<name>]` — for inspecting operator-config scope profiles. Both commands are purely additive, touch only the Session plane, and leave grammar/resolution logic untouched.

- **`profile list [--json]`** iterates `OperatorConfig.profiles` via `BTreeMap`, calls `OperatorProfile::binding()` per entry (reporting malformed profiles as `invalid:` rather than hard-failing), and marks the `$OMNIGRAPH_PROFILE`-active entry.
- **`profile show [<name>] [--json]`** resolves a named (or env-active) profile's endpoint by reading `servers`/`clusters` maps directly rather than going through `scope::resolve_scope`, then falls back to flat operator defaults when no name or active profile is set.
- Tests are hermetic via `OMNIGRAPH_HOME` and cover all three `name.or(active)` branches including the previously missing case (b): no positional arg + `$OMNIGRAPH_PROFILE` set.

<h3>Confidence Score: 5/5</h3>

Purely additive read-only commands over already-parsed operator config; no mutations, no addressing or grammar changes.

All new code reads existing in-memory config state that is already loaded and validated. The `profile list` gracefully degrades on malformed profiles rather than aborting, and `profile show` fails loudly on an invalid binding as intended. Tests cover all three `name.or(active)` branches including the previously-missing env-var case.

crates/omnigraph-cli/src/output.rs — the `ProfileListItem.binding` JSON field shape is worth a second look before this command's output becomes a script-automation contract.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/omnigraph-cli/src/cli.rs | Adds `Profile { command: ProfileCommand }` to the top-level command enum and defines `ProfileCommand` with `List` and `Show` subcommands. Clean, additive change. |
| crates/omnigraph-cli/src/main.rs | Implements `Command::Profile` dispatch: `List` iterates profiles and captures binding/active state; `Show` resolves a named (or env-active) profile's endpoint, falling back to flat operator defaults. `output_format` correctly uses `to_possible_value()/get_name()` rather than Debug formatting. |
| crates/omnigraph-cli/src/output.rs | Adds `ProfileListItem` and `ProfileDetail` structs plus `print_profile_list`/`print_profile_detail`. The `binding` field on `ProfileListItem` serializes as a combined opaque string in JSON, inconsistent with `ProfileDetail`'s structured `scope_kind`+`target` — ships as an observable JSON contract per Hyrum's Law. |
| crates/omnigraph-cli/src/planes.rs | Correctly adds `Profile` to `Plane::Session` and `command_label`. Minimal, correct change. |
| crates/omnigraph-cli/tests/cli_data.rs | Adds hermetic profile tests via `OMNIGRAPH_HOME`: list with binding/active/invalid checks, JSON shape, show with cluster root + store URI, flat-defaults fallback, active-profile-via-env (case (b) now covered), and unknown-name error path. |
| docs/dev/rfc-011-cli-refactoring.md | Status promoted from Proposed → Accepted; D8 marked shipped; D11 gated on RFC #219 noted; D5 deferred documented. |
| docs/user/cli/reference.md | Adds `profile list | show [<name>]` to the command table and updates the profile concept description with inspection pointers. Consistent with implementation. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[omnigraph profile] --> B{subcommand}
    B --> C[list]
    B --> D[show]

    C --> C1[load_operator_config]
    C1 --> C2[read OMNIGRAPH_PROFILE]
    C2 --> C3[iterate op.profiles BTreeMap]
    C3 --> C4{profile.binding ok?}
    C4 -->|Ok| C5["binding = 'server/cluster/store: name'"]
    C4 -->|Err| C6["binding = 'invalid: reason'"]
    C5 & C6 --> C7[mark active if name == env var]
    C7 --> C8[print_profile_list]
    C8 --> C9{--json?}
    C9 -->|yes| C10[print_json array]
    C9 -->|no| C11[text output per item]

    D --> D1[load_operator_config]
    D1 --> D2[read OMNIGRAPH_PROFILE]
    D2 --> D3{name.or active}
    D3 -->|Some name| D4[op.profile lookup]
    D4 -->|not found| D5[error: unknown profile]
    D4 -->|found| D6[profile.binding?]
    D6 --> D7{kind}
    D7 -->|Server| D8[look up servers map for endpoint]
    D7 -->|Cluster| D9[cluster_root for endpoint]
    D7 -->|Store| D10[URI is both target and endpoint]
    D3 -->|None| D11[flat defaults: default_server or default_store]
    D8 & D9 & D10 & D11 --> D12[build ProfileDetail]
    D12 --> D13[print_profile_detail]
    D13 --> D14{--json?}
    D14 -->|yes| D15[print_json object]
    D14 -->|no| D16[text output]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fomnigraph-cli%2Fsrc%2Foutput.rs%3A890-896%0A**%60binding%60%20in%20%60profile%20list%20--json%60%20is%20an%20opaque%20string%3B%20inconsistent%20with%20%60profile%20show%20--json%60**%0A%0A%60ProfileListItem.binding%60%20serializes%20to%20a%20combined%20human-readable%20string%20%28%60%22server%3A%20prod%22%60%2C%20%60%22cluster%3A%20brain%22%60%2C%20%60%22invalid%3A%20%E2%80%A6%22%60%29%20in%20the%20JSON%20output%2C%20while%20%60ProfileDetail%60%20%28from%20%60profile%20show%20--json%60%29%20exposes%20separate%20%60scope_kind%60%20and%20%60target%60%20fields.%20A%20script%20consuming%20%60profile%20list%20--json%60%20must%20parse%20the%20%60binding%60%20string%20%28e.g.%2C%20split%20on%20%60%22%3A%20%22%60%29%20to%20recover%20the%20kind%20and%20target%2C%20whereas%20%60profile%20show%20--json%60%20delivers%20them%20pre-structured.%20Per%20the%20Hyrum's%20Law%20deny-list%20item%2C%20this%20combined-string%20format%20becomes%20a%20locked%20contract%20the%20moment%20it%20ships%20%E2%80%94%20including%20the%20%60%22invalid%3A%20%3Cfull%20error%20text%3E%22%60%20variant%2C%20whose%20message%20text%20is%20error-message%20prose.%0A%0AConsider%20aligning%20%60ProfileListItem%60%20with%20%60ProfileDetail%60%20by%20using%20separate%20%60binding_kind%60%20and%20%60binding_target%60%20fields%20%28and%20an%20optional%20%60error%60%20for%20invalid%20profiles%29%20before%20this%20shape%20is%20published.%0A%0A&repo=modernrelay%2Fomnigraph&pr=255&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["feat(cli): add read-only \`profile list\` ..."](https://github.com/modernrelay/omnigraph/commit/fe254f693e4cb4d7e6900a8664d905a19a2afef5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37724753)</sub>

<!-- /greptile_comment -->