### PR TITLE
docs(readme): one sentence per line in the intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,11 @@
 [![Rust](https://img.shields.io/badge/rust-stable-orange.svg)](rust-toolchain.toml)
 [![Crates.io](https://img.shields.io/crates/v/omnigraph-cli.svg)](https://crates.io/crates/omnigraph-cli)
 
-**Lakehouse graph db for context assembly & multi-agent coordination**
+**Lakehouse graph db for context assembly & multi-agent coordination**\
 Multimodal retrieval, Git-style branching, object storage-native
 
-Omnigraph is the operational state and coordination layer for fleets of agents.
-Run it as a server, declared as code; hundreds of agents operate and enrich the graph on
-parallel isolated branches, and every change is reviewed and merged safely.
+Omnigraph is the operational state and coordination layer for fleets of agents.\
+Run it as a server, declared as code; hundreds of agents operate and enrich the graph on parallel isolated branches, and every change is reviewed and merged safely.
 
 ## Key capabilities
 


### PR DESCRIPTION
The headline/subhead and the two intro sentences were rendering as run-on text
(markdown joins adjacent source lines). Add hard line breaks so each lands on
its own line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds CommonMark hard line breaks (`\`) to the README intro so the headline/subhead and the two opening sentences render on separate lines instead of collapsing into run-on text.

- Appends `\` to the bold headline so the subhead ("Multimodal retrieval, Git-style branching, object storage-native") renders on its own line below it.
- Appends `\` to the end of the first intro sentence and joins the previously split second sentence onto a single source line, so both sentences land on distinct visual lines when rendered on GitHub.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only whitespace/formatting changes to the README intro, no code or logic touched.

The change is two trailing backslashes added to README.md. No source code, configuration, tests, or docs links are modified, and the hard line breaks render correctly in CommonMark/GitHub Flavored Markdown.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Two hard line breaks added to the intro block; no content changes, no broken links, and no other sections touched. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["README source\n(before)"] -->|"adjacent lines\njoined by GFM"| B["Run-on rendered text\n(headline + subhead merged;\ntwo sentences merged)"]
    C["README source\n(after)"] -->|"trailing backslash\nhard break"| D["Headline\nSubhead on its own line"]
    C -->|"trailing backslash\nhard break"| E["Sentence 1\nSentence 2 on its own line"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["README source\n(before)"] -->|"adjacent lines\njoined by GFM"| B["Run-on rendered text\n(headline + subhead merged;\ntwo sentences merged)"]
    C["README source\n(after)"] -->|"trailing backslash\nhard break"| D["Headline\nSubhead on its own line"]
    C -->|"trailing backslash\nhard break"| E["Sentence 1\nSentence 2 on its own line"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["docs(readme): one sentence per line in t..."](https://github.com/modernrelay/omnigraph/commit/2b0565621a34bb6b1d4d8a502e7f77b55984d95a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38008836)</sub>

<!-- /greptile_comment -->