### PR TITLE
docs(readme): remove CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-stable-orange.svg)](rust-toolchain.toml)
 [![Crates.io](https://img.shields.io/crates/v/omnigraph-cli.svg)](https://crates.io/crates/omnigraph-cli)
-[![CI](https://github.com/ModernRelay/omnigraph/actions/workflows/ci.yml/badge.svg)](https://github.com/ModernRelay/omnigraph/actions/workflows/ci.yml)
 
 **Lakehouse native graph engine built for context assembly**
 


### PR DESCRIPTION
Removes the CI status badge from the README header.

The badge had been reading "failing" mostly from concurrency-cancelled runs
(rapid doc pushes cancel in-flight runs, which report as `cancelled`) plus a
now-fixed S3-job break (#265) — not from a broken default branch. It's been
more noise than signal. CI health remains visible on the Actions tab.

License, Rust, and Crates.io badges are kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the CI status badge from `README.md`. The badge had been displaying "failing" due to cancelled runs from rapid doc pushes and a now-fixed S3 job issue (#265), making it misleading noise rather than a useful signal.

- The single removed line is the GitHub Actions CI badge; the License, Rust, and Crates.io badges are all preserved.
- No code, configuration, or functional behavior is changed.

<h3>Confidence Score: 5/5</h3>

Removes a single markdown badge line with no functional impact; safe to merge.

The change touches only one line in README.md, removing an auto-generated markdown image link. Nothing runnable, configurable, or testable is affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Removes the CI status badge line; no functional code changes. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[README.md badges] --> B[License: MIT badge kept]
    A --> C[Rust stable badge kept]
    A --> D[Crates.io badge kept]
    A --> E[CI status badge removed]
    E --> F[Was showing failing due to cancelled runs & S3 job break]
    F --> G[CI health still visible on GitHub Actions tab]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[README.md badges] --> B[License: MIT badge kept]
    A --> C[Rust stable badge kept]
    A --> D[Crates.io badge kept]
    A --> E[CI status badge removed]
    E --> F[Was showing failing due to cancelled runs & S3 job break]
    F --> G[CI health still visible on GitHub Actions tab]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["docs(readme): remove CI status badge"](https://github.com/modernrelay/omnigraph/commit/2cffea627e7f25353df79d68d2cbf38794772c15) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37858057)</sub>

<!-- /greptile_comment -->