### PR TITLE
feat(engine): `WriteTxn` - validate schema + open each data table once per write

### DIFF
--- a/crates/omnigraph/src/db/mod.rs
+++ b/crates/omnigraph/src/db/mod.rs
@@ -10,6 +10,7 @@ pub use commit_graph::GraphCommit;
 pub use graph_coordinator::{GraphCoordinator, ReadTarget, ResolvedTarget, SnapshotId};
 pub use manifest::{Snapshot, SubTableEntry, SubTableUpdate};
 pub(crate) use omnigraph::ensure_public_branch_ref;
+pub(crate) use omnigraph::WriteTxn;
 pub use omnigraph::{
     CleanupPolicyOptions, InitOptions, MergeOutcome, Omnigraph, OpenMode, PendingIndex,
     RepairAction, RepairClassification, RepairOptions, RepairStats, SchemaApplyOptions,

--- a/crates/omnigraph/src/db/omnigraph.rs
+++ b/crates/omnigraph/src/db/omnigraph.rs
@@ -1673,7 +1673,7 @@ impl Omnigraph {
         &self,
         table_key: &str,
         op_kind: crate::db::MutationOpKind,
-    ) -> Result<(SnapshotHandle, String, Option<String>)> {
+    ) -> Result<(Option<SnapshotHandle>, u64, String, Option<String>)> {
         table_ops::open_for_mutation(self, table_key, op_kind).await
     }
 
@@ -1683,7 +1683,7 @@ impl Omnigraph {
         table_key: &str,
         op_kind: crate::db::MutationOpKind,
         txn: Option<&crate::db::WriteTxn>,
-    ) -> Result<(SnapshotHandle, String, Option<String>)> {
+    ) -> Result<(Option<SnapshotHandle>, u64, String, Option<String>)> {
         table_ops::open_for_mutation_on_branch(self, branch, table_key, op_kind, txn).await
     }
 
@@ -1804,6 +1804,7 @@ impl Omnigraph {
         expected_table_versions: &std::collections::HashMap<String, u64>,
         actor_id: Option<&str>,
         txn: Option<&crate::db::WriteTxn>,
+        committed_handles: std::collections::HashMap<String, crate::storage_layer::SnapshotHandle>,
     ) -> Result<u64> {
         table_ops::commit_updates_on_branch_with_expected(
             self,
@@ -1812,6 +1813,7 @@ impl Omnigraph {
             expected_table_versions,
             actor_id,
             txn,
+            committed_handles,
         )
         .await
     }
@@ -2543,10 +2545,13 @@ edge WorksAt: Person -> Company
     }
 
     async fn seed_person_row(db: &mut Omnigraph, name: &str, age: Option<i32>) {
-        let (ds, full_path, table_branch) = db
+        // No-txn entry, so the handle is always `Some` (collapse #1's skip is
+        // gated on `txn.is_some()`).
+        let (ds, _expected_version, full_path, table_branch) = db
             .open_for_mutation("node:Person", crate::db::MutationOpKind::Insert)
             .await
             .unwrap();
+        let ds = ds.unwrap();
         let schema: Arc<Schema> = Arc::new(ds.dataset().schema().into());
         let columns: Vec<Arc<dyn Array>> = schema
             .fields()

--- a/crates/omnigraph/src/db/omnigraph.rs
+++ b/crates/omnigraph/src/db/omnigraph.rs
@@ -86,18 +86,27 @@ pub struct SchemaApplyPreview {
 /// general "no re-resolution" handle — the commit-time OCC re-read, the live-HEAD
 /// drift probe, and the fork-authority reads stay fresh (correctness machinery).
 ///
-/// SCAFFOLDING: the carrier + `open_write_txn` are landed; the next pass threads
-/// `Option<&WriteTxn>` through `open_for_mutation_on_branch` / staging (non-strict
-/// bound-branch path) to open the base once from the pinned entry with the warm
-/// session (a session-aware pinned opener returning a `SnapshotHandle`) and skip the
-/// per-table schema re-validation — turning the two RED cost gates green.
-#[allow(dead_code)]
+/// Threaded as `Option<&WriteTxn>` through the mutate/load write chain
+/// (`open_for_mutation_on_branch`, `commit_all`, `commit_updates_on_branch_with_expected`)
+/// so a single write validates the schema contract EXACTLY ONCE — at capture. When
+/// present, the per-table resolves source the pinned `base` entry instead of calling
+/// `resolved_branch_target` / `snapshot_for_branch` / `fresh_snapshot_for_branch`
+/// (each of which re-runs `ensure_schema_state_valid`). When absent (`None` — every
+/// non-mutate/load caller), every threaded function behaves byte-identically to
+/// before. The carrier never removes a version guard or changes which dataset version
+/// the per-table open targets: strict ops keep `open_dataset_head_for_write` +
+/// `ensure_expected_version`, and the commit-time OCC re-read still opens a fresh
+/// manifest snapshot (via `fresh_snapshot_for_branch_unchecked`) — only the redundant
+/// schema re-validation is dropped.
 pub(crate) struct WriteTxn {
     /// The resolved branch (`None` = main).
     pub(crate) branch: Option<String>,
     /// The pinned base snapshot (per-table location + version + e_tag), captured once.
     pub(crate) base: Snapshot,
-    /// The shared per-graph Session, threaded into the base opens to warm caches.
+    /// The shared per-graph Session, captured here so the follow-up change that
+    /// makes the per-table base opens session-aware can reuse it. Not read yet by
+    /// the schema-once threading (which only uses `base` + `branch`).
+    #[allow(dead_code)]
     pub(crate) session: Arc<lance::session::Session>,
 }
 
@@ -765,7 +774,6 @@ impl Omnigraph {
     /// session — instead of re-resolving (re-validating the schema) and cold-opening
     /// HEAD per table. Strict ops, the fork path, and the commit-time OCC re-read keep
     /// their fresh reads (those are correctness machinery — see the handoff doc).
-    #[allow(dead_code)]
     pub(crate) async fn open_write_txn(&self, branch: Option<&str>) -> Result<WriteTxn> {
         let resolved = self.resolved_branch_target(branch).await?;
         Ok(WriteTxn {
@@ -809,12 +817,39 @@ impl Omnigraph {
 
     pub(crate) async fn fresh_snapshot_for_branch(&self, branch: Option<&str>) -> Result<Snapshot> {
         self.ensure_schema_state_valid().await?;
-        let requested = ReadTarget::Branch(branch.unwrap_or("main").to_string());
-        let coord = self.coordinator.read().await;
-        coord
-            .resolve_target(&requested)
-            .await
-            .map(|resolved| resolved.snapshot)
+        self.fresh_snapshot_for_branch_unchecked(branch).await
+    }
+
+    /// Fresh per-branch manifest snapshot WITHOUT the schema-contract
+    /// re-validation. Identical OCC freshness to [`fresh_snapshot_for_branch`]
+    /// — a fresh manifest re-read from storage, never the warm cache — only the
+    /// redundant `ensure_schema_state_valid` is dropped. Used inside a single
+    /// write once a `WriteTxn` has already validated the contract at capture: the
+    /// commit-time drift re-read needs the live manifest, not a second contract
+    /// read. Callers with no `WriteTxn` MUST use the checked variant.
+    ///
+    /// Reads the manifest directly via `ManifestCoordinator` rather than
+    /// `resolve_target`. The OCC re-read uses only the returned `Snapshot`
+    /// (per-table location + version), which `ManifestCoordinator::open().snapshot()`
+    /// produces identically to `GraphCoordinator::open(...).snapshot()` — but
+    /// `resolve_target` additionally opens the commit graph (an extra
+    /// `_graph_commits.lance` probe) the OCC read never consults. Skipping that
+    /// load is a pure read-cost reduction, not a freshness change. The checked
+    /// `fresh_snapshot_for_branch` delegates here, so its no-`txn` callers
+    /// (commit_all's None arm, optimize, repair, fork reclaim) get the same
+    /// identical `Snapshot` via this lighter manifest-only read; they consume
+    /// only the snapshot and never relied on the commit-graph side load.
+    pub(crate) async fn fresh_snapshot_for_branch_unchecked(
+        &self,
+        branch: Option<&str>,
+    ) -> Result<Snapshot> {
+        let manifest = match branch {
+            Some(branch) => {
+                crate::db::manifest::ManifestCoordinator::open_at_branch(self.uri(), branch).await?
+            }
+            None => crate::db::manifest::ManifestCoordinator::open(self.uri()).await?,
+        };
+        Ok(manifest.snapshot())
     }
 
     pub(crate) async fn version(&self) -> u64 {
@@ -1647,8 +1682,9 @@ impl Omnigraph {
         branch: Option<&str>,
         table_key: &str,
         op_kind: crate::db::MutationOpKind,
+        txn: Option<&crate::db::WriteTxn>,
     ) -> Result<(SnapshotHandle, String, Option<String>)> {
-        table_ops::open_for_mutation_on_branch(self, branch, table_key, op_kind).await
+        table_ops::open_for_mutation_on_branch(self, branch, table_key, op_kind, txn).await
     }
 
     /// Fork `table_key` onto `active_branch` from the given source state,
@@ -1767,6 +1803,7 @@ impl Omnigraph {
         updates: &[crate::db::SubTableUpdate],
         expected_table_versions: &std::collections::HashMap<String, u64>,
         actor_id: Option<&str>,
+        txn: Option<&crate::db::WriteTxn>,
     ) -> Result<u64> {
         table_ops::commit_updates_on_branch_with_expected(
             self,
@@ -1774,6 +1811,7 @@ impl Omnigraph {
             updates,
             expected_table_versions,
             actor_id,
+            txn,
         )
         .await
     }

--- a/crates/omnigraph/src/db/omnigraph.rs
+++ b/crates/omnigraph/src/db/omnigraph.rs
@@ -79,6 +79,28 @@ pub struct SchemaApplyPreview {
     pub catalog: Catalog,
 }
 
+/// A capture-once write transaction (RFC-013 step 3b). Pins the operation's read
+/// base + the shared `Session` ONCE so the per-table opens reuse the pinned version
+/// and the warm session instead of re-resolving / re-validating / cold-opening per
+/// table. The schema contract is validated once (when `base` is captured). NOT a
+/// general "no re-resolution" handle — the commit-time OCC re-read, the live-HEAD
+/// drift probe, and the fork-authority reads stay fresh (correctness machinery).
+///
+/// SCAFFOLDING: the carrier + `open_write_txn` are landed; the next pass threads
+/// `Option<&WriteTxn>` through `open_for_mutation_on_branch` / staging (non-strict
+/// bound-branch path) to open the base once from the pinned entry with the warm
+/// session (a session-aware pinned opener returning a `SnapshotHandle`) and skip the
+/// per-table schema re-validation — turning the two RED cost gates green.
+#[allow(dead_code)]
+pub(crate) struct WriteTxn {
+    /// The resolved branch (`None` = main).
+    pub(crate) branch: Option<String>,
+    /// The pinned base snapshot (per-table location + version + e_tag), captured once.
+    pub(crate) base: Snapshot,
+    /// The shared per-graph Session, threaded into the base opens to warm caches.
+    pub(crate) session: Arc<lance::session::Session>,
+}
+
 /// Top-level handle to an Omnigraph database.
 ///
 /// An Omnigraph is a Lance-native graph database with git-style branching.
@@ -734,6 +756,23 @@ impl Omnigraph {
 
     pub(crate) async fn restore_coordinator(&self, coordinator: GraphCoordinator) {
         *self.coordinator.write().await = coordinator;
+    }
+
+    /// Open a capture-once write transaction (RFC-013 step 3b): validate the schema
+    /// contract ONCE and pin the base snapshot + the shared per-graph `Session`. The
+    /// per-table opens take `Option<&WriteTxn>` and, on the bound branch for the
+    /// non-strict (Insert/Merge) path, open from the pinned base entry with the warm
+    /// session — instead of re-resolving (re-validating the schema) and cold-opening
+    /// HEAD per table. Strict ops, the fork path, and the commit-time OCC re-read keep
+    /// their fresh reads (those are correctness machinery — see the handoff doc).
+    #[allow(dead_code)]
+    pub(crate) async fn open_write_txn(&self, branch: Option<&str>) -> Result<WriteTxn> {
+        let resolved = self.resolved_branch_target(branch).await?;
+        Ok(WriteTxn {
+            branch: resolved.branch,
+            base: resolved.snapshot,
+            session: Arc::clone(&self.read_caches.session),
+        })
     }
 
     pub(crate) async fn resolved_branch_target(

--- a/crates/omnigraph/src/db/omnigraph.rs
+++ b/crates/omnigraph/src/db/omnigraph.rs
@@ -767,12 +767,20 @@ impl Omnigraph {
     }
 
     /// Open a capture-once write transaction (RFC-013 step 3b): validate the schema
-    /// contract ONCE and pin the base snapshot + the shared per-graph `Session`. The
-    /// per-table opens take `Option<&WriteTxn>` and, on the bound branch for the
-    /// non-strict (Insert/Merge) path, source the pinned base entry — instead of
-    /// re-resolving (re-validating the schema) per table. Strict ops, the fork path,
-    /// and the commit-time OCC re-read keep their fresh reads (those are correctness
-    /// machinery — see the handoff doc).
+    /// contract ONCE and pin the base snapshot. The per-table opens take
+    /// `Option<&WriteTxn>` and, on the bound branch for the non-strict (Insert/Merge)
+    /// path, source the pinned base entry — instead of re-resolving (re-validating the
+    /// schema) per table. Strict ops, the fork path, and the commit-time OCC re-read
+    /// keep their fresh reads (those are correctness machinery — see the handoff doc).
+    ///
+    /// "Once" covers the table-touch hot path captured here (proven by the node-insert
+    /// gate `write_validates_schema_contract_once`); it does NOT yet cover edge endpoint
+    /// / cardinality RI validation (`ensure_node_id_exists`, the loader's RI/cardinality),
+    /// which still resolve through `snapshot_for_branch` and re-validate. Those reads must
+    /// observe LIVE committed state, so unifying them (validate-once + pinned + re-checked
+    /// read-set) is step 4's §7.1 work — threading `txn.base` there would re-introduce the
+    /// stale-read class the #298 cardinality fix removed. A session-aware base open is
+    /// likewise deferred to step 5 (handoff §1d).
     pub(crate) async fn open_write_txn(&self, branch: Option<&str>) -> Result<WriteTxn> {
         let resolved = self.resolved_branch_target(branch).await?;
         Ok(WriteTxn {

--- a/crates/omnigraph/src/db/omnigraph.rs
+++ b/crates/omnigraph/src/db/omnigraph.rs
@@ -81,11 +81,14 @@ pub struct SchemaApplyPreview {
 }
 
 /// A capture-once write transaction (RFC-013 step 3b). Pins the operation's read
-/// base + the shared `Session` ONCE so the per-table opens reuse the pinned version
-/// and the warm session instead of re-resolving / re-validating / cold-opening per
-/// table. The schema contract is validated once (when `base` is captured). NOT a
-/// general "no re-resolution" handle — the commit-time OCC re-read, the live-HEAD
-/// drift probe, and the fork-authority reads stay fresh (correctness machinery).
+/// base ONCE so the per-table opens reuse the pinned version instead of
+/// re-resolving / re-validating per table. The schema contract is validated once
+/// (when `base` is captured). NOT a general "no re-resolution" handle — the
+/// commit-time OCC re-read, the live-HEAD drift probe, and the fork-authority reads
+/// stay fresh (correctness machinery). Step 5 (PublishPlan unification) makes this
+/// the non-optional publish carrier and adds session-aware base opens there, gated
+/// by an S3 cost test — the warm-session benefit on the single remaining open is an
+/// object-store phenomenon, so it earns its own gate rather than riding this PR.
 ///
 /// Threaded as `Option<&WriteTxn>` through the mutate/load write chain
 /// (`open_for_mutation_on_branch`, `commit_all`, `commit_updates_on_branch_with_expected`)
@@ -104,11 +107,6 @@ pub(crate) struct WriteTxn {
     pub(crate) branch: Option<String>,
     /// The pinned base snapshot (per-table location + version + e_tag), captured once.
     pub(crate) base: Snapshot,
-    /// The shared per-graph Session, captured here so the follow-up change that
-    /// makes the per-table base opens session-aware can reuse it. Not read yet by
-    /// the schema-once threading (which only uses `base` + `branch`).
-    #[allow(dead_code)]
-    pub(crate) session: Arc<lance::session::Session>,
 }
 
 /// Top-level handle to an Omnigraph database.
@@ -771,16 +769,15 @@ impl Omnigraph {
     /// Open a capture-once write transaction (RFC-013 step 3b): validate the schema
     /// contract ONCE and pin the base snapshot + the shared per-graph `Session`. The
     /// per-table opens take `Option<&WriteTxn>` and, on the bound branch for the
-    /// non-strict (Insert/Merge) path, open from the pinned base entry with the warm
-    /// session — instead of re-resolving (re-validating the schema) and cold-opening
-    /// HEAD per table. Strict ops, the fork path, and the commit-time OCC re-read keep
-    /// their fresh reads (those are correctness machinery — see the handoff doc).
+    /// non-strict (Insert/Merge) path, source the pinned base entry — instead of
+    /// re-resolving (re-validating the schema) per table. Strict ops, the fork path,
+    /// and the commit-time OCC re-read keep their fresh reads (those are correctness
+    /// machinery — see the handoff doc).
     pub(crate) async fn open_write_txn(&self, branch: Option<&str>) -> Result<WriteTxn> {
         let resolved = self.resolved_branch_target(branch).await?;
         Ok(WriteTxn {
             branch: resolved.branch,
             base: resolved.snapshot,
-            session: Arc::clone(&self.read_caches.session),
         })
     }
 

--- a/crates/omnigraph/src/db/omnigraph.rs
+++ b/crates/omnigraph/src/db/omnigraph.rs
@@ -41,6 +41,7 @@ pub use repair::{
 };
 pub use schema_apply::SchemaApplyOptions;
 pub use table_ops::PendingIndex;
+pub(crate) use table_ops::OpenedForMutation;
 
 use super::commit_graph::GraphCommit;
 use super::manifest::{
@@ -1673,7 +1674,7 @@ impl Omnigraph {
         &self,
         table_key: &str,
         op_kind: crate::db::MutationOpKind,
-    ) -> Result<(Option<SnapshotHandle>, u64, String, Option<String>)> {
+    ) -> Result<OpenedForMutation> {
         table_ops::open_for_mutation(self, table_key, op_kind).await
     }
 
@@ -1683,7 +1684,7 @@ impl Omnigraph {
         table_key: &str,
         op_kind: crate::db::MutationOpKind,
         txn: Option<&crate::db::WriteTxn>,
-    ) -> Result<(Option<SnapshotHandle>, u64, String, Option<String>)> {
+    ) -> Result<OpenedForMutation> {
         table_ops::open_for_mutation_on_branch(self, branch, table_key, op_kind, txn).await
     }
 
@@ -2547,11 +2548,11 @@ edge WorksAt: Person -> Company
     async fn seed_person_row(db: &mut Omnigraph, name: &str, age: Option<i32>) {
         // No-txn entry, so the handle is always `Some` (collapse #1's skip is
         // gated on `txn.is_some()`).
-        let (ds, _expected_version, full_path, table_branch) = db
+        let (ds, full_path, table_branch) = db
             .open_for_mutation("node:Person", crate::db::MutationOpKind::Insert)
             .await
-            .unwrap();
-        let ds = ds.unwrap();
+            .unwrap()
+            .require_handle("seed_person_row test");
         let schema: Arc<Schema> = Arc::new(ds.dataset().schema().into());
         let columns: Vec<Arc<dyn Array>> = schema
             .fields()

--- a/crates/omnigraph/src/db/omnigraph/table_ops.rs
+++ b/crates/omnigraph/src/db/omnigraph/table_ops.rs
@@ -488,11 +488,40 @@ pub(super) async fn needs_index_work_edge(
         || !db.storage().has_btree_index(&ds, "dst").await?)
 }
 
+/// Result of opening a sub-table for mutation. `handle` is `None` only when a
+/// non-strict (Insert/Merge) op on the WriteTxn's own branch skipped the
+/// accumulation open (RFC-013 step 3b collapse #1) — there the caller needs just
+/// `expected_version`. It is ALWAYS `Some` for strict ops, the fork path, and
+/// every no-`txn` caller (branch merge), which use [`Self::require_handle`].
+#[derive(Debug)]
+pub(crate) struct OpenedForMutation {
+    /// The opened dataset, or `None` on the non-strict-txn open-skip path.
+    pub(crate) handle: Option<SnapshotHandle>,
+    /// The publisher's CAS fence: the opened handle's version, or — when the open
+    /// was skipped — the pinned base entry's version (equal absent uncovered drift).
+    pub(crate) expected_version: u64,
+    pub(crate) full_path: String,
+    pub(crate) table_branch: Option<String>,
+}
+
+impl OpenedForMutation {
+    /// Destructure for a caller that REQUIRES the handle (strict ops, the fork
+    /// path, every no-`txn` caller). The `None` skip fires solely on the
+    /// non-strict `txn` path, which these callers are not — so a panic here means
+    /// a future change broke that contract, named by `ctx`.
+    pub(crate) fn require_handle(self, ctx: &str) -> (SnapshotHandle, String, Option<String>) {
+        let handle = self.handle.unwrap_or_else(|| {
+            panic!("{ctx}: open_for_mutation returned no handle on a path that requires one")
+        });
+        (handle, self.full_path, self.table_branch)
+    }
+}
+
 pub(super) async fn open_for_mutation(
     db: &Omnigraph,
     table_key: &str,
     op_kind: crate::db::MutationOpKind,
-) -> Result<(Option<SnapshotHandle>, u64, String, Option<String>)> {
+) -> Result<OpenedForMutation> {
     let current_branch = db
         .coordinator
         .read()
@@ -519,7 +548,7 @@ pub(super) async fn open_for_mutation_on_branch(
     table_key: &str,
     op_kind: crate::db::MutationOpKind,
     txn: Option<&crate::db::WriteTxn>,
-) -> Result<(Option<SnapshotHandle>, u64, String, Option<String>)> {
+) -> Result<OpenedForMutation> {
     db.ensure_schema_apply_not_locked("write").await?;
     // Source the resolved (snapshot, branch). With a `WriteTxn` the contract was
     // validated once at capture, so use the pinned base + resolved branch instead
@@ -558,16 +587,21 @@ pub(super) async fn open_for_mutation_on_branch(
         match resolved_branch.as_deref() {
             // Non-strict, table already on the active branch → no open, no fork.
             Some(active_branch) if entry.table_branch.as_deref() == Some(active_branch) => {
-                return Ok((
-                    None,
-                    entry.table_version,
+                return Ok(OpenedForMutation {
+                    handle: None,
+                    expected_version: entry.table_version,
                     full_path,
-                    Some(active_branch.to_string()),
-                ));
+                    table_branch: Some(active_branch.to_string()),
+                });
             }
             // Main branch, non-strict → no open. (Main never forks.)
             None => {
-                return Ok((None, entry.table_version, full_path, None));
+                return Ok(OpenedForMutation {
+                    handle: None,
+                    expected_version: entry.table_version,
+                    full_path,
+                    table_branch: None,
+                });
             }
             // Non-strict but the table isn't on the active branch yet — falls
             // through to fork below.
@@ -586,7 +620,12 @@ pub(super) async fn open_for_mutation_on_branch(
                     .ensure_expected_version(&ds, table_key, entry.table_version)?;
             }
             let version = ds.version();
-            Ok((Some(ds), version, full_path, None))
+            Ok(OpenedForMutation {
+                handle: Some(ds),
+                expected_version: version,
+                full_path,
+                table_branch: None,
+            })
         }
         Some(active_branch) => {
             let (ds, table_branch) = open_owned_dataset_for_branch_write(
@@ -600,7 +639,12 @@ pub(super) async fn open_for_mutation_on_branch(
             )
             .await?;
             let version = ds.version();
-            Ok((Some(ds), version, full_path, table_branch))
+            Ok(OpenedForMutation {
+                handle: Some(ds),
+                expected_version: version,
+                full_path,
+                table_branch,
+            })
         }
     }
 }

--- a/crates/omnigraph/src/db/omnigraph/table_ops.rs
+++ b/crates/omnigraph/src/db/omnigraph/table_ops.rs
@@ -499,7 +499,10 @@ pub(super) async fn open_for_mutation(
         .await
         .current_branch()
         .map(str::to_string);
-    open_for_mutation_on_branch(db, current_branch.as_deref(), table_key, op_kind).await
+    // `open_for_mutation` is the no-txn entry (branch merge). Passing `None`
+    // keeps the exact pre-WriteTxn code path (a fresh `resolved_branch_target`
+    // that re-validates the schema).
+    open_for_mutation_on_branch(db, current_branch.as_deref(), table_key, op_kind, None).await
 }
 
 /// Open a sub-table for mutation. The `op_kind` selects the strict-vs-relaxed
@@ -513,15 +516,27 @@ pub(super) async fn open_for_mutation_on_branch(
     branch: Option<&str>,
     table_key: &str,
     op_kind: crate::db::MutationOpKind,
+    txn: Option<&crate::db::WriteTxn>,
 ) -> Result<(SnapshotHandle, String, Option<String>)> {
     db.ensure_schema_apply_not_locked("write").await?;
-    let resolved = db.resolved_branch_target(branch).await?;
-    let entry = resolved
-        .snapshot
+    // Source the resolved (snapshot, branch). With a `WriteTxn` the contract was
+    // validated once at capture, so use the pinned base + resolved branch instead
+    // of `resolved_branch_target` (which re-runs `ensure_schema_state_valid`). The
+    // base is the same fresh per-branch manifest read the no-txn path would have
+    // resolved — only the redundant schema re-validation is dropped. Without a txn
+    // this is byte-identical to the prior `resolved_branch_target` call.
+    let (snapshot, resolved_branch) = match txn {
+        Some(txn) => (txn.base.clone(), txn.branch.clone()),
+        None => {
+            let resolved = db.resolved_branch_target(branch).await?;
+            (resolved.snapshot, resolved.branch)
+        }
+    };
+    let entry = snapshot
         .entry(table_key)
         .ok_or_else(|| OmniError::manifest(format!("no manifest entry for {}", table_key)))?;
     let full_path = format!("{}/{}", db.root_uri, entry.table_path);
-    match resolved.branch.as_deref() {
+    match resolved_branch.as_deref() {
         None => {
             let ds = db
                 .storage()
@@ -1065,12 +1080,22 @@ async fn prepare_updates_for_commit(
     db: &Omnigraph,
     branch: Option<&str>,
     updates: &[crate::db::SubTableUpdate],
+    txn: Option<&crate::db::WriteTxn>,
 ) -> Result<Vec<crate::db::SubTableUpdate>> {
     if updates.is_empty() {
         return Ok(Vec::new());
     }
 
-    let snapshot = db.snapshot_for_branch(branch).await?;
+    // With a `WriteTxn` the schema contract was validated once at capture, so
+    // reuse the pinned base entries (same per-branch manifest snapshot) instead
+    // of `snapshot_for_branch` (which re-runs `ensure_schema_state_valid`). Only
+    // the `entry(table_key).table_path` is read out of it here, identical to the
+    // no-txn path; the post-`commit_staged` index build below still reopens the
+    // dataset at its just-committed version. Without a txn, byte-identical.
+    let snapshot = match txn {
+        Some(txn) => txn.base.clone(),
+        None => db.snapshot_for_branch(branch).await?,
+    };
     let mut prepared = Vec::with_capacity(updates.len());
 
     for update in updates {
@@ -1237,7 +1262,7 @@ pub(super) async fn commit_updates(
         .await
         .current_branch()
         .map(str::to_string);
-    let prepared = prepare_updates_for_commit(db, current_branch.as_deref(), updates).await?;
+    let prepared = prepare_updates_for_commit(db, current_branch.as_deref(), updates, None).await?;
     commit_prepared_updates(db, &prepared, None).await
 }
 
@@ -1281,9 +1306,10 @@ pub(super) async fn commit_updates_on_branch_with_expected(
     updates: &[crate::db::SubTableUpdate],
     expected_table_versions: &std::collections::HashMap<String, u64>,
     actor_id: Option<&str>,
+    txn: Option<&crate::db::WriteTxn>,
 ) -> Result<u64> {
     db.ensure_schema_apply_not_locked("write commit").await?;
-    let prepared = prepare_updates_for_commit(db, branch, updates).await?;
+    let prepared = prepare_updates_for_commit(db, branch, updates, txn).await?;
     commit_prepared_updates_on_branch_with_expected(
         db,
         branch,

--- a/crates/omnigraph/src/db/omnigraph/table_ops.rs
+++ b/crates/omnigraph/src/db/omnigraph/table_ops.rs
@@ -492,7 +492,7 @@ pub(super) async fn open_for_mutation(
     db: &Omnigraph,
     table_key: &str,
     op_kind: crate::db::MutationOpKind,
-) -> Result<(SnapshotHandle, String, Option<String>)> {
+) -> Result<(Option<SnapshotHandle>, u64, String, Option<String>)> {
     let current_branch = db
         .coordinator
         .read()
@@ -501,7 +501,9 @@ pub(super) async fn open_for_mutation(
         .map(str::to_string);
     // `open_for_mutation` is the no-txn entry (branch merge). Passing `None`
     // keeps the exact pre-WriteTxn code path (a fresh `resolved_branch_target`
-    // that re-validates the schema).
+    // that re-validates the schema). With `txn = None` the non-strict early-skip
+    // in `open_for_mutation_on_branch` never fires, so this always returns a
+    // `Some(handle)` for its callers.
     open_for_mutation_on_branch(db, current_branch.as_deref(), table_key, op_kind, None).await
 }
 
@@ -517,7 +519,7 @@ pub(super) async fn open_for_mutation_on_branch(
     table_key: &str,
     op_kind: crate::db::MutationOpKind,
     txn: Option<&crate::db::WriteTxn>,
-) -> Result<(SnapshotHandle, String, Option<String>)> {
+) -> Result<(Option<SnapshotHandle>, u64, String, Option<String>)> {
     db.ensure_schema_apply_not_locked("write").await?;
     // Source the resolved (snapshot, branch). With a `WriteTxn` the contract was
     // validated once at capture, so use the pinned base + resolved branch instead
@@ -536,6 +538,43 @@ pub(super) async fn open_for_mutation_on_branch(
         .entry(table_key)
         .ok_or_else(|| OmniError::manifest(format!("no manifest entry for {}", table_key)))?;
     let full_path = format!("{}/{}", db.root_uri, entry.table_path);
+
+    // Collapse #1 (RFC-013 step 3b): a non-strict op (Insert/Merge) on the txn's
+    // own branch needs no dataset open for ACCUMULATION — the only thing the
+    // caller reads from this handle on the non-strict path is `.version()` (the
+    // publisher's CAS fence), which is exactly the pinned base version. The base
+    // already validated the schema contract once, and the staging reopen
+    // (`reopen_for_mutation`) plus the publisher CAS in `commit_all` are the real
+    // drift guards. So skip `open_dataset_head_for_write` entirely and source the
+    // expected version from the pinned entry.
+    //
+    // Gated on `txn.is_some()`: without a txn (branch merge's `open_for_mutation`)
+    // every arm below is byte-identical to before. STRICT ops (Update/Delete/
+    // SchemaRewrite) always open live HEAD + run `ensure_expected_version`
+    // (read-modify-write SI), and any write that must FORK (the table isn't yet on
+    // the resolved branch) opens too (the fork is a real Lance state advance the
+    // manifest snapshot can't substitute for).
+    if txn.is_some() && !op_kind.strict_pre_stage_version_check() {
+        match resolved_branch.as_deref() {
+            // Non-strict, table already on the active branch → no open, no fork.
+            Some(active_branch) if entry.table_branch.as_deref() == Some(active_branch) => {
+                return Ok((
+                    None,
+                    entry.table_version,
+                    full_path,
+                    Some(active_branch.to_string()),
+                ));
+            }
+            // Main branch, non-strict → no open. (Main never forks.)
+            None => {
+                return Ok((None, entry.table_version, full_path, None));
+            }
+            // Non-strict but the table isn't on the active branch yet — falls
+            // through to fork below.
+            Some(_) => {}
+        }
+    }
+
     match resolved_branch.as_deref() {
         None => {
             let ds = db
@@ -546,7 +585,8 @@ pub(super) async fn open_for_mutation_on_branch(
                 db.storage()
                     .ensure_expected_version(&ds, table_key, entry.table_version)?;
             }
-            Ok((ds, full_path, None))
+            let version = ds.version();
+            Ok((Some(ds), version, full_path, None))
         }
         Some(active_branch) => {
             let (ds, table_branch) = open_owned_dataset_for_branch_write(
@@ -559,7 +599,8 @@ pub(super) async fn open_for_mutation_on_branch(
                 op_kind,
             )
             .await?;
-            Ok((ds, full_path, table_branch))
+            let version = ds.version();
+            Ok((Some(ds), version, full_path, table_branch))
         }
     }
 }
@@ -1081,6 +1122,14 @@ async fn prepare_updates_for_commit(
     branch: Option<&str>,
     updates: &[crate::db::SubTableUpdate],
     txn: Option<&crate::db::WriteTxn>,
+    // Post-`commit_staged` handles handed out by `StagedMutation::commit_all`
+    // (RFC-013 step 3b, collapse #4): table_key → the handle already open at
+    // its just-committed version. When a table's handle is present, the index
+    // build below reuses it and SKIPS the `reopen_for_mutation` open. Absent
+    // entries (other writers — schema apply, merge, ensure_indices, tests —
+    // pass `HashMap::new()`; inline-committed/delete tables are never staged)
+    // keep the byte-identical `reopen_for_mutation` path.
+    mut committed_handles: std::collections::HashMap<String, SnapshotHandle>,
 ) -> Result<Vec<crate::db::SubTableUpdate>> {
     if updates.is_empty() {
         return Ok(Vec::new());
@@ -1109,21 +1158,34 @@ async fn prepare_updates_for_commit(
         let mut prepared_update = update.clone();
         if prepared_update.row_count > 0 {
             let full_path = format!("{}/{}", db.root_uri, entry.table_path);
-            // Strict version check is correct here: this runs INSIDE
+            // Reuse the post-`commit_staged` handle when the caller handed one
+            // out (collapse #4): it is already open at exactly
+            // `prepared_update.table_version`, so the defense-in-depth strict
+            // re-check `reopen_for_mutation` would run is trivially satisfied
+            // and the open is redundant. When no handle is present (other
+            // writers, or any non-staged table), fall back to the byte-identical
+            // `reopen_for_mutation` path.
+            //
+            // Strict version check is correct on the fallback: this runs INSIDE
             // the publisher commit path, after `commit_staged` already
             // advanced Lance HEAD to `prepared_update.table_version`.
             // The check is a defense-in-depth assertion that the
             // dataset state matches what we just committed; not the
             // pre-stage race the op-kind policy targets.
-            let mut ds = reopen_for_mutation(
-                db,
-                &prepared_update.table_key,
-                &full_path,
-                prepared_update.table_branch.as_deref(),
-                prepared_update.table_version,
-                crate::db::MutationOpKind::SchemaRewrite,
-            )
-            .await?;
+            let mut ds = match committed_handles.remove(&prepared_update.table_key) {
+                Some(ds) => ds,
+                None => {
+                    reopen_for_mutation(
+                        db,
+                        &prepared_update.table_key,
+                        &full_path,
+                        prepared_update.table_branch.as_deref(),
+                        prepared_update.table_version,
+                        crate::db::MutationOpKind::SchemaRewrite,
+                    )
+                    .await?
+                }
+            };
             // Any column not yet buildable (e.g. a vector column whose rows
             // have null embeddings) is deferred and logged inside
             // build_indices; a later ensure_indices/optimize materializes it.
@@ -1262,7 +1324,14 @@ pub(super) async fn commit_updates(
         .await
         .current_branch()
         .map(str::to_string);
-    let prepared = prepare_updates_for_commit(db, current_branch.as_deref(), updates, None).await?;
+    let prepared = prepare_updates_for_commit(
+        db,
+        current_branch.as_deref(),
+        updates,
+        None,
+        std::collections::HashMap::new(),
+    )
+    .await?;
     commit_prepared_updates(db, &prepared, None).await
 }
 
@@ -1307,9 +1376,11 @@ pub(super) async fn commit_updates_on_branch_with_expected(
     expected_table_versions: &std::collections::HashMap<String, u64>,
     actor_id: Option<&str>,
     txn: Option<&crate::db::WriteTxn>,
+    committed_handles: std::collections::HashMap<String, SnapshotHandle>,
 ) -> Result<u64> {
     db.ensure_schema_apply_not_locked("write commit").await?;
-    let prepared = prepare_updates_for_commit(db, branch, updates, txn).await?;
+    let prepared =
+        prepare_updates_for_commit(db, branch, updates, txn, committed_handles).await?;
     commit_prepared_updates_on_branch_with_expected(
         db,
         branch,

--- a/crates/omnigraph/src/exec/merge.rs
+++ b/crates/omnigraph/src/exec/merge.rs
@@ -1071,10 +1071,10 @@ async fn publish_rewritten_merge_table(
     // `open_for_mutation` is the no-txn entry, so collapse #1's non-strict
     // open-skip (gated on `txn.is_some()`) never fires here — the handle is
     // always `Some`.
-    let (ds, _expected_version, full_path, table_branch) = target_db
+    let (mut current_ds, full_path, table_branch) = target_db
         .open_for_mutation(table_key, crate::db::MutationOpKind::Merge)
-        .await?;
-    let mut current_ds = ds.expect("no-txn open_for_mutation always opens its dataset");
+        .await?
+        .require_handle("branch merge");
 
     // Phase 1: merge_insert changed/new rows (preserves _row_created_at_version for
     // existing rows, bumps _row_last_updated_at_version only for actually-changed rows).
@@ -1243,10 +1243,10 @@ async fn publish_adopted_delta(
     // `open_for_mutation` is the no-txn entry, so collapse #1's non-strict
     // open-skip (gated on `txn.is_some()`) never fires here — the handle is
     // always `Some`.
-    let (ds, _expected_version, full_path, table_branch) = target_db
+    let (mut current_ds, full_path, table_branch) = target_db
         .open_for_mutation(table_key, crate::db::MutationOpKind::Merge)
-        .await?;
-    let mut current_ds = ds.expect("no-txn open_for_mutation always opens its dataset");
+        .await?
+        .require_handle("branch merge");
 
     // Phase 1a: append the NEW rows. `stage_append_stream` is a streaming
     // `Operation::Append` — no hash join — so it never buffers the delta and

--- a/crates/omnigraph/src/exec/merge.rs
+++ b/crates/omnigraph/src/exec/merge.rs
@@ -1068,10 +1068,13 @@ async fn publish_rewritten_merge_table(
     // source onto target). The inline `delete_where` later in this
     // function operates on rows the rewrite chose to remove, not
     // user-facing predicates, so Merge is the correct policy here.
-    let (ds, full_path, table_branch) = target_db
+    // `open_for_mutation` is the no-txn entry, so collapse #1's non-strict
+    // open-skip (gated on `txn.is_some()`) never fires here — the handle is
+    // always `Some`.
+    let (ds, _expected_version, full_path, table_branch) = target_db
         .open_for_mutation(table_key, crate::db::MutationOpKind::Merge)
         .await?;
-    let mut current_ds = ds;
+    let mut current_ds = ds.expect("no-txn open_for_mutation always opens its dataset");
 
     // Phase 1: merge_insert changed/new rows (preserves _row_created_at_version for
     // existing rows, bumps _row_last_updated_at_version only for actually-changed rows).
@@ -1237,10 +1240,13 @@ async fn publish_adopted_delta(
     table_key: &str,
     delta: &AdoptDelta,
 ) -> Result<crate::db::SubTableUpdate> {
-    let (ds, full_path, table_branch) = target_db
+    // `open_for_mutation` is the no-txn entry, so collapse #1's non-strict
+    // open-skip (gated on `txn.is_some()`) never fires here — the handle is
+    // always `Some`.
+    let (ds, _expected_version, full_path, table_branch) = target_db
         .open_for_mutation(table_key, crate::db::MutationOpKind::Merge)
         .await?;
-    let mut current_ds = ds;
+    let mut current_ds = ds.expect("no-txn open_for_mutation always opens its dataset");
 
     // Phase 1a: append the NEW rows. `stage_append_stream` is a streaming
     // `Operation::Append` — no hash join — so it never buffers the delta and

--- a/crates/omnigraph/src/exec/mutation.rs
+++ b/crates/omnigraph/src/exec/mutation.rs
@@ -666,17 +666,25 @@ async fn open_table_for_mutation(
     // is the pinned base's, identical to the opened handle's `.version()`. Use it
     // directly for `ensure_path` so the no-open path still captures the publisher
     // CAS fence.
-    let (handle, expected_version, full_path, table_branch) = db
+    let opened = db
         .open_for_mutation_on_branch(branch, table_key, op_kind, txn)
         .await?;
+    // Pin the open-skip contract (collapse #1): a missing handle is legal ONLY on
+    // the non-strict `txn` path. A future change that returns `None` elsewhere
+    // (e.g. a new strict arm) trips this in debug builds rather than silently
+    // handing a `None` to a `require_handle` consumer.
+    debug_assert!(
+        opened.handle.is_some() || (txn.is_some() && !op_kind.strict_pre_stage_version_check()),
+        "open_for_mutation_on_branch returned no handle outside the non-strict txn open-skip path",
+    );
     staging.ensure_path(
         table_key,
-        full_path.clone(),
-        table_branch.clone(),
-        expected_version,
+        opened.full_path.clone(),
+        opened.table_branch.clone(),
+        opened.expected_version,
         op_kind,
     );
-    Ok((handle, full_path, table_branch))
+    Ok((opened.handle, opened.full_path, opened.table_branch))
 }
 
 /// D₂ parse-time check: a single mutation query is either insert/update-only
@@ -854,17 +862,22 @@ impl Omnigraph {
                 // interleave between our commit_staged and our publish
                 // (which would correctly fail our CAS but leave Lance
                 // HEAD advanced — the residual class MR-870 recovers).
-                let (updates, expected_versions, sidecar_handle, _queue_guards, committed_handles) =
-                    staged
-                        .commit_all(
-                            self,
-                            requested.as_deref(),
-                            crate::db::manifest::SidecarKind::Mutation,
-                            actor_id,
-                            fork_queue_guards,
-                            Some(&txn),
-                        )
-                        .await?;
+                let super::staging::CommittedMutation {
+                    updates,
+                    expected_versions,
+                    sidecar_handle,
+                    guards: _queue_guards,
+                    committed_handles,
+                } = staged
+                    .commit_all(
+                        self,
+                        requested.as_deref(),
+                        crate::db::manifest::SidecarKind::Mutation,
+                        actor_id,
+                        fork_queue_guards,
+                        Some(&txn),
+                    )
+                    .await?;
                 // Failpoint that wedges the documented finalize→publisher
                 // residual: per-table `commit_staged` calls already
                 // advanced Lance HEAD on every touched table; a failure

--- a/crates/omnigraph/src/exec/mutation.rs
+++ b/crates/omnigraph/src/exec/mutation.rs
@@ -1166,11 +1166,12 @@ impl Omnigraph {
             // + iterate pending edges in-memory for the `src` column,
             // group-by-src. The pending side already includes the row
             // we just appended (above). When the open was skipped (collapse
-            // #1), resolve a pinned read handle for the committed scan from the
-            // txn base — but only when cardinality is non-default, so the common
-            // default-cardinality edge keeps the open-free path. The pinned base
-            // read is the correct committed state (an edge insert never moves the
-            // table's Lance HEAD before the end-of-query commit).
+            // #1), resolve a read handle for the committed scan at LIVE HEAD
+            // (`edge_cardinality_read_handle`, #298) — NOT the pinned txn.base,
+            // which would undercount edges a concurrent writer committed since
+            // capture. Only when cardinality is non-default, so the common
+            // default-cardinality edge keeps the open-free path. (The residual
+            // validate→commit race is the §7.1 gap — step 4.)
             if !edge_type.cardinality.is_default() {
                 let committed_ds = match handle {
                     Some(h) => h,

--- a/crates/omnigraph/src/exec/mutation.rs
+++ b/crates/omnigraph/src/exec/mutation.rs
@@ -602,29 +602,36 @@ use super::staging::{MutationStaging, PendingMode};
 /// ([lance-format/lance#6658](https://github.com/lance-format/lance/issues/6658))
 /// and we can stage deletes on the same path as inserts/updates.
 impl Omnigraph {
-    /// Resolve a pinned READ handle for an edge table's committed-state
-    /// cardinality scan when collapse #1 skipped the accumulation open. The
-    /// edge-insert path no longer opens the edge dataset (non-strict op + txn),
-    /// but `@card` validation needs to scan committed `src` values. The pinned
-    /// `txn.base` entry is the correct committed image: an edge insert never
-    /// advances the table's Lance HEAD before the end-of-query commit, so the
-    /// base version equals live committed HEAD. Falls back to a fresh
-    /// per-branch snapshot only if no txn is in flight (defensive — the `None`
-    /// handle that reaches this is always under a txn today).
+    /// Resolve a LIVE-HEAD read handle for an edge table's committed-state `@card`
+    /// scan when collapse #1 skipped the accumulation open. The edge-insert path no
+    /// longer opens the edge dataset (non-strict op + txn), but cardinality is
+    /// validated ONCE (never rechecked at commit), so the scan must observe the
+    /// freshest committed edges — NOT the pinned `txn.base`. A concurrent writer can
+    /// commit edges to this table after `txn` capture; counting against the stale
+    /// base undercounts and lets a violating insert through (invariant 9). The table
+    /// LOCATION is read from the pinned entry (stable across versions); the dataset is
+    /// opened at live HEAD via `open_dataset_head_for_write` (a read here despite the
+    /// name — no lock/stage), restoring the pre-3b image (the mutation's own open).
+    /// The residual validate→commit race (a writer committing between this scan and
+    /// the end-of-query commit) is the §7.1 gap, closed by RFC-013 step 4.
     async fn edge_cardinality_read_handle(
         &self,
         txn: Option<&crate::db::WriteTxn>,
         table_key: &str,
     ) -> Result<SnapshotHandle> {
-        let entry = match txn {
-            Some(txn) => txn.base.entry(table_key).cloned(),
-            None => None,
-        };
-        match entry {
-            Some(entry) => self.storage().open_snapshot_at_entry(&entry).await,
+        let branch = txn.and_then(|t| t.branch.as_deref());
+        match txn.and_then(|t| t.base.entry(table_key)) {
+            Some(entry) => {
+                let full_path = self.storage().dataset_uri(&entry.table_path);
+                self.storage()
+                    .open_dataset_head_for_write(table_key, &full_path, branch)
+                    .await
+            }
+            // Unreachable today (the `None` handle only reaches here under a txn whose
+            // base contains the table). Defensive: resolve the table fresh (live)
+            // without the schema re-validation `snapshot_for_branch` would re-run.
             None => {
-                let branch = txn.and_then(|t| t.branch.clone());
-                let snapshot = self.snapshot_for_branch(branch.as_deref()).await?;
+                let snapshot = self.fresh_snapshot_for_branch_unchecked(branch).await?;
                 self.storage().open_snapshot_at_table(&snapshot, table_key).await
             }
         }

--- a/crates/omnigraph/src/exec/mutation.rs
+++ b/crates/omnigraph/src/exec/mutation.rs
@@ -607,6 +607,7 @@ async fn open_table_for_mutation(
     branch: Option<&str>,
     table_key: &str,
     op_kind: crate::db::MutationOpKind,
+    txn: Option<&crate::db::WriteTxn>,
 ) -> Result<(SnapshotHandle, String, Option<String>)> {
     if let Some(prior) = staging.inline_committed.get(table_key) {
         let path = staging.paths.get(table_key).ok_or_else(|| {
@@ -615,6 +616,9 @@ async fn open_table_for_mutation(
                 table_key
             ))
         })?;
+        // The inline-committed reopen does NOT validate the schema contract
+        // (it reopens at the post-inline-commit Lance version directly), so it
+        // takes no `txn` — threading it here would change nothing.
         let ds = db
             .reopen_for_mutation(
                 table_key,
@@ -627,7 +631,7 @@ async fn open_table_for_mutation(
         return Ok((ds, path.full_path.clone(), path.table_branch.clone()));
     }
     let (ds, full_path, table_branch) = db
-        .open_for_mutation_on_branch(branch, table_key, op_kind)
+        .open_for_mutation_on_branch(branch, table_key, op_kind, txn)
         .await?;
     let expected_version = ds.version();
     staging.ensure_path(
@@ -720,14 +724,14 @@ impl Omnigraph {
         params: &ParamMap,
         actor_id: Option<&str>,
     ) -> Result<MutationResult> {
-        self.ensure_schema_state_valid().await?;
         // Converge any pending recovery sidecar (a previously failed
         // writer's Phase B → Phase C residual) before executing: the
         // inline delete path advances Lance HEAD during execution and
         // the staged path's commit-time drift guard refuses
         // sidecar-covered drift, so a long-lived handle must heal here
         // — not at restart. One `list_dir` when no sidecars exist (the
-        // steady state).
+        // steady state). MUST run before `open_write_txn` below — the heal
+        // may advance the manifest, so the pinned base must be captured after.
         self.heal_pending_recovery_sidecars().await?;
         let requested = Self::normalize_branch_name(branch)?;
         // Reject internal `__run__*` / system-prefixed branches at the
@@ -737,6 +741,16 @@ impl Omnigraph {
         if let Some(name) = requested.as_deref() {
             crate::db::ensure_public_branch_ref(name, "mutate")?;
         }
+        // Capture-once write transaction (RFC-013 step 3b). `open_write_txn`
+        // validates the schema contract ONCE (it resolves the branch target,
+        // whose first line is `ensure_schema_state_valid`) and pins the base
+        // snapshot for this write. Threaded as `Some(&txn)` through execution,
+        // staging commit, and the manifest publish so the per-table opens and
+        // the commit-time OCC re-read reuse the pinned base instead of
+        // re-validating the contract at every resolve point. Captured AFTER the
+        // recovery heal (which may advance the manifest) and AFTER `requested`
+        // is known so it pins the post-heal snapshot for the correct branch.
+        let txn = self.open_write_txn(requested.as_deref()).await?;
         let resolved_params = enrich_mutation_params(params)?;
 
         // Per-query staging accumulator. Inserts and updates push batches
@@ -785,7 +799,13 @@ impl Omnigraph {
         };
 
         let exec_result = self
-            .execute_named_mutation(&ir, &resolved_params, requested.as_deref(), &mut staging)
+            .execute_named_mutation(
+                &ir,
+                &resolved_params,
+                requested.as_deref(),
+                &mut staging,
+                Some(&txn),
+            )
             .await;
 
         match exec_result {
@@ -806,6 +826,7 @@ impl Omnigraph {
                         crate::db::manifest::SidecarKind::Mutation,
                         actor_id,
                         fork_queue_guards,
+                        Some(&txn),
                     )
                     .await?;
                 // Failpoint that wedges the documented finalize→publisher
@@ -824,6 +845,7 @@ impl Omnigraph {
                     &updates,
                     &expected_versions,
                     actor_id,
+                    Some(&txn),
                 )
                 .await?;
                 // Phase C succeeded — sidecar can be deleted. If this
@@ -938,6 +960,7 @@ impl Omnigraph {
         params: &ParamMap,
         branch: Option<&str>,
         staging: &mut MutationStaging,
+        txn: Option<&crate::db::WriteTxn>,
     ) -> Result<MutationResult> {
         let mut total = MutationResult::default();
         for op in &ir.ops {
@@ -946,7 +969,7 @@ impl Omnigraph {
                     type_name,
                     assignments,
                 } => {
-                    self.execute_insert(type_name, assignments, params, branch, staging)
+                    self.execute_insert(type_name, assignments, params, branch, staging, txn)
                         .await?
                 }
                 MutationOpIR::Update {
@@ -954,14 +977,16 @@ impl Omnigraph {
                     assignments,
                     predicate,
                 } => {
-                    self.execute_update(type_name, assignments, predicate, params, branch, staging)
-                        .await?
+                    self.execute_update(
+                        type_name, assignments, predicate, params, branch, staging, txn,
+                    )
+                    .await?
                 }
                 MutationOpIR::Delete {
                     type_name,
                     predicate,
                 } => {
-                    self.execute_delete(type_name, predicate, params, branch, staging)
+                    self.execute_delete(type_name, predicate, params, branch, staging, txn)
                         .await?
                 }
             };
@@ -978,6 +1003,7 @@ impl Omnigraph {
         params: &ParamMap,
         branch: Option<&str>,
         staging: &mut MutationStaging,
+        txn: Option<&crate::db::WriteTxn>,
     ) -> Result<MutationResult> {
         let mut resolved: HashMap<String, Literal> = HashMap::new();
         for a in assignments {
@@ -1026,7 +1052,7 @@ impl Omnigraph {
                 crate::db::MutationOpKind::Insert
             };
             let (_ds, _full_path, _table_branch) =
-                open_table_for_mutation(self, staging, branch, &table_key, insert_kind).await?;
+                open_table_for_mutation(self, staging, branch, &table_key, insert_kind, txn).await?;
             // Accumulate. @key inserts go into the Merge stream (so a
             // later update on the same id coalesces correctly); no-key
             // inserts go into the Append stream.
@@ -1066,6 +1092,7 @@ impl Omnigraph {
                 branch,
                 &table_key,
                 crate::db::MutationOpKind::Insert,
+                txn,
             )
             .await?;
             // Accumulate the new edge row. Edge IDs are ULID-generated so
@@ -1098,6 +1125,7 @@ impl Omnigraph {
         params: &ParamMap,
         branch: Option<&str>,
         staging: &mut MutationStaging,
+        txn: Option<&crate::db::WriteTxn>,
     ) -> Result<MutationResult> {
         // Defense in depth: ensure this is a node type
         if !self.catalog().node_types.contains_key(type_name) {
@@ -1128,6 +1156,7 @@ impl Omnigraph {
             branch,
             &table_key,
             crate::db::MutationOpKind::Update,
+            txn,
         )
         .await?;
 
@@ -1228,13 +1257,14 @@ impl Omnigraph {
         params: &ParamMap,
         branch: Option<&str>,
         staging: &mut MutationStaging,
+        txn: Option<&crate::db::WriteTxn>,
     ) -> Result<MutationResult> {
         let is_node = self.catalog().node_types.contains_key(type_name);
         if is_node {
-            self.execute_delete_node(type_name, predicate, params, branch, staging)
+            self.execute_delete_node(type_name, predicate, params, branch, staging, txn)
                 .await
         } else {
-            self.execute_delete_edge(type_name, predicate, params, branch, staging)
+            self.execute_delete_edge(type_name, predicate, params, branch, staging, txn)
                 .await
         }
     }
@@ -1246,6 +1276,7 @@ impl Omnigraph {
         params: &ParamMap,
         branch: Option<&str>,
         staging: &mut MutationStaging,
+        txn: Option<&crate::db::WriteTxn>,
     ) -> Result<MutationResult> {
         let pred_sql = predicate_to_sql(predicate, params, false)?;
 
@@ -1256,6 +1287,7 @@ impl Omnigraph {
             branch,
             &table_key,
             crate::db::MutationOpKind::Delete,
+            txn,
         )
         .await?;
         let initial_version = ds.version();
@@ -1353,6 +1385,7 @@ impl Omnigraph {
                 branch,
                 &edge_table_key,
                 crate::db::MutationOpKind::Delete,
+                txn,
             )
             .await?;
 
@@ -1391,6 +1424,7 @@ impl Omnigraph {
         params: &ParamMap,
         branch: Option<&str>,
         staging: &mut MutationStaging,
+        txn: Option<&crate::db::WriteTxn>,
     ) -> Result<MutationResult> {
         let pred_sql = predicate_to_sql(predicate, params, true)?;
 
@@ -1401,6 +1435,7 @@ impl Omnigraph {
             branch,
             &table_key,
             crate::db::MutationOpKind::Delete,
+            txn,
         )
         .await?;
 

--- a/crates/omnigraph/src/exec/mutation.rs
+++ b/crates/omnigraph/src/exec/mutation.rs
@@ -601,6 +601,36 @@ use super::staging::{MutationStaging, PendingMode};
 /// away once Lance exposes a two-phase delete API
 /// ([lance-format/lance#6658](https://github.com/lance-format/lance/issues/6658))
 /// and we can stage deletes on the same path as inserts/updates.
+impl Omnigraph {
+    /// Resolve a pinned READ handle for an edge table's committed-state
+    /// cardinality scan when collapse #1 skipped the accumulation open. The
+    /// edge-insert path no longer opens the edge dataset (non-strict op + txn),
+    /// but `@card` validation needs to scan committed `src` values. The pinned
+    /// `txn.base` entry is the correct committed image: an edge insert never
+    /// advances the table's Lance HEAD before the end-of-query commit, so the
+    /// base version equals live committed HEAD. Falls back to a fresh
+    /// per-branch snapshot only if no txn is in flight (defensive — the `None`
+    /// handle that reaches this is always under a txn today).
+    async fn edge_cardinality_read_handle(
+        &self,
+        txn: Option<&crate::db::WriteTxn>,
+        table_key: &str,
+    ) -> Result<SnapshotHandle> {
+        let entry = match txn {
+            Some(txn) => txn.base.entry(table_key).cloned(),
+            None => None,
+        };
+        match entry {
+            Some(entry) => self.storage().open_snapshot_at_entry(&entry).await,
+            None => {
+                let branch = txn.and_then(|t| t.branch.clone());
+                let snapshot = self.snapshot_for_branch(branch.as_deref()).await?;
+                self.storage().open_snapshot_at_table(&snapshot, table_key).await
+            }
+        }
+    }
+}
+
 async fn open_table_for_mutation(
     db: &Omnigraph,
     staging: &mut MutationStaging,
@@ -608,7 +638,7 @@ async fn open_table_for_mutation(
     table_key: &str,
     op_kind: crate::db::MutationOpKind,
     txn: Option<&crate::db::WriteTxn>,
-) -> Result<(SnapshotHandle, String, Option<String>)> {
+) -> Result<(Option<SnapshotHandle>, String, Option<String>)> {
     if let Some(prior) = staging.inline_committed.get(table_key) {
         let path = staging.paths.get(table_key).ok_or_else(|| {
             OmniError::manifest_internal(format!(
@@ -618,7 +648,8 @@ async fn open_table_for_mutation(
         })?;
         // The inline-committed reopen does NOT validate the schema contract
         // (it reopens at the post-inline-commit Lance version directly), so it
-        // takes no `txn` — threading it here would change nothing.
+        // takes no `txn` — threading it here would change nothing. Deletes are
+        // strict ops, so this always opens (returns `Some`).
         let ds = db
             .reopen_for_mutation(
                 table_key,
@@ -628,12 +659,16 @@ async fn open_table_for_mutation(
                 op_kind,
             )
             .await?;
-        return Ok((ds, path.full_path.clone(), path.table_branch.clone()));
+        return Ok((Some(ds), path.full_path.clone(), path.table_branch.clone()));
     }
-    let (ds, full_path, table_branch) = db
+    // `open_for_mutation_on_branch` returns the expected version even when it
+    // skips the open (collapse #1, the non-strict insert/merge path): the version
+    // is the pinned base's, identical to the opened handle's `.version()`. Use it
+    // directly for `ensure_path` so the no-open path still captures the publisher
+    // CAS fence.
+    let (handle, expected_version, full_path, table_branch) = db
         .open_for_mutation_on_branch(branch, table_key, op_kind, txn)
         .await?;
-    let expected_version = ds.version();
     staging.ensure_path(
         table_key,
         full_path.clone(),
@@ -641,7 +676,7 @@ async fn open_table_for_mutation(
         expected_version,
         op_kind,
     );
-    Ok((ds, full_path, table_branch))
+    Ok((handle, full_path, table_branch))
 }
 
 /// D₂ parse-time check: a single mutation query is either insert/update-only
@@ -819,16 +854,17 @@ impl Omnigraph {
                 // interleave between our commit_staged and our publish
                 // (which would correctly fail our CAS but leave Lance
                 // HEAD advanced — the residual class MR-870 recovers).
-                let (updates, expected_versions, sidecar_handle, _queue_guards) = staged
-                    .commit_all(
-                        self,
-                        requested.as_deref(),
-                        crate::db::manifest::SidecarKind::Mutation,
-                        actor_id,
-                        fork_queue_guards,
-                        Some(&txn),
-                    )
-                    .await?;
+                let (updates, expected_versions, sidecar_handle, _queue_guards, committed_handles) =
+                    staged
+                        .commit_all(
+                            self,
+                            requested.as_deref(),
+                            crate::db::manifest::SidecarKind::Mutation,
+                            actor_id,
+                            fork_queue_guards,
+                            Some(&txn),
+                        )
+                        .await?;
                 // Failpoint that wedges the documented finalize→publisher
                 // residual: per-table `commit_staged` calls already
                 // advanced Lance HEAD on every touched table; a failure
@@ -846,6 +882,7 @@ impl Omnigraph {
                     &expected_versions,
                     actor_id,
                     Some(&txn),
+                    committed_handles,
                 )
                 .await?;
                 // Phase C succeeded — sidecar can be deleted. If this
@@ -1051,6 +1088,10 @@ impl Omnigraph {
             } else {
                 crate::db::MutationOpKind::Insert
             };
+            // Node inserts are non-strict (Insert/Merge), so with a `WriteTxn`
+            // this opens NOTHING (collapse #1) — the handle is discarded anyway;
+            // only `ensure_path`'s captured version (read inside
+            // `open_table_for_mutation`) is used downstream.
             let (_ds, _full_path, _table_branch) =
                 open_table_for_mutation(self, staging, branch, &table_key, insert_kind, txn).await?;
             // Accumulate. @key inserts go into the Merge stream (so a
@@ -1085,8 +1126,10 @@ impl Omnigraph {
                 )?;
             }
             let table_key = format!("edge:{}", type_name);
-            // Capture pre-write metadata on first touch (no Lance write).
-            let (ds, _full_path, _table_branch) = open_table_for_mutation(
+            // Capture pre-write metadata on first touch. Edge inserts are
+            // non-strict, so with a `WriteTxn` this opens NOTHING (collapse #1)
+            // and returns `None`.
+            let (handle, _full_path, _table_branch) = open_table_for_mutation(
                 self,
                 staging,
                 branch,
@@ -1102,9 +1145,26 @@ impl Omnigraph {
             // Edge cardinality validation: scan committed edges via Lance
             // + iterate pending edges in-memory for the `src` column,
             // group-by-src. The pending side already includes the row
-            // we just appended (above).
-            validate_edge_cardinality_with_pending(self, &ds, staging, &table_key, edge_type)
+            // we just appended (above). When the open was skipped (collapse
+            // #1), resolve a pinned read handle for the committed scan from the
+            // txn base — but only when cardinality is non-default, so the common
+            // default-cardinality edge keeps the open-free path. The pinned base
+            // read is the correct committed state (an edge insert never moves the
+            // table's Lance HEAD before the end-of-query commit).
+            if !edge_type.cardinality.is_default() {
+                let committed_ds = match handle {
+                    Some(h) => h,
+                    None => self.edge_cardinality_read_handle(txn, &table_key).await?,
+                };
+                validate_edge_cardinality_with_pending(
+                    self,
+                    &committed_ds,
+                    staging,
+                    &table_key,
+                    edge_type,
+                )
                 .await?;
+            }
 
             self.invalidate_graph_index().await;
 
@@ -1150,7 +1210,7 @@ impl Omnigraph {
         let blob_props = self.catalog().node_types[type_name].blob_properties.clone();
 
         let table_key = format!("node:{}", type_name);
-        let (ds, _full_path, _table_branch) = open_table_for_mutation(
+        let (handle, _full_path, _table_branch) = open_table_for_mutation(
             self,
             staging,
             branch,
@@ -1159,6 +1219,9 @@ impl Omnigraph {
             txn,
         )
         .await?;
+        // Update is a STRICT op, so collapse #1 never skips its open — the
+        // handle is always `Some` (and it's needed for the committed scan below).
+        let ds = handle.expect("strict Update op always opens its dataset");
 
         // Scan committed via Lance + apply the same predicate to pending
         // batches via DataFusion `MemTable` (read-your-writes for prior
@@ -1281,7 +1344,7 @@ impl Omnigraph {
         let pred_sql = predicate_to_sql(predicate, params, false)?;
 
         let table_key = format!("node:{}", type_name);
-        let (ds, full_path, table_branch) = open_table_for_mutation(
+        let (handle, full_path, table_branch) = open_table_for_mutation(
             self,
             staging,
             branch,
@@ -1290,6 +1353,8 @@ impl Omnigraph {
             txn,
         )
         .await?;
+        // Delete is a STRICT op, so collapse #1 never skips its open.
+        let ds = handle.expect("strict Delete op always opens its dataset");
         let initial_version = ds.version();
 
         // Scan matching IDs for cascade. Per D₂ this never overlaps with
@@ -1379,7 +1444,7 @@ impl Omnigraph {
 
             let edge_table_key = format!("edge:{}", edge_name);
             let cascade_filter = cascade_filters.join(" OR ");
-            let (edge_ds, edge_full_path, edge_table_branch) = open_table_for_mutation(
+            let (edge_handle, edge_full_path, edge_table_branch) = open_table_for_mutation(
                 self,
                 staging,
                 branch,
@@ -1388,6 +1453,8 @@ impl Omnigraph {
                 txn,
             )
             .await?;
+            // Delete is a STRICT op, so collapse #1 never skips its open.
+            let edge_ds = edge_handle.expect("strict Delete op always opens its dataset");
 
             let (_new_edge_ds, edge_delete) = self
                 .storage_inline_residual()
@@ -1429,7 +1496,7 @@ impl Omnigraph {
         let pred_sql = predicate_to_sql(predicate, params, true)?;
 
         let table_key = format!("edge:{}", type_name);
-        let (ds, full_path, table_branch) = open_table_for_mutation(
+        let (handle, full_path, table_branch) = open_table_for_mutation(
             self,
             staging,
             branch,
@@ -1438,6 +1505,8 @@ impl Omnigraph {
             txn,
         )
         .await?;
+        // Delete is a STRICT op, so collapse #1 never skips its open.
+        let ds = handle.expect("strict Delete op always opens its dataset");
 
         let (_new_ds, delete_state) = self
             .storage_inline_residual()

--- a/crates/omnigraph/src/exec/staging.rs
+++ b/crates/omnigraph/src/exec/staging.rs
@@ -485,6 +485,7 @@ impl StagedMutation {
             Vec<(String, Option<String>)>,
             Vec<tokio::sync::OwnedMutexGuard<()>>,
         )>,
+        txn: Option<&crate::db::WriteTxn>,
     ) -> Result<(
         Vec<SubTableUpdate>,
         HashMap<String, u64>,
@@ -585,7 +586,18 @@ impl StagedMutation {
         // Multi-coordinator deployments (§VI.27 aspirational) get
         // genuine cross-process drift detection from this read for
         // free.
-        let snapshot = db.fresh_snapshot_for_branch(branch).await?;
+        //
+        // This MUST be a FRESH per-branch manifest read (never the warm
+        // cache) for the OCC re-capture below — but with a `WriteTxn` the
+        // schema contract was already validated at capture, so use the
+        // `_unchecked` variant, which drops the redundant
+        // `ensure_schema_state_valid` AND the commit-graph load the OCC read
+        // never consults (a fresh manifest read yields the same `Snapshot`).
+        // Without a txn this is byte-identical to the prior checked call.
+        let snapshot = match txn {
+            Some(_) => db.fresh_snapshot_for_branch_unchecked(branch).await?,
+            None => db.fresh_snapshot_for_branch(branch).await?,
+        };
         for entry in staged.iter_mut() {
             let current = snapshot
                 .entry(&entry.table_key)

--- a/crates/omnigraph/src/exec/staging.rs
+++ b/crates/omnigraph/src/exec/staging.rs
@@ -440,6 +440,26 @@ struct StagedTableEntry {
     staged_write: StagedHandle,
 }
 
+/// Output of [`StagedMutation::commit_all`] (Phase B): the publisher's input plus
+/// the queue guards the caller must hold across the manifest publish.
+pub(crate) struct CommittedMutation {
+    /// Per-table updates to publish to the manifest.
+    pub(crate) updates: Vec<SubTableUpdate>,
+    /// Per-table manifest pins refreshed under the write queue — the publisher's CAS fence.
+    pub(crate) expected_versions: HashMap<String, u64>,
+    /// Recovery sidecar to delete after Phase C succeeds (`None` when nothing staged).
+    pub(crate) sidecar_handle: Option<RecoverySidecarHandle>,
+    /// Per-`(table, branch)` write-queue guards — the caller MUST hold these across
+    /// the manifest publish (see `commit_all`) so no writer interleaves between
+    /// `commit_staged` and the publish.
+    pub(crate) guards: Vec<tokio::sync::OwnedMutexGuard<()>>,
+    /// Post-`commit_staged` handle per STAGED table (table_key → handle at the
+    /// just-committed version). Carried out (RFC-013 step 3b, collapse #4) so the
+    /// publish-prepare index build reuses it instead of a fresh `reopen_for_mutation`
+    /// at the same version. Inline-committed / delete tables are absent (no staged handle).
+    pub(crate) committed_handles: HashMap<String, SnapshotHandle>,
+}
+
 impl StagedMutation {
     /// **Phase B** of the two-phase commit: acquire per-`(table_key,
     /// branch)` queues, revalidate manifest pins, write the recovery
@@ -486,18 +506,7 @@ impl StagedMutation {
             Vec<tokio::sync::OwnedMutexGuard<()>>,
         )>,
         txn: Option<&crate::db::WriteTxn>,
-    ) -> Result<(
-        Vec<SubTableUpdate>,
-        HashMap<String, u64>,
-        Option<RecoverySidecarHandle>,
-        Vec<tokio::sync::OwnedMutexGuard<()>>,
-        // Post-`commit_staged` handle per STAGED table (table_key → handle at
-        // the just-committed version). Carried out (RFC-013 step 3b, collapse
-        // #4) so the publish-prepare index build reuses it instead of a fresh
-        // `reopen_for_mutation` at the same version. Inline-committed / delete
-        // tables are NOT in the map (they have no staged handle).
-        HashMap<String, SnapshotHandle>,
-    )> {
+    ) -> Result<CommittedMutation> {
         let StagedMutation {
             inline_committed,
             mut staged,
@@ -836,13 +845,13 @@ impl StagedMutation {
             committed_handles.insert(table_key, new_ds);
         }
 
-        Ok((
+        Ok(CommittedMutation {
             updates,
             expected_versions,
             sidecar_handle,
             guards,
             committed_handles,
-        ))
+        })
     }
 }
 

--- a/crates/omnigraph/src/exec/staging.rs
+++ b/crates/omnigraph/src/exec/staging.rs
@@ -491,6 +491,12 @@ impl StagedMutation {
         HashMap<String, u64>,
         Option<RecoverySidecarHandle>,
         Vec<tokio::sync::OwnedMutexGuard<()>>,
+        // Post-`commit_staged` handle per STAGED table (table_key → handle at
+        // the just-committed version). Carried out (RFC-013 step 3b, collapse
+        // #4) so the publish-prepare index build reuses it instead of a fresh
+        // `reopen_for_mutation` at the same version. Inline-committed / delete
+        // tables are NOT in the map (they have no staged handle).
+        HashMap<String, SnapshotHandle>,
     )> {
         let StagedMutation {
             inline_committed,
@@ -631,15 +637,20 @@ impl StagedMutation {
             // live Lance HEAD still equals that manifest pin. If an external
             // raw Lance write or a pre-fix maintenance path moved HEAD without
             // publishing `__manifest`, this write must not silently fold it.
-            let head = db
-                .storage()
-                .open_dataset_head_for_write(
-                    &entry.table_key,
-                    &entry.path.full_path,
-                    entry.path.table_branch.as_deref(),
-                )
-                .await?
-                .version();
+            //
+            // `latest_version_id` reads the latest manifest pointer off the
+            // already-open staged handle (the #2 staging open) WITHOUT a fresh
+            // `Dataset::open` — the same cheap live-HEAD probe
+            // `ManifestCoordinator::probe_latest_version` uses. This replaces a
+            // redundant `open_dataset_head_for_write` (RFC-013 step 3b, collapse
+            // #3): the drift comparison below is byte-identical; only how `head`
+            // is obtained changes (probe vs cold open).
+            let head = entry
+                .dataset
+                .dataset()
+                .latest_version_id()
+                .await
+                .map_err(|e| OmniError::Lance(e.to_string()))?;
             if head < current {
                 return Err(OmniError::manifest_internal(format!(
                     "table '{}' Lance HEAD version {} is behind manifest version {}",
@@ -798,6 +809,12 @@ impl StagedMutation {
 
         let mut updates: Vec<SubTableUpdate> = inline_committed.into_values().collect();
 
+        // Carry each staged table's post-`commit_staged` handle out so the
+        // publish-prepare index build reuses it (collapse #4) instead of
+        // re-opening the dataset at the same just-committed version.
+        let mut committed_handles: HashMap<String, SnapshotHandle> =
+            HashMap::with_capacity(staged.len());
+
         for entry in staged {
             let StagedTableEntry {
                 table_key,
@@ -810,15 +827,22 @@ impl StagedMutation {
             let new_ds = db.storage().commit_staged(dataset, staged_write).await?;
             let state = db.storage().table_state(&path.full_path, &new_ds).await?;
             updates.push(SubTableUpdate {
-                table_key,
+                table_key: table_key.clone(),
                 table_version: state.version,
                 table_branch: path.table_branch.clone(),
                 row_count: state.row_count,
                 version_metadata: state.version_metadata,
             });
+            committed_handles.insert(table_key, new_ds);
         }
 
-        Ok((updates, expected_versions, sidecar_handle, guards))
+        Ok((
+            updates,
+            expected_versions,
+            sidecar_handle,
+            guards,
+            committed_handles,
+        ))
     }
 }
 

--- a/crates/omnigraph/src/instrumentation.rs
+++ b/crates/omnigraph/src/instrumentation.rs
@@ -43,6 +43,13 @@ pub struct QueryIoProbes {
     /// handle cache (Fix 3) serves them.
     pub table_wrapper: Option<Arc<dyn WrappingObjectStore>>,
     pub probe_count: Arc<AtomicU64>,
+    /// Counts table-open CALLS through the two instrumented chokepoints
+    /// (`open_dataset_tracked` / `open_table_dataset`). Unlike the opener-read
+    /// term (which mixes with the merge-insert/RI scan on the write path), this is
+    /// an exact open-invocation count — lets a write cost test assert
+    /// `opens <= |touched_tables|` (RFC-013 step 3b). `forbidden_apis` guarantees
+    /// every write-path open routes through these chokepoints, so the count is complete.
+    pub open_count: Arc<AtomicU64>,
 }
 
 tokio::task_local! {
@@ -78,6 +85,12 @@ pub(crate) fn table_wrapper() -> Option<Arc<dyn WrappingObjectStore>> {
 /// No-op when no probes are installed (production).
 pub(crate) fn record_probe() {
     let _ = current(|p| p.probe_count.fetch_add(1, Ordering::Relaxed));
+}
+
+/// Record one table-open call against the active per-query probes. No-op in
+/// production. Called at both open chokepoints so a cost test can count opens.
+pub(crate) fn record_open() {
+    let _ = current(|p| p.open_count.fetch_add(1, Ordering::Relaxed));
 }
 
 /// Per-operation staged-write counts, installed for a task via
@@ -177,6 +190,7 @@ pub(crate) async fn open_dataset_tracked(
     uri: &str,
     wrapper: Option<Arc<dyn WrappingObjectStore>>,
 ) -> Result<Dataset> {
+    record_open();
     let result = match wrapper {
         None => Dataset::open(uri).await,
         Some(wrapper) => {
@@ -203,6 +217,7 @@ pub(crate) async fn open_table_dataset(
     version: u64,
     session: Option<&Arc<lance::session::Session>>,
 ) -> Result<Dataset> {
+    record_open();
     let mut builder = DatasetBuilder::from_uri(location).with_version(version);
     if let Some(session) = session {
         builder = builder.with_session(session.clone());

--- a/crates/omnigraph/src/instrumentation.rs
+++ b/crates/omnigraph/src/instrumentation.rs
@@ -50,8 +50,12 @@ pub struct QueryIoProbes {
     /// them would make the `data_open_count <= |touched_tables|` write gate
     /// (RFC-013 step 3b) unreachable by threading alone. Unlike the opener-read
     /// term (which mixes with the merge-insert/RI scan on the write path), this is
-    /// an exact open-invocation count. `forbidden_apis` guarantees every write-path
-    /// open routes through these chokepoints, so the count is complete.
+    /// an exact open-invocation count. `forbidden_apis` keeps engine code OUTSIDE the
+    /// storage layer (`exec/`, `db/omnigraph/`, `loader/`, `changes/`) from opening
+    /// datasets except through these chokepoints, so the count is complete for the
+    /// keyed-write data path the gate measures. (`table_store.rs` is allow-listed and
+    /// does hold direct `Dataset::open`s — but only for branch-management ops
+    /// (`delete_branch`/`list_branches`/`force_delete_branch`), never that hot path.)
     pub data_open_count: Arc<AtomicU64>,
     /// Internal/system-table (`__manifest`, `_graph_commits*`) open CALLS — the
     /// complement of `data_open_count`, kept for symmetry and debugging.

--- a/crates/omnigraph/src/instrumentation.rs
+++ b/crates/omnigraph/src/instrumentation.rs
@@ -43,13 +43,19 @@ pub struct QueryIoProbes {
     /// handle cache (Fix 3) serves them.
     pub table_wrapper: Option<Arc<dyn WrappingObjectStore>>,
     pub probe_count: Arc<AtomicU64>,
-    /// Counts table-open CALLS through the two instrumented chokepoints
-    /// (`open_dataset_tracked` / `open_table_dataset`). Unlike the opener-read
+    /// Counts DATA-table open CALLS through the two instrumented chokepoints
+    /// (`open_dataset_tracked` / `open_table_dataset`), classified by URI so the
+    /// internal/system tables (`__manifest`, `_graph_commits*`) are EXCLUDED — the
+    /// publisher CAS and commit-graph append open those every write, and counting
+    /// them would make the `data_open_count <= |touched_tables|` write gate
+    /// (RFC-013 step 3b) unreachable by threading alone. Unlike the opener-read
     /// term (which mixes with the merge-insert/RI scan on the write path), this is
-    /// an exact open-invocation count — lets a write cost test assert
-    /// `opens <= |touched_tables|` (RFC-013 step 3b). `forbidden_apis` guarantees
-    /// every write-path open routes through these chokepoints, so the count is complete.
-    pub open_count: Arc<AtomicU64>,
+    /// an exact open-invocation count. `forbidden_apis` guarantees every write-path
+    /// open routes through these chokepoints, so the count is complete.
+    pub data_open_count: Arc<AtomicU64>,
+    /// Internal/system-table (`__manifest`, `_graph_commits*`) open CALLS — the
+    /// complement of `data_open_count`, kept for symmetry and debugging.
+    pub internal_open_count: Arc<AtomicU64>,
 }
 
 tokio::task_local! {
@@ -87,10 +93,37 @@ pub(crate) fn record_probe() {
     let _ = current(|p| p.probe_count.fetch_add(1, Ordering::Relaxed));
 }
 
-/// Record one table-open call against the active per-query probes. No-op in
-/// production. Called at both open chokepoints so a cost test can count opens.
-pub(crate) fn record_open() {
-    let _ = current(|p| p.open_count.fetch_add(1, Ordering::Relaxed));
+/// Internal/system table directory names. An open of one of these is a metadata
+/// open (publisher CAS, commit-graph append, recovery audit), NOT a data-table
+/// open. Kept in sync with the dir constants in `db/manifest/layout.rs`,
+/// `db/commit_graph.rs`, and `db/recovery_audit.rs`.
+const INTERNAL_TABLE_DIRS: [&str; 4] = [
+    "__manifest",
+    "_graph_commits.lance",
+    "_graph_commit_actors.lance",
+    "_graph_commit_recoveries.lance",
+];
+
+/// True when `uri`'s last path segment names an internal/system table.
+fn open_is_internal(uri: &str) -> bool {
+    let trimmed = uri.trim_end_matches('/');
+    let last = trimmed.rsplit('/').next().unwrap_or(trimmed);
+    INTERNAL_TABLE_DIRS.contains(&last)
+}
+
+/// Record one table-open call against the active per-query probes, classified by
+/// table class (the URI's last segment) so the write gate counts DATA-table opens
+/// only and ignores the publisher/commit-graph metadata opens. No-op in production
+/// (the classification runs only inside the probe closure, which `current` skips
+/// when no probes are installed). Called at both open chokepoints.
+pub(crate) fn record_open(uri: &str) {
+    let _ = current(|p| {
+        if open_is_internal(uri) {
+            p.internal_open_count.fetch_add(1, Ordering::Relaxed);
+        } else {
+            p.data_open_count.fetch_add(1, Ordering::Relaxed);
+        }
+    });
 }
 
 /// Per-operation staged-write counts, installed for a task via
@@ -190,7 +223,7 @@ pub(crate) async fn open_dataset_tracked(
     uri: &str,
     wrapper: Option<Arc<dyn WrappingObjectStore>>,
 ) -> Result<Dataset> {
-    record_open();
+    record_open(uri);
     let result = match wrapper {
         None => Dataset::open(uri).await,
         Some(wrapper) => {
@@ -217,7 +250,7 @@ pub(crate) async fn open_table_dataset(
     version: u64,
     session: Option<&Arc<lance::session::Session>>,
 ) -> Result<Dataset> {
-    record_open();
+    record_open(location);
     let mut builder = DatasetBuilder::from_uri(location).with_version(version);
     if let Some(session) = session {
         builder = builder.with_session(session.clone());

--- a/crates/omnigraph/src/loader/mod.rs
+++ b/crates/omnigraph/src/loader/mod.rs
@@ -497,14 +497,14 @@ async fn load_jsonl_reader<R: BufRead>(
         // CAS fence) for `ensure_path` — it discards the handle. With a
         // non-strict load op (Merge/Append) and a `WriteTxn`, collapse #1 skips
         // the dataset open and returns the pinned base version directly.
-        let (_handle, expected_version, full_path, table_branch) = db
+        let opened = db
             .open_for_mutation_on_branch(branch, &table_key, load_op_kind, Some(&txn))
             .await?;
         staging.ensure_path(
             &table_key,
-            full_path,
-            table_branch,
-            expected_version,
+            opened.full_path,
+            opened.table_branch,
+            opened.expected_version,
             load_op_kind,
         );
         let schema = batch.schema();
@@ -570,14 +570,14 @@ async fn load_jsonl_reader<R: BufRead>(
     for (edge_name, table_key, batch, loaded_count) in prepared_edges {
         // Same as the node phase: only the captured expected version is used;
         // collapse #1 skips the open for a non-strict load op under a `WriteTxn`.
-        let (_handle, expected_version, full_path, table_branch) = db
+        let opened = db
             .open_for_mutation_on_branch(branch, &table_key, load_op_kind, Some(&txn))
             .await?;
         staging.ensure_path(
             &table_key,
-            full_path,
-            table_branch,
-            expected_version,
+            opened.full_path,
+            opened.table_branch,
+            opened.expected_version,
             load_op_kind,
         );
         let schema = batch.schema();
@@ -605,7 +605,13 @@ async fn load_jsonl_reader<R: BufRead>(
     // `_queue_guards` holds per-(table_key, branch) write queues
     // across the manifest publish below — see exec/mutation.rs for
     // the rationale (interleaving prevention).
-    let (updates, expected_versions, sidecar_handle, _queue_guards, committed_handles) = staged
+    let crate::exec::staging::CommittedMutation {
+        updates,
+        expected_versions,
+        sidecar_handle,
+        guards: _queue_guards,
+        committed_handles,
+    } = staged
         .commit_all(
             db,
             branch,

--- a/crates/omnigraph/src/loader/mod.rs
+++ b/crates/omnigraph/src/loader/mod.rs
@@ -187,7 +187,10 @@ impl Omnigraph {
             &omnigraph_policy::ResourceScope::Branch(branch.to_string()),
             actor_id,
         )?;
-        self.ensure_schema_state_valid().await?;
+        // Schema-contract validation is captured ONCE per write via the
+        // `WriteTxn` opened in `load_jsonl_reader` (after branch resolution).
+        // The redundant `ensure_schema_state_valid` that used to run here is
+        // subsumed by `open_write_txn`'s `resolved_branch_target` call.
         // Converge any pending recovery sidecar (a previously failed
         // writer's Phase B → Phase C residual) before staging anything:
         // without this, sidecar-covered drift wedges every load on the
@@ -397,7 +400,16 @@ async fn load_jsonl_reader<R: BufRead>(
     // inline path.
 
     let mut result = LoadResult::default();
-    let snapshot = db.snapshot_for_branch(branch).await?;
+    // Capture-once write transaction (RFC-013 step 3b). `open_write_txn`
+    // validates the schema contract ONCE and pins the base snapshot. Threaded
+    // as `Some(&txn)` through the per-table opens and the manifest publish so
+    // each resolve point reuses the pinned base instead of re-validating the
+    // contract. The branch already exists here (fork-if-missing ran in
+    // `load_as` before this), so this captures the post-fork snapshot. The
+    // load's own base read (`db.snapshot_for_branch` previously) is the same
+    // per-branch snapshot, so reuse `txn.base` for it — dropping a validation.
+    let txn = db.open_write_txn(branch).await?;
+    let snapshot = txn.base.clone();
     let mut staging = MutationStaging::default();
     let pending_mode = match mode {
         LoadMode::Merge => PendingMode::Merge,
@@ -482,7 +494,7 @@ async fn load_jsonl_reader<R: BufRead>(
     // delayed until after all validation succeeds.
     for (type_name, table_key, batch, loaded_count) in prepared_nodes {
         let (ds, full_path, table_branch) = db
-            .open_for_mutation_on_branch(branch, &table_key, load_op_kind)
+            .open_for_mutation_on_branch(branch, &table_key, load_op_kind, Some(&txn))
             .await?;
         let expected_version = ds.version();
         staging.ensure_path(
@@ -554,7 +566,7 @@ async fn load_jsonl_reader<R: BufRead>(
     // Phase 2e: accumulate every edge type. Same dispatch as Phase 2b.
     for (edge_name, table_key, batch, loaded_count) in prepared_edges {
         let (ds, full_path, table_branch) = db
-            .open_for_mutation_on_branch(branch, &table_key, load_op_kind)
+            .open_for_mutation_on_branch(branch, &table_key, load_op_kind, Some(&txn))
             .await?;
         let expected_version = ds.version();
         staging.ensure_path(
@@ -596,6 +608,7 @@ async fn load_jsonl_reader<R: BufRead>(
             crate::db::manifest::SidecarKind::Load,
             actor_id,
             fork_queue_guards,
+            Some(&txn),
         )
         .await?;
     // Same finalize → publisher residual as mutations: per-table
@@ -603,8 +616,14 @@ async fn load_jsonl_reader<R: BufRead>(
     // publish has not run yet. Reuse the mutation failpoint name so
     // one failpoint pins the shared `MutationStaging` boundary.
     crate::failpoints::maybe_fail("mutation.post_finalize_pre_publisher")?;
-    db.commit_updates_on_branch_with_expected(branch, &updates, &expected_versions, actor_id)
-        .await?;
+    db.commit_updates_on_branch_with_expected(
+        branch,
+        &updates,
+        &expected_versions,
+        actor_id,
+        Some(&txn),
+    )
+    .await?;
     // The recovery sidecar protects the per-table commit_staged →
     // manifest publish window. Phase C succeeded — clean up
     // best-effort: failing the user here would error out a write

--- a/crates/omnigraph/src/loader/mod.rs
+++ b/crates/omnigraph/src/loader/mod.rs
@@ -493,10 +493,13 @@ async fn load_jsonl_reader<R: BufRead>(
     // Phase 2b: accumulate every node type in memory. Fragment writes are
     // delayed until after all validation succeeds.
     for (type_name, table_key, batch, loaded_count) in prepared_nodes {
-        let (ds, full_path, table_branch) = db
+        // The loader only needs the captured expected version (the publisher's
+        // CAS fence) for `ensure_path` — it discards the handle. With a
+        // non-strict load op (Merge/Append) and a `WriteTxn`, collapse #1 skips
+        // the dataset open and returns the pinned base version directly.
+        let (_handle, expected_version, full_path, table_branch) = db
             .open_for_mutation_on_branch(branch, &table_key, load_op_kind, Some(&txn))
             .await?;
-        let expected_version = ds.version();
         staging.ensure_path(
             &table_key,
             full_path,
@@ -565,10 +568,11 @@ async fn load_jsonl_reader<R: BufRead>(
 
     // Phase 2e: accumulate every edge type. Same dispatch as Phase 2b.
     for (edge_name, table_key, batch, loaded_count) in prepared_edges {
-        let (ds, full_path, table_branch) = db
+        // Same as the node phase: only the captured expected version is used;
+        // collapse #1 skips the open for a non-strict load op under a `WriteTxn`.
+        let (_handle, expected_version, full_path, table_branch) = db
             .open_for_mutation_on_branch(branch, &table_key, load_op_kind, Some(&txn))
             .await?;
-        let expected_version = ds.version();
         staging.ensure_path(
             &table_key,
             full_path,
@@ -601,7 +605,7 @@ async fn load_jsonl_reader<R: BufRead>(
     // `_queue_guards` holds per-(table_key, branch) write queues
     // across the manifest publish below — see exec/mutation.rs for
     // the rationale (interleaving prevention).
-    let (updates, expected_versions, sidecar_handle, _queue_guards) = staged
+    let (updates, expected_versions, sidecar_handle, _queue_guards, committed_handles) = staged
         .commit_all(
             db,
             branch,
@@ -622,6 +626,7 @@ async fn load_jsonl_reader<R: BufRead>(
         &expected_versions,
         actor_id,
         Some(&txn),
+        committed_handles,
     )
     .await?;
     // The recovery sidecar protects the per-table commit_staged →

--- a/crates/omnigraph/tests/helpers/cost.rs
+++ b/crates/omnigraph/tests/helpers/cost.rs
@@ -58,6 +58,10 @@ pub struct IoCounts {
     pub commit_graph_reads: u64,
     /// Version-probe invocations (the cheap freshness check).
     pub version_probes: u64,
+    /// Table-open CALL count through the two instrumented chokepoints — an exact
+    /// open-invocation count (not the opener-read term). Step-3b target:
+    /// `open_count <= |touched_tables|` for a write.
+    pub open_count: u64,
 }
 
 impl IoCounts {
@@ -225,6 +229,7 @@ struct ProbeHandles {
     commit_graph: IOTracker,
     table: PrefixCounter,
     probe_count: Arc<AtomicU64>,
+    open_count: Arc<AtomicU64>,
 }
 
 impl ProbeHandles {
@@ -234,6 +239,7 @@ impl ProbeHandles {
             commit_graph: IOTracker::default(),
             table: PrefixCounter::default(),
             probe_count: Arc::new(AtomicU64::new(0)),
+            open_count: Arc::new(AtomicU64::new(0)),
         };
         let probes = QueryIoProbes {
             manifest_wrapper: Some(Arc::new(h.manifest.clone()) as Arc<dyn WrappingObjectStore>),
@@ -242,6 +248,7 @@ impl ProbeHandles {
             ),
             table_wrapper: Some(Arc::new(h.table.clone()) as Arc<dyn WrappingObjectStore>),
             probe_count: Arc::clone(&h.probe_count),
+            open_count: Arc::clone(&h.open_count),
         };
         (probes, h)
     }
@@ -256,6 +263,7 @@ impl ProbeHandles {
             manifest_reads: self.manifest.stats().read_iops,
             commit_graph_reads: self.commit_graph.stats().read_iops,
             version_probes: self.probe_count.load(Ordering::Relaxed),
+            open_count: self.open_count.load(Ordering::Relaxed),
         }
     }
 }

--- a/crates/omnigraph/tests/helpers/cost.rs
+++ b/crates/omnigraph/tests/helpers/cost.rs
@@ -58,10 +58,14 @@ pub struct IoCounts {
     pub commit_graph_reads: u64,
     /// Version-probe invocations (the cheap freshness check).
     pub version_probes: u64,
-    /// Table-open CALL count through the two instrumented chokepoints — an exact
-    /// open-invocation count (not the opener-read term). Step-3b target:
-    /// `open_count <= |touched_tables|` for a write.
-    pub open_count: u64,
+    /// DATA-table open CALL count through the two instrumented chokepoints — an
+    /// exact open-invocation count (not the opener-read term), classified by URI so
+    /// internal/system-table opens are excluded. Step-3b target:
+    /// `data_open_count <= |touched_tables|` for a write.
+    pub data_open_count: u64,
+    /// Internal/system-table (`__manifest`, `_graph_commits*`) open CALL count —
+    /// the complement of `data_open_count` (publisher CAS + commit-graph append).
+    pub internal_open_count: u64,
 }
 
 impl IoCounts {
@@ -229,7 +233,8 @@ struct ProbeHandles {
     commit_graph: IOTracker,
     table: PrefixCounter,
     probe_count: Arc<AtomicU64>,
-    open_count: Arc<AtomicU64>,
+    data_open_count: Arc<AtomicU64>,
+    internal_open_count: Arc<AtomicU64>,
 }
 
 impl ProbeHandles {
@@ -239,7 +244,8 @@ impl ProbeHandles {
             commit_graph: IOTracker::default(),
             table: PrefixCounter::default(),
             probe_count: Arc::new(AtomicU64::new(0)),
-            open_count: Arc::new(AtomicU64::new(0)),
+            data_open_count: Arc::new(AtomicU64::new(0)),
+            internal_open_count: Arc::new(AtomicU64::new(0)),
         };
         let probes = QueryIoProbes {
             manifest_wrapper: Some(Arc::new(h.manifest.clone()) as Arc<dyn WrappingObjectStore>),
@@ -248,7 +254,8 @@ impl ProbeHandles {
             ),
             table_wrapper: Some(Arc::new(h.table.clone()) as Arc<dyn WrappingObjectStore>),
             probe_count: Arc::clone(&h.probe_count),
-            open_count: Arc::clone(&h.open_count),
+            data_open_count: Arc::clone(&h.data_open_count),
+            internal_open_count: Arc::clone(&h.internal_open_count),
         };
         (probes, h)
     }
@@ -263,7 +270,8 @@ impl ProbeHandles {
             manifest_reads: self.manifest.stats().read_iops,
             commit_graph_reads: self.commit_graph.stats().read_iops,
             version_probes: self.probe_count.load(Ordering::Relaxed),
-            open_count: self.open_count.load(Ordering::Relaxed),
+            data_open_count: self.data_open_count.load(Ordering::Relaxed),
+            internal_open_count: self.internal_open_count.load(Ordering::Relaxed),
         }
     }
 }

--- a/crates/omnigraph/tests/validators.rs
+++ b/crates/omnigraph/tests/validators.rs
@@ -237,6 +237,58 @@ async fn cardinality_rejected_on_mutation_insert_edge() {
     );
 }
 
+/// RFC-013 step 3b regression guard (cursor High / codex P1 on #298): edge `@card`
+/// validation must scan LIVE committed HEAD, not the pinned `txn.base`. Collapse #1
+/// skips the edge accumulation open, so a non-strict edge insert under a `WriteTxn`
+/// reopens for the cardinality scan — and that scan must observe edges a concurrent
+/// writer committed after this mutation captured its base, or a `@card` max is
+/// silently exceeded (invariant 9). The residual validate→commit TOCTOU is the §7.1
+/// gap (step 4); this only un-widens what 3b widened (live HEAD vs mutation-start base).
+///
+/// Deterministic — no failpoint: handle B's coordinator is stale by construction
+/// (the write path does not probe the manifest version, unlike the read path). B MUST
+/// NOT read between A's commit and B's insert — a read refreshes B's coordinator and
+/// masks the bug (the same caveat as the served stale-view repro in `writes.rs`).
+#[tokio::test]
+async fn cardinality_rejected_for_stale_handle_after_concurrent_edge_commit() {
+    let (dir, mut db_a) = init_with(CARDINALITY_SCHEMA, CARDINALITY_SEED).await;
+    let uri = dir.path().to_str().unwrap();
+
+    // Handle B opens the same graph at the seed version (no edges yet); it then
+    // never reads again, so its in-memory coordinator stays pinned at the seed.
+    let mut db_b = Omnigraph::open(uri).await.unwrap();
+
+    // Handle A commits WorksAt(Alice -> Acme): Alice is now at the @card(0..1) max.
+    // This advances the on-disk manifest; B's coordinator is now stale.
+    mutate_main(
+        &mut db_a,
+        CARDINALITY_MUTATIONS,
+        "add_employment",
+        &params(&[("$person", "Alice"), ("$company", "Acme")]),
+    )
+    .await
+    .unwrap();
+
+    // Handle B (stale, never read since A committed) inserts a second WorksAt for
+    // Alice. B is non-strict + under a WriteTxn, so collapse #1 skips the open and the
+    // cardinality scan reopens: it MUST read live HEAD (Alice has 1) → reject (1+1 > 1),
+    // not the stale base (Alice has 0) → which would wrongly pass and commit a 2nd edge.
+    let err = mutate_main(
+        &mut db_b,
+        CARDINALITY_MUTATIONS,
+        "add_employment",
+        &params(&[("$person", "Alice"), ("$company", "Beta")]),
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        err.to_string().to_lowercase().contains("cardinality")
+            || err.to_string().to_lowercase().contains("@card"),
+        "a stale-handle edge insert must be rejected by @card against live HEAD, got: {}",
+        err
+    );
+}
+
 #[tokio::test]
 async fn cardinality_rejected_on_jsonl_load() {
     // Already covered by existing loader Phase 3 logic but assert the

--- a/crates/omnigraph/tests/write_cost.rs
+++ b/crates/omnigraph/tests/write_cost.rs
@@ -24,10 +24,10 @@
 mod helpers;
 
 use helpers::cost::{
-    IoCounts, assert_flat, assert_grows, local_graph, measure_insert, measure_insert_as,
+    IoCounts, assert_flat, assert_grows, local_graph, measure, measure_insert, measure_insert_as,
     measure_with_staged,
 };
-use helpers::{MUTATION_QUERIES, commit_many, commit_many_as, mixed_params};
+use helpers::{MUTATION_QUERIES, commit_many, commit_many_as, init_and_load, mixed_params};
 
 // ── (A) The internal-table LOCK — the acceptance test for step 2 (compaction) ──
 //
@@ -168,4 +168,78 @@ async fn keyed_insert_routes_through_merge_insert_only() {
     assert_eq!(staged.stage_merge_insert, 1, "keyed Person insert stages one merge-insert");
     assert_eq!(staged.stage_append, 0, "keyed insert must not stage_append");
     assert_eq!(staged.create_vector_index, 0, "no inline vector-index build on a plain insert");
+}
+
+// ── (D) Step-3b capture-once fitness asserts (RED today → GREEN after WriteTxn) ──
+
+/// A write must validate the schema contract EXACTLY ONCE (3 `read_text` + 2 `exists`).
+/// Today the write path re-validates at every resolve point (entry, per-table
+/// `resolved_branch_target`, commit-time `fresh_snapshot_for_branch`), so the delta is
+/// a multiple of that. Step 3b's `WriteTxn` validates once and threads it. The shape is
+/// the write twin of `warm_read_cost.rs::warm_query_validates_schema_contract_once`,
+/// built with ZERO production change via the counting storage adapter.
+#[tokio::test]
+async fn write_validates_schema_contract_once() {
+    use omnigraph::instrumentation::CountingStorageAdapter;
+    use omnigraph::storage::storage_for_uri;
+
+    let dir = tempfile::tempdir().unwrap();
+    let _ = init_and_load(&dir).await;
+    let uri = dir.path().to_str().unwrap();
+    let (adapter, counts) = CountingStorageAdapter::new(storage_for_uri(uri).unwrap());
+    let db = omnigraph::db::Omnigraph::open_with_storage(uri, adapter)
+        .await
+        .unwrap();
+
+    let before_read_text = counts.read_text();
+    let before_exists = counts.exists();
+    db.mutate(
+        "main",
+        MUTATION_QUERIES,
+        "insert_person",
+        &mixed_params(&[("$name", "schema_once")], &[("$age", 30)]),
+    )
+    .await
+    .unwrap();
+
+    let read_text_delta = counts.read_text() - before_read_text;
+    let exists_delta = counts.exists() - before_exists;
+    eprintln!("schema-contract reads on one write: read_text={read_text_delta} exists={exists_delta}");
+    assert_eq!(
+        read_text_delta, 3,
+        "a write must validate the schema contract once (3 reads), not N times",
+    );
+    assert_eq!(
+        exists_delta, 2,
+        "a write must probe contract-file existence once (2 probes), not N times",
+    );
+}
+
+/// A keyed single-table write must open its table AT MOST ONCE. Today it opens ~4×
+/// (accumulation, staging, commit drift-guard, publish-prepare/index-build), each a
+/// fresh cold `Dataset::open`. Step 3b opens the base once (with the shared Session),
+/// threads the commit-return handle, and replaces the drift-guard open with a cheap
+/// `latest_version_id` probe — collapsing to 1 open. Counted by the exact `open_count`
+/// chokepoint probe (`forbidden_apis` guarantees every write open routes through it).
+#[tokio::test]
+async fn keyed_insert_opens_table_at_most_once() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut db = local_graph(&dir).await;
+    let io = {
+        let (res, io) = measure(db.mutate(
+            "main",
+            MUTATION_QUERIES,
+            "insert_person",
+            &mixed_params(&[("$name", "opens")], &[("$age", 30)]),
+        ))
+        .await;
+        res.unwrap();
+        io
+    };
+    eprintln!("open_count for a single-table keyed insert = {}", io.open_count);
+    assert!(
+        io.open_count <= 1,
+        "a keyed single-table write must open its table at most once, got {}",
+        io.open_count,
+    );
 }

--- a/crates/omnigraph/tests/write_cost.rs
+++ b/crates/omnigraph/tests/write_cost.rs
@@ -217,13 +217,16 @@ async fn write_validates_schema_contract_once() {
 
 /// A keyed single-table write must open its DATA table AT MOST ONCE. Today it opens
 /// ~4× (accumulation, staging, commit drift-guard, publish-prepare/index-build), each
-/// a fresh cold `Dataset::open`. Step 3b opens the base once (with the shared Session),
-/// threads the commit-return handle, and replaces the drift-guard open with a cheap
-/// `latest_version_id` probe — collapsing to 1 open. Counted by `data_open_count`, the
+/// a fresh cold `Dataset::open`. Step 3b opens the base once (a *session-aware* base
+/// open is deferred to step 5), threads the commit-return handle, and replaces the
+/// drift-guard open with a cheap `latest_version_id` probe — collapsing to 1 open.
+/// Counted by `data_open_count`, the
 /// table-class-scoped chokepoint probe: the internal-table opens (publisher CAS +
 /// commit-graph append) are EXCLUDED, since they are unrelated to data-table reuse and
-/// would otherwise keep this count >1 regardless of threading. (`forbidden_apis`
-/// guarantees every write open routes through the instrumented chokepoints.)
+/// would otherwise keep this count >1 regardless of threading. (`forbidden_apis` keeps
+/// engine code outside the storage layer from opening datasets except through the
+/// instrumented chokepoints — `table_store.rs`'s own direct opens are branch-management
+/// ops, not this keyed-write path.)
 #[tokio::test]
 async fn keyed_insert_opens_table_at_most_once() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/omnigraph/tests/write_cost.rs
+++ b/crates/omnigraph/tests/write_cost.rs
@@ -215,12 +215,15 @@ async fn write_validates_schema_contract_once() {
     );
 }
 
-/// A keyed single-table write must open its table AT MOST ONCE. Today it opens ~4×
-/// (accumulation, staging, commit drift-guard, publish-prepare/index-build), each a
-/// fresh cold `Dataset::open`. Step 3b opens the base once (with the shared Session),
+/// A keyed single-table write must open its DATA table AT MOST ONCE. Today it opens
+/// ~4× (accumulation, staging, commit drift-guard, publish-prepare/index-build), each
+/// a fresh cold `Dataset::open`. Step 3b opens the base once (with the shared Session),
 /// threads the commit-return handle, and replaces the drift-guard open with a cheap
-/// `latest_version_id` probe — collapsing to 1 open. Counted by the exact `open_count`
-/// chokepoint probe (`forbidden_apis` guarantees every write open routes through it).
+/// `latest_version_id` probe — collapsing to 1 open. Counted by `data_open_count`, the
+/// table-class-scoped chokepoint probe: the internal-table opens (publisher CAS +
+/// commit-graph append) are EXCLUDED, since they are unrelated to data-table reuse and
+/// would otherwise keep this count >1 regardless of threading. (`forbidden_apis`
+/// guarantees every write open routes through the instrumented chokepoints.)
 #[tokio::test]
 async fn keyed_insert_opens_table_at_most_once() {
     let dir = tempfile::tempdir().unwrap();
@@ -236,10 +239,13 @@ async fn keyed_insert_opens_table_at_most_once() {
         res.unwrap();
         io
     };
-    eprintln!("open_count for a single-table keyed insert = {}", io.open_count);
+    eprintln!(
+        "data_open_count={} internal_open_count={} for a single-table keyed insert",
+        io.data_open_count, io.internal_open_count
+    );
     assert!(
-        io.open_count <= 1,
-        "a keyed single-table write must open its table at most once, got {}",
-        io.open_count,
+        io.data_open_count <= 1,
+        "a keyed single-table write must open its data table at most once, got {}",
+        io.data_open_count,
     );
 }

--- a/docs/dev/handoff-rfc-013-write-path.md
+++ b/docs/dev/handoff-rfc-013-write-path.md
@@ -33,9 +33,10 @@ for the canonical list. Current reality:
 - **#254** `ragnorc/bug-4-schema-apply-occ` — schema-apply vs optimize false-fail
   (same op-class family as #297, logical side).
 
-**Next step to implement: Step 3b (capture-once `WriteTxn`)** — see §4. After that:
-Phase 7 (step 4), then the big one — **Design A / `PublishPlan` unification (step 5)** —
-see §5, which is the convergent fix for the bug *class* this area keeps generating.
+**Step 3b is DONE** (capture-once `WriteTxn`, schema-once + open-collapse; see §4) on
+`rfc-013-step-3b-writetxn-v2`. **Next: Phase 7 (step 4), then the big one — Design A /
+`PublishPlan` unification (step 5)** — see §5, the convergent fix for the bug *class* this
+area keeps generating, which also absorbs 3b's deferred session-aware write opens.
 
 ---
 
@@ -183,48 +184,51 @@ reopen/replan **semantics** are permanent. (Noted in RFC §6.6.)
 
 ---
 
-## 4. NEXT: Step 3b — capture-once `WriteTxn` (designed + validated this cycle)
+## 4. DONE: Step 3b — capture-once `WriteTxn` (shipped on `rfc-013-step-3b-writetxn-v2`)
 
-**Goal:** collapse the redundant per-write opens (3–4×/table → 1), warm the shared
-`Session` on write opens, and validate the schema contract **once** per write — making
-mid-write re-resolution unrepresentable (invariant 3). **Constant-factor/RTT win, not a
-depth-slope win** (1a).
+**Delivered:** a single `mutate`/`load` now validates the schema contract **once** and opens
+each touched data table **at most once** — a constant-factor/RTT win (not a depth-slope win;
+1a). Two cost gates in `write_cost.rs` lock it: `write_validates_schema_contract_once`
+(3 `read_text` / 2 `exists`, was 12/9) and `keyed_insert_opens_table_at_most_once`
+(`data_open_count <= 1`, was 4). The carrier is the minimal `WriteTxn { branch, base }`,
+threaded as `Option<&WriteTxn>` (`Some` on the hot mutate/load path, `None` byte-identical
+everywhere else); it **converges into** step 5's `PublishPlan`.
 
-**Scope:** the hot writers only — `load_as` + `mutate_as` (they share `MutationStaging`).
-NOT the 4-writer→`PublishPlan` collapse (that's step 5). NOT Phase 7. NOT recovery-off-hot-path.
+Commits (off merged-#297 main):
+- **Stage 0** — scope `open_count` → `data_open_count`/`internal_open_count` by URI class
+  (the review fix: `open_dataset_tracked` also opens `__manifest`/`_graph_commits`, so the
+  raw counter conflated them and the gate was unreachable). Re-baselined RED 4.
+- **Commit A (schema-once)** — capture `txn` once at entry (the single validation); the 4
+  validation sites collapse: S1 (entry `ensure_schema_state_valid`) removed; S3a
+  (`open_for_mutation_on_branch`) + S3b (`prepare_updates_for_commit`) source `txn.base`;
+  S4 (`commit_all`) uses new `fresh_snapshot_for_branch_unchecked` (the OCC manifest re-read
+  minus the schema re-validation). `fresh_snapshot_for_branch{,_unchecked}` now read the
+  manifest directly via `ManifestCoordinator` (drops a spurious commit-graph `exists` probe;
+  same `Snapshot`).
+- **Commit B (open collapse 4→1)** — #1 accumulation open ELIMINATED (the node path discarded
+  the handle; read `txn.base.entry().table_version`); #2 staging open KEPT (the one open);
+  #3 commit drift-guard reads live HEAD via `entry.dataset.dataset().latest_version_id()` (a
+  cheap manifest-pointer probe off the staged handle, not a fresh open); #4 index build reuses
+  the `commit_staged` handle threaded through `CommittedMutation`/`prepare_updates_for_commit`.
+- **Commit B.1 + cleanup** — named the two positional returns (`OpenedForMutation`,
+  `CommittedMutation`) + a `debug_assert` pinning the open-skip contract; **removed the
+  unearned `WriteTxn.session` field** (the collapse uses skip/probe/reuse, not a session).
 
-**Three design corrections to RFC §4.1 (apply these — the old sketch is wrong on them):**
-1. **Thread the evolving handle, not a version-keyed `HandleCache`.** The opens aren't N
-   reads of one immutable version; they're the table at *successive HEADs* (staging
-   commits, index build commits). Carry the handle Lance returns from each commit forward;
-   don't re-open by key. (The read-side version-keyed cache is correctly NOT reused for
-   write handles.)
-2. **Drop "re-resolution unrepresentable" as the invariant.** Three fresh reads are
-   load-bearing correctness machinery, not waste: the commit-time `fresh_snapshot_for_branch`
-   (cross-process OCC), the post-commit HEAD re-derive (HEAD moved between stages), and the
-   fork-authority reads. Model "pinned read **base** for the pre-first-commit phase +
-   named commit-protocol re-reads," not "forbid all re-derivation."
-3. **Ship a minimal carrier**, not the §4.1 bundle: `WriteTxn { branch, base: Snapshot,
-   session, schema_validated_once }`. It **converges into** step 5's `PublishPlan` (step 5
-   grows it), so it's lower-liability than scattering localized fixes.
+**RFC §4.1 corrections — how they resolved:**
+1. *Thread the evolving handle, not a version-keyed cache* → realized as collapse #4 (carry
+   the `commit_staged` handle forward into the index build).
+2. *Don't forbid re-resolution* → honored: the commit-time OCC re-read
+   (`fresh_snapshot_for_branch_unchecked` — fresh manifest, only schema-revalidation dropped)
+   and the fork-authority reads stay fresh.
+3. *Minimal carrier* → `WriteTxn { branch, base }` (even the `session` from the original
+   sketch was dropped as unearned).
 
-**Likely-eliminable open:** the accumulation open (#1) may use its `Dataset` only for
-`ds.version()`, and the version is already in `base.entry(table).table_version` — so it may
-be *deleted*, not cached (verify during impl).
-
-**Implementation sequence (test-first):**
-1. **Cost gate (red).** Add to `write_cost.rs`: `validate_schema_contract_calls == 1`
-   (reuse `CountingStorageAdapter`, zero prod change) and `opens ≤ |touched_tables|` (add
-   `open_count` to `QueryIoProbes`). Red against current code.
-2. **Thread the `Session` into the write opener** (`open_dataset_head_for_write` opens
-   read-style by pinned version with `Some(&session)`).
-3. **Introduce `WriteTxn`**, captured once at entry of `mutate_as`/`load_as`, threaded
-   through staging; serve opens from one forwarded handle; re-probe version at the commit
-   drift-guard.
-4. **Collapse schema validation to once-per-write** (single point:
-   `resolved_branch_target`/`fresh_snapshot_for_branch` both call `ensure_schema_state_valid`
-   first-line).
-5. Gate green; `cargo test --workspace --locked`; S3 round-trip check on `write_cost_s3.rs`.
+**Deferred to step 5 (NOT in this PR):** session-aware write base opens. The one remaining
+open (#2) stays a HEAD open; warming the shared `Session` across writes is an object-store
+(S3) phenomenon invisible on local FS, so it earns its own `write_cost_s3.rs` gate in step 5,
+where `txn` becomes the non-optional publish carrier. No new concurrency test was needed here:
+#2 stays a HEAD open (no pinned+session base introduced), so the publisher CAS + #3 live-HEAD
+probe fences are unchanged (covered by the green `writes.rs`/`consistency.rs`).
 
 **Guardrails (don't regress):** schema validation is deliberately uncached for drift
 detection — collapse to 1 *per write*, never cache across writes on a long-lived handle

--- a/docs/dev/handoff-rfc-013-write-path.md
+++ b/docs/dev/handoff-rfc-013-write-path.md
@@ -234,13 +234,23 @@ reopen/replan **semantics** are permanent. (Noted in RFC §6.6.)
 
 ## 4. DONE: Step 3b — capture-once `WriteTxn` (shipped on `rfc-013-step-3b-writetxn-v2`)
 
-**Delivered:** a single `mutate`/`load` now validates the schema contract **once** and opens
-each touched data table **at most once** — a constant-factor/RTT win (not a depth-slope win;
-1a). Two cost gates in `write_cost.rs` lock it: `write_validates_schema_contract_once`
-(3 `read_text` / 2 `exists`, was 12/9) and `keyed_insert_opens_table_at_most_once`
-(`data_open_count <= 1`, was 4). The carrier is the minimal `WriteTxn { branch, base }`,
-threaded as `Option<&WriteTxn>` (`Some` on the hot mutate/load path, `None` byte-identical
-everywhere else); it **converges into** step 5's `PublishPlan`.
+**Delivered:** on the **table-touch hot path**, a single `mutate`/`load` validates the schema
+contract **once** and opens each touched data table **at most once** — a constant-factor/RTT
+win (not a depth-slope win; 1a). Two cost gates in `write_cost.rs` lock it (both on a node
+insert): `write_validates_schema_contract_once` (3 `read_text` / 2 `exists`, was 12/9) and
+`keyed_insert_opens_table_at_most_once` (`data_open_count <= 1`, was 4). The carrier is the
+minimal `WriteTxn { branch, base }`, threaded as `Option<&WriteTxn>` (`Some` on the hot
+mutate/load path, `None` byte-identical everywhere else); it **converges into** step 5's
+`PublishPlan`.
+
+**Not "once" everywhere (scope, not regression):** edge endpoint / cardinality RI validation
+(`ensure_node_id_exists`, the loader's RI + cardinality) still resolves through
+`snapshot_for_branch` and re-validates the schema — and reads **warm**, not live. Threading
+`txn.base` there to make it "once" would re-introduce the stale-read class the #298 cardinality
+fix removed (it now reads live HEAD). Doing schema-once *and* fresh reads for those validations
+needs the unified, re-checked read-set — **step 4 §7.1** (§1d). So #298 **un-regresses
+cardinality only; it does not close write-validation freshness.** No edge-insert/load schema-once
+gate yet (only the node gates above).
 
 Commits (off merged-#297 main):
 - **Stage 0** — scope `open_count` → `data_open_count`/`internal_open_count` by URI class

--- a/docs/dev/handoff-rfc-013-write-path.md
+++ b/docs/dev/handoff-rfc-013-write-path.md
@@ -22,11 +22,11 @@ for the canonical list. Current reality:
 - **Step 2a** — internal-table compaction: `optimize` now compacts `__manifest` /
   `_graph_commits` / `_graph_commit_actors` (#291). Plus the RFC latency-model
   correction (#292).
+- **Optimize-vs-write race** — optimize survives a cross-process write race on the
+  same table (#297, **LANDED** — origin/main `6d4606a8`; see §6 for why it's not
+  redundant with Design A). Step 3b stacks on top of this.
 
 **Open PRs (land these; relationships in §7):**
-- **#297** `fix-optimize-concurrency-race` — optimize survives a cross-process write
-  race (the work this cycle produced). **Merge it** (see §6 for why it's not redundant
-  with Design A).
 - **#296** `correctness-by-design-fix` — recovery roll-forward converges on a concurrent
   manifest advance (this is the fix for the flaky `iss-schema-apply-reopen-recovery-race`).
 - **#295** `docs/rfc-013-step-3b` — the step-3b RFC doc.
@@ -282,12 +282,13 @@ open; delete #6658 shipped). Track, don't build yet.
 - The prod bug is **live**; Design A is the largest write-path change in the RFC. Don't hold a
   correctness fix hostage to a big refactor, and don't do a big refactor under bug-fix urgency.
 - Genuinely throwaway under Design A: only the loop's *location* + the `head_advanced` proxy
-  (~a dozen lines). Everything else relocates or persists. **Merge #297.**
+  (~a dozen lines). Everything else relocates or persists. **#297 LANDED.**
 
 ---
 
 ## 7. Open PRs and their relationships
-- **#297** (this) — maintenance-class fix (optimize vs write). Merge.
+- **#297** — maintenance-class fix (optimize vs write). **LANDED** (origin/main `6d4606a8`);
+  step 3b stacks on it.
 - **#254** — logical-class fix (schema-apply vs optimize false-fail). Same op-class family;
   both are de-risking inputs for Design A's per-class commit models.
 - **#296** — recovery roll-forward converges on concurrent manifest advance. This is the fix

--- a/docs/dev/handoff-rfc-013-write-path.md
+++ b/docs/dev/handoff-rfc-013-write-path.md
@@ -1,0 +1,352 @@
+# Handoff: finishing RFC-013 (write-path latency + correctness)
+
+**Status:** living handoff. **Source of truth is [`rfc-013-write-path-latency.md`](rfc-013-write-path-latency.md)** —
+this doc is the *current-state map + the decisions/validation from the latest work cycle
++ the concrete next actions*. When they disagree, the RFC wins (and fix this doc).
+
+**Audience:** the engineer/agent who picks up RFC-013 next.
+
+---
+
+## 0. TL;DR — where we are and what's next
+
+RFC-013 makes the write path fast **and** correct on object storage (217 Lance tables
+under one `__manifest` catalog, on R2/S3). It is sequenced as steps; read §9 of the RFC
+for the canonical list. Current reality:
+
+**Landed on `main`:**
+- **Step 1** — Tier-1 cost gate + the shared `helpers::cost` harness (#288).
+- **Step 3a** — opener bypass: write opens go direct (`Dataset::open` by URI + version)
+  instead of the Lance-namespace builder (#288). **This already banked the dominant
+  depth win** — see §2 below; it reframes everything.
+- **Step 2a** — internal-table compaction: `optimize` now compacts `__manifest` /
+  `_graph_commits` / `_graph_commit_actors` (#291). Plus the RFC latency-model
+  correction (#292).
+
+**Open PRs (land these; relationships in §7):**
+- **#297** `fix-optimize-concurrency-race` — optimize survives a cross-process write
+  race (the work this cycle produced). **Merge it** (see §6 for why it's not redundant
+  with Design A).
+- **#296** `correctness-by-design-fix` — recovery roll-forward converges on a concurrent
+  manifest advance (this is the fix for the flaky `iss-schema-apply-reopen-recovery-race`).
+- **#295** `docs/rfc-013-step-3b` — the step-3b RFC doc.
+- **#254** `ragnorc/bug-4-schema-apply-occ` — schema-apply vs optimize false-fail
+  (same op-class family as #297, logical side).
+
+**Next step to implement: Step 3b (capture-once `WriteTxn`)** — see §4. After that:
+Phase 7 (step 4), then the big one — **Design A / `PublishPlan` unification (step 5)** —
+see §5, which is the convergent fix for the bug *class* this area keeps generating.
+
+---
+
+## 1. The corrected mental model (read this before touching anything)
+
+Three reframes from the latest cycle that the older RFC prose may not fully reflect:
+
+### 1a. 3a already won the depth fight → the residual is constant-factor + RTT
+Before 3a, the write re-opened each table through the lance-namespace builder ~13×, and
+that path was **O(depth)** (it re-opened `__manifest` + `list_table_versions` per open —
+**not** a Lance back-walk; the root cause was OmniGraph's own namespace round-trips, not
+Lance — validated against Lance source). 3a swapped it for the direct opener, which is
+**O(1)** (`from_uri(loc).with_version(N)` = arithmetic path + one HEAD). So:
+
+- The dominant **O(depth) data-table** term is **gone**.
+- Step 2a flattened the secondary **internal-table** scan term.
+- What remains is the **~110-hop serial backbone × RTT + compute** — a constant in
+  depth. The latency model is **`wall = (serial_hops + ops/effective_concurrency)·RTT
+  + compute`**; on a capped store (R2) the op-count term re-enters wall-clock, on an
+  unlimited store it parallelizes away. Measured: prod one-row write 27→15.76s after
+  2a; the remaining 15.76s is the serial backbone — **step 3b's target**, not step 2's.
+- Step 3b's win is therefore the **call-count/RTT collapse** (redundant opens, the
+  flat-46 schema reads), NOT a depth slope. Don't expect a depth-slope improvement from
+  3b; gate it on the constant-factor (S3 round-trips), not a curve.
+
+### 1b. Two op classes, two commit models (the §6.6 principle)
+Every concurrency bug in this area is **one op class using the other's commit model**:
+
+| class | examples | commutes? | correct commit model |
+|---|---|---|---|
+| **maintenance** | compaction (`Rewrite`), `optimize_indices` | yes (content-preserving) | Lance native rebase + app reopen/replan on real overlap + **monotonic manifest fast-forward** — no epoch, no read-set |
+| **logical mutation** | load / mutate / merge / delete | no (lost-update, write-skew) | strict cross-process OCC: read-set + write-set CAS under the `writer_epoch` fence |
+
+Applying strict OCC + equality-CAS uniformly is the mistake: too strong for maintenance
+(false conflicts — #297's bug), too weak for logical cross-process (§6.5 corruption).
+
+### 1c. The root liability (what keeps generating these bugs)
+Lance gives **per-table atomic commits** but **no cross-table/cross-step atomicity**, so
+every multi-commit op advances per-table Lance HEAD **before** the manifest references it
+(the "A-before-B window"). The resulting `HEAD vs manifest` delta is **ambiguous**
+(external drift? my own in-flight work? a crashed writer?), and **many uncoordinated code
+paths each re-interpret it** (4 writers + the maintenance path + recovery + the write-path
+drift guard). Each interpreter is a fresh chance to misclassify. That is the bug class:
+- §6.5 cross-process logical corruption,
+- #297's own-HEAD-drift misclassification,
+- the flaky write-path "HEAD ahead of manifest, run repair" guard,
+- the recovery classifier edges.
+
+**The convergent fix is Design A (one publish authority — step 5); Lance MTT eventually
+retires the window entirely.** See §5.
+
+---
+
+## 2. Validated facts — do NOT re-derive these
+
+Established this cycle against **Lance 7.0.0 source**
+(`~/.cargo/registry/src/index.crates.io-*/lance-7.0.0`) and current engine code. Cited so
+you can trust them without re-investigating.
+
+**Lance (upstream):**
+- `from_uri(loc).with_version(N).load()` and `checkout_version(N)` are **O(1)** (computed
+  V2 path `_versions/{u64::MAX-N:020}.manifest` + one HEAD; no listing/back-walk).
+  (`lance-table/src/io/commit.rs` `default_resolve_version`.)
+- A shared `Arc<Session>` (`DatasetBuilder::with_session`) warms metadata/index caches
+  keyed by `(URI, version, e_tag)`. Caveat: the *first* manifest read on open is uncached
+  — the Session warms the *scan/index* metadata, not the first open. **`WriteParams` *does*
+  carry a `session` field** (`lance/src/dataset/write.rs`), but it only matters on the
+  `WriteDestination::Uri` arm; OmniGraph's staged path always drives off an **already-open
+  `Dataset`**, and Lance takes the store/session from that handle. So to attach the shared
+  Session to a write base, open read-style (`open_table_dataset` → `from_uri().with_version()
+  .with_session()`) and drive the staged write off that handle.
+- A held `Arc<Dataset>` at a pinned version is `Send + Sync`, immutable, safe to reuse for
+  many scans/count/staged-write base in one txn (OmniGraph's `TableHandleCache` already
+  relies on this).
+- **No compaction `RetryExecutor`** (only Delete/MergeInsert/Update have one).
+  `commit_compaction` commits a fixed `Rewrite` via `apply_commit` direct. In
+  `commit_transaction`, a semantic `RetryableCommitConflict` **escapes the retry loop**
+  via `?` at `io/commit.rs:979`; the loop only retries the OCC `CommitConflict`
+  (`:1096`), and even that re-rebases the *same* transaction (never re-plans). ⇒
+  **compaction needs app-level reopen+REPLAN; you cannot "set conflict_retries" and let
+  Lance own it.**
+- `check_rewrite_txn`: a `Rewrite` rebases **cleanly** past a concurrent `Append`/disjoint
+  `Update`/`Delete` (preserving both); only a same-fragment overlap yields a retryable
+  conflict. ⇒ the common concurrent insert/update/delete is rebased for free; the app
+  retry fires only on real overlap.
+
+**Engine (internal):**
+- Read path (post-#268) already has the capture-once machinery: `Snapshot` (`db/manifest.rs`),
+  warm `GraphCoordinator` behind a `latest_version_id`/incarnation probe, a held
+  `TableHandleCache` keyed `(table,branch,version,e_tag)`, **one shared `Session` per
+  graph** (`read_caches.session`). **Writes bypass all of it by construction**
+  (`resolved_branch_target` returns `read_caches: None`; the 3a write opener attaches no
+  session and opens by latest, not pinned version).
+- A single write opens each table **3–4×** (accumulation → staging reopen → commit
+  drift-guard → publish prepare), each a fresh cold open. `validate_schema_contract`
+  (`db/schema_state.rs`, via `ensure_schema_state_valid`) runs uncached (~3 `read_text`
+  + 2 `exists`) at every resolve point (~the flat-46). Both are constant-factor, flat in
+  depth — 3b's targets.
+- Strict-op guards are the lost-update floor (3 layers: pre-stage `ensure_expected_version`
+  `table_store.rs`; commit-time strict drift `exec/staging.rs`; publisher CAS
+  `publisher.rs`). Capture-once **supplies** the pinned operand — never remove a guard.
+- Fork-on-first-write authority reads (`classify_fork_ref` → `fresh_snapshot_for_branch`)
+  must stay **fresh** (not served from a pinned base).
+- Cost harness: `helpers::cost` (`measure`/`measure_with_staged`/`IoCounts`/`assert_flat`/
+  `local_graph`/`s3_graph`). The schema-once assert can reuse `CountingStorageAdapter`
+  (`warm_read_cost.rs::warm_query_validates_schema_contract_once`) with **zero** prod
+  change; an open-count assert wants a small `open_count` AtomicU64 in `QueryIoProbes`
+  (copy the `probe_count`/`record_probe` pattern). The forbidden-API guard
+  (`tests/forbidden_apis.rs`) makes an instrumentation-level counter complete.
+
+---
+
+## 3. The #297 cycle (this branch) — what it is, and the lesson
+
+`fix-optimize-concurrency-race` (5 commits): a CLI `optimize` racing a served write on the
+same table failed (Lance Rewrite lost, or the equality-CAS publish lost). Fix: unify both
+compaction paths on the internal path's **reopen+replan** shape, with a **two-level retry**
+— outer loop reopens+replans on a real Lance overlap; inner Phase-C loop makes the manifest
+publish a **monotonic fast-forward** (advance to compacted version `N`, or no-op when the
+manifest already moved to `≥ N`), never the strict equality CAS. Sidecar written once;
+in-process queue kept as a contention reducer (not the cross-process guard); no `writer_epoch`.
+
+**Two review rounds surfaced two follow-on bugs I introduced with the retry loop** — both
+fixed, both regression-tested (own-HEAD-drift via negative control):
+1. **Own-HEAD-drift misclassification** (`56d004e0`): the drift guard re-ran every
+   iteration and, after a partial Phase-B commit (auto_cleanup strip or compact, then a
+   later op conflicts), saw `HEAD > manifest` from *our own* covered work and deleted the
+   sidecar + returned `skipped_for_drift` (stranding uncovered drift). Fix: track
+   `head_advanced`; the drift guard fires only when `!head_advanced`.
+2. **Publish exhaustion spurious error** (`e9d16a2c`): the publish loop returned `Err` on
+   its final retry even if the conflict meant a concurrent writer already published `≥ N`
+   (postcondition met). Fix: re-check `current >= state.version` on exhaustion.
+
+**The lesson (write it on the wall):** *wrapping a sequence of side-effecting commits in a
+retry silently converts every "checked once, before any side effect" precondition into
+"re-checked after partial side effects."* That's a distinct bug class; it needs
+fault-injection tests **at each commit boundary**, not just end-to-end concurrency tests.
+(The `optimize.before_compact` / `optimize.inject_reindex_conflict` failpoints exist for
+exactly this.)
+
+**Temporary mechanism flag:** `head_advanced` is an in-memory proxy for "is this HEAD
+movement mine." Under Design A the authority answers that from the plan/sidecar **identity**
+— so `head_advanced` is the part that gets *replaced*, while the monotonic-publish +
+reopen/replan **semantics** are permanent. (Noted in RFC §6.6.)
+
+---
+
+## 4. NEXT: Step 3b — capture-once `WriteTxn` (designed + validated this cycle)
+
+**Goal:** collapse the redundant per-write opens (3–4×/table → 1), warm the shared
+`Session` on write opens, and validate the schema contract **once** per write — making
+mid-write re-resolution unrepresentable (invariant 3). **Constant-factor/RTT win, not a
+depth-slope win** (1a).
+
+**Scope:** the hot writers only — `load_as` + `mutate_as` (they share `MutationStaging`).
+NOT the 4-writer→`PublishPlan` collapse (that's step 5). NOT Phase 7. NOT recovery-off-hot-path.
+
+**Three design corrections to RFC §4.1 (apply these — the old sketch is wrong on them):**
+1. **Thread the evolving handle, not a version-keyed `HandleCache`.** The opens aren't N
+   reads of one immutable version; they're the table at *successive HEADs* (staging
+   commits, index build commits). Carry the handle Lance returns from each commit forward;
+   don't re-open by key. (The read-side version-keyed cache is correctly NOT reused for
+   write handles.)
+2. **Drop "re-resolution unrepresentable" as the invariant.** Three fresh reads are
+   load-bearing correctness machinery, not waste: the commit-time `fresh_snapshot_for_branch`
+   (cross-process OCC), the post-commit HEAD re-derive (HEAD moved between stages), and the
+   fork-authority reads. Model "pinned read **base** for the pre-first-commit phase +
+   named commit-protocol re-reads," not "forbid all re-derivation."
+3. **Ship a minimal carrier**, not the §4.1 bundle: `WriteTxn { branch, base: Snapshot,
+   session, schema_validated_once }`. It **converges into** step 5's `PublishPlan` (step 5
+   grows it), so it's lower-liability than scattering localized fixes.
+
+**Likely-eliminable open:** the accumulation open (#1) may use its `Dataset` only for
+`ds.version()`, and the version is already in `base.entry(table).table_version` — so it may
+be *deleted*, not cached (verify during impl).
+
+**Implementation sequence (test-first):**
+1. **Cost gate (red).** Add to `write_cost.rs`: `validate_schema_contract_calls == 1`
+   (reuse `CountingStorageAdapter`, zero prod change) and `opens ≤ |touched_tables|` (add
+   `open_count` to `QueryIoProbes`). Red against current code.
+2. **Thread the `Session` into the write opener** (`open_dataset_head_for_write` opens
+   read-style by pinned version with `Some(&session)`).
+3. **Introduce `WriteTxn`**, captured once at entry of `mutate_as`/`load_as`, threaded
+   through staging; serve opens from one forwarded handle; re-probe version at the commit
+   drift-guard.
+4. **Collapse schema validation to once-per-write** (single point:
+   `resolved_branch_target`/`fresh_snapshot_for_branch` both call `ensure_schema_state_valid`
+   first-line).
+5. Gate green; `cargo test --workspace --locked`; S3 round-trip check on `write_cost_s3.rs`.
+
+**Guardrails (don't regress):** schema validation is deliberately uncached for drift
+detection — collapse to 1 *per write*, never cache across writes on a long-lived handle
+(`lifecycle::long_lived_handle_rejects_schema_*`). The commit-time fresh read is OCC
+machinery, not redundancy. Keep all 3 strict-op guards. Keep fork-authority reads fresh.
+Pin the *correct* branch (server-bound-to-main writing a feature branch falls to a fresh
+open). A branch `rfc-013-step-3b-writetxn` exists off an earlier main; rebase onto the
+post-#297 main before starting.
+
+---
+
+## 5. Design A — the `PublishPlan` unification (step 5) = the convergent fix
+
+**This is the real fix for the bug class in §1c.** Collapse the four hand-rolled writers +
+the maintenance path into **one `publish(txn, plan)` authority** where the CAS + bounded
+retry is **unconditional and unbypassable** (no caller can "hold the queue → skip the CAS").
+Properties:
+- **One interpreter of the `HEAD vs manifest` delta** — and "is this my work?" is answered
+  by the plan/sidecar **identity**, not a re-derived comparison. The own-HEAD-drift bug, the
+  §6.5 writers, the write-path guard — all close *by construction*.
+- **Recovery = the same `PublishPlan` re-applied** — the crash-recovery interpreter and the
+  live interpreter become the same code (`iss-merge-recovery-partial-rollforward` gone).
+- Each `TableAction` commits by its **class** (§1b): `Rewrite` = maintenance (Lance rebase
+  + reopen/replan + monotonic fast-forward, **no epoch**); load/mutate = logical (strict OCC
+  + `writer_epoch`).
+
+**Why it composes with Lance MTT (don't over-build):**
+- The **unification itself is convergent** — when MTT lands, it slots *underneath* the same
+  authority; nothing wasted. Build this.
+- The **`writer_epoch`** is the one MTT-redundant piece (MTT's commit-handler lease subsumes
+  a cross-process fence). Build it *last and minimally*, gated on actually deploying
+  multi-writer topologies. Per the deny-list, don't reimplement what the substrate will own.
+
+**Sequencing judgment (this cycle's strongest signal):** the bug density here (this PR alone
+= 3 review rounds, all "a writer re-interprets the delta") means the current N-writers interim
+is high integrated-over-time liability. **Consider pulling the *convergent half* of step 5
+(the single authority + recovery-as-plan) forward — possibly ahead of 3b** — because it stops
+the bug class rather than patching instances. #297 + #254 are the *de-risking inputs*: they
+validate the maintenance-class and logical-class commit models in isolation first, so Design
+A implements a known spec rather than designing under refactor pressure. Do NOT build more
+substrate-shaped scaffolding (custom WAL / job queue / second coordination table) to paper
+over the window — strictly higher liability than either Design A or waiting for MTT.
+
+**Deeper-than-A (post-MTT or as Lance exposes uncommitted variants):** all-uncommitted-fragments
++ one manifest commit would shrink the A-before-B window itself, blocked today by Lance not
+exposing uncommitted variants for `compact_files` / `optimize_indices` / vector index (#6666
+open; delete #6658 shipped). Track, don't build yet.
+
+---
+
+## 6. Why #297 is still needed even if you do Design A
+- Design A **relocates** #297's maintenance-class commit logic into the authority's
+  `TableAction::Rewrite` path; it does not eliminate it. #297 is the *validated spec + tests*.
+- The two regression tests + §6.6 are the **contract** Design A must keep green.
+- The prod bug is **live**; Design A is the largest write-path change in the RFC. Don't hold a
+  correctness fix hostage to a big refactor, and don't do a big refactor under bug-fix urgency.
+- Genuinely throwaway under Design A: only the loop's *location* + the `head_advanced` proxy
+  (~a dozen lines). Everything else relocates or persists. **Merge #297.**
+
+---
+
+## 7. Open PRs and their relationships
+- **#297** (this) — maintenance-class fix (optimize vs write). Merge.
+- **#254** — logical-class fix (schema-apply vs optimize false-fail). Same op-class family;
+  both are de-risking inputs for Design A's per-class commit models.
+- **#296** — recovery roll-forward converges on concurrent manifest advance. This is the fix
+  for the flaky `iss-schema-apply-reopen-recovery-race` (the handoff in
+  `handoff-schema-apply-recovery-flake.md`). It touches `recovery.rs` and is *aligned* with
+  #297's "postcondition is the state, not winning the CAS" principle — reconcile the monotonic
+  publish with #296's converge helper if #296 lands first.
+- **#295** — the step-3b RFC doc (apply §4's three corrections to it).
+
+---
+
+## 8. Remaining RFC steps after 3b (RFC §9 is canonical)
+- **Step 4 / Phase 7** (`iss-991`): lineage into `__manifest` (publish `graph_commit` +
+  mutable `graph_head:<branch>` in the same merge-insert; `_graph_commits` becomes a
+  projection). Removes the per-write `commit_graph.refresh`; closes the manifest→commit-graph
+  atomicity + commit-graph-parent-under-concurrency gaps. **Hard prereq: step 2 (done).**
+  Carries the §7.1 *concurrent* write-skew fix (needs the `graph_head` contention row).
+- **Step 5 / Design A** — §5 above.
+- **Step 2b** — internal-table cleanup + the Q8 monotonic watermark (a Lance boundary tag).
+  Deferred: only the secondary version-count/space term, touches the read/open path, and is
+  MTT-redundant. Land when version-count cost bites.
+- **§7.1 sequential write-skew** (`iss-overwrite-orphans-committed-edges`) — inbound-RI
+  validation on node removal; independent, ships anytime.
+- **#20** — the prod per-write `storage.ops` span metric (RFC §5.3), still owed.
+- Branch ops: Lance `Clone` for create (`iss-691`).
+
+---
+
+## 9. Gotchas / traps (learned the hard way)
+- **In-process queue ≠ cross-process lock.** Any "I hold the queue → skip the retry/CAS"
+  reasoning is a bug across processes. This is the recurring trap.
+- **Monotonic publish must be `≥`-conditional, never "no assertion."** The `__manifest`
+  merge-insert is unconditional `UpdateAll` keyed on `object_id` (`publisher.rs:379`), so
+  the equality (or monotonic) pre-check is the *only* guard — dropping it lets `UpdateAll`
+  regress a newer version = lost write.
+- **The drift guard interprets an ambiguous delta.** Re-evaluating it in a retry over
+  self-mutated state is how #297's follow-on bug happened. Gate any HEAD-vs-manifest
+  interpretation on "have *we* committed yet."
+- **`compact_files` fires Lance's auto_cleanup GC hook** (commits with
+  `skip_auto_cleanup=false`, no override) — optimize strips stale `lance.auto_cleanup.*`
+  config before compacting to stay non-destructive on upgraded graphs. The strip is a
+  separate commit (relevant to the partial-commit retry trap).
+- **Lance rebases the common concurrent case for free** — so the data-table conflict usually
+  surfaces as the manifest fast-forward, not a Lance error. The Lance-Rewrite-overlap path is
+  rare and needs failpoint injection to test.
+
+---
+
+## 10. Verification (the gate)
+- `cargo test --workspace --locked` — the canonical gate (matches CI).
+- `cargo test -p omnigraph-engine --features failpoints --test failpoints optimize` —
+  the optimize concurrency/recovery tests.
+- `cargo test -p omnigraph-engine --test write_cost` / `write_cost_s3` (bucket-gated) —
+  cost gates (3b adds the schema-once + open-count asserts here).
+- `cargo test -p omnigraph-engine --test maintenance` — optimize/repair/cleanup.
+- Re-read [`invariants.md`](invariants.md), [`lance.md`](lance.md), [`testing.md`](testing.md)
+  before each change (always-on requirement).
+
+Lance source for re-validation:
+`/Users/ragnor/.cargo/registry/src/index.crates.io-*/lance-7.0.0` (key files: `io/commit.rs`,
+`io/commit/conflict_resolver.rs`, `dataset/optimize.rs`, `dataset/write/retry.rs`,
+`dataset/builder.rs`).

--- a/docs/dev/handoff-rfc-013-write-path.md
+++ b/docs/dev/handoff-rfc-013-write-path.md
@@ -88,6 +88,54 @@ drift guard). Each interpreter is a fresh chance to misclassify. That is the bug
 **The convergent fix is Design A (one publish authority — step 5); Lance MTT eventually
 retires the window entirely.** See §5.
 
+### 1d. The second facet: the write base is a stale pin (no probe)
+The READ path resolves its base behind a freshness probe (`resolve_target_inner`
+omnigraph.rs:~1072 → `probe_latest_incarnation` → `refresh_manifest_only`); the WRITE path
+does NOT (`resolved_branch_target` omnigraph.rs:~778 returns the warm `coord.snapshot()` for
+the bound branch, no probe). So a long-lived server's write base lags the live manifest. That
+single staleness feeds **two distinct failure modes**, both surfaced this cycle:
+
+1. **Stale validation *reads* → integrity under-enforced.** Write-path RI checks read
+   committed state off the stale base. 3b's collapse #1 made it worse for edge `@card`:
+   `edge_cardinality_read_handle` (mutation.rs:~614) scans the pinned `txn.base` instead of
+   live HEAD (was live HEAD pre-3b), so a concurrent edge committed after `txn` capture is
+   uncounted → a `@card` max can be exceeded (cursor **High** / codex **P1** on #298,
+   **VALID**). **#298 fix: restore the live-HEAD read for that scan** (un-regress; gate-safe —
+   the `data_open_count` gate is a node insert) + a deterministic regression test (commit A's
+   edge, then B validates → must see A) + correct the wrong "pinned base == live HEAD" doc
+   comment (mutation.rs:~605-613, which assumes a single writer). The *structural* liability
+   underneath: there is **no unified write-validation read-set** — endpoint
+   (`ensure_node_id_exists`, warm `snapshot_for_branch`), cardinality (mutation: pinned
+   `txn.base`; loader: warm `snapshot_for_branch` — the SAME check forks per write path),
+   commit drift guard (live `fresh_snapshot_for_branch`), and uniqueness
+   (`enforce_unique_constraints_intra_batch`, intra-batch only — cross-version uniqueness is a
+   documented gap). Three freshness levels chosen ad hoc, none re-validated at commit → the
+   §7.1 TOCTOU class, and each new constraint forks the pattern again.
+
+2. **Stale OCC *pin* → false-fail on a maintenance advance.** A served strict update/delete
+   pins the stale base version, then false-fails `ExpectedVersionMismatch` after an external
+   `optimize` advanced `__manifest` — even though the advance was content-preserving
+   compaction the logical write should fast-forward past (invariant 7). It's the **write-side
+   mirror of #297/§6.6** (#297 made optimize fast-forward past a logical write; this is a
+   logical write that must fast-forward past optimize). A served read clears it (the read
+   probes the shared coordinator). Validated repro on prod (omnigraph.ragnor.co) +
+   `writes.rs::served_strict_delete_after_external_optimize_advance_auto_refreshes`
+   (`#[ignore]` on branch `fix/write-path-stale-view-probe`). **The naive "just probe" fix is
+   proven wrong** — a blanket probe silently refreshes past *logical* advances too, breaking
+   `consistency::stale_handle_public_mutation_must_refresh_then_retry` (the deliberate
+   cross-process lost-update OCC primitive). The fix must **discriminate by op class**.
+
+**Both fold into Design A (step 5), same as §1c.** `open_txn`'s one warm probe makes the base
+fresh (absorbs maintenance advances cheaply); the **op-class-aware strict precondition** —
+derive from Lance's per-version transaction metadata (all `Rewrite`/`ReserveFragments` =
+maintenance → fast-forward the pin; any `Append`/`Update`/`Delete`/`Merge` = logical → fail
+loudly; NO parallel marker, invariant 1/15) — is the correctness fence for anything that lands
+after. And the §7.1 read-set-in-CAS unifies the validation read-set + re-validates it under the
+`graph_head` contention. So **the stale-view false-fail, the cardinality/validation-read-set
+liability, and #297's mirror are one bug** (the write base is a stale, un-probed, un-classified
+pin) with **one home: the single PublishPlan delta-interpreter** (§1c + §5). Strong corroboration
+of Design A — three symptoms, one fix.
+
 ---
 
 ## 2. Validated facts — do NOT re-derive these
@@ -305,12 +353,27 @@ open; delete #6658 shipped). Track, don't build yet.
 ---
 
 ## 8. Remaining RFC steps after 3b (RFC §9 is canonical)
+- **#298 follow-up (do on the 3b PR, before merge): the edge-`@card` stale-read regression**
+  (§1d.1). Restore the live-HEAD cardinality scan, add the deterministic regression test, fix
+  the wrong doc comment. Small, gate-safe, un-regresses an integrity check (invariant 9). The
+  residual concurrent TOCTOU is the §7.1 gap (step 4) — un-widen here, don't over-reach.
 - **Step 4 / Phase 7** (`iss-991`): lineage into `__manifest` (publish `graph_commit` +
   mutable `graph_head:<branch>` in the same merge-insert; `_graph_commits` becomes a
   projection). Removes the per-write `commit_graph.refresh`; closes the manifest→commit-graph
   atomicity + commit-graph-parent-under-concurrency gaps. **Hard prereq: step 2 (done).**
-  Carries the §7.1 *concurrent* write-skew fix (needs the `graph_head` contention row).
-- **Step 5 / Design A** — §5 above.
+  Carries the §7.1 *concurrent* write-skew fix (needs the `graph_head` contention row) —
+  **frame §7.1 as "unify the entire write-validation read-set" (endpoint + cardinality +
+  cross-version uniqueness), not merely "add `graph_head`"** (§1d.1): the bespoke
+  `edge_cardinality_read_handle` and the mutation-vs-loader freshness fork dissolve into one
+  pinned read-set re-validated under the `graph_head` contention, or the liability survives as
+  a second special-case.
+- **Step 5 / Design A** — §5 above. **Acceptance item: the served-strict-write stale-view
+  false-fail** (§1d.2) — the op-class-aware precondition + `open_txn` probe. The contract is
+  two tests passing *together*: un-ignore
+  `writes.rs::served_strict_delete_after_external_optimize_advance_auto_refreshes` (goes green)
+  *while* `consistency::stale_handle_public_mutation_must_refresh_then_retry` stays green
+  (maintenance fast-forwards; logical fails loudly). Self-contained enough to ship standalone
+  like #297 if prod pain is acute; otherwise fold into the single PublishPlan delta-interpreter.
 - **Step 2b** — internal-table cleanup + the Q8 monotonic watermark (a Lance boundary tag).
   Deferred: only the secondary version-count/space term, touches the read/open path, and is
   MTT-redundant. Land when version-count cost bites.

--- a/docs/dev/handoff-schema-apply-recovery-flake.md
+++ b/docs/dev/handoff-schema-apply-recovery-flake.md
@@ -1,0 +1,216 @@
+# Handoff: flaky schema-apply → reopen recovery race
+
+**Type:** bug investigation handoff (not yet fixed)
+**Status:** root-caused to a layer + hypothesis; exact mechanism and fix NOT yet validated
+**Severity:** medium — flaky CI; a real (rare) schema-apply-then-reopen failure under load
+**Scope:** pre-existing on `main`; **independent of** RFC-013 step 2 (internal-table
+compaction, PR #291) and step 3a (#288) — those paths never touch schema apply or
+the recovery sweep, and the full `--workspace` gate passes clean on a re-run.
+
+> Do **not** "fix" this by changing the test to use a single handle. That was
+> empirically shown to *reduce but not eliminate* the flake (see Experiments), so it
+> would mask a real product race. This is a correct-by-design fix in the engine, not
+> a test edit.
+
+---
+
+## 1. Symptom
+
+The test
+`crates/omnigraph-server/tests/schema_routes.rs::schema_apply_route_hard_drops_property_with_allow_data_loss`
+intermittently fails. The HTTP schema apply **succeeds** (`applied == true`); the
+*subsequent* `Omnigraph::open(graph)` (which the test does to verify the catalog)
+panics on `.unwrap()` with:
+
+```
+OmniError::Manifest(Conflict,
+  "stale view of node:Person: expected manifest version 5 but current is 7",
+  ExpectedVersionMismatch { expected: 5, actual: 7 })
+```
+
+The values (5, 7) vary; the shape is always "recovery roll-forward expected version
+N, manifest is at M > N." It is raised from the **open-time recovery sweep**, i.e.
+inside `Omnigraph::open`, not from the apply itself.
+
+---
+
+## 2. Reproduction
+
+- **Needs sibling-test parallelism (CPU contention).** Running the target test
+  *alone* is rock-solid (0/20 failures). The flake only appears when other tests in
+  the same binary run concurrently and perturb the timing inside the apply→reopen
+  sequence.
+- Fast repro loop (≈13–40% per run):
+  ```bash
+  cargo test -p omnigraph-server --test schema_routes --no-run
+  for i in $(seq 1 15); do
+    cargo test -p omnigraph-server --test schema_routes 2>&1 \
+      | grep -q "schema_apply_route_hard_drops_property_with_allow_data_loss ... FAILED" \
+      && echo "iter $i FAIL"
+  done
+  ```
+- It originally surfaced in a full `cargo test --workspace` run (max parallelism).
+- Each test uses its own `tempfile::tempdir()`, so this is **not** cross-test shared
+  state — it's a timing race inside one test's own graph.
+
+---
+
+## 3. Experiments run (the discriminating evidence)
+
+Each variant was stress-run under the full `schema_routes` suite (parallel siblings):
+
+| Variant | Flake rate |
+|---|---|
+| Target test in isolation (no sibling parallelism) | **0/20** |
+| **Control** — as written (server handle + out-of-band `Omnigraph::open` load + reopen) | 6/15 ≈ 40% |
+| Drop the live server handle (`drop(app)`) before the reopen | 4/15 ≈ 27% |
+| Remove the out-of-band separate-handle load | 2/15 ≈ 13% |
+| Remove the load **and** drop the server handle (≈ single-handle) | 8/20 ≈ 40% |
+
+**Interpretation:**
+- It is **concurrency-triggered**, not a topology bug: 0% isolated, flaky under
+  parallel load.
+- **No single factor eliminates it.** Removing the out-of-band load roughly halves
+  the rate (it amplifies the race) but leaves a ~13% base. Dropping the live server
+  handle does not clearly help. So the "single-handle test" patch is a **band-aid**,
+  not the fix.
+- The residual base rate with the out-of-band load removed means there is a real
+  race in the **schema-apply → reopen → recovery** path itself.
+
+Caveat on the experiments: `drop(app)` may not synchronously tear down the server's
+engine handle (it can be held by an `Arc`/spawned task), so the "single-handle"
+rows are not airtight. This is one of the things to validate (§6).
+
+---
+
+## 4. Root-cause hypothesis (NOT yet proven)
+
+The failing path is the **open-time recovery sweep's roll-forward** raising
+`ExpectedVersionMismatch` from the publisher's `check_expected_table_versions`.
+
+The hard-drop schema apply (`allow_data_loss=true` → `DropMode::Hard`) is a
+**multi-step migration**: it performs several Lance commits + `__manifest` publishes,
+advancing `node:Person`'s manifest version across multiple versions (e.g. 5 → … → 7).
+To be crash-safe across the Lance-HEAD-before-manifest-publish gap, schema apply
+writes a **recovery sidecar** (`__recovery/{ulid}.json`) pinning per-table
+`expected_version` / `post_commit_pin` before its Phase B.
+
+Hypothesis: under CPU contention, the timing of (a) the migration's multi-version
+advancement, (b) the sidecar's Phase-D deletion, and (c) a later/over­lapping
+`Omnigraph::open` recovery sweep interleaves such that the recovery roll-forward
+reads a sidecar whose pinned `expected` is **stale relative to a manifest that
+legitimately advanced several versions**, and **re-publishes at the stale `expected`
+instead of recognizing the migration already completed** → `expected 5, actual 7`.
+
+In other words: the recovery classifier / roll-forward likely does not correctly
+handle a table whose manifest is **already past `post_commit_pin`** by more than one
+step (multi-step migration), or a sidecar whose operation has already fully
+committed. The single-step assumption baked into the Optimize-style pin
+(`post_commit_pin = expected_version + 1`) may not generalize to multi-commit schema
+migrations.
+
+---
+
+## 5. Likely solution (correct-by-design, surgical)
+
+Make the **open-time recovery classifier idempotent against a manifest that advanced
+past the sidecar's pin**:
+
+- If the table's current manifest/Lance version is already `>= post_commit_pin`
+  (operation completed, possibly across multiple versions), classify it as
+  *already-rolled-forward / completed* (the `RolledPastExpected` family) and **delete
+  the sidecar without republishing** — never attempt a publish at the stale
+  `expected`.
+- Ensure the schema-apply sidecar records a pin that the classifier can interpret for
+  a **multi-step** migration (a range / "completed at or beyond" semantics), not a
+  strict single-step `expected + 1`.
+
+This also hardens *real* crash recovery for multi-step schema apply (not just the
+test), and is small + local to `recovery.rs` (+ possibly the schema-apply sidecar
+write in `schema_apply.rs`). It does **not** rearchitect recovery.
+
+Per repo rule 12 (test-first for bug fixes): land a **deterministic** repro first —
+ideally a failpoint that forces the interleaving (pause after the migration's commits
+but before sidecar delete, then run an open) so the red→green is reliable, not a
+stress-loop probability. See the `failpoints.rs` pattern + the schema-apply failpoints
+already in the tree.
+
+---
+
+## 6. What MUST be validated before fixing
+
+1. **Which sidecar is being rolled forward?** Confirm it is the *schema-apply*
+   sidecar (vs the out-of-band `load`'s sidecar, vs another writer). Instrument /
+   log the sidecar `operation_id`, `kind`, and `SidecarTablePin` at the point the
+   recovery sweep raises the error.
+2. **The exact classifier path.** Trace which `TableClassification` arm the failing
+   table hits (`recovery.rs::classify_table`, ~L600) and which roll-forward call
+   raises `ExpectedVersionMismatch` (`heal_pending_sidecars_roll_forward` ~L761,
+   `roll_forward_all` ~L1215, `restore`+publish ~L1275). Confirm it is the
+   multi-step-advanced / already-completed case being mishandled.
+3. **Is `post_commit_pin = expected + 1` the bug?** Verify the hard-drop migration
+   advances `node:Person` by **>1** version, and that the sidecar pins a single-step
+   `+1`, so the classifier can't recognize completion at +2.
+4. **Engine-level reproduction (no server).** Build a deterministic engine-level
+   repro: persistent handle applies a multi-step hard-drop, then a fresh
+   `Omnigraph::open` — ideally with a failpoint forcing the interleave — to confirm
+   the bug is in the engine recovery path and not server-specific (runtime, handle
+   lifecycle). The current evidence is server-test-only.
+5. **Is the out-of-band load *necessary or only amplifying*?** Confirm the ~13% base
+   rate (load removed) is the same root cause, not a second distinct race. If the
+   load is required, the bug is specifically about a second writer's version
+   advancement; if not, it's purely intra-apply.
+6. **`drop(app)` cleanliness.** Verify whether the server's engine handle is truly
+   gone after `drop(app)` (it may be `Arc`-held). If not, the "single-handle"
+   experiments don't isolate the live-handle factor and should be redone with a
+   genuinely single-handle setup.
+
+---
+
+## 7. Relationship to Lance MTT
+
+This bug lives in the **recovery-sidecar roll-forward**, which exists only to bridge
+the Lance-HEAD-before-manifest-publish gap in omnigraph's faked multi-table
+atomicity. `invariants.md` already calls recovery sidecars "scaffolding to remove
+once the substrate closes the gap." Lance **MTT** (native atomic multi-table commits,
+RFC §8 / lance#7264) closes that gap → retires the sidecar → **eliminates this bug
+class.**
+
+Implications:
+- **Don't wait for MTT** — it is the "strategic exit, not a current dependency,"
+  uncertain and far off, and this bug is live now.
+- **Don't over-invest** — keep the fix surgical (classifier idempotency), because the
+  whole sidecar layer is MTT-disposable. A surgical fix retires cleanly with the
+  layer; a recovery rearchitecture would be throwaway.
+
+---
+
+## 8. Key pointers
+
+- Failing test: `crates/omnigraph-server/tests/schema_routes.rs`
+  → `schema_apply_route_hard_drops_property_with_allow_data_loss` (~L777,
+  `#[tokio::test(flavor = "multi_thread")]`).
+- Error type: `OmniError::Manifest` / `ManifestConflictDetails::ExpectedVersionMismatch`
+  (`crates/omnigraph/src/error.rs`); raised by `check_expected_table_versions`
+  (`crates/omnigraph/src/db/manifest/publisher.rs`, ~L356).
+- Recovery sweep + classifier: `crates/omnigraph/src/db/manifest/recovery.rs`
+  — `TableClassification` (~L335), `classify_table` (~L600), roll-forward
+  (`heal_pending_sidecars_roll_forward` ~L761, `roll_forward_all` ~L1215, restore +
+  publish ~L1275).
+- Schema-apply sidecar write: `crates/omnigraph/src/db/omnigraph/schema_apply.rs`
+  (the `SidecarKind` schema-apply pins; `db.coordinator.write().refresh()` ~L692).
+- Open entry point that runs the sweep: `Omnigraph::open` (read-write mode) →
+  `db/manifest/recovery.rs` sweep.
+- Repro: §2 above. Stress under `schema_routes` suite parallelism; 0% isolated.
+
+---
+
+## 9. Suggested next steps
+
+1. Add tracing at the recovery roll-forward error site (sidecar kind/id, pins,
+   observed vs expected) and capture a failing run (§6.1, §6.2).
+2. Reproduce deterministically at the engine level with a failpoint (§6.4) — this is
+   the red test (rule 12).
+3. Implement the classifier-idempotency fix (§5) in a separate commit; confirm
+   red→green and that the stress loop goes to 0 failures over ≥50 iterations.
+4. Keep it a standalone PR (not bundled with RFC-013 follow-ons).

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -93,6 +93,8 @@ Working documents for in-flight feature work. Removed when the work lands.
 | CLI refactoring — one addressing & config model post-`omnigraph.yaml`: scope + `--graph` + derived access path, served-default / privileged-direct, profiles, named queries, capability classifier (completes RFC-008) | [rfc-011-cli-refactoring.md](rfc-011-cli-refactoring.md) |
 | Provider-independent embedding configuration — one resolved `EmbeddingConfig` + sealed provider enum (Gemini/OpenAI/Mock), identity recorded in the schema IR, query-time same-space validation, NFR floor | [rfc-012-embedding-provider-config.md](rfc-012-embedding-provider-config.md) |
 | Write-path latency — capture-once `WriteTxn`, version-pinned opens, one `GraphPublishAuthority` fed declarative `PublishPlan`s, manifest-authoritative lineage, epoch fence, bounded history (compaction + cleanup), and an IO-counted cost contract (`iss-write-s3-roundtrip-amplification`, `iss-991`) | [rfc-013-write-path-latency.md](rfc-013-write-path-latency.md) |
+| RFC-013 handoff — current-state map, latest validation, and concrete next actions for finishing write-path latency and correctness work | [handoff-rfc-013-write-path.md](handoff-rfc-013-write-path.md) |
+| Schema-apply recovery flake handoff — investigation notes and validation plan for the intermittent schema-apply reopen race | [handoff-schema-apply-recovery-flake.md](handoff-schema-apply-recovery-flake.md) |
 
 ## Boundary
 

--- a/docs/dev/rfc-013-write-path-latency.md
+++ b/docs/dev/rfc-013-write-path-latency.md
@@ -523,7 +523,10 @@ struct WriteTxn {
     branch: BranchRef,
     base: PinnedSnapshot,   // {manifest_version, per-table (loc,version,e_tag), schema_hash, writer_epoch}
     session: Arc<Session>,  // shared per-graph; warms metadata/index caches across opens
-    handles: HandleCache,   // open-by-version; each table opened once, reused across stages
+    handles: HandleMap,     // open the base once WITH session; thread the handle each
+                            // commit RETURNS forward (HEAD walks N→N+1→N+2). NOT a
+                            // version-keyed cache — HEAD moves, so a (table,version) key
+                            // misses; reuse = forward the commit-return handle. [3b-validated]
 }
 
 // A typed, declarative publish plan — the COMPLETE "what", built before any HEAD moves.
@@ -546,8 +549,17 @@ impl GraphPublishAuthority {
 
 Properties that make it optimal:
 
-- **Stages take `&WriteTxn`/`&PublishPlan`, never storage** — re-resolution and
-  open-latest are *unrepresentable*. Invariants 2/3/15 hold by construction.
+- **Stages take `&WriteTxn`/`&PublishPlan` for the BASE** — re-resolving the pinned
+  read base / open-latest for the pre-commit phase is unrepresentable; invariants 2/3/15
+  hold for the base by construction. **Caveat [3b-validated]:** this is NOT "no
+  re-resolution anywhere." Three commit-boundary reads are irreducible correctness
+  machinery and MUST stay fresh: the commit-time `fresh_snapshot_for_branch` (cross-process
+  OCC), the live-HEAD drift probe (a concurrent writer may have moved HEAD since staging),
+  and the fork-authority reads (`classify_fork_ref` deliberately bypasses the cached base —
+  a pinned base there re-opens the "force-delete a live fork" bug). Model "pinned base for
+  the pre-commit phase + named fresh re-reads at the commit/fork boundary." The achievable
+  open count is **1 base open (with session) + 1 cheap `latest_version_id` probe + threaded
+  commit handles**, not literally one open.
 - **The recovery sidecar *is* the serialized `PublishPlan`.** Phase C and
   recovery both call `plan.apply()` — a merge that bumps tables A+B can never
   roll A forward and silently drop B. The


### PR DESCRIPTION
## `WriteTxn`

A single `mutate`/`load` re-validated the schema contract ~4× and opened each touched data table 4× — redundant per-write I/O that scales with the write's internal structure, not its work. This threads a capture-once `WriteTxn { branch, base }` so a write **validates the schema once** and **opens each data table at most once**. Constant-factor/RTT win (3a already removed the depth-slope term).

### Locked by two cost gates (`write_cost.rs`)
- `write_validates_schema_contract_once` — **3 read_text / 2 exists** (was 12/9)
- `keyed_insert_opens_table_at_most_once` — **`data_open_count = 1`** (was 4)

### How
- **Schema-once:** capture `txn` once at entry (the single validation); the 4 sites collapse — entry check removed; `open_for_mutation_on_branch` + `prepare_updates_for_commit` source `txn.base`; `commit_all` uses `fresh_snapshot_for_branch_unchecked` (the OCC manifest re-read minus the schema re-validation, also dropping a spurious commit-graph `exists` probe — same `Snapshot`).
- **Open-collapse 4→1:** #1 accumulation open eliminated (node path discarded it; read the pinned `entry.table_version`); #2 staging open kept (the one open); #3 drift-guard reads live HEAD via a cheap `latest_version_id()` probe off the already-open staged handle (not a fresh open); #4 index build reuses the `commit_staged` handle threaded through `CommittedMutation` instead of reopening.
- **Counter fix (review finding):** `open_count` → `data_open_count`/`internal_open_count` classified by URI, so the gate measures data-table opens (not the `__manifest`/`_graph_commits` opens the publisher/commit-graph append make) and is actually reachable.
- Positional returns named (`OpenedForMutation`, `CommittedMutation`) + a `debug_assert` pinning the open-skip contract (a `None` handle is legal only on the non-strict-txn path).

When `txn` is `None` (branch merge, schema apply, tests) every threaded path is byte-identical. Strict ops keep live-HEAD + `ensure_expected_version`; the fork path and the commit-time OCC re-read stay fresh (correctness machinery).

### Deferred to step 5
Session-aware write base opens — the one remaining open stays a HEAD open; the warm-session benefit is an object-store (S3) phenomenon invisible on local FS, so it earns its own `write_cost_s3.rs` gate in step 5, where `WriteTxn` becomes the non-optional publish carrier (PublishPlan unification).

### Verification
Full engine suite + failpoints (59, recovery-sidecar lifecycle) + `cargo test --workspace --locked` all green. No new concurrency test needed: #2 stays a HEAD open (no pinned/session base introduced), so the publisher CAS + #3 live-HEAD probe fences are unchanged.

Stacked on merged #297 (optimize-vs-write race).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the mutate/load write hot path (schema validation timing, skipped opens, pinned base) while relying on preserved strict-op and OCC guards; edge cardinality now depends on an extra live-HEAD open on a narrow path, with regression coverage but remaining TOCTOU called out for step 4.
> 
> **Overview**
> **RFC-013 step 3b** adds a capture-once **`WriteTxn { branch, base }`**: `mutate` and `load` call `open_write_txn` after recovery heal (and drop the duplicate entry `ensure_schema_state_valid`), then thread `Option<&WriteTxn>` through staging and publish. Resolve sites reuse **`txn.base`** instead of re-running `resolved_branch_target` / `snapshot_for_branch` (which re-validated the schema contract). **`None`** keeps branch merge and other callers byte-identical.
> 
> **Open collapse (4→1 on the hot path):** `open_for_mutation_on_branch` returns **`OpenedForMutation`**; for non-strict Insert/Merge under a txn on the target branch it **skips** the accumulation `Dataset::open` and only pins **`expected_version`** from the manifest entry. Staging still does one reopen; commit drift uses **`latest_version_id()`** on the staged handle instead of another open; **`CommittedMutation.committed_handles`** lets publish-time index build reuse post-`commit_staged` handles instead of **`reopen_for_mutation`**.
> 
> **OCC stays fresh:** commit-time manifest re-read uses **`fresh_snapshot_for_branch_unchecked`** (manifest-only, no second schema check / commit-graph probe) when a txn is present. Strict Update/Delete, fork paths, and publisher CAS behavior are unchanged.
> 
> **Integrity:** when the edge open is skipped, non-default **`@card`** validation uses **`edge_cardinality_read_handle`** (live HEAD), plus a regression test for stale-handle concurrent commits. IO probes add **`data_open_count`** / **`internal_open_count`**; **`write_cost.rs`** gates schema-once reads and **`data_open_count <= 1`** on keyed insert.
> 
> Developer handoff docs for RFC-013 and schema-apply recovery flake are added/linked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9a2a4b51827a8e315fd93be3c77b80cd07cad7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements RFC-013 step 3b: a capture-once `WriteTxn { branch, base }` that validates the schema contract exactly once per `mutate`/`load` call and collapses ~4 data-table opens per write down to 1 (on the non-strict main-branch insert path). All previously-flagged issues (cardinality stale-handle regression, feature-branch schema re-validation) are addressed or explicitly deferred to step 4 with regression tests and handoff documentation.

- **Schema-once:** `open_write_txn` captures a pinned base snapshot after the single `ensure_schema_state_valid` call; `open_for_mutation_on_branch`, `prepare_updates_for_commit`, and the OCC re-read in `commit_all` all consume it via `fresh_snapshot_for_branch_unchecked` (dropped commit-graph side-load) rather than re-resolving.
- **Open-collapse (4→1):** collapse #1 skips the accumulation open for non-strict Insert/Merge on the txn's own branch; collapse #3 replaces a fresh `open_dataset_head_for_write` drift-guard call with `latest_version_id()` on the already-open staged handle; collapse #4 threads post-`commit_staged` handles via `CommittedMutation.committed_handles` to reuse them for the index build.
- **Cardinality fix + regression test:** `edge_cardinality_read_handle` restores the live-HEAD read for non-default `@card` validation when collapse #1 skipped the accumulation open; `cardinality_rejected_for_stale_handle_after_concurrent_edge_commit` locks this deterministically.

<h3>Confidence Score: 5/5</h3>

The write pipeline change is well-guarded: strict ops (Update/Delete/Overwrite) are untouched by the open-collapse, the OCC re-read in commit_all still uses a fresh manifest snapshot, and the publisher CAS still fences against concurrent advances. The cardinality regression introduced by collapse #1 is correctly repaired and regression-tested.

The schema-once and open-collapse paths are gated conservatively — strict ops, the fork path, and no-txn callers all keep their prior behavior byte-identical. The two locked cost gates make regressions detectable in CI. The one flagged item is a defensive fallback arm documented as unreachable today and carries only forward-looking risk.

The defensive None arm in edge_cardinality_read_handle (exec/mutation.rs) warrants attention if future work makes txn.base not contain the edge table entry — it would open at a pinned manifest version rather than live HEAD, silently reintroducing the staleness the function was added to prevent.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/omnigraph/src/db/omnigraph.rs | Introduces WriteTxn struct and open_write_txn/fresh_snapshot_for_branch_unchecked; wires txn through open_for_mutation_on_branch and commit_updates_on_branch_with_expected. Logic is sound. |
| crates/omnigraph/src/db/omnigraph/table_ops.rs | Core collapse logic: adds OpenedForMutation struct, implements collapse #1 (non-strict txn early-return for main/active branch), and collapse #4 (post-commit handle reuse in prepare_updates_for_commit). Guards and edge cases (fork path, strict ops) are correctly kept out of the collapse paths. |
| crates/omnigraph/src/exec/mutation.rs | Threads WriteTxn through execute_named_mutation and all op sub-fns; adds edge_cardinality_read_handle to restore live-HEAD cardinality scan when collapse #1 skipped the accumulation open; gates cardinality validation on !is_default() (safe, matching the inner early-return in validate_edge_cardinality_with_pending). Strict op callers use .expect() for always-Some handles. |
| crates/omnigraph/src/exec/staging.rs | Refactors commit_all return type to CommittedMutation; replaces the collapse #3 fresh open_dataset_head_for_write drift-guard open with latest_version_id() on the already-open staged handle; carries committed_handles for collapse #4 index-build reuse. OCC correctness (fresh manifest re-read, strict CAS check) is preserved. |
| crates/omnigraph/src/loader/mod.rs | Replaces db.snapshot_for_branch(branch) with open_write_txn + txn.base; threads txn through per-table opens and commit_all. Overwrite path uses MutationOpKind::SchemaRewrite (strict), so collapse #1 never fires for it — correct. Branch already exists before open_write_txn is called. |
| crates/omnigraph/src/instrumentation.rs | Adds data_open_count/internal_open_count to QueryIoProbes; record_open classifies by URI last segment; INTERNAL_TABLE_DIRS covers the four system tables. open_dataset_tracked and open_table_dataset both call record_open. |
| crates/omnigraph/tests/write_cost.rs | Adds two locked cost gates: write_validates_schema_contract_once (3 read_text / 2 exists) and keyed_insert_opens_table_at_most_once (data_open_count <= 1). Gates are tight and independently verifiable. |
| crates/omnigraph/tests/validators.rs | Adds cardinality_rejected_for_stale_handle_after_concurrent_edge_commit — deterministic regression guard for the #298 cardinality fix: handle B commits a second edge for a @card(0..1) endpoint that handle A already saturated; validates that the live-HEAD reopen rejects the insert. |

</details>



<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Client
    participant M as mutate()/load()
    participant WT as open_write_txn
    participant OFM as open_for_mutation_on_branch
    participant S as MutationStaging
    participant CA as commit_all
    participant P as ManifestPublisher

    C->>M: mutate(branch, query, params)
    M->>M: heal_pending_recovery_sidecars()
    M->>WT: open_write_txn(branch)
    WT->>WT: resolved_branch_target → ensure_schema_state_valid (ONCE)
    WT-->>M: "WriteTxn { branch, base }"

    loop per table (Insert/Merge on txn branch)
        M->>OFM: "open_for_mutation_on_branch(branch, table, Insert, Some(&txn))"
        OFM->>OFM: ensure_schema_apply_not_locked
        OFM->>OFM: use txn.base entry (no re-validate)
        Note over OFM: Collapse #1: non-strict + txn → handle=None, expected_version=base.version
        OFM-->>M: "OpenedForMutation { handle: None, expected_version }"
        M->>S: ensure_path(table, full_path, table_branch, expected_version)
    end

    M->>S: stage_merge_insert / stage_append per table
    M->>CA: "commit_all(db, branch, ..., Some(&txn))"
    CA->>CA: acquire per-(table,branch) write queues
    CA->>CA: fresh_snapshot_for_branch_unchecked (OCC re-read, no schema check)
    CA->>CA: "Collapse #3: latest_version_id() drift check (no new Dataset::open)"
    CA->>CA: commit_staged per table → committed_handles map
    CA-->>M: "CommittedMutation { updates, expected_versions, committed_handles }"

    M->>P: "commit_updates_on_branch_with_expected(branch, updates, ..., Some(&txn), committed_handles)"
    P->>P: "prepare_updates_for_commit: Collapse #4 reuses committed_handles for index build"
    P->>P: fresh_snapshot_for_branch_unchecked (OCC re-read)
    P->>P: ManifestBatchPublisher::publish (CAS on expected_versions)
    P-->>C: commit version
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Client
    participant M as mutate()/load()
    participant WT as open_write_txn
    participant OFM as open_for_mutation_on_branch
    participant S as MutationStaging
    participant CA as commit_all
    participant P as ManifestPublisher

    C->>M: mutate(branch, query, params)
    M->>M: heal_pending_recovery_sidecars()
    M->>WT: open_write_txn(branch)
    WT->>WT: resolved_branch_target → ensure_schema_state_valid (ONCE)
    WT-->>M: "WriteTxn { branch, base }"

    loop per table (Insert/Merge on txn branch)
        M->>OFM: "open_for_mutation_on_branch(branch, table, Insert, Some(&txn))"
        OFM->>OFM: ensure_schema_apply_not_locked
        OFM->>OFM: use txn.base entry (no re-validate)
        Note over OFM: Collapse #1: non-strict + txn → handle=None, expected_version=base.version
        OFM-->>M: "OpenedForMutation { handle: None, expected_version }"
        M->>S: ensure_path(table, full_path, table_branch, expected_version)
    end

    M->>S: stage_merge_insert / stage_append per table
    M->>CA: "commit_all(db, branch, ..., Some(&txn))"
    CA->>CA: acquire per-(table,branch) write queues
    CA->>CA: fresh_snapshot_for_branch_unchecked (OCC re-read, no schema check)
    CA->>CA: "Collapse #3: latest_version_id() drift check (no new Dataset::open)"
    CA->>CA: commit_staged per table → committed_handles map
    CA-->>M: "CommittedMutation { updates, expected_versions, committed_handles }"

    M->>P: "commit_updates_on_branch_with_expected(branch, updates, ..., Some(&txn), committed_handles)"
    P->>P: "prepare_updates_for_commit: Collapse #4 reuses committed_handles for index build"
    P->>P: fresh_snapshot_for_branch_unchecked (OCC re-read)
    P->>P: ManifestBatchPublisher::publish (CAS on expected_versions)
    P-->>C: commit version
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `crates/omnigraph/src/exec/mutation.rs`, line 820-843 ([link](https://github.com/modernrelay/omnigraph/blob/47707d166b4a48b4f3831e35f5814d50afd40a09/crates/omnigraph/src/exec/mutation.rs#L820-L843)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Schema re-validated on feature-branch path despite captured `txn`**

   The fork-queue-guard check calls `self.snapshot_for_branch(Some(active)).await?`, which calls `resolved_branch_target` → `ensure_schema_state_valid()` — a full schema re-validation. This fires for every feature-branch `mutate` call (when `requested.as_deref()` is `Some`), so feature-branch inserts validate the schema at least twice despite the captured `txn`. The two cost gates (`write_validates_schema_contract_once` and `keyed_insert_opens_table_at_most_once`) only instrument main-branch inserts where `requested.as_deref()` is `None`, leaving this path uncovered.

   The guard's only use of this snapshot is reading `table_branch` to detect whether a fork is needed — a field that can't change between `open_write_txn` capture and this point without holding the write-queue guard that also serializes our path. Using `&txn.base` directly here would eliminate the redundant validation.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fomnigraph%2Fsrc%2Fexec%2Fmutation.rs%0ALine%3A%20820-843%0A%0AComment%3A%0A**Schema%20re-validated%20on%20feature-branch%20path%20despite%20captured%20%60txn%60**%0A%0AThe%20fork-queue-guard%20check%20calls%20%60self.snapshot_for_branch%28Some%28active%29%29.await%3F%60%2C%20which%20calls%20%60resolved_branch_target%60%20%E2%86%92%20%60ensure_schema_state_valid%28%29%60%20%E2%80%94%20a%20full%20schema%20re-validation.%20This%20fires%20for%20every%20feature-branch%20%60mutate%60%20call%20%28when%20%60requested.as_deref%28%29%60%20is%20%60Some%60%29%2C%20so%20feature-branch%20inserts%20validate%20the%20schema%20at%20least%20twice%20despite%20the%20captured%20%60txn%60.%20The%20two%20cost%20gates%20%28%60write_validates_schema_contract_once%60%20and%20%60keyed_insert_opens_table_at_most_once%60%29%20only%20instrument%20main-branch%20inserts%20where%20%60requested.as_deref%28%29%60%20is%20%60None%60%2C%20leaving%20this%20path%20uncovered.%0A%0AThe%20guard's%20only%20use%20of%20this%20snapshot%20is%20reading%20%60table_branch%60%20to%20detect%20whether%20a%20fork%20is%20needed%20%E2%80%94%20a%20field%20that%20can't%20change%20between%20%60open_write_txn%60%20capture%20and%20this%20point%20without%20holding%20the%20write-queue%20guard%20that%20also%20serializes%20our%20path.%20Using%20%60%26txn.base%60%20directly%20here%20would%20eliminate%20the%20redundant%20validation.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modernrelay%2Fomnigraph&pr=298&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

2. `crates/omnigraph/src/db/omnigraph.rs`, line 115-126 ([link](https://github.com/modernrelay/omnigraph/blob/47707d166b4a48b4f3831e35f5814d50afd40a09/crates/omnigraph/src/db/omnigraph.rs#L115-L126)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`_unchecked` variant is `pub(crate)` without the caller precondition enforced**

   The doc comment states "Callers with no `WriteTxn` MUST use the checked variant," but the function is `pub(crate)`, so any code in the engine crate can call it without a `WriteTxn` in scope. The invariant is upheld by convention only. Consider a ZST witness token, a private submodule, or a stronger name like `_without_schema_check` to make the safety consequence visible at every call site.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fomnigraph%2Fsrc%2Fdb%2Fomnigraph.rs%0ALine%3A%20115-126%0A%0AComment%3A%0A**%60_unchecked%60%20variant%20is%20%60pub%28crate%29%60%20without%20the%20caller%20precondition%20enforced**%0A%0AThe%20doc%20comment%20states%20%22Callers%20with%20no%20%60WriteTxn%60%20MUST%20use%20the%20checked%20variant%2C%22%20but%20the%20function%20is%20%60pub%28crate%29%60%2C%20so%20any%20code%20in%20the%20engine%20crate%20can%20call%20it%20without%20a%20%60WriteTxn%60%20in%20scope.%20The%20invariant%20is%20upheld%20by%20convention%20only.%20Consider%20a%20ZST%20witness%20token%2C%20a%20private%20submodule%2C%20or%20a%20stronger%20name%20like%20%60_without_schema_check%60%20to%20make%20the%20safety%20consequence%20visible%20at%20every%20call%20site.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modernrelay%2Fomnigraph&pr=298&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["docs(engine): tighten 3b claims to match..."](https://github.com/modernrelay/omnigraph/commit/c9a2a4b51827a8e315fd93be3c77b80cd07cad7c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39282015)</sub>

<!-- /greptile_comment -->