### PR TITLE
ci(release): single-writer release publish — fix the matrix finalize race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,34 @@
 name: Release
 
+# Build per-platform binaries in a matrix, then publish the GitHub release ONCE
+# from a single job. The matrix used to call `softprops/action-gh-release`
+# concurrently — three jobs racing to create/finalize the same release, which
+# exhausted the action's finalize retries and dropped whole platforms' assets.
+# The matrix now only uploads workflow artifacts; `publish_release` is the sole
+# writer of the release (no race).
+#
+# Triggers:
+#   - push of a v* tag (normal release)
+#   - workflow_dispatch with an explicit `tag` (re-publish a past tag without
+#     re-cutting it; resolves the same `${{ inputs.tag || github.ref_name }}`)
+
 on:
   push:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to (re)publish (e.g. v0.7.0). Required for manual dispatches."
+        required: true
+        type: string
 
 jobs:
   build_release:
     name: Build ${{ matrix.asset_name }}
     runs-on: ${{ matrix.runner }}
     permissions:
-      contents: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -27,6 +44,8 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v5.0.1
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
 
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
@@ -81,20 +100,46 @@ jobs:
             throw "Windows release archive is missing expected binaries"
           }
 
-      - name: Publish GitHub release assets
+      # Upload artifacts only — the single `publish_release` job attaches them to
+      # the release, so no two jobs ever write the release concurrently.
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset_name }}
+          path: |
+            ${{ matrix.asset_name }}.*
+          if-no-files-found: error
+          retention-days: 1
+
+  publish_release:
+    name: Publish GitHub release
+    needs: build_release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Publish release (single writer — no matrix race)
         uses: softprops/action-gh-release@v2.5.0
         with:
-          files: |
-            ${{ matrix.asset_name }}.*
+          tag_name: ${{ inputs.tag || github.ref_name }}
+          files: dist/**
+          overwrite_files: true
 
   update_homebrew_tap:
     name: Update Homebrew tap
-    needs: build_release
+    needs: publish_release
     runs-on: ubuntu-latest
     permissions:
       contents: read
     env:
       HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
     steps:
       - name: Skip if HOMEBREW_TAP_TOKEN is not configured
         if: env.HOMEBREW_TAP_TOKEN == ''
@@ -105,6 +150,8 @@ jobs:
       - name: Checkout source
         if: env.HOMEBREW_TAP_SKIP != '1'
         uses: actions/checkout@v5.0.1
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Checkout Homebrew tap
         if: env.HOMEBREW_TAP_SKIP != '1'
@@ -119,7 +166,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          ./scripts/update-homebrew-formula.sh "${GITHUB_REF_NAME}" homebrew-tap/Formula/omnigraph.rb
+          ./scripts/update-homebrew-formula.sh "${RELEASE_TAG}" homebrew-tap/Formula/omnigraph.rb
 
       # Diagnostic only: brew is not on PATH on the ubuntu runner by default, so
       # set it up explicitly. Both this setup and the audit below are best-effort
@@ -158,22 +205,26 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add Formula/omnigraph.rb
-          git commit -m "Update Omnigraph formula to ${GITHUB_REF_NAME}"
+          git commit -m "Update Omnigraph formula to ${RELEASE_TAG}"
           git push origin HEAD:main
 
   smoke_windows_installer:
     name: Smoke Windows installer
-    needs: build_release
-    if: startsWith(github.ref, 'refs/tags/v')
+    needs: publish_release
+    if: ${{ inputs.tag != '' || startsWith(github.ref, 'refs/tags/v') }}
     runs-on: windows-latest
     permissions:
       contents: read
+    env:
+      RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
     steps:
       - name: Checkout source
         uses: actions/checkout@v5.0.1
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Install from tagged release
-        run: ./scripts/install.ps1 -Version "$env:GITHUB_REF_NAME" -InstallDir "$env:RUNNER_TEMP/omnigraph-bin"
+        run: ./scripts/install.ps1 -Version "$env:RELEASE_TAG" -InstallDir "$env:RUNNER_TEMP/omnigraph-bin"
 
       - name: Smoke installed binaries
         run: |


### PR DESCRIPTION
On the `v0.7.0` tag, the release matrix dropped the macOS and Windows binaries: all three platform jobs call `softprops/action-gh-release` concurrently and race on "Finalizing release" → retry exhaustion → lost assets (linux won the race).

**Fix:** split build from publish.
- The matrix only uploads workflow artifacts now (`actions/upload-artifact`).
- A single `publish_release` job downloads all artifacts and makes **one** `action-gh-release` call — the sole writer, so there's no race.
- `update_homebrew_tap` and `smoke_windows_installer` now `needs: publish_release`.

Also adds a `tag` `workflow_dispatch` input (resolved as `inputs.tag || github.ref_name`, like publish-crates.yml) so a tag can be re-published without re-cutting it — and uses the resolved tag in the Homebrew/smoke steps instead of `GITHUB_REF_NAME` (which is the branch on a dispatch).

After merge: `gh workflow run release.yml -f tag=v0.7.0` rebuilds all three platforms and attaches them in one clean publish (also triggers the Homebrew tap update if `HOMEBREW_TAP_TOKEN` is set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the v0.7.0 release asset drop by replacing the concurrent matrix publish pattern with a single-writer `publish_release` job. It also adds a `workflow_dispatch` `tag` input so any past release can be rebuilt and re-attached without re-cutting the tag, and corrects downstream jobs (`update_homebrew_tap`, `smoke_windows_installer`) to use the resolved tag instead of `GITHUB_REF_NAME`.

- **Matrix now uploads workflow artifacts only** (`actions/upload-artifact@v4`); the `contents: write` permission is removed from the build jobs.
- **`publish_release` is the sole GitHub release writer**: it downloads all three platform artifacts and makes one `softprops/action-gh-release` call.
- **Note**: `release-edge.yml` still uses the original concurrent matrix pattern (`softprops/action-gh-release` called in each matrix job); the same race exists there and would benefit from a follow-up PR applying this same fix.

<h3>Confidence Score: 4/5</h3>

Safe to merge. The single-writer pattern correctly eliminates the release-asset race, and the workflow_dispatch re-publish path is well-structured.

The structural change is sound: build jobs lose contents: write, artifacts are staged via upload-artifact, and publish_release is the only job that touches the GitHub release. The workflow_dispatch tag resolution mirrors the pattern already in publish-crates.yml. The single finding — ${{ }} wrapping on the smoke_windows_installer if: — is inconsistent with every other condition in the file and technically allows an API caller to bypass the guard with tag='', but poses no real risk given required: true and the two controlled trigger paths.

.github/workflows/release.yml line 214 — the if: condition on smoke_windows_installer should drop the ${{ }} wrapper to match the rest of the file.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Splits the matrix build from release publishing to eliminate the concurrent-write race. The new publish_release job is the sole writer to the GitHub release. One if: condition uses a discouraged ${{ }} wrapper that is inconsistent with the rest of the file. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant T as Tag push / workflow_dispatch
    participant BL as build_release (linux)
    participant BM as build_release (macos)
    participant BW as build_release (windows)
    participant A as actions/upload-artifact
    participant PR as publish_release
    participant DA as actions/download-artifact
    participant GH as GitHub Release
    participant HB as update_homebrew_tap
    participant SW as smoke_windows_installer

    T->>BL: trigger
    T->>BM: trigger
    T->>BW: trigger

    BL->>A: "upload omnigraph-linux-x86_64.*"
    BM->>A: "upload omnigraph-macos-arm64.*"
    BW->>A: "upload omnigraph-windows-x86_64.*"

    A-->>PR: (needs: build_release)
    PR->>DA: download all artifacts to dist/
    DA-->>PR: "dist/**"
    PR->>GH: single softprops/action-gh-release call (no race)

    GH-->>HB: (needs: publish_release)
    GH-->>SW: (needs: publish_release, if: tag condition)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant T as Tag push / workflow_dispatch
    participant BL as build_release (linux)
    participant BM as build_release (macos)
    participant BW as build_release (windows)
    participant A as actions/upload-artifact
    participant PR as publish_release
    participant DA as actions/download-artifact
    participant GH as GitHub Release
    participant HB as update_homebrew_tap
    participant SW as smoke_windows_installer

    T->>BL: trigger
    T->>BM: trigger
    T->>BW: trigger

    BL->>A: "upload omnigraph-linux-x86_64.*"
    BM->>A: "upload omnigraph-macos-arm64.*"
    BW->>A: "upload omnigraph-windows-x86_64.*"

    A-->>PR: (needs: build_release)
    PR->>DA: download all artifacts to dist/
    DA-->>PR: "dist/**"
    PR->>GH: single softprops/action-gh-release call (no race)

    GH-->>HB: (needs: publish_release)
    GH-->>SW: (needs: publish_release, if: tag condition)
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Frelease.yml%3A214%0ADrop%20the%20%60%24%7B%7B%20%7D%7D%60%20wrapper%20to%20match%20every%20other%20%60if%3A%60%20condition%20in%20this%20file%20and%20avoid%20the%20documented%20string-coercion%20gotcha.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%3A%20inputs.tag%20!%3D%20''%20%7C%7C%20startsWith%28github.ref%2C%20'refs%2Ftags%2Fv'%29%0A%60%60%60%0A%0A&repo=modernrelay%2Fomnigraph&pr=261&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["ci(release): single-writer release publi..."](https://github.com/modernrelay/omnigraph/commit/007edb770c6f5dce2d969a9466ef88e63f168938) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37835150)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->