### PR TITLE
docs(readme): embedded quick-start run-through + trimmed Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,15 @@ omnigraph branch create --from main review/new-hires --store ./graph.omni
 omnigraph branch merge  review/new-hires --into main --store ./graph.omni
 ```
 
-**Storage backends** — the same flow runs on any backend; change only the graph address:
+**Storage backends** — the same flow runs on any backend; only the graph address changes:
 
-| Backend | Use it for | Address |
+| Backend | Use it for | Graph address |
 |---|---|---|
-| **Embedded** (local filesystem) | dev, demos, single machine — the default | `--store ./graph.omni` |
-| **Object storage** (AWS S3, R2, GCS-S3) | shared, multi-host, durable | `--store s3://bucket/graph.omni` + the `AWS_*` env |
+| **Embedded** (local filesystem) | dev, demos, single machine — the default | `./graph.omni` |
+| **Object storage** (AWS S3, R2, GCS-S3) | shared, multi-host, durable | `s3://bucket/graph.omni` (+ the `AWS_*` env) |
 | **RustFS / MinIO** | rehearse the S3 path locally, no cloud account | `s3://…` against a local endpoint → [deployment guide](docs/user/deployment.md#testing-against-s3-locally) |
+
+`init` takes the address as its positional argument (`omnigraph init --schema schema.pg <address>`); `load`, `query`, and `branch` take it via `--store <address>`.
 
 For a **served, multi-graph deployment** (the cluster model), see [Common Commands](#common-commands) below.
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,43 @@ brew tap ModernRelay/tap
 brew install ModernRelay/tap/omnigraph
 ```
 
+## Quick start
+
+The fastest path is an **embedded, local file-backed graph** — no server, no
+object store, no Docker:
+
+```bash
+# A schema and one row of data
+cat > schema.pg <<'PG'
+node Person {
+  slug: String @key
+  name: String
+  title: String?
+}
+PG
+echo '{"type":"Person","data":{"slug":"alice","name":"Alice","title":"Engineer"}}' > people.jsonl
+
+# Create → load (--mode is required) → query
+omnigraph init  --schema schema.pg ./graph.omni
+omnigraph load  --data people.jsonl --mode overwrite --store ./graph.omni
+omnigraph query find_people --store ./graph.omni --params '{"t":"Engineer"}' \
+  -e 'query find_people($t: String) { match { $p: Person { title: $t } } return { $p.name } }'
+
+# Branch, write in isolation, merge — Git-style across the whole graph
+omnigraph branch create --from main review/new-hires --store ./graph.omni
+omnigraph branch merge  review/new-hires --into main --store ./graph.omni
+```
+
+**Storage backends** — the same flow runs on any backend; change only the graph address:
+
+| Backend | Use it for | Address |
+|---|---|---|
+| **Embedded** (local filesystem) | dev, demos, single machine — the default | `--store ./graph.omni` |
+| **Object storage** (AWS S3, R2, GCS-S3) | shared, multi-host, durable | `--store s3://bucket/graph.omni` + the `AWS_*` env |
+| **RustFS / MinIO** | rehearse the S3 path locally, no cloud account | `s3://…` against a local endpoint → [deployment guide](docs/user/deployment.md#testing-against-s3-locally) |
+
+For a **served, multi-graph deployment** (the cluster model), see [Common Commands](#common-commands) below.
+
 ## Set it up with an AI agent
 
 Omnigraph is built to be set up by coding agents. Paste this into Claude Code,
@@ -143,19 +180,8 @@ profiles, and policy/queries tooling.
 
 For programmatic access to a running `omnigraph-server`:
 
-- **TypeScript SDK** — [`@modernrelay/omnigraph`](https://www.npmjs.com/package/@modernrelay/omnigraph) ([source](https://github.com/ModernRelay/omnigraph-ts/tree/main/packages/sdk)). Instance-per-client, typed errors, camelCase types, async-iterator streaming export.
-
-  ```bash
-  npm install @modernrelay/omnigraph
-  ```
-
-- **Model Context Protocol server** — [`@modernrelay/omnigraph-mcp`](https://www.npmjs.com/package/@modernrelay/omnigraph-mcp) ([source](https://github.com/ModernRelay/omnigraph-ts/tree/main/packages/mcp)). Bridges Omnigraph to LLM hosts (Claude Desktop, Claude Code, …) over stdio. Exposes tools and resources for schema, branches, queries, mutations, ingest, and bundles curated best-practices guidance from the cookbook.
-
-  ```bash
-  npm install -g @modernrelay/omnigraph-mcp
-  ```
-
-Both packages are versioned in lockstep with `omnigraph-server` on major.minor: `@modernrelay/omnigraph@X.Y.*` targets `omnigraph-server@X.Y.*`. See [`ModernRelay/omnigraph-ts`](https://github.com/ModernRelay/omnigraph-ts) for the monorepo.
+- **TypeScript SDK + MCP server** — [`@modernrelay/omnigraph`](https://www.npmjs.com/package/@modernrelay/omnigraph) and [`@modernrelay/omnigraph-mcp`](https://www.npmjs.com/package/@modernrelay/omnigraph-mcp), versioned in lockstep with `omnigraph-server`. Source, docs, and examples: [`ModernRelay/omnigraph-ts`](https://github.com/ModernRelay/omnigraph-ts).
+- **Python SDK** — coming soon.
 
 ## Docs
 

--- a/docs/user/quickstart.md
+++ b/docs/user/quickstart.md
@@ -12,8 +12,8 @@ A schema (`.pg`) declares your node and edge types. Save this as `schema.pg`:
 
 ```
 node Person {
-  name: String,
-  title: String?,
+  name: String
+  title: String?
 }
 ```
 


### PR DESCRIPTION
Two README follow-ups requested after #257 merged.

## Quick start (new)
A copy-pasteable **embedded, local file-backed** run-through (schema → init → load → query → branch) — no server, no object store, no Docker. It's followed by a **Storage backends** table that shows the one thing that changes across the options:

| Backend | Use it for | Address |
|---|---|---|
| Embedded (local filesystem) | dev, demos, single machine — default | `--store ./graph.omni` |
| Object storage (S3/R2/GCS-S3) | shared, multi-host, durable | `--store s3://bucket/graph.omni` + `AWS_*` |
| RustFS / MinIO | rehearse S3 locally, no cloud account | `s3://…` at a local endpoint → deployment guide |

…with a pointer to **Common Commands** for the served, multi-graph cluster model. This is how I'd display "embedded vs object storage vs RustFS": one run-through, one address column — the commands don't change, only the address does.

## Clients (trimmed)
Collapsed from the long per-package writeup to a two-line pointer: the npm packages (`@modernrelay/omnigraph` + `-mcp`) and the [`omnigraph-ts`](https://github.com/ModernRelay/omnigraph-ts) repo for source/docs. **Python SDK — coming soon.**

Docs-only; addresses are verified against the 0.7.0 CLI (`--store` works for init/load/query/branch).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact; the quickstart schema fix reduces copy-paste parse failures.
> 
> **Overview**
> Adds a **Quick start** section to the README with a copy-paste embedded workflow (schema → `init` → `load` → inline `query` → branch create/merge), plus a **Storage backends** table and notes on how graph addresses differ for embedded vs S3 vs local S3-compatible endpoints, with a link to **Common Commands** for cluster deployments.
> 
> **Clients** is shortened to bullet pointers for the TypeScript SDK/MCP packages and the `omnigraph-ts` repo, and adds **Python SDK — coming soon.**
> 
> **`docs/user/quickstart.md`** drops invalid trailing commas in the sample `Person` schema so it matches the parser (aligned with the README example style).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33aebaf65614b1b5786a730218f37268086e96d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a copy-pasteable embedded quick-start block to the README (schema → `init` → `load` → inline `query` → `branch create`/`merge`) with a storage-backends table, and also fixes a trailing-comma parse error in `docs/user/quickstart.md` that was flagged in a prior review.

- **README.md** — new Quick start section using `--store ./graph.omni`, followed by a backend comparison table (embedded / S3 / RustFS-MinIO) and a pointer to Common Commands for cluster deployments; Clients section condensed to a two-line pointer.
- **docs/user/quickstart.md** — removes trailing commas from `name: String,` / `title: String?,` so the schema parses correctly against the `.pg` grammar.

<h3>Confidence Score: 5/5</h3>

Documentation-only changes with no runtime or API impact; safe to merge.

Both files are purely documentation. The schema comma fix in quickstart.md corrects a pre-existing parse error. The README additions are accurate against the 0.7.0 CLI surface, with one minor footnote that slightly overstates the constraint on load and branch addressing — a prose clarification, not a breakage.

README.md line 90 — the addressing footnote could mislead users comparing it against quickstart.md examples.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Adds embedded Quick start section (schema → init → load → inline query → branch) and a storage-backend table; trims Clients to a two-liner. One footnote overstates --store as the only addressing mechanism for load and branch, creating a contradiction with quickstart.md. |
| docs/user/quickstart.md | Removes trailing commas from schema property declarations, fixing a parse error reported in prior review; no other changes. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Write schema.pg] --> B[omnigraph init --schema schema.pg ./graph.omni]
    B --> C[omnigraph load --data people.jsonl --mode overwrite --store ./graph.omni]
    C --> D[omnigraph query find_people -e '...' --store ./graph.omni]
    D --> E[omnigraph branch create --from main review/new-hires --store ./graph.omni]
    E --> F[omnigraph branch merge review/new-hires --into main --store ./graph.omni]

    subgraph Backends [Storage backends — only the address changes]
        G["Embedded: ./graph.omni"]
        H["Object storage: s3://bucket/graph.omni"]
        I["RustFS/MinIO: s3://… local endpoint"]
    end

    B -.->|swap address| Backends
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Write schema.pg] --> B[omnigraph init --schema schema.pg ./graph.omni]
    B --> C[omnigraph load --data people.jsonl --mode overwrite --store ./graph.omni]
    C --> D[omnigraph query find_people -e '...' --store ./graph.omni]
    D --> E[omnigraph branch create --from main review/new-hires --store ./graph.omni]
    E --> F[omnigraph branch merge review/new-hires --into main --store ./graph.omni]

    subgraph Backends [Storage backends — only the address changes]
        G["Embedded: ./graph.omni"]
        H["Object storage: s3://bucket/graph.omni"]
        I["RustFS/MinIO: s3://… local endpoint"]
    end

    B -.->|swap address| Backends
```

</a>

<sub>Reviews (2): Last reviewed commit: ["docs(readme,quickstart): fix init addres..."](https://github.com/modernrelay/omnigraph/commit/33aebaf65614b1b5786a730218f37268086e96d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37854359)</sub>

<!-- /greptile_comment -->