### PR TITLE
release: v0.7.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Tools that support `@`-imports (Claude Code) auto-include all three files via th
 
 `CLAUDE.md` is a symlink to this file — there is exactly one source of truth. Edit `AGENTS.md`.
 
-**Version surveyed:** 0.7.0
+**Version surveyed:** 0.7.1
 **Workspace crates:** `omnigraph-compiler`, `omnigraph` (engine), `omnigraph-policy`, `omnigraph-api-types` (shared HTTP wire DTOs), `omnigraph-cluster`, `omnigraph-cli`, `omnigraph-server`
 **Storage substrate:** Lance 7.x (columnar, versioned, branchable)
 **License:** MIT

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4851,7 +4851,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-api-types"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "omnigraph-compiler",
  "omnigraph-engine",
@@ -4862,7 +4862,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -4886,7 +4886,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-cluster"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "fail",
  "omnigraph-compiler",
@@ -4904,7 +4904,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-compiler"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -4923,7 +4923,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-engine"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -4967,7 +4967,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-policy"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "cedar-policy",
  "clap",
@@ -4980,7 +4980,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-server"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/crates/omnigraph-api-types/Cargo.toml
+++ b/crates/omnigraph-api-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-api-types"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 description = "Shared HTTP wire DTOs for Omnigraph — request/response types and engine-result → DTO mappings used by both omnigraph-server and omnigraph-cli (RFC-009). Plain serde/utoipa types; no transport or server internals."
 license = "MIT"
@@ -9,8 +9,8 @@ homepage = "https://github.com/ModernRelay/omnigraph"
 documentation = "https://docs.rs/omnigraph-api-types"
 
 [dependencies]
-omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.7.0" }
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.0" }
+omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.7.1" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.1" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 utoipa = { workspace = true }

--- a/crates/omnigraph-cli/Cargo.toml
+++ b/crates/omnigraph-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-cli"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 description = "CLI for the Omnigraph graph database."
 license = "MIT"
@@ -13,12 +13,12 @@ name = "omnigraph"
 path = "src/main.rs"
 
 [dependencies]
-omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.7.0" }
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.0" }
-omnigraph-api-types = { path = "../omnigraph-api-types", version = "0.7.0" }
-omnigraph-cluster = { path = "../omnigraph-cluster", version = "0.7.0" }
-omnigraph-policy = { path = "../omnigraph-policy", version = "0.7.0" }
-omnigraph-server = { path = "../omnigraph-server", version = "0.7.0" }
+omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.7.1" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.1" }
+omnigraph-api-types = { path = "../omnigraph-api-types", version = "0.7.1" }
+omnigraph-cluster = { path = "../omnigraph-cluster", version = "0.7.1" }
+omnigraph-policy = { path = "../omnigraph-policy", version = "0.7.1" }
+omnigraph-server = { path = "../omnigraph-server", version = "0.7.1" }
 clap = { workspace = true }
 color-eyre = { workspace = true }
 serde = { workspace = true }

--- a/crates/omnigraph-cluster/Cargo.toml
+++ b/crates/omnigraph-cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-cluster"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 description = "Cluster configuration validation, planning, and config-only apply for Omnigraph."
 license = "MIT"
@@ -14,8 +14,8 @@ documentation = "https://docs.rs/omnigraph-cluster"
 failpoints = ["dep:fail", "fail/failpoints", "omnigraph/failpoints"]
 
 [dependencies]
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.0" }
-omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.7.0" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.1" }
+omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.7.1" }
 fail = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/omnigraph-compiler/Cargo.toml
+++ b/crates/omnigraph-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-compiler"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 description = "Schema/query compiler for Omnigraph. Zero Lance dependency."
 license = "MIT"

--- a/crates/omnigraph-policy/Cargo.toml
+++ b/crates/omnigraph-policy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-policy"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 description = "Policy / authorization layer for Omnigraph — Cedar-backed PolicyEngine, PolicyChecker trait, ResourceScope enum."
 license = "MIT"

--- a/crates/omnigraph-server/Cargo.toml
+++ b/crates/omnigraph-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-server"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 description = "HTTP server for the Omnigraph graph database."
 license = "MIT"
@@ -19,11 +19,11 @@ default = []
 aws = ["dep:aws-config", "dep:aws-sdk-secretsmanager"]
 
 [dependencies]
-omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.7.0" }
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.0" }
-omnigraph-policy = { path = "../omnigraph-policy", version = "0.7.0" }
-omnigraph-api-types = { path = "../omnigraph-api-types", version = "0.7.0" }
-omnigraph-cluster = { path = "../omnigraph-cluster", version = "0.7.0" }
+omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.7.1" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.1" }
+omnigraph-policy = { path = "../omnigraph-policy", version = "0.7.1" }
+omnigraph-api-types = { path = "../omnigraph-api-types", version = "0.7.1" }
+omnigraph-cluster = { path = "../omnigraph-cluster", version = "0.7.1" }
 axum = { workspace = true }
 clap = { workspace = true }
 color-eyre = { workspace = true }

--- a/crates/omnigraph/Cargo.toml
+++ b/crates/omnigraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-engine"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 description = "Runtime engine for the Omnigraph graph database."
 license = "MIT"
@@ -16,8 +16,8 @@ default = []
 failpoints = ["dep:fail", "fail/failpoints"]
 
 [dependencies]
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.0" }
-omnigraph-policy = { path = "../omnigraph-policy", version = "0.7.0" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.1" }
+omnigraph-policy = { path = "../omnigraph-policy", version = "0.7.1" }
 lance = { workspace = true }
 lance-datafusion = { workspace = true }
 datafusion = { workspace = true }
@@ -52,7 +52,7 @@ chrono = { workspace = true }
 arc-swap = { workspace = true }
 
 [dev-dependencies]
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.0" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.1" }
 tokio = { workspace = true }
 lance-namespace-impls = { workspace = true }
 lance-io = "7.0.0"

--- a/docs/releases/v0.7.1.md
+++ b/docs/releases/v0.7.1.md
@@ -1,0 +1,67 @@
+# Omnigraph v0.7.1
+
+A patch release on top of v0.7.0: three correctness fixes (camelCase filters,
+cluster-apply crash loops, branch-merge OOM on embedding tables), one CLI
+catalog-metadata improvement, and a warm-read performance fix. No breaking
+changes, no on-disk format change, and no migration — drop-in over v0.7.0.
+
+## Fixes
+
+- **camelCase property filters now execute (#283).** A query — or a chained
+  mutation — that filtered on a camelCase schema field (e.g. `repoName`) linted
+  and planned cleanly but failed at run time with `No field named reponame.
+  Column names are case sensitive.` The identifier's case was destroyed at two
+  engine→Lance boundaries: the read-filter pushdown built the column with a
+  case-normalizing constructor, and the pending-batch mutation scan re-parsed
+  the predicate through a normalizing SQL context. Both now preserve case (the
+  read path uses a case-preserving column reference; the pending scan disables
+  SQL identifier normalization), so camelCase fields work consistently in read
+  and write predicates and a camelCase `@index` equality still routes to the
+  scalar index. The fix is correct-by-construction rather than a per-query
+  guard; a regression test pins index routing so a silent full-scan fallback
+  can't slip back in.
+
+- **`cluster apply` no longer crash-loops a booting server (#284).** Applying a
+  schema change while a graph had non-main (agent/review) branches, or a
+  migration that needed a backfill, could throw a freshly-booting
+  `omnigraph-server --cluster` into an unescapable crash loop. Neither input is
+  an engine bug — the engine rejects both cleanly and before moving any graph
+  state — but `cluster apply` wrote a recovery sidecar before calling the
+  engine and left it in place on the clean rejection, and the server refuses to
+  boot while a sidecar is pending. The asymmetric-cleanup path is fixed so a
+  pre-movement rejection leaves no stale sidecar, breaking the loop.
+
+- **Branch-merge fast-forward no longer OOMs on embedding tables (#277).** A
+  branch→main fast-forward merge of a forked, embedding-bearing table
+  re-derived the whole branch through a single Lance `merge_insert` — a
+  full-outer hash join over the entire delta — which exhausted the DataFusion
+  memory pool on high-dimensional embeddings (e.g. 8k rows × 3072-dim) and hung
+  or failed the merge. New rows now stream through `stage_append` (no hash
+  join), only genuinely-changed rows are upserted, embeddings are no longer
+  stringified to diff them, and index coverage defers to the reconciler, so a
+  fast-forward merge completes in bounded work. The three-way merge path is
+  unchanged.
+
+## Improvements
+
+- **`omnigraph queries list` surfaces stored-query `@description` /
+  `@instruction` (#280).** The CLI now shows a stored query's catalog metadata —
+  what it does and how to invoke it — in both human and `--json` output,
+  matching what `GET /queries` already returned. Previously both fields were
+  silently dropped on the CLI side.
+
+- **Warm reads no longer pay an O(history) metadata tax (#268).** Warm reads
+  used to re-derive per-query metadata (coordinator re-open, `__manifest` +
+  commit-graph re-scans, per-table re-open, double schema validation) on a cost
+  that scaled with commit history and never warmed up. A warm same-branch read
+  now does one cheap version probe, one schema read, and zero table opens on a
+  warm repeat (warm coordinator reuse, open-by-location+version, validate-once,
+  held `Dataset` handles + one shared Lance `Session` per graph). This also
+  closes a commit-DAG fork where a same-branch write after an external commit
+  could append off a stale cached head.
+
+## Upgrade notes
+
+Drop-in over v0.7.0 — no configuration, schema, or data changes. Upgrade the
+server and CLI together as usual. Graphs created on v0.7.0 read and write
+identically on v0.7.1.

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "0.7.0"
+    "version": "0.7.1"
   },
   "paths": {
     "/graphs": {


### PR DESCRIPTION
## Summary

Patch release over v0.7.0. **No breaking changes, no on-disk format change, no migration — drop-in.**

### Fixes
- **#283** camelCase property/filter case preserved at the engine→Lance boundary (read pushdown + pending mutation scan) — fixes `No field named reponame` (#285, #286)
- **#284** `cluster apply` no longer crash-loops a booting server (recovery-sidecar left after a pre-movement rejection)
- **#277** branch-merge fast-forward no longer OOMs on high-dimensional embedding tables (streaming append, no full-outer hash join)

### Improvements
- **#280** `omnigraph queries list` surfaces stored-query `@description` / `@instruction`
- **#268** warm reads no longer pay an O(commit-history) metadata re-derivation tax

### Version coherence (AGENTS.md rule 4)
All 7 crate manifests + path-dep constraints, `Cargo.lock`, `openapi.json` (regenerated), and the AGENTS.md surveyed version bumped `0.7.0 → 0.7.1`. Full workspace gate green (1472 tests, `cargo test --workspace --locked`).

Release notes: `docs/releases/v0.7.1.md`.

> ⚠️ Merging this and pushing the `v0.7.1` tag triggers `release.yml` (binaries + GitHub release + Homebrew tap) **and** `publish-crates.yml` (crates.io publish — irreversible). Tag only after this merges to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a patch release bump from v0.7.0 to v0.7.1, containing only mechanical version string updates across all 7 crate manifests, `Cargo.lock`, `openapi.json`, and `AGENTS.md`, plus a new release-notes file. No source code logic changes are included in the diff — the underlying fixes (camelCase filter preservation, cluster-apply sidecar cleanup, branch-merge OOM, queries-list metadata, warm-read performance) were landed separately and this PR formalizes the release boundary.

- All 7 published crate manifests (`omnigraph-engine`, `omnigraph-compiler`, `omnigraph-policy`, `omnigraph-api-types`, `omnigraph-cluster`, `omnigraph-server`, `omnigraph-cli`) and all intra-workspace path-dep version constraints are consistently bumped to `0.7.1`, satisfying AGENTS.md rule 4.
- `Cargo.lock`, `openapi.json` (version field only — schema is unchanged), and the AGENTS.md surveyed version line are all updated in lockstep.
- A new `docs/releases/v0.7.1.md` release note is added, following the format established by `v0.7.0.md`.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the diff is purely mechanical version string updates with no logic changes, and all 7 crate manifests, Cargo.lock, openapi.json, and AGENTS.md are updated consistently.

All versioning artifacts in the primary repo are internally consistent and the release notes are accurate and follow the established format. The only loose end is the omnigraph-ts companion repo, whose spec/openapi.json and SDK package.json remain at 0.7.0. Since the OpenAPI schema itself is unchanged in this patch, no generated TypeScript types are wrong today, but the version number mismatch will be visible to SDK consumers once the tag ships. A companion PR there before tagging would close the gap cleanly.

No files in this PR require special attention. The cross-repo concern (omnigraph-ts spec/openapi.json at 0.7.0) is outside this changeset and should be addressed in a companion PR before the v0.7.1 tag is pushed.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Version surveyed line updated from 0.7.0 to 0.7.1; no other changes. |
| Cargo.lock | All 7 omnigraph-* package version entries updated from 0.7.0 to 0.7.1 consistently. |
| openapi.json | Only the info.version field changed (0.7.0 → 0.7.1); all paths and schemas are unchanged, confirming no API contract changes in this patch. |
| docs/releases/v0.7.1.md | New release notes file; describes all five changes (3 fixes, 2 improvements) with public GitHub issue references, upgrade notes, and no internal codenames. |
| crates/omnigraph-cli/Cargo.toml | Version bumped to 0.7.1; all 6 intra-workspace path-dep version constraints updated to 0.7.1. |
| crates/omnigraph-server/Cargo.toml | Version bumped to 0.7.1; all 5 intra-workspace path-dep constraints updated to 0.7.1. |
| crates/omnigraph/Cargo.toml | Engine crate version bumped to 0.7.1; compiler and policy dep constraints updated to 0.7.1 including dev-dependencies. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    PR["PR #290: release v0.7.1"] --> AGENTS["AGENTS.md\nVersion surveyed: 0.7.1"]
    PR --> LOCK["Cargo.lock\n7 crates → 0.7.1"]
    PR --> NOTES["docs/releases/v0.7.1.md\nNew release notes"]
    PR --> OA["openapi.json\ninfo.version → 0.7.1"]

    LOCK --> compiler["omnigraph-compiler 0.7.1"]
    LOCK --> engine["omnigraph-engine 0.7.1"]
    LOCK --> policy["omnigraph-policy 0.7.1"]
    LOCK --> api["omnigraph-api-types 0.7.1"]
    LOCK --> cluster["omnigraph-cluster 0.7.1"]
    LOCK --> server["omnigraph-server 0.7.1"]
    LOCK --> cli["omnigraph-cli 0.7.1"]

    PR --> TAG["v0.7.1 tag → release.yml + publish-crates.yml"]
    TAG --> CRATESIO["crates.io publish (irreversible)"]
    TAG --> GH["GitHub Release + Homebrew tap"]

    OA -. "spec not updated" .-> TS["omnigraph-ts\nspec/openapi.json still 0.7.0\n⚠ companion PR needed"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    PR["PR #290: release v0.7.1"] --> AGENTS["AGENTS.md\nVersion surveyed: 0.7.1"]
    PR --> LOCK["Cargo.lock\n7 crates → 0.7.1"]
    PR --> NOTES["docs/releases/v0.7.1.md\nNew release notes"]
    PR --> OA["openapi.json\ninfo.version → 0.7.1"]

    LOCK --> compiler["omnigraph-compiler 0.7.1"]
    LOCK --> engine["omnigraph-engine 0.7.1"]
    LOCK --> policy["omnigraph-policy 0.7.1"]
    LOCK --> api["omnigraph-api-types 0.7.1"]
    LOCK --> cluster["omnigraph-cluster 0.7.1"]
    LOCK --> server["omnigraph-server 0.7.1"]
    LOCK --> cli["omnigraph-cli 0.7.1"]

    PR --> TAG["v0.7.1 tag → release.yml + publish-crates.yml"]
    TAG --> CRATESIO["crates.io publish (irreversible)"]
    TAG --> GH["GitHub Release + Homebrew tap"]

    OA -. "spec not updated" .-> TS["omnigraph-ts\nspec/openapi.json still 0.7.0\n⚠ companion PR needed"]
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aopenapi.json%3A7-10%0A**Stale%20OpenAPI%20spec%20copy%20in%20omnigraph-ts**%0A%0AThe%20%60spec%2Fopenapi.json%60%20in%20the%20%60omnigraph-ts%60%20repo%20is%20still%20pinned%20at%20%60%22version%22%3A%20%220.7.0%22%60%2C%20and%20%60packages%2Fsdk%2Fpackage.json%60%20is%20likewise%20at%20%600.7.0%60.%20Since%20that%20SDK%20uses%20%60%40hey-api%2Fopenapi-ts%60%20to%20generate%20its%20types%20from%20that%20spec%2C%20consumers%20who%20try%20to%20match%20their%20SDK%20version%20against%20the%20server%20version%20after%20this%20release%20will%20see%20a%20mismatch.%20The%20schema%20itself%20is%20unchanged%20here%20%28only%20the%20version%20string%20changed%29%2C%20so%20there%20is%20no%20generated-type%20drift%20today%20%E2%80%94%20but%20a%20companion%20PR%20in%20%60omnigraph-ts%60%20bumping%20the%20spec%20version%20and%20package%20version%20to%20%600.7.1%60%20would%20keep%20the%20two%20repos%20in%20step%20before%20the%20tag%20is%20pushed.%0A%0A&repo=modernrelay%2Fomnigraph&pr=290&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["release: v0.7.1"](https://github.com/modernrelay/omnigraph/commit/babdc01443bc12c10ae510cea0d987ac3ce61803) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38720887)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=59169be6-01cf-4bae-80fc-604b6a708098))

<!-- /greptile_comment -->