### PR TITLE
docs(cli): fix the --help capability legend (config→profile)

### DIFF
--- a/crates/omnigraph-cli/src/cli.rs
+++ b/crates/omnigraph-cli/src/cli.rs
@@ -21,7 +21,7 @@ direct — direct storage access; reject --server (init, optimize, repair, clean
 schema plan, lint).\n  \
 control — manage or inspect a cluster (cluster via --config; policy & queries via \
 --cluster).\n  \
-local — no graph; local config & tooling: embed, login, logout, config, version.\n\
+local — no graph; local config & tooling: embed, login, logout, profile, version.\n\
 See the 'Command capabilities' section of the CLI reference for which flags apply where.")]
 pub(crate) struct Cli {
     /// Actor id for direct-engine writes; overrides `cli.actor`. No effect on


### PR DESCRIPTION
## What
The `local` line of `omnigraph --help`'s "COMMANDS BY CAPABILITY" legend was stale:
- listed `config` — the `config migrate` group was removed with the omnigraph.yaml excision (#252);
- omitted `profile` — added by RFC-011 D8 (#255).

One-line fix: `embed, login, logout, profile, version`. Follow-up to #252/#255 (should have updated the legend there).

## Verification
- `cargo test --workspace --locked` green (the `help_groups_commands_by_capability` test pins the legend header + command ordering, both unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects a one-line stale string in the `omnigraph --help` capability legend, swapping `config` (removed in #252) for `profile` (added in #255) in the `local` row.

- Replaces `config` with `profile` in the `after_help` string of the `Cli` struct in `crates/omnigraph-cli/src/cli.rs`, keeping the legend accurate for the current command surface.
- The matching `local` capability list in `docs/user/cli/reference.md` (line 40) still contains `config` and omits `profile`, leaving the reference doc out of sync with both the `--help` text and the actual command surface.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the single changed line correctly updates a stale help string with no runtime impact.

The single changed line in `cli.rs` is correct. The CLI reference doc at `docs/user/cli/reference.md` line 40 still lists `config` and omits `profile` in the local capability group — the same drift this PR addresses in the `--help` text — leaving the two canonical descriptions of the local command surface out of sync after this PR merges.

docs/user/cli/reference.md — the `local` capability list on line 40 still needs `config` replaced with `profile`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/omnigraph-cli/src/cli.rs | One-line fix replacing `config` with `profile` in the `local` capability legend of `--help`; correct and unambiguous. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["omnigraph --help"] --> B["COMMANDS BY CAPABILITY legend"]
    B --> C["any"]
    B --> D["served"]
    B --> E["direct"]
    B --> F["control"]
    B --> G["local"]
    G --> H["embed, login, logout, profile, version"]
    style G fill:#d4edda,stroke:#28a745
    style H fill:#d4edda,stroke:#28a745
```

<sub>Reviews (1): Last reviewed commit: ["docs(cli): fix the --help capability leg..."](https://github.com/modernrelay/omnigraph/commit/bc8f834ff231ad0da66eeaa0d2aa3bac4bda6380) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37729705)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=fba7c581-edb6-48b3-90ce-1db695f47e8b))

<!-- /greptile_comment -->