### PR TITLE
docs(releases): add 0_7_essence.md (core points of 0.7)

### DIFF
--- a/docs/releases/0_7_essence.md
+++ b/docs/releases/0_7_essence.md
@@ -1,0 +1,54 @@
+# Omnigraph 0.7 — Essence
+
+The core points of the 0.7 release. Full notes: [v0.7.0.md](v0.7.0.md).
+
+**In one line:** 0.7 makes Omnigraph a **cluster-first server**. A deployment is a
+declarative cluster on your own object storage, config collapses to two
+single-owner surfaces, the CLI is unified and capability-aware, and
+`omnigraph.yaml` is gone.
+
+## Five core changes
+
+1. **Cluster-only server.** `omnigraph-server` boots only from
+   `--cluster <dir | s3://bucket/prefix>` and serves every graph under
+   `/graphs/{id}/…`. No positional-URI boot, no single-graph flat mode. A cluster
+   can live entirely on object storage (`storage:` in `cluster.yaml`), so a
+   serving box needs only the bucket URI plus credentials (config-free).
+
+2. **Config is two single-owner surfaces.** The team owns `cluster.yaml` (graphs,
+   schemas, stored queries, policies); each operator owns
+   `~/.omnigraph/config.yaml` (identity, named servers, aliases, defaults).
+   Credentials live in `~/.omnigraph/credentials`, never in a config file.
+   **`omnigraph.yaml` is removed** and is read by neither the CLI nor the server.
+
+3. **Unified, capability-aware CLI.** One bulk-write command, `omnigraph load`,
+   with a required `--mode merge|append|overwrite`. Honest addressing via
+   `--store` / `--server` / `--cluster` / `--profile` / `--graph` (a remote is
+   reached only with `--server`). Stored queries and mutations are invoked **by
+   name**; operator aliases get their own namespace (`omnigraph alias <name>`);
+   destructive writes against a non-local target require `--yes`.
+
+4. **Engine & substrate.** Lance 6.0.1 → 7.0.0; indexed graph traversal; index
+   materialization as derived state (`schema apply` records intent, `optimize`
+   reconciles); recovery heals on the next write rather than only at restart;
+   composite `@unique(a, b)` enforced as a true key.
+
+5. **Provider-independent embeddings.** One embedding client behind a sealed
+   provider enum (OpenAI-compatible / native Gemini / mock), defaulting to
+   **OpenRouter**. `@embed("source", model="…")` records the embedding identity,
+   and a query whose resolved model differs from the recorded one is rejected
+   (no silent cross-space ranking).
+
+## Must-know breaking changes
+
+- **`omnigraph.yaml` is removed.** No migrate command; recreate config as a team
+  `cluster.yaml` plus a per-operator `~/.omnigraph/config.yaml`.
+- **`omnigraph-server` requires `--cluster`.** No positional-URI / single-graph boot.
+- **Default embedding provider flips to OpenRouter.** Gemini-direct users set
+  `OMNIGRAPH_EMBED_PROVIDER=gemini`.
+- **`query --alias` is removed** in favor of `omnigraph alias <name>`.
+- **`query`/`mutate` positional is a stored-query *name*,** not a graph URI;
+  `--target`, the positional `http(s)://` → remote dispatch, and `--as` on served
+  writes are gone.
+- **`omnigraph load` `--mode` is required**, `omnigraph ingest` is deprecated, and
+  loading into a missing branch errors without `--from`.

--- a/docs/releases/0_7_essence.md
+++ b/docs/releases/0_7_essence.md
@@ -1,54 +1,23 @@
-# Omnigraph 0.7 — Essence
+:rocket: *Omnigraph 0.7: the essence*
 
-The core points of the 0.7 release. Full notes: [v0.7.0.md](v0.7.0.md).
+0.7 makes Omnigraph a *cluster-first server*. A deployment is a declarative cluster on your own object storage, config collapses to two single-owner surfaces, the CLI is unified, and `omnigraph.yaml` is gone.
 
-**In one line:** 0.7 makes Omnigraph a **cluster-first server**. A deployment is a
-declarative cluster on your own object storage, config collapses to two
-single-owner surfaces, the CLI is unified and capability-aware, and
-`omnigraph.yaml` is gone.
+*Five core changes*
 
-## Five core changes
+1. *Cluster-only server.* `omnigraph-server` boots only from `--cluster <dir | s3://bucket/prefix>` and serves every graph under `/graphs/{id}/…`. A cluster can live entirely on object storage, so a serving box needs only the bucket URI + credentials (config-free).
 
-1. **Cluster-only server.** `omnigraph-server` boots only from
-   `--cluster <dir | s3://bucket/prefix>` and serves every graph under
-   `/graphs/{id}/…`. No positional-URI boot, no single-graph flat mode. A cluster
-   can live entirely on object storage (`storage:` in `cluster.yaml`), so a
-   serving box needs only the bucket URI plus credentials (config-free).
+2. *Config = two single-owner surfaces.* The team owns `cluster.yaml` (graphs, schemas, stored queries, policies); each operator owns `~/.omnigraph/config.yaml` (identity, named servers, aliases, defaults). Credentials live in `~/.omnigraph/credentials`, never in a config file. `omnigraph.yaml` is removed.
 
-2. **Config is two single-owner surfaces.** The team owns `cluster.yaml` (graphs,
-   schemas, stored queries, policies); each operator owns
-   `~/.omnigraph/config.yaml` (identity, named servers, aliases, defaults).
-   Credentials live in `~/.omnigraph/credentials`, never in a config file.
-   **`omnigraph.yaml` is removed** and is read by neither the CLI nor the server.
+3. *Unified, capability-aware CLI.* One bulk-write command `omnigraph load` (required `--mode merge|append|overwrite`); address via `--store` / `--server` / `--cluster` / `--profile` / `--graph` (a remote is reached only with `--server`); stored queries run by name; operator aliases via `omnigraph alias <name>`; destructive non-local writes require `--yes`.
 
-3. **Unified, capability-aware CLI.** One bulk-write command, `omnigraph load`,
-   with a required `--mode merge|append|overwrite`. Honest addressing via
-   `--store` / `--server` / `--cluster` / `--profile` / `--graph` (a remote is
-   reached only with `--server`). Stored queries and mutations are invoked **by
-   name**; operator aliases get their own namespace (`omnigraph alias <name>`);
-   destructive writes against a non-local target require `--yes`.
+4. *Engine & substrate.* Lance 6.0.1 → 7.0.0, indexed graph traversal, index materialization as derived state (`schema apply` records intent, `optimize` reconciles), recovery heals on the next write (not just at restart), composite `@unique(a, b)` as a true key.
 
-4. **Engine & substrate.** Lance 6.0.1 → 7.0.0; indexed graph traversal; index
-   materialization as derived state (`schema apply` records intent, `optimize`
-   reconciles); recovery heals on the next write rather than only at restart;
-   composite `@unique(a, b)` enforced as a true key.
+5. *Provider-independent embeddings.* One client behind a sealed provider enum (OpenAI-compatible / native Gemini / mock), default OpenRouter. `@embed("source", model="…")` records the embedding identity; a query whose model differs is rejected (no silent cross-space ranking).
 
-5. **Provider-independent embeddings.** One embedding client behind a sealed
-   provider enum (OpenAI-compatible / native Gemini / mock), defaulting to
-   **OpenRouter**. `@embed("source", model="…")` records the embedding identity,
-   and a query whose resolved model differs from the recorded one is rejected
-   (no silent cross-space ranking).
-
-## Must-know breaking changes
-
-- **`omnigraph.yaml` is removed.** No migrate command; recreate config as a team
-  `cluster.yaml` plus a per-operator `~/.omnigraph/config.yaml`.
-- **`omnigraph-server` requires `--cluster`.** No positional-URI / single-graph boot.
-- **Default embedding provider flips to OpenRouter.** Gemini-direct users set
-  `OMNIGRAPH_EMBED_PROVIDER=gemini`.
-- **`query --alias` is removed** in favor of `omnigraph alias <name>`.
-- **`query`/`mutate` positional is a stored-query *name*,** not a graph URI;
-  `--target`, the positional `http(s)://` → remote dispatch, and `--as` on served
-  writes are gone.
-- **`omnigraph load` `--mode` is required**, `omnigraph ingest` is deprecated, and
-  loading into a missing branch errors without `--from`.
+*Must-know breaking changes*
+• `omnigraph.yaml` removed (no migrate command; use `cluster.yaml` + `~/.omnigraph/config.yaml`)
+• `omnigraph-server` requires `--cluster` (no positional-URI / single-graph boot)
+• default embedding provider flips to OpenRouter (Gemini-direct users: `OMNIGRAPH_EMBED_PROVIDER=gemini`)
+• `query --alias` removed → `omnigraph alias <name>`
+• `query` / `mutate` positional is a stored-query name, not a graph URI; `--target` and positional `http(s)://`→remote are gone
+• `omnigraph load` needs `--mode`; `ingest` deprecated; loading a missing branch errors without `--from`


### PR DESCRIPTION
A one-page distillation of the 0.7 release for quick reference, alongside the
full `v0.7.0.md`:

- Cluster-only server (boots only from `--cluster`, clusters on object storage)
- Config = two single-owner surfaces (`cluster.yaml` + `~/.omnigraph/config.yaml`); `omnigraph.yaml` removed
- Unified, capability-aware CLI (one `load`, honest addressing, stored-query-by-name, aliases, `--yes`)
- Engine & substrate (Lance 7, indexed traversal, derived-state indexes, recovery liveness, composite `@unique`)
- Provider-independent embeddings (OpenRouter default, same-space guarantee)
- Must-know breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `docs/releases/0_7_essence.md`, a one-page quick-reference distillation of the v0.7.0 release that sits alongside the full `v0.7.0.md`. The content is accurate and well-structured against the canonical release notes.

- **Five core changes covered**: cluster-only server, two-surface config (`cluster.yaml` + `~/.omnigraph/config.yaml`), unified capability-aware CLI, Lance 7 engine/substrate improvements, and provider-independent embeddings — all checked against `v0.7.0.md` and `AGENTS.md` with no factual errors found.
- **Breaking changes list**: correctly captures six of the most impactful removals (`omnigraph.yaml`, positional-URI boot, OpenRouter default, `query --alias`, positional graph URI, `--mode` requirement), but omits the `--yes` requirement for non-interactive destructive writes, which `v0.7.0.md` explicitly flags as a breaking change for CI scripts.

<h3>Confidence Score: 5/5</h3>

Documentation-only addition; no code paths, APIs, or on-disk formats are touched. Safe to merge after addressing the missing breaking-change bullet.

The change is a single new markdown file that accurately summarises the v0.7.0 release against both v0.7.0.md and AGENTS.md. All five core changes and the majority of must-know breaking changes are correctly stated; the one gap (the --yes requirement for CI scripts doing non-interactive destructive writes) is an omission in a summary doc, not a wrong statement, and the full details exist in the canonical v0.7.0.md.

docs/releases/0_7_essence.md — the must-know breaking changes list should include the --yes requirement for non-interactive destructive writes.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/releases/0_7_essence.md | New companion summary doc for the v0.7.0 release; all five core changes and most breaking changes accurately reflect the canonical v0.7.0.md. The `--yes` requirement for non-interactive destructive writes is noted as a feature in item 3 but omitted from the must-know breaking changes list. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[omnigraph CLI verb] --> B{Capability declared?}
    B --> C[any]
    B --> D[served]
    B --> E[direct]
    B --> F[control]
    B --> G[local]

    C --> H["--store / --server / --cluster / --profile"]
    D --> I["--server (+ --graph for multi-graph)"]
    E --> J["--store s3://… or file://…"]
    F --> K["--cluster dir | s3://…"]
    G --> L["No graph address needed"]

    I --> M[HTTP dispatch via GraphClient]
    J --> N[Embedded engine direct storage]
    H --> M
    H --> N

    M --> O{Destructive + non-local?}
    N --> O
    O -- "interactive TTY" --> P[Prompt user]
    O -- "non-TTY / --json" --> Q{--yes passed?}
    Q -- yes --> R[Execute]
    Q -- no --> S[Refuse]
    P -- confirmed --> R
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[omnigraph CLI verb] --> B{Capability declared?}
    B --> C[any]
    B --> D[served]
    B --> E[direct]
    B --> F[control]
    B --> G[local]

    C --> H["--store / --server / --cluster / --profile"]
    D --> I["--server (+ --graph for multi-graph)"]
    E --> J["--store s3://… or file://…"]
    F --> K["--cluster dir | s3://…"]
    G --> L["No graph address needed"]

    I --> M[HTTP dispatch via GraphClient]
    J --> N[Embedded engine direct storage]
    H --> M
    H --> N

    M --> O{Destructive + non-local?}
    N --> O
    O -- "interactive TTY" --> P[Prompt user]
    O -- "non-TTY / --json" --> Q{--yes passed?}
    Q -- yes --> R[Execute]
    Q -- no --> S[Refuse]
    P -- confirmed --> R
```

</a>

<sub>Reviews (2): Last reviewed commit: ["docs(releases): 0\_7\_essence as a Slack-p..."](https://github.com/modernrelay/omnigraph/commit/884338475da6dd65d36d42224528cca2ea7767c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38181334)</sub>

<!-- /greptile_comment -->