### PR TITLE
ci(publish): add omnigraph-api-types + omnigraph-cluster to crates.io publish order

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,6 +1,6 @@
 name: Publish to crates.io
 
-# Publishes the four workspace crates to crates.io in dependency order.
+# Publishes the publishable workspace crates to crates.io in dependency order.
 #
 # Triggers:
 #   - push of any v* tag (future releases auto-publish alongside release.yml)
@@ -115,10 +115,14 @@ jobs:
 
           # Order matters: each crate must precede anything that depends on it.
           # omnigraph-compiler and omnigraph-policy have no internal deps;
-          # omnigraph-engine depends on both; server depends on engine + the
-          # two leaf crates; cli depends on everything.
+          # omnigraph-engine depends on both; omnigraph-api-types and
+          # omnigraph-cluster depend on engine (+ compiler); server depends on
+          # engine + api-types + cluster + the two leaf crates; cli depends on
+          # everything.
           publish_if_new omnigraph-compiler
           publish_if_new omnigraph-policy
           publish_if_new omnigraph-engine
+          publish_if_new omnigraph-api-types
+          publish_if_new omnigraph-cluster
           publish_if_new omnigraph-server
           publish_if_new omnigraph-cli


### PR DESCRIPTION
The crates.io publish on the `v0.7.0` tag failed: the workflow's publish list predated `omnigraph-api-types` (RFC-009 shared wire DTOs) and `omnigraph-cluster`. It published `omnigraph-compiler`/`omnigraph-policy`/`omnigraph-engine` v0.7.0, then errored on `omnigraph-server` (`no matching package named omnigraph-api-types found`).

Fix: add both crates in dependency order (after `omnigraph-engine`, before `omnigraph-server`). The workflow is idempotent (per-crate crates.io version check), so re-dispatching for `v0.7.0` skips the three already-published and finishes api-types → cluster → server → cli.

After merge: `gh workflow run publish-crates.yml --ref main -f tag=v0.7.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a broken crates.io publish by inserting `omnigraph-api-types` and `omnigraph-cluster` into the workflow's publish list in the correct dependency order (after `omnigraph-engine`, before `omnigraph-server`). The dependency order is verified by the crates' own `Cargo.toml` files — both new crates depend on `omnigraph-engine` and `omnigraph-compiler`, while `omnigraph-server` depends on both of them.

- Adds `publish_if_new omnigraph-api-types` and `publish_if_new omnigraph-cluster` between `omnigraph-engine` and `omnigraph-server` in the publish sequence.
- Updates the header comment to accurately describe all seven publishable crates and their dependency relationships.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change adds two missing crates in the correct topological order, which is directly verifiable against each crate's Cargo.toml.

The two inserted publish calls are in exactly the right position: both new crates depend on engine (and compiler), while server depends on both of them. The Cargo.toml files confirm the stated dependency chain, and the workflow's idempotency guard means re-running for v0.7.0 is safe. No logic in the existing workflow is altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish-crates.yml | Adds omnigraph-api-types and omnigraph-cluster to the publish list in dependency order (after engine, before server); updates the header comment to match. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[omnigraph-compiler] --> C[omnigraph-engine]
    B[omnigraph-policy] --> C
    C --> D[omnigraph-api-types]
    C --> E[omnigraph-cluster]
    A --> D
    A --> E
    D --> F[omnigraph-server]
    E --> F
    C --> F
    A --> F
    B --> F
    F --> G[omnigraph-cli]
    D --> G
    E --> G
    C --> G
    A --> G
    B --> G

    style D fill:#90EE90,stroke:#228B22
    style E fill:#90EE90,stroke:#228B22
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[omnigraph-compiler] --> C[omnigraph-engine]
    B[omnigraph-policy] --> C
    C --> D[omnigraph-api-types]
    C --> E[omnigraph-cluster]
    A --> D
    A --> E
    D --> F[omnigraph-server]
    E --> F
    C --> F
    A --> F
    B --> F
    F --> G[omnigraph-cli]
    D --> G
    E --> G
    C --> G
    A --> G
    B --> G

    style D fill:#90EE90,stroke:#228B22
    style E fill:#90EE90,stroke:#228B22
```

</a>

<sub>Reviews (1): Last reviewed commit: ["ci(publish): add omnigraph-api-types + o..."](https://github.com/modernrelay/omnigraph/commit/9ed86ecf9e7b938b34f22a5ea8d2e7d4b2446ee7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37791661)</sub>

<!-- /greptile_comment -->