### PR TITLE
docs(readme): make Common Commands cluster-first, not store-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,51 +78,50 @@ value.
 
 ## Common Commands
 
-Every command declares the **capability** it needs and how it's addressed.
-Direct storage (`init`, `load`, `branch`, …) takes a positional `file://`/`s3://`
-URI or `--store <uri>`; a served graph is addressed with `--server <name|url>`
-(never a positional `http(s)://` URI). `query`/`mutate` invoke a stored query
-**by name** (the positional is the query name, not a graph URI).
+A deployment is a **cluster**. A `cluster.yaml` declares its graphs, schemas,
+stored queries, and policies; you converge it with `cluster apply` and serve it.
+The server is cluster-first — it boots only from a cluster and serves every graph
+under `/graphs/{id}/…`. Day-to-day work goes through that server: graphs are
+addressed with `--server <name>` (+ `--graph <id>`), and `query`/`mutate` invoke
+a stored query from the catalog **by name**.
 
 ```bash
-# Create a graph and load data (--mode is required; overwrite is destructive)
-omnigraph init --schema ./schema.pg ./graph.omni
-omnigraph load --data ./data.jsonl --mode merge --store ./graph.omni
-
-# Read / write — ad-hoc .gq against a local store (positional selects the query)
-omnigraph query  --query ./queries.gq get_person    --params '{"name":"Alice"}' --store ./graph.omni
-omnigraph mutate --query ./queries.gq insert_person  --params '{"name":"Mina"}'  --store ./graph.omni
-
-# Branch and merge (Git-style, across the whole graph)
-omnigraph branch create --from main feature-x --store ./graph.omni
-omnigraph branch merge  feature-x --into main --store ./graph.omni
-
-# Against a running server: invoke a stored query by name from the catalog
-omnigraph query find_people --server prod --graph knowledge --params '{"q":"AI safety"}'
-```
-
-Operator settings (identity, named servers/clusters, credentials, defaults) live
-in `~/.omnigraph/config.yaml`; with a default scope set, the addressing flags can
-be omitted. See [docs/user/cli/index.md](docs/user/cli/index.md) and the
-[CLI reference](docs/user/cli/reference.md) for schema apply, snapshots, commits,
-profiles, and policy/queries tooling.
-
-## Serving (cluster-first)
-
-A deployment is a **cluster**: a `cluster.yaml` (graphs, schemas, stored queries,
-policies, storage) that you converge with `cluster apply`, then serve. The server
-boots from the cluster only — it has no single-graph mode — and serves every
-graph under `/graphs/{id}/…`.
-
-```bash
-omnigraph cluster apply  --config ./company-brain          # converge the declared state
+# 1. Converge the declared cluster, then serve it
+omnigraph cluster apply --config ./company-brain
 omnigraph-server --cluster ./company-brain --bind 0.0.0.0:8080
-# or config-free from object storage — the bucket IS the deployment:
-omnigraph-server --cluster s3://my-bucket/company-brain --bind 0.0.0.0:8080
+#    or config-free from object storage — the bucket IS the deployment:
+#    omnigraph-server --cluster s3://my-bucket/company-brain --bind 0.0.0.0:8080
+
+# 2. Work against the served graph — stored queries invoked by name
+omnigraph query  find_people --server prod --graph knowledge --params '{"q":"AI safety"}'
+omnigraph mutate add_person  --server prod --graph knowledge --params '{"name":"Mina"}'
+omnigraph load   --data ./data.jsonl --mode merge --server prod --graph knowledge
+
+# 3. Branch and merge, Git-style across the whole graph
+omnigraph branch create --from main review/2026-06 --server prod --graph knowledge
+omnigraph branch merge  review/2026-06 --into main --server prod --graph knowledge
 ```
 
-See the [cluster guide](docs/user/clusters/index.md) and
-[deployment guide](docs/user/deployment.md).
+Set a default scope (or a `--profile`) in `~/.omnigraph/config.yaml` — operator
+identity, named servers/clusters, credentials — and the `--server`/`--graph`
+flags drop away (`omnigraph query find_people --params …`).
+
+**Local / ad-hoc.** For quick iteration on a standalone graph (no cluster, no
+server), address storage directly with `--store` (or a positional `file://` /
+`s3://` URI) and run ad-hoc `.gq` with `--query` (the positional then selects
+which query in the file):
+
+```bash
+omnigraph init  --schema ./schema.pg ./graph.omni
+omnigraph load  --data ./data.jsonl --mode merge --store ./graph.omni
+omnigraph query --query ./queries.gq get_person --params '{"name":"Alice"}' --store ./graph.omni
+```
+
+See [docs/user/cli/index.md](docs/user/cli/index.md), the
+[CLI reference](docs/user/cli/reference.md), the
+[cluster guide](docs/user/clusters/index.md), and the
+[deployment guide](docs/user/deployment.md) for schema apply, snapshots, commits,
+profiles, and policy/queries tooling.
 
 ## Clients
 


### PR DESCRIPTION
Follow-up to #262. The Common Commands examples led with `--store ./graph.omni` for everything, which frames Omnigraph as a single-graph-file tool — contrary to the cluster-first paradigm.

Reframed so the everyday loop is the headline:
1. `cluster apply` → `omnigraph-server --cluster …` (the deployment is a cluster; config-free s3 boot noted).
2. Work against the **served** graph: `--server <name> --graph <id>`, stored queries invoked **by name**; `load`/`branch` over the server too.
3. Branch/merge across the whole graph.

`--store` is demoted to a clearly-secondary **Local / ad-hoc** note (standalone-graph iteration). The former separate "Serving" section folds into step 1, and a default `--profile`/scope drops the addressing flags.

All served examples verified against the binary to resolve correctly (`→ http://…/graphs/<id> (served)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR rewrites the "Common Commands" section of `README.md` to put the cluster-first deployment loop front-and-centre. Previously the section led with `--store ./graph.omni` examples, which framed Omnigraph as a single-graph-file tool; now it opens with `cluster apply` → `omnigraph-server` → daily work via `--server`/`--graph`, and folds the former "Serving" section into step 1.

- The cluster deploy-and-serve flow becomes the three-step headline; stored-query invocation by name is shown as the default query pattern against the live server.
- `--store` and ad-hoc `.gq` usage is demoted to a clearly-marked **Local / ad-hoc** sub-section with a brief explanation of when to use it.
- Links to the cluster guide and deployment guide are consolidated into a single "See also" paragraph at the end of the section.

<h3>Confidence Score: 4/5</h3>

Documentation-only change with no code modifications; safe to merge.

The reframing is accurate to the architecture and the cluster-first paradigm is well-supported by AGENTS.md. Two small rough edges: `cluster apply` omits `--as <actor>` that the cookbook reference consistently includes for all write operations (a user without an actor default would fail at step 1), and the intro prose quietly drops the `|url` form of `--server` that the CLI reference and cookbook still document. Neither blocks the PR but each makes a first-time reader's experience slightly worse than it could be.

README.md — the two command examples in the Common Commands section noted above.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Rewrites the "Common Commands" section to lead with the cluster-first deployment flow (apply → serve → work via --server/--graph) and demotes --store usage to a clearly-marked "Local / ad-hoc" sub-section; minor accuracy gaps around the omitted --as flag on cluster apply and the dropped |url variant in the --server description. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[cluster.yaml\ndeclares graphs, schemas,\nstored queries, policies] --> B[omnigraph cluster apply\n--config ./company-brain]
    B --> C[omnigraph-server\n--cluster ./company-brain\n--bind 0.0.0.0:8080]
    C --> D{Day-to-day work\nvia --server prod}
    D --> E[omnigraph query find_people\n--server prod --graph knowledge]
    D --> F[omnigraph mutate add_person\n--server prod --graph knowledge]
    D --> G[omnigraph load --data ...\n--server prod --graph knowledge]
    D --> H[omnigraph branch create/merge\n--server prod --graph knowledge]

    subgraph local[Local / ad-hoc only]
        I[omnigraph init --schema ./schema.pg ./graph.omni]
        J[omnigraph load --store ./graph.omni]
        K[omnigraph query --query ./queries.gq --store ./graph.omni]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[cluster.yaml\ndeclares graphs, schemas,\nstored queries, policies] --> B[omnigraph cluster apply\n--config ./company-brain]
    B --> C[omnigraph-server\n--cluster ./company-brain\n--bind 0.0.0.0:8080]
    C --> D{Day-to-day work\nvia --server prod}
    D --> E[omnigraph query find_people\n--server prod --graph knowledge]
    D --> F[omnigraph mutate add_person\n--server prod --graph knowledge]
    D --> G[omnigraph load --data ...\n--server prod --graph knowledge]
    D --> H[omnigraph branch create/merge\n--server prod --graph knowledge]

    subgraph local[Local / ad-hoc only]
        I[omnigraph init --schema ./schema.pg ./graph.omni]
        J[omnigraph load --store ./graph.omni]
        K[omnigraph query --query ./queries.gq --store ./graph.omni]
    end
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0AREADME.md%3A90-91%0A**Missing%20%60--as%20%3Cactor%3E%60%20on%20%60cluster%20apply%60**%0A%0AThe%20authoritative%20cluster%20control-plane%20reference%20in%20the%20cookbook%20consistently%20shows%20%60omnigraph%20cluster%20apply%20--config%20%3Cdir%3E%20--as%20%3Cactor%3E%60%20%28see%20%5B%60skills%2Fomnigraph-best-practices%2Freferences%2Fcommands.md%60%5D%28https%3A%2F%2Fgithub.com%2Fmodernrelay%2Fomnigraph-cookbooks%2Fblob%2FHEAD%2Fskills%2Fomnigraph-best-practices%2Freferences%2Fcommands.md%23cluster-control-plane-omnigraph--070%29%29%2C%20where%20%60--as%60%20is%20included%20on%20all%20write%20operations%20%28%60apply%60%2C%20%60approve%60%29%20but%20not%20on%20read-only%20ones%20%28%60validate%60%2C%20%60plan%60%2C%20%60status%60%29.%20A%20user%20whose%20operator%20config%20has%20no%20%60actor%60%20default%20set%20will%20hit%20an%20error%20here%20before%20ever%20seeing%20the%20rest%20of%20the%20quickstart.%20Even%20if%20%60--as%60%20defaults%20gracefully%2C%20making%20the%20example%20self-contained%20matches%20the%20rest%20of%20the%20ecosystem%20docs.%0A%0A%23%23%23%20Issue%202%20of%202%0AREADME.md%3A81-86%0A**%60--server%20%3Cname%7Curl%3E%60%20narrowed%20to%20%60--server%20%3Cname%3E%60%20in%20intro%20prose**%0A%0AThe%20old%20text%20and%20the%20authoritative%20addressing%20reference%20in%20the%20cookbook%20both%20document%20%60--server%20%3Cname%7Curl%3E%60%20%E2%80%94%20a%20literal%20%60http%28s%29%3A%2F%2F%60%20URL%20is%20also%20valid%20and%20commonly%20used%20in%20CI%20or%20when%20a%20named%20server%20entry%20hasn't%20been%20configured.%20Dropping%20the%20%60%7Curl%60%20variant%20from%20the%20introductory%20description%20may%20confuse%20readers%20who%20want%20to%20target%20a%20server%20by%20URL%20without%20setting%20up%20%60~%2F.omnigraph%2Fconfig.yaml%60%20first.%20The%20CLI%20reference%20still%20has%20the%20full%20form%2C%20but%20the%20README%20intro%20now%20mismatches%20it.%0A%0A&repo=modernrelay%2Fomnigraph&pr=263&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(readme): make Common Commands clust..."](https://github.com/modernrelay/omnigraph/commit/bb3935d85258e603311c2e4117cf56b6d762fab9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37839671)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->