### PR TITLE
docs(dev): ledger update — cross-repo drift status

### DIFF
--- a/docs/dev/docs-issues.md
+++ b/docs/dev/docs-issues.md
@@ -40,17 +40,19 @@ fixed. Branch `docs/user-coherence-0-7-1`.
   `apply_schema_update_and_dependent_query_in_one_run`,
   `apply_blocks_graph_delete_without_approval`). Update these comments in a
   cluster-crate change.
-- **Cross-repo drift from this sweep** (separate repos — track here, fix in a
-  follow-up in each repo):
-  - `omnigraph-ts` SDK ships a stale generated `spec/openapi.json` +
-    `packages/sdk/src/generated/types.gen.ts` still describing the `GET /queries`
-    catalog as the `mcp.expose` subset. Regenerate from this repo's
-    `openapi.json` once the SDK's deferred refresh happens (the SDK is known to
-    lag the API by design).
-  - `omnigraph-cookbooks/docs/best-practices.md` (~line 372) still describes
-    client-side auth as resolving through the removed `bearer_token_env` chain.
-    Update to the keyed-credential model (`OMNIGRAPH_TOKEN_<NAME>` →
-    credentials file → `OMNIGRAPH_BEARER_TOKEN`).
+- **Cross-repo drift from this sweep** (separate repos):
+  - `omnigraph-ts` SDK — its generated `spec/openapi.json` +
+    `packages/sdk/src/generated/types.gen.ts` still describe the `GET /queries`
+    catalog as the `mcp.expose` subset. **No hand-fix:** the SDK's
+    `scripts/sync-spec.ts` pulls openapi.json from a *tagged* omnigraph release
+    (`/omnigraph/v{version}/openapi.json`), and the catalog fix landed on main
+    *after* the v0.7.1 tag — so it is in no tag yet and a hand-edit would be
+    overwritten on the next sync. It flows in automatically when the SDK bumps
+    to a tag containing the fix (v0.7.2+). Tracked, not actioned.
+  - `omnigraph-cookbooks/docs/best-practices.md` `bearer_token_env` chain —
+    **RESOLVED** by omnigraph-cookbooks PR #26 (2026-06-21), which deleted
+    `docs/best-practices.md` as part of the 0.7 restructure; the stale chain
+    survives nowhere on `main`.
 
 ## Verification checklist (re-run on the next docs audit)
 


### PR DESCRIPTION
Follow-up to #293. Keeps the user-docs coherence ledger honest after the cross-repo work:

- **omnigraph-cookbooks** `bearer_token_env` chain — **resolved** by cookbooks PR #26 (deleted `docs/best-practices.md` in the 0.7 restructure; the stale chain survives nowhere on `main`).
- **omnigraph-ts** catalog `mcp.expose` description — documented why there's no hand-fix: the SDK's `sync-spec.ts` pulls openapi.json from a *tagged* omnigraph release, and the catalog fix (#293) landed on main after the v0.7.1 tag, so it reaches the SDK on its next version bump (v0.7.2+), not via an out-of-band edit.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This docs-only PR updates the internal dev coherence ledger with resolution status for the two cross-repo drift findings surfaced in the 0.7.1 sweep (#293). Both claims were verified against the related repos: `docs/best-practices.md` is confirmed absent from `omnigraph-cookbooks`, and `scripts/sync-spec.ts` in `omnigraph-ts` does indeed fetch `openapi.json` from a pinned git tag, making a hand-edit futile.

- **omnigraph-ts stale spec** — documents why no hand-fix is appropriate: `sync-spec.ts` overwrites `spec/openapi.json` from a tagged release on every run, so the fix will flow in naturally at v0.7.2+.
- **omnigraph-cookbooks `bearer_token_env`** — marks the item RESOLVED; `docs/best-practices.md` was deleted wholesale in the cookbooks 0.7 restructure (PR #26), confirming no stale content survives on `main`.

<h3>Confidence Score: 5/5</h3>

Docs-only change to a dev-internal ledger; no code, configuration, or public-facing content is modified.

Both cross-repo factual claims are accurate — the cookbooks file is confirmed deleted, and the omnigraph-ts sync mechanism matches the ledger's description. The two comments are minor organisational suggestions that do not affect correctness.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/dev/docs-issues.md | Docs-only ledger update: documents the no-hand-fix rationale for the omnigraph-ts stale spec (tag-pinned sync), and marks the cookbooks bearer_token_env entry RESOLVED. Both claims verified against the related repos. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Cross-repo drift findings\n(docs/dev/docs-issues.md)"] --> B["omnigraph-ts stale\nspec/openapi.json"]
    A --> C["omnigraph-cookbooks\nbest-practices.md\nbearer_token_env chain"]

    B --> D{"How does SDK sync?"}
    D --> E["scripts/sync-spec.ts fetches\nomnigraph/v{version}/openapi.json\nfrom a git tag"]
    E --> F["Fix landed on main\nafter v0.7.1 tag"]
    F --> G["Hand-edit would be\noverwritten on next sync\nTracked, not actioned"]
    G --> H["Resolves automatically\nat SDK v0.7.2+"]

    C --> I{"File exists in\nomnigraph-cookbooks?"}
    I --> J["docs/best-practices.md\ndeleted in 0.7 restructure\n(cookbooks PR #26)"]
    J --> K["RESOLVED — stale chain\nsurvives nowhere on main"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Cross-repo drift findings\n(docs/dev/docs-issues.md)"] --> B["omnigraph-ts stale\nspec/openapi.json"]
    A --> C["omnigraph-cookbooks\nbest-practices.md\nbearer_token_env chain"]

    B --> D{"How does SDK sync?"}
    D --> E["scripts/sync-spec.ts fetches\nomnigraph/v{version}/openapi.json\nfrom a git tag"]
    E --> F["Fix landed on main\nafter v0.7.1 tag"]
    F --> G["Hand-edit would be\noverwritten on next sync\nTracked, not actioned"]
    G --> H["Resolves automatically\nat SDK v0.7.2+"]

    C --> I{"File exists in\nomnigraph-cookbooks?"}
    I --> J["docs/best-practices.md\ndeleted in 0.7 restructure\n(cookbooks PR #26)"]
    J --> K["RESOLVED — stale chain\nsurvives nowhere on main"]
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Adocs%2Fdev%2Fdocs-issues.md%3A43-55%0A**RESOLVED%20item%20lives%20in%20the%20%22Open%22%20section**%0A%0AThe%20section%20header%20reads%20%22Open%20%E2%80%94%20surfaced%202026-06-20%2C%20not%20yet%20fixed%22%2C%20but%20the%20cookbooks%20entry%20is%20now%20annotated%20**RESOLVED**%20inline.%20A%20future%20auditor%20scanning%20for%20open%20work%20may%20skim%20past%20the%20inline%20tag%20and%20count%20it%20as%20an%20outstanding%20item%2C%20especially%20once%20the%20list%20grows.%20Consider%20either%20removing%20the%20resolved%20bullet%20entirely%20%28the%20finding%20is%20already%20captured%20as%20a%20%60P2%60%20row%20in%20the%20Resolved%20table%20above%20via%20the%20%60bearer_token_env%60%20fix%29%2C%20or%20moving%20it%20up%20into%20the%20table%20with%20a%20short%20%22cookbooks%20%60docs%2Fbest-practices.md%60%20deleted%20%28PR%20%2326%29%22%20row%20so%20the%20%22Open%22%20section%20stays%20strictly%20unresolved%20items.%0A%0A%23%23%23%20Issue%202%20of%202%0Adocs%2Fdev%2Fdocs-issues.md%3A45-51%0AThe%20omnigraph-ts%20SDK's%20%60package.json%60%20currently%20pins%20%60omnigraph.serverVersion%60%20to%20%60%220.7.0%22%60%2C%20not%20%60%220.7.1%22%60.%20The%20ledger's%20%22v0.7.2%2B%22%20ceiling%20is%20still%20correct%20%28the%20fix%20post-dates%20the%20v0.7.1%20tag%29%2C%20but%20noting%20%600.7.0%60%20as%20the%20current%20pin%20would%20make%20the%20lag%20explicit%20%E2%80%94%20a%20reader%20looking%20at%20the%20SDK%20today%20would%20see%20it%20is%20two%20minor%20versions%20behind%2C%20not%20one.%20See%20%5B%60omnigraph-ts%2Fpackage.json%60%5D%28https%3A%2F%2Fgithub.com%2Fmodernrelay%2Fomnigraph-ts%2Fblob%2FHEAD%2Fpackage.json%23L13-L15%29.%0A%0A%60%60%60suggestion%0A%20%20%20%20%60packages%2Fsdk%2Fsrc%2Fgenerated%2Ftypes.gen.ts%60%20still%20describe%20the%20%60GET%20%2Fqueries%60%0A%20%20%20%20catalog%20as%20the%20%60mcp.expose%60%20subset.%20**No%20hand-fix%3A**%20the%20SDK's%0A%20%20%20%20%60scripts%2Fsync-spec.ts%60%20pulls%20openapi.json%20from%20a%20*tagged*%20omnigraph%20release%0A%20%20%20%20%28%60%2Fomnigraph%2Fv%7Bversion%7D%2Fopenapi.json%60%29%2C%20and%20the%20catalog%20fix%20landed%20on%20main%0A%20%20%20%20*after*%20the%20v0.7.1%20tag%20%E2%80%94%20so%20it%20is%20in%20no%20tag%20yet%20and%20a%20hand-edit%20would%20be%0A%20%20%20%20overwritten%20on%20the%20next%20sync.%20It%20flows%20in%20automatically%20when%20the%20SDK%20bumps%0A%20%20%20%20to%20a%20tag%20containing%20the%20fix%20%28v0.7.2%2B%29.%20SDK%20currently%20pins%20%60serverVersion%60%0A%20%20%20%20%60%220.7.0%22%60%20%28two%20versions%20behind%29.%20Tracked%2C%20not%20actioned.%0A%60%60%60%0A%0A&repo=modernrelay%2Fomnigraph&pr=294&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(dev): update coherence ledger — coo..."](https://github.com/modernrelay/omnigraph/commit/fd99a471093e946a15112ef0532b899710352ea2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38838744)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->