### PR TITLE
test(cli): pass --yes in the S3 e2e overwrite load (RFC-011 Decision 9)

### DIFF
--- a/crates/omnigraph-cli/tests/system_local.rs
+++ b/crates/omnigraph-cli/tests/system_local.rs
@@ -640,6 +640,10 @@ fn local_cli_s3_end_to_end_init_load_read_flow() {
             .arg("load")
             .arg("--mode")
             .arg("overwrite")
+            // `--yes` clears the RFC-011 Decision 9 destructive-write
+            // confirmation: `--mode overwrite` against a non-local (s3://)
+            // target is refused without it.
+            .arg("--yes")
             .arg("--data")
             .arg(fixture("test.jsonl"))
             .arg(&graph_uri),


### PR DESCRIPTION
## What

The `RustFS S3 Integration` CI job was red — turning the CI badge red — on
`local_cli_s3_end_to_end_init_load_read_flow`. The test runs
`load --mode overwrite` against an `s3://` target, which the RFC-011 Decision 9
destructive-write guard now correctly refuses without `--yes`:

```
refusing destructive `load --mode overwrite` against non-local target s3://… without confirmation; pass --yes to confirm
```

## Why it slipped through

The guard is intended and already covered by `cli_data.rs`. This S3 e2e test only
runs in the bucket-gated `RustFS S3 Integration` job (not the default
`cargo test --workspace` gate), so the missing `--yes` wasn't caught when the
guard landed. The default workspace gate stays green because the S3 test skips
without `OMNIGRAPH_S3_TEST_BUCKET`.

## Fix

Add `--yes` to the overwrite load, matching the established pattern used by the
other overwrite-against-non-local tests in `system_local.rs` (~L1305, ~L1331).
No product change — test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `--yes` to the `load --mode overwrite` call in `local_cli_s3_end_to_end_init_load_read_flow` so that the RFC-011 Decision 9 destructive-write guard accepts the command when targeting an `s3://` URI. This is a test-only fix with no product logic change.

- The guard correctly rejects `--mode overwrite` against non-local targets unless `--yes` is supplied; the S3 e2e test was missing that flag and only ran in the bucket-gated `RustFS S3 Integration` job, so the default workspace gate stayed green while the badge job turned red.
- All other `overwrite` invocations in the file are either against local paths (guard does not fire) or against `--server` targets that already carry `--yes` (L1312, L1336); no further sites need updating.

<h3>Confidence Score: 5/5</h3>

Single-line test fix in a bucket-gated integration test; no product code is changed, and the added flag is the established pattern throughout the file.

The change is one .arg("--yes") in a test that only runs in the CI bucket-gated job. All other overwrite call sites in the file were checked: those against local paths correctly omit --yes, and the two --server-based overwrite calls already carry it. There is nothing here that could affect production behavior.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/omnigraph-cli/tests/system_local.rs | Adds `--yes` to the overwrite load command in the S3 e2e test, satisfying the RFC-011 Decision 9 destructive-write guard for non-local targets; matches the identical pattern already used at L1312 and L1336. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test as local_cli_s3_end_to_end_init_load_read_flow
    participant CLI as omnigraph CLI
    participant Guard as RFC-011 Decision 9 Guard
    participant S3 as s3:// target

    Test->>CLI: load --mode overwrite --yes --data test.jsonl s3://…
    CLI->>Guard: check destructive write on non-local target
    Guard-->>CLI: --yes present → confirmed
    CLI->>S3: write (overwrite)
    S3-->>CLI: success
    CLI-->>Test: exit 0
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test as local_cli_s3_end_to_end_init_load_read_flow
    participant CLI as omnigraph CLI
    participant Guard as RFC-011 Decision 9 Guard
    participant S3 as s3:// target

    Test->>CLI: load --mode overwrite --yes --data test.jsonl s3://…
    CLI->>Guard: check destructive write on non-local target
    Guard-->>CLI: --yes present → confirmed
    CLI->>S3: write (overwrite)
    S3-->>CLI: success
    CLI-->>Test: exit 0
```

</a>

<sub>Reviews (1): Last reviewed commit: ["test(cli): pass --yes in the S3 e2e over..."](https://github.com/modernrelay/omnigraph/commit/242509e624f5bd6d8d9f1bccdb708fe3c5898ffa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37846319)</sub>

<!-- /greptile_comment -->