### PR TITLE
docs(readme): widen --server to <name|url>; show --as on cluster apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,12 @@ A deployment is a **cluster**. A `cluster.yaml` declares its graphs, schemas,
 stored queries, and policies; you converge it with `cluster apply` and serve it.
 The server is cluster-first — it boots only from a cluster and serves every graph
 under `/graphs/{id}/…`. Day-to-day work goes through that server: graphs are
-addressed with `--server <name>` (+ `--graph <id>`), and `query`/`mutate` invoke
-a stored query from the catalog **by name**.
+addressed with `--server <name|url>` (+ `--graph <id>`), and `query`/`mutate`
+invoke a stored query from the catalog **by name**.
 
 ```bash
-# 1. Converge the declared cluster, then serve it
-omnigraph cluster apply --config ./company-brain
+# 1. Converge the declared cluster, then serve it (--as attributes the apply)
+omnigraph cluster apply --config ./company-brain --as you
 omnigraph-server --cluster ./company-brain --bind 0.0.0.0:8080
 #    or config-free from object storage — the bucket IS the deployment:
 #    omnigraph-server --cluster s3://my-bucket/company-brain --bind 0.0.0.0:8080


### PR DESCRIPTION
Two accuracy nits from the #263 review (vs. the cookbook's authoritative addressing reference): `--server <name|url>` (accepts a literal URL too, not just a name), and `cluster apply … --as <actor>` to make the control-plane attribution explicit. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This docs-only PR corrects two inaccuracies in the README's "Common Commands" section to align with the authoritative CLI reference and the cookbook's addressing guide.

- Widens `--server <name>` to `--server <name|url>` — confirmed by `docs/user/cli/reference.md` (lines 5, 36) and the cookbook's `commands.md`, which both note that `--server` accepts either an operator-defined name from `~/.omnigraph/config.yaml` or a literal `http(s)://` URL.
- Adds `--as you` to the `cluster apply` example — the cookbook's `cluster.md` uses `--as <you>` and notes that `--as <actor>` attributes sidecars, audit rows, and engine commits; the updated inline comment makes this behaviour discoverable.

<h3>Confidence Score: 5/5</h3>

Docs-only change; no code paths, schemas, or contracts are touched. Both edits are verified against the CLI reference and cookbook.

Both changes are accurate corrections: `--server <name|url>` matches `docs/user/cli/reference.md` exactly, and `cluster apply --as` is the pattern shown in the cookbook's authoritative loop. The only open question is whether to use angle-bracket notation for the placeholder — a style preference, not a correctness concern.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Two accuracy fixes in the "Common Commands" section: widened `--server <name>` to `--server <name|url>` to reflect URL support, and added `--as you` to the `cluster apply` example with an explanatory comment. Both changes match the authoritative CLI reference and cookbook. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Op as Operator
    participant CLI as omnigraph CLI
    participant Server as omnigraph-server

    Op->>CLI: cluster apply --config ./company-brain --as you
    CLI->>CLI: Converge cluster (graphs, schemas, queries, policies)
    CLI-->>Op: Apply complete (actor attributed)

    Op->>Server: omnigraph-server --cluster ./company-brain --bind 0.0.0.0:8080
    Server-->>Op: "Serving graphs under /graphs/{id}/..."

    Op->>CLI: query find_people --server prod --graph knowledge
    CLI->>Server: Invoke stored query by name (catalog lane)
    Server-->>Op: Results
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Op as Operator
    participant CLI as omnigraph CLI
    participant Server as omnigraph-server

    Op->>CLI: cluster apply --config ./company-brain --as you
    CLI->>CLI: Converge cluster (graphs, schemas, queries, policies)
    CLI-->>Op: Apply complete (actor attributed)

    Op->>Server: omnigraph-server --cluster ./company-brain --bind 0.0.0.0:8080
    Server-->>Op: "Serving graphs under /graphs/{id}/..."

    Op->>CLI: query find_people --server prod --graph knowledge
    CLI->>Server: Invoke stored query by name (catalog lane)
    Server-->>Op: Results
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A90%0AThe%20cookbook's%20authoritative%20loop%20example%20%28used%20as%20the%20reference%20for%20this%20PR%29%20writes%20the%20placeholder%20with%20angle%20brackets%3A%20%60--as%20%3Cyou%3E%60.%20Without%20them%2C%20%60you%60%20in%20a%20shell%20code%20block%20reads%20as%20a%20literal%20actor%20value%20rather%20than%20a%20stand-in%2C%20which%20could%20confuse%20readers%20who%20expect%20a%20format%20like%20%60act-alice%60.%20Using%20the%20angle-bracket%20form%20or%20a%20concrete%20example%20actor%20keeps%20this%20consistent%20with%20the%20cookbook.%0A%0A%60%60%60suggestion%0Aomnigraph%20cluster%20apply%20--config%20.%2Fcompany-brain%20--as%20%3Cyou%3E%0A%60%60%60%0A%0A&repo=modernrelay%2Fomnigraph&pr=264&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(readme): widen --server to &lt;name|ur..."](https://github.com/modernrelay/omnigraph/commit/262d73840ba13a46fedc6b1fc43bb80447e3450b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37840376)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->