### PR TITLE
test(engine): pin camelCase @index → scalar-index routing (#283 follow-up)

### DIFF
--- a/crates/omnigraph/tests/lance_surface_guards.rs
+++ b/crates/omnigraph/tests/lance_surface_guards.rs
@@ -991,3 +991,80 @@ async fn unenforced_primary_key_is_immutable_once_set() {
          — revisit migrate_v1_to_v2's field-guard and re-pin docs/dev/lance.md."
     );
 }
+
+// --- Guard 20: camelCase @index equality routes to the scalar index (#283) ----
+//
+// The #283 read-pushdown fix builds the filter column with datafusion `ident()`
+// (case-preserving) instead of `col()` (SQL identifier normalization, which
+// lowercases an unquoted name). The correctness tests in literal_filters.rs /
+// writes.rs prove the right rows come back, but a result-only assertion also
+// passes on a full-scan fallback — exactly the gap testing.md warns about. This
+// guard pins the *plan*: an equality on a camelCase BTREE column must compile to
+// a `ScalarIndexQuery` under the fix's expr shape, and must NOT under the old
+// `col()` shape (which lowercases `repoName` → a nonexistent `reponame`). A
+// regression that breaks camelCase index routing — or a revert to `col()` —
+// turns this red instead of silently degrading to a full scan.
+#[tokio::test]
+async fn camelcase_index_equality_routes_to_scalar_index() {
+    use datafusion::physical_plan::displayable;
+    use datafusion::prelude::{col, ident, lit};
+
+    let dir = tempfile::tempdir().unwrap();
+    let uri = dir.path().join("camelcase_index.lance");
+    let uri = uri.to_str().unwrap();
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("repoName", DataType::Utf8, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(StringArray::from(vec!["a", "b", "c", "d"])),
+            Arc::new(StringArray::from(vec![
+                "acme", "globex", "initech", "umbrella",
+            ])),
+        ],
+    )
+    .unwrap();
+    let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+    let params = WriteParams {
+        mode: WriteMode::Create,
+        enable_stable_row_ids: true,
+        data_storage_version: Some(LanceFileVersion::V2_2),
+        ..Default::default()
+    };
+    let mut ds = Dataset::write(reader, uri, Some(params)).await.unwrap();
+    ds.create_index_builder(&["repoName"], IndexType::BTree, &ScalarIndexParams::default())
+        .replace(true)
+        .await
+        .unwrap();
+
+    async fn plan_str(ds: &Dataset, filter: datafusion::prelude::Expr) -> lance::Result<String> {
+        let mut scanner = ds.scan();
+        scanner.filter_expr(filter);
+        let plan = scanner.create_plan().await?;
+        Ok(format!("{}", displayable(plan.as_ref()).indent(true)))
+    }
+
+    // The fix's shape: ident() preserves case → resolves `repoName` → index.
+    let used = plan_str(&ds, ident("repoName").eq(lit("acme")))
+        .await
+        .expect("ident(\"repoName\") must plan against the case-preserved schema");
+    assert!(
+        used.contains("ScalarIndexQuery"),
+        "camelCase @index equality must route to the scalar index (not full scan), got:\n{used}"
+    );
+
+    // The pre-fix shape: col() normalizes `repoName` → `reponame`, which does not
+    // exist in the case-sensitive schema, so planning fails. This is precisely
+    // why `col()` could never reach the index and surfaced the #283 runtime error
+    // — it could not silently full-scan past the index either.
+    let err = plan_str(&ds, col("repoName").eq(lit("acme"))).await;
+    assert!(
+        err.is_err(),
+        "col() lowercases repoName→reponame against a case-sensitive schema; \
+         planning must fail rather than resolve, confirming ident() is required \
+         for camelCase index routing. got plan:\n{err:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Follow-up to #285 addressing the one Greptile **P2** on that PR: the #283 fix
shipped correctness tests but not the *plan-level* index-routing assertion the
case study's own validation checklist (step 5) promised. A result-only test
passes even on a silent full-scan fallback — the failure mode `testing.md`
explicitly warns against.

## Change

Adds lance-surface **Guard 20** (`camelcase_index_equality_routes_to_scalar_index`),
mirroring the adjacent Guard 16 (`scalar_index_use_requires_matched_literal_type`):

- Builds a BTREE on a **camelCase** column (`repoName`).
- Asserts the scan plan contains `ScalarIndexQuery` under the fix's
  case-preserving `ident("repoName")` expr — i.e. the index is actually used.
- Asserts the pre-fix `col("repoName")` expr **fails to plan** (it normalizes
  `repoName` → a nonexistent `reponame`), confirming `col()` could never reach
  the index and pinning that `ident()` is required for camelCase routing.

A regression that breaks camelCase index routing — or a revert to `col()` —
turns this red instead of degrading silently to a full scan. The substrate side
(Lance routes a camelCase BTREE) is now pinned here; the engine call-site side
is already covered by the existing `camelcase_property_filter_executes` e2e
(a `col()` revert errors there).

Test-only; full `lance_surface_guards` file green (13 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Guard 20 (`camelcase_index_equality_routes_to_scalar_index`) to `lance_surface_guards.rs`, a plan-level regression test for the #283 camelCase `@index` routing fix. It closes the gap where a result-only test could pass even on a silent full-scan fallback.

- Asserts that `ident(\"repoName\").eq(lit(\"acme\"))` on a BTREE-indexed camelCase column produces `ScalarIndexQuery` in the DataFusion physical plan, confirming the fix's case-preserving expr shape actually routes to the index.
- Asserts that the pre-fix `col(\"repoName\")` form fails to plan entirely (DataFusion normalizes to lowercase `reponame`, which doesn't exist in the case-sensitive schema), proving `col()` was never capable of silently full-scanning past the index either.

<h3>Confidence Score: 5/5</h3>

Test-only change with no production code impact; safe to merge.

The change adds a single, well-scoped guard test that mirrors the existing Guard 16 pattern. Both assertion paths (ident routing succeeds, col() fails to plan) correctly reflect DataFusion's documented identifier normalization behavior. Write parameters, index creation, and tempdir isolation all match the established guard conventions. No production code is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/omnigraph/tests/lance_surface_guards.rs | Adds Guard 20: test-only, well-isolated, mirrors Guard 16's structure, correct plan assertions for both ident() and col() paths. No logic or safety issues found. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Write dataset\n(repoName: Utf8 BTREE)"] --> B["create_index_builder\n(repoName, BTree)"]
    B --> C["plan_str(ident('repoName').eq(lit('acme')))"]
    C --> D{"contains\n'ScalarIndexQuery'?"}
    D -->|"yes ✅"| E["Assert: index routing works\n(ident preserves case)"]
    D -->|"no ❌"| F["FAIL: camelCase @index\nfell back to full scan"]
    B --> G["plan_str(col('repoName').eq(lit('acme')))"]
    G --> H{"is_err()?"}
    H -->|"yes ✅"| I["Assert: col() normalizes\nrepoName → reponame (not found)"]
    H -->|"no ❌"| J["FAIL: col() resolved\nagainst case-sensitive schema\n(regression)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Write dataset\n(repoName: Utf8 BTREE)"] --> B["create_index_builder\n(repoName, BTree)"]
    B --> C["plan_str(ident('repoName').eq(lit('acme')))"]
    C --> D{"contains\n'ScalarIndexQuery'?"}
    D -->|"yes ✅"| E["Assert: index routing works\n(ident preserves case)"]
    D -->|"no ❌"| F["FAIL: camelCase @index\nfell back to full scan"]
    B --> G["plan_str(col('repoName').eq(lit('acme')))"]
    G --> H{"is_err()?"}
    H -->|"yes ✅"| I["Assert: col() normalizes\nrepoName → reponame (not found)"]
    H -->|"no ❌"| J["FAIL: col() resolved\nagainst case-sensitive schema\n(regression)"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["test(engine): pin camelCase @index → sca..."](https://github.com/modernrelay/omnigraph/commit/2a2c6fac72bb24b2090c31a886b421186e31c039) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38681434)</sub>

<!-- /greptile_comment -->