### PR TITLE
docs(readme): align with cluster-first paradigm + RFC-011 CLI ergonomics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,9 +210,9 @@ omnigraph load --data ./seed.jsonl --mode overwrite s3://my-bucket/graph.omni
 # Load a review batch onto its own branch (--from forks it if missing)
 omnigraph load --branch review/2026-04-25 --from main --mode merge --data ./batch.jsonl s3://my-bucket/graph.omni
 
-# Run a hybrid (vector + BM25) query
-omnigraph read --query ./queries.gq --name find_similar \
-  --params '{"q":"trends in AI safety"}' --format table s3://my-bucket/graph.omni
+# Run a hybrid (vector + BM25) query — ad-hoc .gq against a store (positional = query name)
+omnigraph query --query ./queries.gq find_similar \
+  --params '{"q":"trends in AI safety"}' --format table --store s3://my-bucket/graph.omni
 
 # Plan + apply schema migration
 omnigraph schema plan  --schema ./next.pg s3://my-bucket/graph.omni

--- a/README.md
+++ b/README.md
@@ -78,18 +78,51 @@ value.
 
 ## Common Commands
 
-The same URI works for local paths, `s3://…`, or `http://host:port`.
+Every command declares the **capability** it needs and how it's addressed.
+Direct storage (`init`, `load`, `branch`, …) takes a positional `file://`/`s3://`
+URI or `--store <uri>`; a served graph is addressed with `--server <name|url>`
+(never a positional `http(s)://` URI). `query`/`mutate` invoke a stored query
+**by name** (the positional is the query name, not a graph URI).
 
 ```bash
-omnigraph init   --schema ./schema.pg ./graph.omni
-omnigraph load   --data   ./data.jsonl ./graph.omni
-omnigraph read   --query  ./queries.gq --name get_person --params '{"name":"Alice"}' ./graph.omni
-omnigraph change --query  ./queries.gq --name insert_person --params '{"name":"Mina"}' ./graph.omni
-omnigraph branch create --from main feature-x ./graph.omni
-omnigraph branch merge  feature-x --into main ./graph.omni
+# Create a graph and load data (--mode is required; overwrite is destructive)
+omnigraph init --schema ./schema.pg ./graph.omni
+omnigraph load --data ./data.jsonl --mode merge --store ./graph.omni
+
+# Read / write — ad-hoc .gq against a local store (positional selects the query)
+omnigraph query  --query ./queries.gq get_person    --params '{"name":"Alice"}' --store ./graph.omni
+omnigraph mutate --query ./queries.gq insert_person  --params '{"name":"Mina"}'  --store ./graph.omni
+
+# Branch and merge (Git-style, across the whole graph)
+omnigraph branch create --from main feature-x --store ./graph.omni
+omnigraph branch merge  feature-x --into main --store ./graph.omni
+
+# Against a running server: invoke a stored query by name from the catalog
+omnigraph query find_people --server prod --graph knowledge --params '{"q":"AI safety"}'
 ```
 
-See [docs/user/cli.md](docs/user/cli.md) for schema apply, snapshots, data loading, commits, and policy commands.
+Operator settings (identity, named servers/clusters, credentials, defaults) live
+in `~/.omnigraph/config.yaml`; with a default scope set, the addressing flags can
+be omitted. See [docs/user/cli/index.md](docs/user/cli/index.md) and the
+[CLI reference](docs/user/cli/reference.md) for schema apply, snapshots, commits,
+profiles, and policy/queries tooling.
+
+## Serving (cluster-first)
+
+A deployment is a **cluster**: a `cluster.yaml` (graphs, schemas, stored queries,
+policies, storage) that you converge with `cluster apply`, then serve. The server
+boots from the cluster only — it has no single-graph mode — and serves every
+graph under `/graphs/{id}/…`.
+
+```bash
+omnigraph cluster apply  --config ./company-brain          # converge the declared state
+omnigraph-server --cluster ./company-brain --bind 0.0.0.0:8080
+# or config-free from object storage — the bucket IS the deployment:
+omnigraph-server --cluster s3://my-bucket/company-brain --bind 0.0.0.0:8080
+```
+
+See the [cluster guide](docs/user/clusters/index.md) and
+[deployment guide](docs/user/deployment.md).
 
 ## Clients
 
@@ -131,10 +164,13 @@ Notes:
 
 ## Workspace Crates
 
-- `crates/omnigraph-compiler`: shared schema/query parser, typechecker, catalog, and IR lowering
-- `crates/omnigraph`: storage/runtime, branching, merge, change detection, and query execution
-- `crates/omnigraph-cli`: CLI for graph lifecycle (init/load), query/mutate, branch/commit/merge, schema/lint, snapshot/export, policy, and maintenance (optimize/cleanup)
-- `crates/omnigraph-server`: Axum HTTP server for remote reads, changes, ingest, export, branches, and commits
+- `crates/omnigraph-compiler`: shared schema/query parser, typechecker, catalog, and IR lowering (zero Lance dependency)
+- `crates/omnigraph` (package `omnigraph-engine`): storage/runtime, branching, merge, change detection, query execution, and embeddings
+- `crates/omnigraph-policy`: Cedar policy compilation and enforcement
+- `crates/omnigraph-api-types`: shared HTTP wire DTOs used by both the server and the CLI
+- `crates/omnigraph-cluster`: cluster config validation, planning, and apply (the control plane)
+- `crates/omnigraph-server`: Axum HTTP server — cluster-first, serving N graphs under `/graphs/{id}/…`
+- `crates/omnigraph-cli`: CLI for graph lifecycle (init/load), query/mutate, branch/commit/merge, schema/lint, snapshot/export, cluster control, policy/queries, profiles, and maintenance (optimize/repair/cleanup)
 
 ## Contributing
 


### PR DESCRIPTION
The README's Common Commands and crate list predated 0.7.0.

- **Common Commands** rewritten to the RFC-011 addressing model: positional/`--store` for direct storage, `--server <name|url>` for served graphs (no positional `http(s)://`), `query`/`mutate` invoke a stored query **by name**, `load` requires `--mode`. Dropped the false "same URI works for local/s3/http" line and the deprecated `read`/`change`/`--name` forms; pointed at `~/.omnigraph/config.yaml`.
- New **Serving (cluster-first)** section: a deployment is a `cluster.yaml` converged with `cluster apply` and served by `omnigraph-server --cluster <dir|s3://…>` (no single-graph mode; config-free boot from a bucket).
- Fixed the stale `docs/user/cli.md` link → `cli/index.md` + CLI reference (docs were restructured into topic sections).
- **Workspace Crates** now lists all seven (adds omnigraph-policy, omnigraph-api-types, omnigraph-cluster).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This docs-only PR modernises the README and AGENTS.md to match the 0.7.0 cluster-first architecture and RFC-011 CLI addressing model, replacing stale pre-0.7.0 commands and a broken doc link.

- **README.md**: Common Commands rewritten around positional/`--store` for direct storage and `--server` for served graphs; deprecated `read`/`change`/`--name` forms removed; new Serving (cluster-first) section added; stale `docs/user/cli.md` link corrected to `docs/user/cli/index.md` (verified to exist); Workspace Crates expanded from 4 to 7 entries.
- **AGENTS.md**: Quick-reference `omnigraph read --query … --name …` replaced with `omnigraph query … --store`, consistent with the RFC-011 positional-name + `--store` form documented in both the README and the [cookbooks commands reference](https://github.com/modernrelay/omnigraph-cookbooks/blob/HEAD/skills/omnigraph-best-practices/references/commands.md).

<h3>Confidence Score: 5/5</h3>

Documentation-only change; no executable code is modified

Every internal doc link in README.md resolves to a real file in the repo; the AGENTS.md command update matches the canonical form in the cookbooks reference; no executable code, migrations, or schema are touched

No files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Common Commands, Serving, Workspace Crates sections rewritten for RFC-011 and cluster-first paradigm; all four internal doc links resolve to real files |
| AGENTS.md | Quick-reference flow updated: deprecated `omnigraph read --name` replaced with `omnigraph query <name> --store`, matching RFC-011 positional/--store addressing |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Developer / Agent] -->|direct storage| B["omnigraph cmd --store uri\nor positional file:///s3:// URI"]
    A -->|served graph| C["omnigraph cmd --server name|url\n(+ --graph id for multi-graph)"]
    A -->|named profile| D["omnigraph cmd --profile name\nor operator defaults in config.yaml"]

    B --> E["Direct storage commands\ninit / load / branch / schema\noptimize / repair / cleanup"]
    C --> F["Stored-query invocation\nomnigraph query name\nomnigraph mutate name"]
    D --> F

    G["cluster apply\n--config dir"] --> H["omnigraph-server\n--cluster dir|s3://"]
    H --> F
    H --> I["Serves N graphs\nunder /graphs/{id}/..."]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Developer / Agent] -->|direct storage| B["omnigraph cmd --store uri\nor positional file:///s3:// URI"]
    A -->|served graph| C["omnigraph cmd --server name|url\n(+ --graph id for multi-graph)"]
    A -->|named profile| D["omnigraph cmd --profile name\nor operator defaults in config.yaml"]

    B --> E["Direct storage commands\ninit / load / branch / schema\noptimize / repair / cleanup"]
    C --> F["Stored-query invocation\nomnigraph query name\nomnigraph mutate name"]
    D --> F

    G["cluster apply\n--config dir"] --> H["omnigraph-server\n--cluster dir|s3://"]
    H --> F
    H --> I["Serves N graphs\nunder /graphs/{id}/..."]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["docs(agents): fix the stale \`read --name..."](https://github.com/modernrelay/omnigraph/commit/7d69ca2f565ef99a5134287fce67a41bba533cf3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37836367)</sub>

<!-- /greptile_comment -->