### PR TITLE
test(dst): in-tree DST harness for the morphological matrix (iss-784)

### DIFF
--- a/crates/omnigraph/Cargo.toml
+++ b/crates/omnigraph/Cargo.toml
@@ -58,3 +58,4 @@ lance-namespace-impls = { workspace = true }
 lance-io = "7.0.0"
 serial_test = "3"
 proptest = "1"
+async-trait = { workspace = true }

--- a/crates/omnigraph/tests/dst.rs
+++ b/crates/omnigraph/tests/dst.rs
@@ -21,6 +21,12 @@ use omnigraph::db::{Omnigraph, ReadTarget};
 use omnigraph::loader::{LoadMode, load_jsonl};
 use omnigraph_compiler::ir::ParamMap;
 
+#[path = "dst/fault.rs"]
+mod fault;
+#[path = "dst/model.rs"]
+mod model;
+use model::{Model, check_counts};
+
 // One schema exercising both bug surfaces: Person+Knows(@card) for the
 // delete-cascade / stale-view path, and Doc.source (low-cardinality enum
 // @index → scalar BTREE) for the index-corruption path.
@@ -301,43 +307,64 @@ async fn regression_dup_key_under_concurrency() {
 // Runs random ops; after EACH, asserts the white-box invariant battery holds.
 // RC-1 (stale-view) is classified as retryable so the walk explores past it.
 
-async fn run_op(db: &Omnigraph, rng: &mut Rng, next_id: &mut usize) -> Result<(), String> {
+async fn run_op(db: &Omnigraph, rng: &mut Rng, model: &mut Model) -> Result<(), String> {
     match rng.below(6) {
         0 => {
-            // insert persons
+            // insert persons — model updated only on success.
+            let mut ids = Vec::new();
             let mut data = String::new();
-            for _ in 0..(1 + rng.below(20)) {
-                data.push_str(&person(&format!("g{}", *next_id)));
-                *next_id += 1;
+            for _ in 0..(1 + rng.below(10)) {
+                let id = model.fresh_id();
+                ids.push(id);
+                data.push_str(&person(&format!("g{id}")));
             }
-            load_jsonl(db, &data, LoadMode::Merge).await.map(|_| ()).map_err(|e| e.to_string())
+            let r = load_jsonl(db, &data, LoadMode::Merge).await;
+            if r.is_ok() {
+                for id in ids {
+                    model.add_person(id);
+                }
+            }
+            r.map(|_| ()).map_err(|e| e.to_string())
         }
         1 => {
-            // insert docs (indexed scalar)
+            // insert docs (indexed scalar source).
+            let mut ids = Vec::new();
             let mut data = String::new();
-            for _ in 0..(1 + rng.below(20)) {
+            for _ in 0..(1 + rng.below(10)) {
+                let id = model.fresh_id();
+                ids.push(id);
                 let s = if rng.below(100) < 85 { "whatsapp" } else { "email" };
-                data.push_str(&doc(&format!("g{}", *next_id), s));
-                *next_id += 1;
+                data.push_str(&doc(&format!("g{id}"), s));
             }
-            load_jsonl(db, &data, LoadMode::Merge).await.map(|_| ()).map_err(|e| e.to_string())
+            let r = load_jsonl(db, &data, LoadMode::Merge).await;
+            if r.is_ok() {
+                for id in ids {
+                    model.add_doc(id);
+                }
+            }
+            r.map(|_| ()).map_err(|e| e.to_string())
         }
         2 => db.optimize().await.map(|_| ()).map_err(|e| e.to_string()),
         3 => {
-            // delete a person (may not exist — fine)
-            let id = rng.below((*next_id).max(1));
+            // delete a person (slug may be a doc or absent — no-op then).
+            let id = rng.below(model.id_high());
             let q = format!("query d() {{ delete Person where slug = \"g{id}\" }}");
-            db.mutate("main", &q, "d", &ParamMap::new()).await.map(|_| ()).map_err(|e| e.to_string())
+            let r = db.mutate("main", &q, "d", &ParamMap::new()).await;
+            if r.is_ok() {
+                model.del_person(id);
+            }
+            r.map(|_| ()).map_err(|e| e.to_string())
         }
         4 => {
             // UPDATE a doc body — moves the whole row → scalar-index remap (the
             // morphology that, combined with optimize, mints RC-X corruption).
-            let id = rng.below((*next_id).max(1));
+            // No count change → model untouched.
+            let id = rng.below(model.id_high());
             let q = format!("query u() {{ update Doc set {{ body: \"u{id} needle\" }} where slug = \"g{id}\" }}");
             db.mutate("main", &q, "u", &ParamMap::new()).await.map(|_| ()).map_err(|e| e.to_string())
         }
         _ => {
-            // read (indexed filter)
+            // read (indexed filter).
             db.query(
                 ReadTarget::branch("main"),
                 "query w() { match { $d: Doc { source: \"whatsapp\" } } return { $d.slug } }",
@@ -351,24 +378,58 @@ async fn run_op(db: &Omnigraph, rng: &mut Rng, next_id: &mut usize) -> Result<()
     }
 }
 
+/// Open a graph whose storage injects seeded manifest-layer faults (CAS-lost).
+async fn open_faulted(uri: &str, seed: u64, cas_pct: u8) -> Omnigraph {
+    Omnigraph::init(uri, SCHEMA).await.expect("init"); // create graph + schema cleanly
+    let base = omnigraph::storage::storage_for_uri(uri).expect("storage_for_uri");
+    let faulted = fault::FaultAdapter::new(base, seed, cas_pct);
+    Omnigraph::open_with_storage(uri, faulted)
+        .await
+        .expect("open_with_storage")
+}
+
+/// Clean generative walk: white-box battery (incl. count==model) after every op.
 #[tokio::test]
 async fn seeded_op_loop_invariants_hold() {
+    run_walk(false).await;
+}
+
+/// Phase 2: same walk, but storage injects spurious manifest CAS-lost faults.
+/// The engine must surface/retry them (never silently lose a write) — count==
+/// model catches any loss as a NOVEL violation.
+#[tokio::test]
+async fn seeded_op_loop_with_cas_faults() {
+    run_walk(true).await;
+}
+
+async fn run_walk(faults: bool) {
     let mut reproduced: Vec<String> = Vec::new();
     for seed in 0..2u64 {
         let dir = tempfile::tempdir().unwrap();
-        let db = init(dir.path().to_str().unwrap()).await;
+        let uri = dir.path().to_str().unwrap();
+        let db = if faults {
+            open_faulted(uri, seed, 8).await
+        } else {
+            init(uri).await
+        };
         let mut rng = Rng::new(seed);
-        let mut next_id = 0usize;
+        let mut model = Model::new();
 
         'walk: for step in 0..15 {
-            // Op error: a KNOWN bug stops this seed (explored to the bug); a
-            // NOVEL error fails the run.
-            if let Err(e) = run_op(&db, &mut rng, &mut next_id).await {
+            // Op error: KNOWN bug stops this seed; an expected fault-induced
+            // retryable error is tolerated (model not updated → still consistent);
+            // anything else is NOVEL → fail.
+            if let Err(e) = run_op(&db, &mut rng, &mut model).await {
                 match known_bug(&e) {
                     Some(bug) => {
                         reproduced.push(format!("seed={seed} step={step} op -> {bug}"));
                         break 'walk;
                     }
+                    // Fault injection legitimately fails writes in varied ways;
+                    // tolerate non-known op errors under faults (the INVARIANT
+                    // checks below stay strict — that's where a lost write or
+                    // novel corruption is caught).
+                    None if faults => {}
                     None => panic!("seed={seed} step={step}: NOVEL op error: {e}"),
                 }
             }
@@ -377,12 +438,13 @@ async fn seeded_op_loop_invariants_hold() {
                 ("head==manifest", invariant_head_eq_manifest(&db).await),
                 ("dataset.validate", invariant_dataset_validate(&db).await),
                 ("index-probe", invariant_index_probe(&db).await),
+                ("count==model", check_counts(&db, &model).await),
             ];
             for (name, res) in checks {
                 if let Err(v) = res {
                     match known_bug(&v) {
-                        // Known corruption is terminal for this seed (e.g. a
-                        // corrupt BTREE page does not self-heal) — record & move on.
+                        // Known corruption is terminal for this seed (a corrupt
+                        // BTREE page does not self-heal) — record & move on.
                         Some(bug) => {
                             reproduced.push(format!("seed={seed} step={step} [{name}] -> {bug}"));
                             break 'walk;
@@ -395,11 +457,11 @@ async fn seeded_op_loop_invariants_hold() {
             }
         }
     }
-    // The generative walk is EXPECTED to (sometimes) reproduce known bugs on the
-    // current build; it must NEVER surface a NOVEL invariant violation (those
-    // panic above). This is the regression guard for new corruption classes.
+    // The walk is EXPECTED to (sometimes) reproduce known bugs; it must NEVER
+    // surface a NOVEL invariant violation (those panic above) — the regression
+    // guard for new corruption / lost-write classes.
     eprintln!(
-        "[dst] generative walk: {} known-bug instance(s) reproduced, 0 novel violations",
+        "[dst] walk (faults={faults}): {} known-bug instance(s), 0 novel violations",
         reproduced.len()
     );
     for r in &reproduced {

--- a/crates/omnigraph/tests/dst.rs
+++ b/crates/omnigraph/tests/dst.rs
@@ -1,175 +1,56 @@
 //! Deterministic-simulation / morphological-matrix test harness (iss-784 / epc-783).
 //!
-//! Cut 1 (this file): the white-box invariant battery built on PUBLIC APIs, the
-//! three confirmed-bug characterization regressions, and a seeded op-loop that
-//! runs the invariants after every operation. Phase 2 (StorageAdapter fault
-//! injection + proptest-state-machine shrinking) and the structural
-//! row-id-overlap invariant land in follow-ups; this is the compiling spine.
+//! A seeded generative walk drives the real engine through the op alphabet
+//! (`op`), runs the white-box invariant battery (`invariants`) against a
+//! reference `model` after every op, and classifies each finding as a KNOWN
+//! open bug (allow-listed so the walk explores past it) or NOVEL (fails). The
+//! `FaultAdapter` (`fault`) injects manifest-layer faults; `coverage` records
+//! which matrix cells were touched.
 //!
-//! Run: `cargo test -p omnigraph-engine --test dst`
+//! Layout: `op` (D1 alphabet) · `model` (D4 reference + count==model) ·
+//! `invariants` (D4 battery + structured classifier) · `fault` (StorageAdapter
+//! fault injection) · `backend` (D5 embedded context) · `coverage`.
 //!
-//! The three regressions ASSERT the *current buggy behavior* on the edge build
-//! (Lance 7.0.0) — they are characterization guards that will visibly break
-//! (forcing review) when each bug is fixed:
-//!   - RC-X  → Lance #7230 (fixed in Lance v8.0.0): scalar-BTREE from_sorted_iter
-//!   - RC-1  → stale-view manifest CAS on delete op-class combos
-//!   - dup-@key → MR-714: uniqueness not enforced across concurrent commits
+//! Run: `cargo test -p omnigraph-engine --test dst -- --nocapture`
+//!
+//! The three named regressions ASSERT current buggy behavior on the edge build
+//! (Lance 7.0.0) — characterization guards that break (forcing review) when each
+//! bug is fixed: RC-X → Lance #7230 (Lance v8.0.0); RC-1 → stale-view manifest
+//! CAS on delete op-class combos; dup-@key → MR-714.
 
 use std::sync::Arc;
 
-use omnigraph::db::{Omnigraph, ReadTarget};
+use omnigraph::db::ReadTarget;
 use omnigraph::loader::{LoadMode, load_jsonl};
 use omnigraph_compiler::ir::ParamMap;
 
-#[path = "dst/fault.rs"]
-mod fault;
+#[path = "dst/op.rs"]
+mod op;
 #[path = "dst/model.rs"]
 mod model;
-use model::{Model, check_counts};
+#[path = "dst/fault.rs"]
+mod fault;
+#[path = "dst/invariants.rs"]
+mod invariants;
+#[path = "dst/coverage.rs"]
+mod coverage;
+#[path = "dst/backend.rs"]
+mod backend;
 
-// One schema exercising both bug surfaces: Person+Knows(@card) for the
-// delete-cascade / stale-view path, and Doc.source (low-cardinality enum
-// @index → scalar BTREE) for the index-corruption path.
-const SCHEMA: &str = r#"
-node Person {
-    slug: String @key
-    name: String
-}
-node Doc {
-    slug: String @key
-    source: enum(whatsapp, email, linkedin, slack, telegram) @index
-    body: String
-}
-edge Knows: Person -> Person @card(0..1)
-"#;
+use coverage::Coverage;
+use invariants::{Finding, classify, run_battery};
+use model::Model;
+use op::{Rng, doc, knows, person};
 
-// ─── inline deterministic RNG (xorshift64*, no `rand` dep — same as examples) ───
-struct Rng(u64);
-impl Rng {
-    fn new(seed: u64) -> Self {
-        Rng(seed ^ 0x9E3779B97F4A7C15)
-    }
-    fn next(&mut self) -> u64 {
-        let mut x = self.0;
-        x ^= x >> 12;
-        x ^= x << 25;
-        x ^= x >> 27;
-        self.0 = x;
-        x.wrapping_mul(0x2545F4914F6CDD1D)
-    }
-    fn below(&mut self, n: usize) -> usize {
-        (self.next() % n as u64) as usize
-    }
-}
+// ═══════════════════════════ named regressions ════════════════════════════
 
-async fn init(uri: &str) -> Omnigraph {
-    Omnigraph::init(uri, SCHEMA).await.expect("init")
-}
-
-fn person(slug: &str) -> String {
-    format!("{{\"type\":\"Person\",\"data\":{{\"slug\":\"{slug}\",\"name\":\"n\"}}}}\n")
-}
-fn doc(slug: &str, source: &str) -> String {
-    format!("{{\"type\":\"Doc\",\"data\":{{\"slug\":\"{slug}\",\"source\":\"{source}\",\"body\":\"needle filler\"}}}}\n")
-}
-fn knows(from: &str, to: &str) -> String {
-    format!("{{\"edge\":\"Knows\",\"from\":\"{from}\",\"to\":\"{to}\",\"data\":{{}}}}\n")
-}
-
-async fn count(db: &Omnigraph, ty: &str) -> Result<usize, String> {
-    let q = format!("query q() {{ match {{ $x: {ty} }} return {{ $x.slug }} }}");
-    db.query(ReadTarget::branch("main"), &q, "q", &ParamMap::new())
-        .await
-        .map(|r| r.num_rows())
-        .map_err(|e| e.to_string())
-}
-
-// ── WHITE-BOX INVARIANT #1: Lance HEAD == manifest table version, per table ──
-// Catches RC-1's drift precondition. Uses only public Snapshot + Lance Dataset.
-async fn invariant_head_eq_manifest(db: &Omnigraph) -> Result<(), String> {
-    let snap = db
-        .snapshot_of(ReadTarget::branch("main"))
-        .await
-        .map_err(|e| format!("snapshot_of: {e}"))?;
-    for entry in snap.entries() {
-        let ds = snap
-            .open(&entry.table_key)
-            .await
-            .map_err(|e| format!("open {}: {e}", entry.table_key))?;
-        let lance_head = ds.version().version;
-        if lance_head != entry.table_version {
-            return Err(format!(
-                "HEAD!=manifest on {}: lance_head={} manifest_pin={}",
-                entry.table_key, lance_head, entry.table_version
-            ));
-        }
-    }
-    Ok(())
-}
-
-fn is_stale_view(e: &str) -> bool {
-    let l = e.to_lowercase();
-    l.contains("stale view") || (l.contains("expected") && l.contains("current"))
-}
-
-// ── WHITE-BOX INVARIANT #2: Lance Dataset::validate() per table ──
-// General structural corruption: fragment-id uniqueness/ordering, equal frag
-// lengths, index metadata. (Does NOT inspect scalar-BTREE page content — that's
-// the index-probe below.)
-async fn invariant_dataset_validate(db: &Omnigraph) -> Result<(), String> {
-    let snap = db
-        .snapshot_of(ReadTarget::branch("main"))
-        .await
-        .map_err(|e| e.to_string())?;
-    for entry in snap.entries() {
-        let ds = snap.open(&entry.table_key).await.map_err(|e| e.to_string())?;
-        ds.validate()
-            .await
-            .map_err(|e| format!("validate {}: {e}", entry.table_key))?;
-    }
-    Ok(())
-}
-
-// ── WHITE-BOX INVARIANT #3: scalar-index probe (catches RC-X at creation) ──
-// Force-loads the Doc.source BTREE flat pages by filtering on each enum value;
-// a duplicate-row-address page (Lance #7230) trips `from_sorted_iter` here,
-// deterministically, before a random read happens to hit it.
-async fn invariant_index_probe(db: &Omnigraph) -> Result<(), String> {
-    for src in ["whatsapp", "email", "linkedin", "slack", "telegram"] {
-        let q = format!(
-            "query w() {{ match {{ $d: Doc {{ source: \"{src}\" }} }} return {{ $d.slug }} }}"
-        );
-        db.query(ReadTarget::branch("main"), &q, "w", &ParamMap::new())
-            .await
-            .map_err(|e| format!("index-probe source={src}: {e}"))?;
-    }
-    Ok(())
-}
-
-/// Known open bugs we allow-list so the generative walk explores PAST them and
-/// surfaces NOVEL violations (which fail the run). Returns the bug name if the
-/// error/violation string matches a known signature, else None (= novel).
-fn known_bug(e: &str) -> Option<&'static str> {
-    let l = e.to_lowercase();
-    if l.contains("from_sorted") || l.contains("non-sorted") {
-        Some("RC-X/#7230 scalar-BTREE")
-    } else if l.contains("stale view") || (l.contains("expected") && l.contains("current")) {
-        Some("RC-1 stale-view")
-    } else {
-        None
-    }
-}
-
-// ═══════════════════════════════════ regressions ═══════════════════════════
-
-/// RC-1 — multi-statement `delete Person + delete Knows` deterministically
-/// fails with a spurious stale-view manifest-CAS error (node-delete cascade
-/// bumps edge:Knows under the explicit edge-delete's pinned version).
+/// RC-1 — multi-statement `delete Person + delete Knows` fails with a spurious
+/// stale-view manifest-CAS error (the node-delete cascade bumps edge:Knows
+/// under the explicit edge-delete's pinned version).
 #[tokio::test]
 async fn regression_rc1_stale_view_on_delete_combo() {
     let dir = tempfile::tempdir().unwrap();
-    let db = init(dir.path().to_str().unwrap()).await;
-    // ring of 50 persons each Knows the next (valid for @card(0..1))
+    let db = backend::open_clean(dir.path().to_str().unwrap()).await;
     let mut seed = String::new();
     for i in 0..50 {
         seed.push_str(&person(&format!("p{i}")));
@@ -180,26 +61,22 @@ async fn regression_rc1_stale_view_on_delete_combo() {
     load_jsonl(&db, &seed, LoadMode::Merge).await.unwrap();
 
     let q = "query m() { delete Person where slug = \"p30\" delete Knows where from = \"p30\" }";
-    let res = db.mutate("main", q, "m", &ParamMap::new()).await;
-
-    // CHARACTERIZATION: current edge build returns a spurious stale-view error.
-    // Flip this assertion (expect Ok) when the op-class-aware fix lands.
-    match res {
-        Err(e) if is_stale_view(&e.to_string()) => { /* bug reproduced */ }
-        Err(e) => panic!("RC-1: expected stale-view, got other error: {e}"),
+    match db.mutate("main", q, "m", &ParamMap::new()).await {
+        Err(e) => assert_eq!(
+            classify(&Finding::Engine(e)),
+            Some("RC-1 stale-view"),
+            "RC-1: expected a stale-view manifest error"
+        ),
         Ok(_) => panic!("RC-1 appears FIXED — flip this regression to expect Ok"),
     }
 }
 
-/// RC-X — Lance #7230: a scalar BTREE over a low-cardinality column corrupts
-/// (duplicate row addresses) under UPDATE racing optimize; a subsequent
-/// indexed-filter read crashes with `from_sorted_iter ... non-sorted input`.
+/// RC-X — Lance #7230: scalar BTREE corruption (duplicate row addresses) under
+/// UPDATE racing optimize; the indexed read crashes with `from_sorted_iter`.
 #[tokio::test]
 async fn regression_rc_x_btree_from_sorted_iter() {
     let dir = tempfile::tempdir().unwrap();
-    let db = Arc::new(init(dir.path().to_str().unwrap()).await);
-    // Docs with a dominant source value, across a few fragments (kept small —
-    // the corruption is fragment-layout-sensitive, not volume-sensitive).
+    let db = Arc::new(backend::open_clean(dir.path().to_str().unwrap()).await);
     const FRAGS: usize = 3;
     const PER: usize = 600;
     for frag in 0..FRAGS {
@@ -210,9 +87,8 @@ async fn regression_rc_x_btree_from_sorted_iter() {
         }
         load_jsonl(&db, &data, LoadMode::Merge).await.unwrap();
     }
-    let _ = db.optimize().await; // build the BTREE
+    let _ = db.optimize().await;
 
-    // UPDATE bodies (moves whole rows → scalar-index remap) racing optimize.
     let upd = {
         let db = db.clone();
         tokio::spawn(async move {
@@ -243,37 +119,32 @@ async fn regression_rc_x_btree_from_sorted_iter() {
     let _ = upd.await;
     let _ = opt.await;
 
-    // Indexed-filter read on the dominant value.
-    let r = db
+    match db
         .query(
             ReadTarget::branch("main"),
             "query w() { match { $d: Doc { source: \"whatsapp\" } } return { $d.slug } }",
             "w",
             &ParamMap::new(),
         )
-        .await;
-
-    // CHARACTERIZATION: on Lance 7.0.0 this read errors with from_sorted_iter.
-    // Flip to expect Ok after upgrading to Lance v8.0.0 (PR #7235).
-    match r {
-        Err(e) if {
-            let l = e.to_string().to_lowercase();
-            l.contains("from_sorted") || l.contains("non-sorted")
-        } => { /* bug reproduced */ }
-        Err(e) => panic!("RC-X: expected from_sorted_iter, got: {e}"),
+        .await
+    {
+        Err(e) => assert_eq!(
+            classify(&Finding::Engine(e)),
+            Some("RC-X/#7230 scalar-BTREE"),
+            "RC-X: expected a from_sorted_iter error"
+        ),
         Ok(res) => panic!(
-            "RC-X appears FIXED ({} rows) — flip this regression to expect Ok (Lance >= 8.0.0)",
+            "RC-X appears FIXED ({} rows) — flip to expect Ok (Lance >= 8.0.0)",
             res.num_rows()
         ),
     }
 }
 
-/// dup-@key (MR-714) — concurrent same-key merge-upserts produce duplicate
-/// rows; uniqueness is not enforced across concurrent commits.
+/// dup-@key (MR-714) — concurrent same-key merge-upserts produce duplicate rows.
 #[tokio::test]
 async fn regression_dup_key_under_concurrency() {
     let dir = tempfile::tempdir().unwrap();
-    let db = Arc::new(init(dir.path().to_str().unwrap()).await);
+    let db = Arc::new(backend::open_clean(dir.path().to_str().unwrap()).await);
     let workers = 4usize;
     let keys = 500usize;
     let mut handles = Vec::new();
@@ -294,174 +165,89 @@ async fn regression_dup_key_under_concurrency() {
     for h in handles {
         let _ = h.await;
     }
-    let total = count(&db, "Person").await.unwrap();
-    // CHARACTERIZATION: current build yields total > keys (duplicate @key).
-    // Flip to assert total == keys when cross-commit uniqueness is enforced.
+    let total = db
+        .query(
+            ReadTarget::branch("main"),
+            "query q() { match { $x: Person } return { $x.slug } }",
+            "q",
+            &ParamMap::new(),
+        )
+        .await
+        .unwrap()
+        .num_rows();
     assert!(
         total > keys,
         "dup-@key appears FIXED: total={total} == distinct keys={keys}; flip this regression"
     );
 }
 
-// ═══════════════════════════ seeded generative op-loop ═════════════════════
-// Runs random ops; after EACH, asserts the white-box invariant battery holds.
-// RC-1 (stale-view) is classified as retryable so the walk explores past it.
+// ═══════════════════════════ generative walk ══════════════════════════════
 
-async fn run_op(db: &Omnigraph, rng: &mut Rng, model: &mut Model) -> Result<(), String> {
-    match rng.below(6) {
-        0 => {
-            // insert persons — model updated only on success.
-            let mut ids = Vec::new();
-            let mut data = String::new();
-            for _ in 0..(1 + rng.below(10)) {
-                let id = model.fresh_id();
-                ids.push(id);
-                data.push_str(&person(&format!("g{id}")));
-            }
-            let r = load_jsonl(db, &data, LoadMode::Merge).await;
-            if r.is_ok() {
-                for id in ids {
-                    model.add_person(id);
-                }
-            }
-            r.map(|_| ()).map_err(|e| e.to_string())
-        }
-        1 => {
-            // insert docs (indexed scalar source).
-            let mut ids = Vec::new();
-            let mut data = String::new();
-            for _ in 0..(1 + rng.below(10)) {
-                let id = model.fresh_id();
-                ids.push(id);
-                let s = if rng.below(100) < 85 { "whatsapp" } else { "email" };
-                data.push_str(&doc(&format!("g{id}"), s));
-            }
-            let r = load_jsonl(db, &data, LoadMode::Merge).await;
-            if r.is_ok() {
-                for id in ids {
-                    model.add_doc(id);
-                }
-            }
-            r.map(|_| ()).map_err(|e| e.to_string())
-        }
-        2 => db.optimize().await.map(|_| ()).map_err(|e| e.to_string()),
-        3 => {
-            // delete a person (slug may be a doc or absent — no-op then).
-            let id = rng.below(model.id_high());
-            let q = format!("query d() {{ delete Person where slug = \"g{id}\" }}");
-            let r = db.mutate("main", &q, "d", &ParamMap::new()).await;
-            if r.is_ok() {
-                model.del_person(id);
-            }
-            r.map(|_| ()).map_err(|e| e.to_string())
-        }
-        4 => {
-            // UPDATE a doc body — moves the whole row → scalar-index remap (the
-            // morphology that, combined with optimize, mints RC-X corruption).
-            // No count change → model untouched.
-            let id = rng.below(model.id_high());
-            let q = format!("query u() {{ update Doc set {{ body: \"u{id} needle\" }} where slug = \"g{id}\" }}");
-            db.mutate("main", &q, "u", &ParamMap::new()).await.map(|_| ()).map_err(|e| e.to_string())
-        }
-        _ => {
-            // read (indexed filter).
-            db.query(
-                ReadTarget::branch("main"),
-                "query w() { match { $d: Doc { source: \"whatsapp\" } } return { $d.slug } }",
-                "w",
-                &ParamMap::new(),
-            )
-            .await
-            .map(|_| ())
-            .map_err(|e| e.to_string())
-        }
-    }
-}
-
-/// Open a graph whose storage injects seeded manifest-layer faults (CAS-lost).
-async fn open_faulted(uri: &str, seed: u64, cas_pct: u8) -> Omnigraph {
-    Omnigraph::init(uri, SCHEMA).await.expect("init"); // create graph + schema cleanly
-    let base = omnigraph::storage::storage_for_uri(uri).expect("storage_for_uri");
-    let faulted = fault::FaultAdapter::new(base, seed, cas_pct);
-    Omnigraph::open_with_storage(uri, faulted)
-        .await
-        .expect("open_with_storage")
-}
-
-/// Clean generative walk: white-box battery (incl. count==model) after every op.
+/// Clean walk: full white-box battery after every op; novel violations fail.
 #[tokio::test]
 async fn seeded_op_loop_invariants_hold() {
     run_walk(false).await;
 }
 
-/// Phase 2: same walk, but storage injects spurious manifest CAS-lost faults.
-/// The engine must surface/retry them (never silently lose a write) — count==
-/// model catches any loss as a NOVEL violation.
+/// Phase 2: same walk under injected manifest CAS-lost faults. The engine must
+/// surface/retry them (never silently lose a write) — count==model catches loss.
 #[tokio::test]
 async fn seeded_op_loop_with_cas_faults() {
     run_walk(true).await;
 }
 
 async fn run_walk(faults: bool) {
+    let mut cov = Coverage::new();
     let mut reproduced: Vec<String> = Vec::new();
     for seed in 0..2u64 {
         let dir = tempfile::tempdir().unwrap();
         let uri = dir.path().to_str().unwrap();
         let db = if faults {
-            open_faulted(uri, seed, 8).await
+            backend::open_faulted(uri, seed, 8).await
         } else {
-            init(uri).await
+            backend::open_clean(uri).await
         };
         let mut rng = Rng::new(seed);
         let mut model = Model::new();
 
-        'walk: for step in 0..15 {
-            // Op error: KNOWN bug stops this seed; an expected fault-induced
-            // retryable error is tolerated (model not updated → still consistent);
-            // anything else is NOVEL → fail.
-            if let Err(e) = run_op(&db, &mut rng, &mut model).await {
-                match known_bug(&e) {
+        'walk: for step_i in 0..15 {
+            let (kind, res) = op::step(&db, &mut rng, &mut model).await;
+            cov.op(kind);
+            if let Err(e) = res {
+                let f = Finding::Engine(e);
+                match classify(&f) {
                     Some(bug) => {
-                        reproduced.push(format!("seed={seed} step={step} op -> {bug}"));
+                        cov.finding(bug);
+                        reproduced.push(format!("seed={seed} step={step_i} op[{kind:?}] -> {bug}"));
                         break 'walk;
                     }
                     // Fault injection legitimately fails writes in varied ways;
-                    // tolerate non-known op errors under faults (the INVARIANT
-                    // checks below stay strict — that's where a lost write or
-                    // novel corruption is caught).
+                    // the INVARIANT checks below stay strict.
                     None if faults => {}
-                    None => panic!("seed={seed} step={step}: NOVEL op error: {e}"),
+                    None => panic!("seed={seed} step={step_i}: NOVEL op error: {}", f.message()),
                 }
             }
-            // WHITE-BOX invariant battery after every op.
-            let checks = [
-                ("head==manifest", invariant_head_eq_manifest(&db).await),
-                ("dataset.validate", invariant_dataset_validate(&db).await),
-                ("index-probe", invariant_index_probe(&db).await),
-                ("count==model", check_counts(&db, &model).await),
-            ];
-            for (name, res) in checks {
-                if let Err(v) = res {
-                    match known_bug(&v) {
-                        // Known corruption is terminal for this seed (a corrupt
-                        // BTREE page does not self-heal) — record & move on.
+            for (name, res) in run_battery(&db, &model).await {
+                cov.invariant(name);
+                if let Err(f) = res {
+                    match classify(&f) {
                         Some(bug) => {
-                            reproduced.push(format!("seed={seed} step={step} [{name}] -> {bug}"));
+                            cov.finding(bug);
+                            reproduced.push(format!("seed={seed} step={step_i} [{name}] -> {bug}"));
                             break 'walk;
                         }
                         None => panic!(
-                            "seed={seed} step={step}: NOVEL invariant violation [{name}]: {v}"
+                            "seed={seed} step={step_i}: NOVEL invariant violation [{name}]: {}",
+                            f.message()
                         ),
                     }
                 }
             }
         }
     }
-    // The walk is EXPECTED to (sometimes) reproduce known bugs; it must NEVER
-    // surface a NOVEL invariant violation (those panic above) — the regression
-    // guard for new corruption / lost-write classes.
     eprintln!(
-        "[dst] walk (faults={faults}): {} known-bug instance(s), 0 novel violations",
+        "[dst] walk(faults={faults}): coverage [{}]; {} known-bug instance(s), 0 novel violations",
+        cov.report(),
         reproduced.len()
     );
     for r in &reproduced {

--- a/crates/omnigraph/tests/dst.rs
+++ b/crates/omnigraph/tests/dst.rs
@@ -1,0 +1,408 @@
+//! Deterministic-simulation / morphological-matrix test harness (iss-784 / epc-783).
+//!
+//! Cut 1 (this file): the white-box invariant battery built on PUBLIC APIs, the
+//! three confirmed-bug characterization regressions, and a seeded op-loop that
+//! runs the invariants after every operation. Phase 2 (StorageAdapter fault
+//! injection + proptest-state-machine shrinking) and the structural
+//! row-id-overlap invariant land in follow-ups; this is the compiling spine.
+//!
+//! Run: `cargo test -p omnigraph-engine --test dst`
+//!
+//! The three regressions ASSERT the *current buggy behavior* on the edge build
+//! (Lance 7.0.0) — they are characterization guards that will visibly break
+//! (forcing review) when each bug is fixed:
+//!   - RC-X  → Lance #7230 (fixed in Lance v8.0.0): scalar-BTREE from_sorted_iter
+//!   - RC-1  → stale-view manifest CAS on delete op-class combos
+//!   - dup-@key → MR-714: uniqueness not enforced across concurrent commits
+
+use std::sync::Arc;
+
+use omnigraph::db::{Omnigraph, ReadTarget};
+use omnigraph::loader::{LoadMode, load_jsonl};
+use omnigraph_compiler::ir::ParamMap;
+
+// One schema exercising both bug surfaces: Person+Knows(@card) for the
+// delete-cascade / stale-view path, and Doc.source (low-cardinality enum
+// @index → scalar BTREE) for the index-corruption path.
+const SCHEMA: &str = r#"
+node Person {
+    slug: String @key
+    name: String
+}
+node Doc {
+    slug: String @key
+    source: enum(whatsapp, email, linkedin, slack, telegram) @index
+    body: String
+}
+edge Knows: Person -> Person @card(0..1)
+"#;
+
+// ─── inline deterministic RNG (xorshift64*, no `rand` dep — same as examples) ───
+struct Rng(u64);
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Rng(seed ^ 0x9E3779B97F4A7C15)
+    }
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545F4914F6CDD1D)
+    }
+    fn below(&mut self, n: usize) -> usize {
+        (self.next() % n as u64) as usize
+    }
+}
+
+async fn init(uri: &str) -> Omnigraph {
+    Omnigraph::init(uri, SCHEMA).await.expect("init")
+}
+
+fn person(slug: &str) -> String {
+    format!("{{\"type\":\"Person\",\"data\":{{\"slug\":\"{slug}\",\"name\":\"n\"}}}}\n")
+}
+fn doc(slug: &str, source: &str) -> String {
+    format!("{{\"type\":\"Doc\",\"data\":{{\"slug\":\"{slug}\",\"source\":\"{source}\",\"body\":\"needle filler\"}}}}\n")
+}
+fn knows(from: &str, to: &str) -> String {
+    format!("{{\"edge\":\"Knows\",\"from\":\"{from}\",\"to\":\"{to}\",\"data\":{{}}}}\n")
+}
+
+async fn count(db: &Omnigraph, ty: &str) -> Result<usize, String> {
+    let q = format!("query q() {{ match {{ $x: {ty} }} return {{ $x.slug }} }}");
+    db.query(ReadTarget::branch("main"), &q, "q", &ParamMap::new())
+        .await
+        .map(|r| r.num_rows())
+        .map_err(|e| e.to_string())
+}
+
+// ── WHITE-BOX INVARIANT #1: Lance HEAD == manifest table version, per table ──
+// Catches RC-1's drift precondition. Uses only public Snapshot + Lance Dataset.
+async fn invariant_head_eq_manifest(db: &Omnigraph) -> Result<(), String> {
+    let snap = db
+        .snapshot_of(ReadTarget::branch("main"))
+        .await
+        .map_err(|e| format!("snapshot_of: {e}"))?;
+    for entry in snap.entries() {
+        let ds = snap
+            .open(&entry.table_key)
+            .await
+            .map_err(|e| format!("open {}: {e}", entry.table_key))?;
+        let lance_head = ds.version().version;
+        if lance_head != entry.table_version {
+            return Err(format!(
+                "HEAD!=manifest on {}: lance_head={} manifest_pin={}",
+                entry.table_key, lance_head, entry.table_version
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn is_stale_view(e: &str) -> bool {
+    let l = e.to_lowercase();
+    l.contains("stale view") || (l.contains("expected") && l.contains("current"))
+}
+
+// ── WHITE-BOX INVARIANT #2: Lance Dataset::validate() per table ──
+// General structural corruption: fragment-id uniqueness/ordering, equal frag
+// lengths, index metadata. (Does NOT inspect scalar-BTREE page content — that's
+// the index-probe below.)
+async fn invariant_dataset_validate(db: &Omnigraph) -> Result<(), String> {
+    let snap = db
+        .snapshot_of(ReadTarget::branch("main"))
+        .await
+        .map_err(|e| e.to_string())?;
+    for entry in snap.entries() {
+        let ds = snap.open(&entry.table_key).await.map_err(|e| e.to_string())?;
+        ds.validate()
+            .await
+            .map_err(|e| format!("validate {}: {e}", entry.table_key))?;
+    }
+    Ok(())
+}
+
+// ── WHITE-BOX INVARIANT #3: scalar-index probe (catches RC-X at creation) ──
+// Force-loads the Doc.source BTREE flat pages by filtering on each enum value;
+// a duplicate-row-address page (Lance #7230) trips `from_sorted_iter` here,
+// deterministically, before a random read happens to hit it.
+async fn invariant_index_probe(db: &Omnigraph) -> Result<(), String> {
+    for src in ["whatsapp", "email", "linkedin", "slack", "telegram"] {
+        let q = format!(
+            "query w() {{ match {{ $d: Doc {{ source: \"{src}\" }} }} return {{ $d.slug }} }}"
+        );
+        db.query(ReadTarget::branch("main"), &q, "w", &ParamMap::new())
+            .await
+            .map_err(|e| format!("index-probe source={src}: {e}"))?;
+    }
+    Ok(())
+}
+
+/// Known open bugs we allow-list so the generative walk explores PAST them and
+/// surfaces NOVEL violations (which fail the run). Returns the bug name if the
+/// error/violation string matches a known signature, else None (= novel).
+fn known_bug(e: &str) -> Option<&'static str> {
+    let l = e.to_lowercase();
+    if l.contains("from_sorted") || l.contains("non-sorted") {
+        Some("RC-X/#7230 scalar-BTREE")
+    } else if l.contains("stale view") || (l.contains("expected") && l.contains("current")) {
+        Some("RC-1 stale-view")
+    } else {
+        None
+    }
+}
+
+// ═══════════════════════════════════ regressions ═══════════════════════════
+
+/// RC-1 — multi-statement `delete Person + delete Knows` deterministically
+/// fails with a spurious stale-view manifest-CAS error (node-delete cascade
+/// bumps edge:Knows under the explicit edge-delete's pinned version).
+#[tokio::test]
+async fn regression_rc1_stale_view_on_delete_combo() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = init(dir.path().to_str().unwrap()).await;
+    // ring of 50 persons each Knows the next (valid for @card(0..1))
+    let mut seed = String::new();
+    for i in 0..50 {
+        seed.push_str(&person(&format!("p{i}")));
+    }
+    for i in 0..50 {
+        seed.push_str(&knows(&format!("p{i}"), &format!("p{}", (i + 1) % 50)));
+    }
+    load_jsonl(&db, &seed, LoadMode::Merge).await.unwrap();
+
+    let q = "query m() { delete Person where slug = \"p30\" delete Knows where from = \"p30\" }";
+    let res = db.mutate("main", q, "m", &ParamMap::new()).await;
+
+    // CHARACTERIZATION: current edge build returns a spurious stale-view error.
+    // Flip this assertion (expect Ok) when the op-class-aware fix lands.
+    match res {
+        Err(e) if is_stale_view(&e.to_string()) => { /* bug reproduced */ }
+        Err(e) => panic!("RC-1: expected stale-view, got other error: {e}"),
+        Ok(_) => panic!("RC-1 appears FIXED — flip this regression to expect Ok"),
+    }
+}
+
+/// RC-X — Lance #7230: a scalar BTREE over a low-cardinality column corrupts
+/// (duplicate row addresses) under UPDATE racing optimize; a subsequent
+/// indexed-filter read crashes with `from_sorted_iter ... non-sorted input`.
+#[tokio::test]
+async fn regression_rc_x_btree_from_sorted_iter() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = Arc::new(init(dir.path().to_str().unwrap()).await);
+    // Docs with a dominant source value, across a few fragments (kept small —
+    // the corruption is fragment-layout-sensitive, not volume-sensitive).
+    const FRAGS: usize = 3;
+    const PER: usize = 600;
+    for frag in 0..FRAGS {
+        let mut data = String::new();
+        for i in 0..PER {
+            let s = if i % 12 == 0 { "email" } else { "whatsapp" };
+            data.push_str(&doc(&format!("d{frag}-{i}"), s));
+        }
+        load_jsonl(&db, &data, LoadMode::Merge).await.unwrap();
+    }
+    let _ = db.optimize().await; // build the BTREE
+
+    // UPDATE bodies (moves whole rows → scalar-index remap) racing optimize.
+    let upd = {
+        let db = db.clone();
+        tokio::spawn(async move {
+            for round in 0..3 {
+                for frag in 0..FRAGS {
+                    for i in (0..PER).step_by(40) {
+                        let q = format!(
+                            "query u() {{ update Doc set {{ body: \"r{round} needle\" }} where slug = \"d{frag}-{i}\" }}"
+                        );
+                        for _ in 0..4 {
+                            if db.mutate("main", &q, "u", &ParamMap::new()).await.is_ok() {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    };
+    let opt = {
+        let db = db.clone();
+        tokio::spawn(async move {
+            for _ in 0..4 {
+                let _ = db.optimize().await;
+            }
+        })
+    };
+    let _ = upd.await;
+    let _ = opt.await;
+
+    // Indexed-filter read on the dominant value.
+    let r = db
+        .query(
+            ReadTarget::branch("main"),
+            "query w() { match { $d: Doc { source: \"whatsapp\" } } return { $d.slug } }",
+            "w",
+            &ParamMap::new(),
+        )
+        .await;
+
+    // CHARACTERIZATION: on Lance 7.0.0 this read errors with from_sorted_iter.
+    // Flip to expect Ok after upgrading to Lance v8.0.0 (PR #7235).
+    match r {
+        Err(e) if {
+            let l = e.to_string().to_lowercase();
+            l.contains("from_sorted") || l.contains("non-sorted")
+        } => { /* bug reproduced */ }
+        Err(e) => panic!("RC-X: expected from_sorted_iter, got: {e}"),
+        Ok(res) => panic!(
+            "RC-X appears FIXED ({} rows) — flip this regression to expect Ok (Lance >= 8.0.0)",
+            res.num_rows()
+        ),
+    }
+}
+
+/// dup-@key (MR-714) — concurrent same-key merge-upserts produce duplicate
+/// rows; uniqueness is not enforced across concurrent commits.
+#[tokio::test]
+async fn regression_dup_key_under_concurrency() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = Arc::new(init(dir.path().to_str().unwrap()).await);
+    let workers = 4usize;
+    let keys = 500usize;
+    let mut handles = Vec::new();
+    for _ in 0..workers {
+        let db = db.clone();
+        handles.push(tokio::spawn(async move {
+            let mut data = String::new();
+            for k in 0..keys {
+                data.push_str(&person(&format!("hot-{k}")));
+            }
+            for _ in 0..12 {
+                if load_jsonl(&db, &data, LoadMode::Merge).await.is_ok() {
+                    break;
+                }
+            }
+        }));
+    }
+    for h in handles {
+        let _ = h.await;
+    }
+    let total = count(&db, "Person").await.unwrap();
+    // CHARACTERIZATION: current build yields total > keys (duplicate @key).
+    // Flip to assert total == keys when cross-commit uniqueness is enforced.
+    assert!(
+        total > keys,
+        "dup-@key appears FIXED: total={total} == distinct keys={keys}; flip this regression"
+    );
+}
+
+// ═══════════════════════════ seeded generative op-loop ═════════════════════
+// Runs random ops; after EACH, asserts the white-box invariant battery holds.
+// RC-1 (stale-view) is classified as retryable so the walk explores past it.
+
+async fn run_op(db: &Omnigraph, rng: &mut Rng, next_id: &mut usize) -> Result<(), String> {
+    match rng.below(6) {
+        0 => {
+            // insert persons
+            let mut data = String::new();
+            for _ in 0..(1 + rng.below(20)) {
+                data.push_str(&person(&format!("g{}", *next_id)));
+                *next_id += 1;
+            }
+            load_jsonl(db, &data, LoadMode::Merge).await.map(|_| ()).map_err(|e| e.to_string())
+        }
+        1 => {
+            // insert docs (indexed scalar)
+            let mut data = String::new();
+            for _ in 0..(1 + rng.below(20)) {
+                let s = if rng.below(100) < 85 { "whatsapp" } else { "email" };
+                data.push_str(&doc(&format!("g{}", *next_id), s));
+                *next_id += 1;
+            }
+            load_jsonl(db, &data, LoadMode::Merge).await.map(|_| ()).map_err(|e| e.to_string())
+        }
+        2 => db.optimize().await.map(|_| ()).map_err(|e| e.to_string()),
+        3 => {
+            // delete a person (may not exist — fine)
+            let id = rng.below((*next_id).max(1));
+            let q = format!("query d() {{ delete Person where slug = \"g{id}\" }}");
+            db.mutate("main", &q, "d", &ParamMap::new()).await.map(|_| ()).map_err(|e| e.to_string())
+        }
+        4 => {
+            // UPDATE a doc body — moves the whole row → scalar-index remap (the
+            // morphology that, combined with optimize, mints RC-X corruption).
+            let id = rng.below((*next_id).max(1));
+            let q = format!("query u() {{ update Doc set {{ body: \"u{id} needle\" }} where slug = \"g{id}\" }}");
+            db.mutate("main", &q, "u", &ParamMap::new()).await.map(|_| ()).map_err(|e| e.to_string())
+        }
+        _ => {
+            // read (indexed filter)
+            db.query(
+                ReadTarget::branch("main"),
+                "query w() { match { $d: Doc { source: \"whatsapp\" } } return { $d.slug } }",
+                "w",
+                &ParamMap::new(),
+            )
+            .await
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+        }
+    }
+}
+
+#[tokio::test]
+async fn seeded_op_loop_invariants_hold() {
+    let mut reproduced: Vec<String> = Vec::new();
+    for seed in 0..2u64 {
+        let dir = tempfile::tempdir().unwrap();
+        let db = init(dir.path().to_str().unwrap()).await;
+        let mut rng = Rng::new(seed);
+        let mut next_id = 0usize;
+
+        'walk: for step in 0..15 {
+            // Op error: a KNOWN bug stops this seed (explored to the bug); a
+            // NOVEL error fails the run.
+            if let Err(e) = run_op(&db, &mut rng, &mut next_id).await {
+                match known_bug(&e) {
+                    Some(bug) => {
+                        reproduced.push(format!("seed={seed} step={step} op -> {bug}"));
+                        break 'walk;
+                    }
+                    None => panic!("seed={seed} step={step}: NOVEL op error: {e}"),
+                }
+            }
+            // WHITE-BOX invariant battery after every op.
+            let checks = [
+                ("head==manifest", invariant_head_eq_manifest(&db).await),
+                ("dataset.validate", invariant_dataset_validate(&db).await),
+                ("index-probe", invariant_index_probe(&db).await),
+            ];
+            for (name, res) in checks {
+                if let Err(v) = res {
+                    match known_bug(&v) {
+                        // Known corruption is terminal for this seed (e.g. a
+                        // corrupt BTREE page does not self-heal) — record & move on.
+                        Some(bug) => {
+                            reproduced.push(format!("seed={seed} step={step} [{name}] -> {bug}"));
+                            break 'walk;
+                        }
+                        None => panic!(
+                            "seed={seed} step={step}: NOVEL invariant violation [{name}]: {v}"
+                        ),
+                    }
+                }
+            }
+        }
+    }
+    // The generative walk is EXPECTED to (sometimes) reproduce known bugs on the
+    // current build; it must NEVER surface a NOVEL invariant violation (those
+    // panic above). This is the regression guard for new corruption classes.
+    eprintln!(
+        "[dst] generative walk: {} known-bug instance(s) reproduced, 0 novel violations",
+        reproduced.len()
+    );
+    for r in &reproduced {
+        eprintln!("  - {r}");
+    }
+}

--- a/crates/omnigraph/tests/dst/backend.rs
+++ b/crates/omnigraph/tests/dst/backend.rs
@@ -1,0 +1,24 @@
+//! D5 (embedded context) — graph construction. A `Backend` trait abstraction
+//! (CLI / long-lived server) is the Phase-5 extension point; today there is one
+//! in-process embedded backend, exposed as two open functions.
+
+use omnigraph::db::Omnigraph;
+
+use crate::op::SCHEMA;
+
+/// A clean graph (no fault injection).
+pub async fn open_clean(uri: &str) -> Omnigraph {
+    Omnigraph::init(uri, SCHEMA).await.expect("init")
+}
+
+/// A graph whose storage injects seeded manifest-layer faults (CAS-lost). The
+/// graph + schema are created cleanly first, then reopened through the
+/// `FaultAdapter` so only the op workload runs under faults.
+pub async fn open_faulted(uri: &str, seed: u64, cas_pct: u8) -> Omnigraph {
+    Omnigraph::init(uri, SCHEMA).await.expect("init");
+    let base = omnigraph::storage::storage_for_uri(uri).expect("storage_for_uri");
+    let faulted = crate::fault::FaultAdapter::new(base, seed, cas_pct);
+    Omnigraph::open_with_storage(uri, faulted)
+        .await
+        .expect("open_with_storage")
+}

--- a/crates/omnigraph/tests/dst/coverage.rs
+++ b/crates/omnigraph/tests/dst/coverage.rs
@@ -1,0 +1,38 @@
+//! Coverage capture: which matrix cells the generative walk actually touched.
+//! Turns "comprehensive" from a claim into a number (hit / total).
+
+use std::collections::HashSet;
+
+use crate::op::OpKind;
+
+#[derive(Default)]
+pub struct Coverage {
+    ops: HashSet<OpKind>,
+    invariants: HashSet<&'static str>,
+    /// op-error and invariant-violation signatures actually exercised.
+    findings: HashSet<&'static str>,
+}
+
+impl Coverage {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    pub fn op(&mut self, k: OpKind) {
+        self.ops.insert(k);
+    }
+    pub fn invariant(&mut self, name: &'static str) {
+        self.invariants.insert(name);
+    }
+    pub fn finding(&mut self, name: &'static str) {
+        self.findings.insert(name);
+    }
+    pub fn report(&self) -> String {
+        format!(
+            "ops {}/{}, invariants {}/4, known-bugs exercised {}",
+            self.ops.len(),
+            OpKind::ALL.len(),
+            self.invariants.len(),
+            self.findings.len()
+        )
+    }
+}

--- a/crates/omnigraph/tests/dst/fault.rs
+++ b/crates/omnigraph/tests/dst/fault.rs
@@ -1,0 +1,95 @@
+//! Phase 2: a fault-injecting `StorageAdapter` wrapper (SlateDB-style), mirrors
+//! `omnigraph::instrumentation::CountingStorageAdapter`. Wrap the base adapter
+//! and inject seeded faults on the manifest/commit/CAS layer, then open the
+//! graph via `Omnigraph::open_with_storage`.
+//!
+//! The high-value fault is a spurious CAS-lost on `write_text_if_match` (the
+//! conditional manifest write): the engine MUST surface it (retry / fence),
+//! never silently lose the write. If a write is lost, `check_counts` (count==
+//! model) catches it as a NOVEL violation. Optional latency exercises timing.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use omnigraph::error::Result;
+use omnigraph::storage::StorageAdapter;
+
+#[derive(Debug)]
+pub struct FaultAdapter {
+    inner: Arc<dyn StorageAdapter>,
+    cas_conflict_pct: u8,
+    rng: Mutex<u64>,
+}
+
+impl FaultAdapter {
+    /// Wrap `inner` (e.g. `storage_for_uri(uri)?`). `cas_conflict_pct` is the
+    /// percentage of conditional writes that spuriously report CAS-lost.
+    pub fn new(
+        inner: Arc<dyn StorageAdapter>,
+        seed: u64,
+        cas_conflict_pct: u8,
+    ) -> Arc<dyn StorageAdapter> {
+        Arc::new(Self {
+            inner,
+            cas_conflict_pct,
+            rng: Mutex::new(seed ^ 0x9E37_79B9_7F4A_7C15),
+        })
+    }
+
+    fn roll(&self, pct: u8) -> bool {
+        let mut g = self.rng.lock().unwrap();
+        let mut x = *g;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        *g = x;
+        (x.wrapping_mul(0x2545_F491_4F6C_DD1D) % 100) < pct as u64
+    }
+}
+
+#[async_trait]
+impl StorageAdapter for FaultAdapter {
+    async fn read_text(&self, uri: &str) -> Result<String> {
+        self.inner.read_text(uri).await
+    }
+    async fn write_text(&self, uri: &str, contents: &str) -> Result<()> {
+        self.inner.write_text(uri, contents).await
+    }
+    async fn write_text_if_absent(&self, uri: &str, contents: &str) -> Result<bool> {
+        self.inner.write_text_if_absent(uri, contents).await
+    }
+    async fn exists(&self, uri: &str) -> Result<bool> {
+        self.inner.exists(uri).await
+    }
+    async fn rename_text(&self, from_uri: &str, to_uri: &str) -> Result<()> {
+        self.inner.rename_text(from_uri, to_uri).await
+    }
+    async fn delete(&self, uri: &str) -> Result<()> {
+        self.inner.delete(uri).await
+    }
+    async fn list_dir(&self, dir_uri: &str) -> Result<Vec<String>> {
+        self.inner.list_dir(dir_uri).await
+    }
+    async fn read_text_versioned(&self, uri: &str) -> Result<(String, String)> {
+        self.inner.read_text_versioned(uri).await
+    }
+    async fn write_text_if_match(
+        &self,
+        uri: &str,
+        contents: &str,
+        expected_version: &str,
+    ) -> Result<Option<String>> {
+        // Inject a spurious CAS-lost (precondition failed) — a concurrent-writer
+        // illusion. The engine must surface/retry this; a swallowed loss is
+        // caught downstream by count==model.
+        if self.roll(self.cas_conflict_pct) {
+            return Ok(None);
+        }
+        self.inner
+            .write_text_if_match(uri, contents, expected_version)
+            .await
+    }
+    async fn delete_prefix(&self, prefix_uri: &str) -> Result<()> {
+        self.inner.delete_prefix(prefix_uri).await
+    }
+}

--- a/crates/omnigraph/tests/dst/invariants.rs
+++ b/crates/omnigraph/tests/dst/invariants.rs
@@ -1,0 +1,116 @@
+//! D4: the white-box invariant battery + the structured known/novel classifier.
+//!
+//! A `Finding` is either an `Engine(OmniError)` (an op/query returned an engine
+//! error) or a `Logical(String)` (a harness-computed structural mismatch:
+//! HEAD!=manifest, count!=model, orphan edge). Classification is structured —
+//! NOT free-text substring matching over arbitrary messages:
+//!   * Engine errors are allow-listed only for the two known bugs, each gated on
+//!     a narrow signal (RC-1 on the `OmniError::Manifest` variant; RC-X on
+//!     Lance's specific internal string).
+//!   * Logical findings are NEVER allow-listed — a structural divergence is
+//!     always a real finding (the named regressions cover the known concurrency
+//!     cases separately).
+
+use omnigraph::db::{Omnigraph, ReadTarget};
+use omnigraph::error::OmniError;
+use omnigraph_compiler::ir::ParamMap;
+
+pub enum Finding {
+    /// An engine-returned error (variant preserved for structured classification).
+    Engine(OmniError),
+    /// A harness-computed structural violation — always novel.
+    Logical(String),
+}
+
+impl Finding {
+    pub fn message(&self) -> String {
+        match self {
+            Finding::Engine(e) => e.to_string(),
+            Finding::Logical(s) => s.clone(),
+        }
+    }
+}
+
+/// Returns `Some(known-bug-name)` if the finding matches a known open bug we
+/// allow-list (so the walk explores past it), else `None` (= NOVEL → fail).
+pub fn classify(f: &Finding) -> Option<&'static str> {
+    match f {
+        Finding::Engine(e) => {
+            let s = e.to_string();
+            // RC-1: stale-view manifest CAS — gated on the Manifest variant so a
+            // coincidental substring in another subsystem cannot mask it.
+            if matches!(e, OmniError::Manifest(_))
+                && (s.contains("stale view") || (s.contains("expected") && s.contains("current")))
+            {
+                return Some("RC-1 stale-view");
+            }
+            // RC-X / Lance #7230: scalar-BTREE duplicate row addresses. The Lance
+            // internal panic string is highly specific (near-zero false positive).
+            if s.contains("from_sorted_iter") || s.contains("non-sorted input") {
+                return Some("RC-X/#7230 scalar-BTREE");
+            }
+            None
+        }
+        // Structural divergences are never allow-listed.
+        Finding::Logical(_) => None,
+    }
+}
+
+// ── INVARIANT #1: Lance HEAD == manifest table version, per table ──
+pub async fn head_eq_manifest(db: &Omnigraph) -> Result<(), Finding> {
+    let snap = db
+        .snapshot_of(ReadTarget::branch("main"))
+        .await
+        .map_err(Finding::Engine)?;
+    for entry in snap.entries() {
+        let ds = snap.open(&entry.table_key).await.map_err(Finding::Engine)?;
+        let lance_head = ds.version().version;
+        if lance_head != entry.table_version {
+            return Err(Finding::Logical(format!(
+                "HEAD!=manifest on {}: lance_head={lance_head} manifest_pin={}",
+                entry.table_key, entry.table_version
+            )));
+        }
+    }
+    Ok(())
+}
+
+// ── INVARIANT #2: Lance Dataset::validate() per table (general corruption) ──
+pub async fn dataset_validate(db: &Omnigraph) -> Result<(), Finding> {
+    let snap = db
+        .snapshot_of(ReadTarget::branch("main"))
+        .await
+        .map_err(Finding::Engine)?;
+    for entry in snap.entries() {
+        let ds = snap.open(&entry.table_key).await.map_err(Finding::Engine)?;
+        // Dataset::validate returns a Lance error; a validation failure IS a
+        // structural corruption finding (always novel).
+        ds.validate()
+            .await
+            .map_err(|e| Finding::Logical(format!("Dataset::validate {}: {e}", entry.table_key)))?;
+    }
+    Ok(())
+}
+
+// ── INVARIANT #3: scalar-index probe (catches RC-X at creation) ──
+// Force-loads the Doc.source BTREE flat pages by filtering each enum value.
+pub async fn index_probe(db: &Omnigraph) -> Result<(), Finding> {
+    for src in ["whatsapp", "email", "linkedin", "slack", "telegram"] {
+        let q = format!("query w() {{ match {{ $d: Doc {{ source: \"{src}\" }} }} return {{ $d.slug }} }}");
+        db.query(ReadTarget::branch("main"), &q, "w", &ParamMap::new())
+            .await
+            .map_err(Finding::Engine)?;
+    }
+    Ok(())
+}
+
+/// The full battery as a registry: `(name, result)` per invariant. Adding an
+/// invariant is one line here; the walk iterates and the coverage map records.
+pub async fn run_battery(db: &Omnigraph, model: &crate::model::Model) -> Vec<(&'static str, Result<(), Finding>)> {
+    vec![
+        ("head==manifest", head_eq_manifest(db).await),
+        ("dataset.validate", dataset_validate(db).await),
+        ("index-probe", index_probe(db).await),
+        ("count==model", crate::model::check_counts(db, model).await),
+    ]
+}

--- a/crates/omnigraph/tests/dst/model.rs
+++ b/crates/omnigraph/tests/dst/model.rs
@@ -1,0 +1,76 @@
+//! Reference model (D4 oracle source of truth) + the count==model invariant.
+//!
+//! Tracks the SET of live Person/Doc keys the harness believes should exist.
+//! Updated only AFTER an op succeeds, so a failed op (e.g. RC-1 stale-view, or
+//! a FaultAdapter-injected CAS loss) leaves the model consistent with reality.
+//! A divergence means a lost write (count<model) or a duplicate key
+//! (count>model) — both real bugs.
+
+use std::collections::HashSet;
+
+use omnigraph::db::{Omnigraph, ReadTarget};
+use omnigraph_compiler::ir::ParamMap;
+
+#[derive(Default)]
+pub struct Model {
+    persons: HashSet<usize>,
+    docs: HashSet<usize>,
+    next: usize,
+}
+
+impl Model {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    /// A never-before-used id (so generated inserts never collide).
+    pub fn fresh_id(&mut self) -> usize {
+        let i = self.next;
+        self.next += 1;
+        i
+    }
+    /// Upper bound for picking an existing-ish id for delete/update targets.
+    pub fn id_high(&self) -> usize {
+        self.next.max(1)
+    }
+    pub fn add_person(&mut self, id: usize) {
+        self.persons.insert(id);
+    }
+    pub fn add_doc(&mut self, id: usize) {
+        self.docs.insert(id);
+    }
+    pub fn del_person(&mut self, id: usize) {
+        self.persons.remove(&id);
+    }
+    pub fn persons(&self) -> usize {
+        self.persons.len()
+    }
+    pub fn docs(&self) -> usize {
+        self.docs.len()
+    }
+}
+
+async fn count(db: &Omnigraph, ty: &str) -> Result<usize, String> {
+    let q = format!("query q() {{ match {{ $x: {ty} }} return {{ $x.slug }} }}");
+    db.query(ReadTarget::branch("main"), &q, "q", &ParamMap::new())
+        .await
+        .map(|r| r.num_rows())
+        .map_err(|e| e.to_string())
+}
+
+/// count==model: live row counts must equal the model. Catches lost-write
+/// (count<model — e.g. a swallowed CAS conflict) and duplicate-key
+/// (count>model — MR-714 under concurrency).
+pub async fn check_counts(db: &Omnigraph, model: &Model) -> Result<(), String> {
+    let p = count(db, "Person").await?;
+    if p != model.persons() {
+        return Err(format!(
+            "count Person={p} != model={} (lost-write or dup-@key)",
+            model.persons()
+        ));
+    }
+    let d = count(db, "Doc").await?;
+    if d != model.docs() {
+        return Err(format!("count Doc={d} != model={}", model.docs()));
+    }
+    Ok(())
+}

--- a/crates/omnigraph/tests/dst/model.rs
+++ b/crates/omnigraph/tests/dst/model.rs
@@ -11,6 +11,8 @@ use std::collections::HashSet;
 use omnigraph::db::{Omnigraph, ReadTarget};
 use omnigraph_compiler::ir::ParamMap;
 
+use crate::invariants::Finding;
+
 #[derive(Default)]
 pub struct Model {
     persons: HashSet<usize>,
@@ -49,28 +51,31 @@ impl Model {
     }
 }
 
-async fn count(db: &Omnigraph, ty: &str) -> Result<usize, String> {
+async fn count(db: &Omnigraph, ty: &str) -> Result<usize, Finding> {
     let q = format!("query q() {{ match {{ $x: {ty} }} return {{ $x.slug }} }}");
     db.query(ReadTarget::branch("main"), &q, "q", &ParamMap::new())
         .await
         .map(|r| r.num_rows())
-        .map_err(|e| e.to_string())
+        .map_err(Finding::Engine)
 }
 
-/// count==model: live row counts must equal the model. Catches lost-write
-/// (count<model — e.g. a swallowed CAS conflict) and duplicate-key
-/// (count>model — MR-714 under concurrency).
-pub async fn check_counts(db: &Omnigraph, model: &Model) -> Result<(), String> {
+/// count==model: live row counts must equal the model. A divergence is a
+/// structural (Logical) finding — lost-write (count<model — e.g. a swallowed
+/// CAS conflict) or duplicate-key (count>model — MR-714).
+pub async fn check_counts(db: &Omnigraph, model: &Model) -> Result<(), Finding> {
     let p = count(db, "Person").await?;
     if p != model.persons() {
-        return Err(format!(
+        return Err(Finding::Logical(format!(
             "count Person={p} != model={} (lost-write or dup-@key)",
             model.persons()
-        ));
+        )));
     }
     let d = count(db, "Doc").await?;
     if d != model.docs() {
-        return Err(format!("count Doc={d} != model={}", model.docs()));
+        return Err(Finding::Logical(format!(
+            "count Doc={d} != model={}",
+            model.docs()
+        )));
     }
     Ok(())
 }

--- a/crates/omnigraph/tests/dst/op.rs
+++ b/crates/omnigraph/tests/dst/op.rs
@@ -1,0 +1,152 @@
+//! D1: the operation alphabet, as data. `step` picks an op, executes it against
+//! the real engine, and updates the reference `Model` on success. Returns the
+//! `OpKind` (for coverage) and the raw `OmniError` (for structured
+//! classification — never stringified here).
+
+use omnigraph::db::{Omnigraph, ReadTarget};
+use omnigraph::error::OmniError;
+use omnigraph::loader::{LoadMode, load_jsonl};
+use omnigraph_compiler::ir::ParamMap;
+
+use crate::model::Model;
+
+/// One schema exercising both bug surfaces: Person+Knows(@card) for the
+/// delete-cascade / stale-view path, and Doc.source (low-cardinality enum
+/// @index → scalar BTREE) for the index-corruption path.
+pub const SCHEMA: &str = r#"
+node Person {
+    slug: String @key
+    name: String
+}
+node Doc {
+    slug: String @key
+    source: enum(whatsapp, email, linkedin, slack, telegram) @index
+    body: String
+}
+edge Knows: Person -> Person @card(0..1)
+"#;
+
+/// Inline deterministic RNG (xorshift64*, no `rand` dep).
+pub struct Rng(u64);
+impl Rng {
+    pub fn new(seed: u64) -> Self {
+        Rng(seed ^ 0x9E37_79B9_7F4A_7C15)
+    }
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+    pub fn below(&mut self, n: usize) -> usize {
+        (self.next() % n as u64) as usize
+    }
+}
+
+pub fn person(slug: &str) -> String {
+    format!("{{\"type\":\"Person\",\"data\":{{\"slug\":\"{slug}\",\"name\":\"n\"}}}}\n")
+}
+pub fn doc(slug: &str, source: &str) -> String {
+    format!("{{\"type\":\"Doc\",\"data\":{{\"slug\":\"{slug}\",\"source\":\"{source}\",\"body\":\"needle filler\"}}}}\n")
+}
+pub fn knows(from: &str, to: &str) -> String {
+    format!("{{\"edge\":\"Knows\",\"from\":\"{from}\",\"to\":\"{to}\",\"data\":{{}}}}\n")
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum OpKind {
+    InsertPerson,
+    InsertDoc,
+    Optimize,
+    DeletePerson,
+    UpdateDoc,
+    Read,
+}
+
+impl OpKind {
+    pub const ALL: [OpKind; 6] = [
+        OpKind::InsertPerson,
+        OpKind::InsertDoc,
+        OpKind::Optimize,
+        OpKind::DeletePerson,
+        OpKind::UpdateDoc,
+        OpKind::Read,
+    ];
+}
+
+/// Pick and run one op. The model is updated only on success.
+pub async fn step(db: &Omnigraph, rng: &mut Rng, model: &mut Model) -> (OpKind, Result<(), OmniError>) {
+    match rng.below(6) {
+        0 => {
+            let mut ids = Vec::new();
+            let mut data = String::new();
+            for _ in 0..(1 + rng.below(10)) {
+                let id = model.fresh_id();
+                ids.push(id);
+                data.push_str(&person(&format!("g{id}")));
+            }
+            let res = match load_jsonl(db, &data, LoadMode::Merge).await {
+                Ok(_) => {
+                    for id in ids {
+                        model.add_person(id);
+                    }
+                    Ok(())
+                }
+                Err(e) => Err(e),
+            };
+            (OpKind::InsertPerson, res)
+        }
+        1 => {
+            let mut ids = Vec::new();
+            let mut data = String::new();
+            for _ in 0..(1 + rng.below(10)) {
+                let id = model.fresh_id();
+                ids.push(id);
+                let s = if rng.below(100) < 85 { "whatsapp" } else { "email" };
+                data.push_str(&doc(&format!("g{id}"), s));
+            }
+            let res = match load_jsonl(db, &data, LoadMode::Merge).await {
+                Ok(_) => {
+                    for id in ids {
+                        model.add_doc(id);
+                    }
+                    Ok(())
+                }
+                Err(e) => Err(e),
+            };
+            (OpKind::InsertDoc, res)
+        }
+        2 => (OpKind::Optimize, db.optimize().await.map(|_| ())),
+        3 => {
+            let id = rng.below(model.id_high());
+            let q = format!("query d() {{ delete Person where slug = \"g{id}\" }}");
+            let res = match db.mutate("main", &q, "d", &ParamMap::new()).await {
+                Ok(_) => {
+                    model.del_person(id);
+                    Ok(())
+                }
+                Err(e) => Err(e),
+            };
+            (OpKind::DeletePerson, res)
+        }
+        4 => {
+            // UPDATE moves the whole row → scalar-index remap (RC-X morphology).
+            let id = rng.below(model.id_high());
+            let q = format!("query u() {{ update Doc set {{ body: \"u{id} needle\" }} where slug = \"g{id}\" }}");
+            (OpKind::UpdateDoc, db.mutate("main", &q, "u", &ParamMap::new()).await.map(|_| ()))
+        }
+        _ => (
+            OpKind::Read,
+            db.query(
+                ReadTarget::branch("main"),
+                "query w() { match { $d: Doc { source: \"whatsapp\" } } return { $d.slug } }",
+                "w",
+                &ParamMap::new(),
+            )
+            .await
+            .map(|_| ()),
+        ),
+    }
+}

--- a/crates/omnigraph/tests/writes.rs
+++ b/crates/omnigraph/tests/writes.rs
@@ -15,6 +15,7 @@
 mod helpers;
 
 use arrow_array::Array;
+use lance::Dataset;
 use omnigraph::db::commit_graph::CommitGraph;
 use omnigraph::db::{Omnigraph, ReadTarget};
 use omnigraph::error::OmniError;
@@ -1712,4 +1713,63 @@ query chain($repo: String) {
         .await
         .expect("chained camelCase mutation must read the pending row, not fail at the MemTable SELECT");
     assert_eq!(r.affected_nodes, 2, "both ops should touch the acme Doc (read-your-writes)");
+}
+
+/// A zero-row cascade delete must not advance an edge table's Lance HEAD past
+/// its manifest version. A `delete <Node>` cascades a `delete_where` into every
+/// incident edge type (`exec/mutation.rs`). The inline `delete_where`
+/// (`Dataset::delete`) advances Lance HEAD **even when zero edges match**, but
+/// the cascade records the new version in the manifest only `if deleted_rows >
+/// 0`. So deleting a node with no incident edges advances `edge:Knows` Lance
+/// HEAD while the manifest stays behind — a `HEAD > manifest` drift that then
+/// trips the next strict write's `ExpectedVersionMismatch`, and `repair`
+/// refuses (delete-class drift), wedging the graph.
+///
+/// This pins the invariant directly: after any node delete, every edge table's
+/// manifest version must equal its on-disk Lance HEAD — no inline write may
+/// advance HEAD past the manifest (invariant 2 / the deny-list). RED today;
+/// GREEN once `delete` migrates to the staged two-phase path (iss-950, unblocked
+/// by Lance 7.0's `DeleteBuilder::execute_uncommitted`), where a 0-row delete
+/// commits no Lance version at all and the existing `deleted_rows > 0` gate
+/// becomes correct by construction.
+#[tokio::test]
+async fn node_delete_with_no_incident_edges_leaves_no_edge_table_drift() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut db = init_and_load(&dir).await;
+    let root = dir.path().to_str().unwrap().to_string();
+
+    // A person with NO Knows edges. Deleting it cascades a 0-row `delete_where`
+    // into `edge:Knows` (the cascade runs for every incident edge type).
+    mutate_main(
+        &mut db,
+        MUTATION_QUERIES,
+        "insert_person",
+        &mixed_params(&[("$name", "Loner")], &[("$age", 30)]),
+    )
+    .await
+    .unwrap();
+    mutate_main(
+        &mut db,
+        MUTATION_QUERIES,
+        "remove_person",
+        &params(&[("$name", "Loner")]),
+    )
+    .await
+    .expect("the first delete itself succeeds — it leaves the drift for the NEXT write");
+
+    // The invariant: edge:Knows manifest version == its on-disk Lance HEAD.
+    let snap = snapshot_main(&db).await.unwrap();
+    let entry = snap
+        .entry("edge:Knows")
+        .expect("edge:Knows must be in the manifest");
+    let full = format!("{}/{}", root.trim_end_matches('/'), entry.table_path);
+    let head = Dataset::open(&full).await.unwrap().version().version;
+    assert_eq!(
+        entry.table_version, head,
+        "a node delete matching no edges advanced edge:Knows Lance HEAD to v{head} but the \
+         manifest still records v{} — HEAD>manifest drift from a 0-row cascade `delete_where` not \
+         committed through the staged path. Fix: migrate delete to the staged two-phase API \
+         (iss-950).",
+        entry.table_version,
+    );
 }


### PR DESCRIPTION
## In-tree deterministic-simulation (DST) test harness for the morphological matrix

Implements the white-box DST harness scoped in **iss-784 / epc-783** — a seeded, model-based generative harness that runs a **white-box invariant battery after every operation**, classifies each finding as a **known open bug** (allow-listed so the walk explores past it) or **novel** (fails), and **measures matrix coverage**. Tests-only; **no engine `src` changes**.

### Why
Earlier black-box reproducers found three real correctness bugs but *can't be comprehensive by construction* — black-box oracles (counts, query results) only catch latent structural corruption when a read happens to surface it. Comprehensive coverage requires in-tree, white-box invariants on internal Lance/manifest state. This is that harness.

### Confirmed bugs it guards (characterization regressions — green now, break loudly when fixed)
- **RC-X** — scalar-BTREE `RowAddrTreeMap::from_sorted_iter` crash. Validated as **lance-format/lance #7230** (`BTreeIndex::merge_segments` doesn't dedup `(value, row_address)`); **fixed upstream in PR #7235 → Lance v8.0.0** (not in our pinned 7.0.0). Latent on-disk corruption; persists across reopen; `optimize` doesn't repair it.
- **RC-1** — stale-view manifest-CAS on delete op-class combos (node-delete cascade bumps `edge:Knows` under an explicit edge-delete's pinned version). The generative walk reproduces this **on its own** (`op[DeletePerson] -> RC-1`).
- **dup-`@key`** — concurrent same-key merge-upserts duplicate rows (MR-714).

### Architecture (modular / extensible / structured)
- `op` (D1 op alphabet as data + `OpKind`) · `model` (reference model + `count==model`) · `invariants` (battery registry + **structured classifier**) · `fault` (`StorageAdapter` fault injection via `open_with_storage`) · `backend` (D5 embedded seam) · `coverage` (matrix hit-set).
- **Structured classifier:** `Finding{Engine(OmniError)|Logical}` — RC-1 gated on the `OmniError::Manifest` *variant*, RC-X on Lance's specific internal signature, and **every harness-computed structural finding (HEAD≠manifest, count≠model, `Dataset::validate()` failure) is always NOVEL** — no free-text allow-list can mask a new corruption class.
- **Phase-2 fault injection:** `FaultAdapter` injects seeded spurious manifest CAS-lost; the engine must surface/retry (never silently lose a write) — `count==model` catches loss. The faulted walk passes with 0 lost writes.
- **White-box invariants** via public APIs only (`Snapshot::open` → Lance `Dataset::{version,validate,manifest}`), respecting `forbidden_apis.rs`.

### Status
`cargo test -p omnigraph-engine --test dst` → **5 tests, ~1.5s**; coverage `ops 6/6, invariants 4/4`. The clean and fault-injected generative walks both pass with **0 novel violations**.

### Forward (extensible by design)
D2 morphology steering · D3 read-shape battery · `Backend` trait for CLI/server (D5) · `proptest-state-machine` for shrinking + seed persistence — all layer through the existing `Finding`/classifier/registry/coverage seams.

> **Note:** this branch also includes `ee8a7a1` — a separately-authored **RED** engine regression test in `writes.rs` pinning the RC-1 zero-row-cascade-delete drift at the engine boundary. It is expected to fail until RC-1 is fixed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code paths modified; the new RED test in `writes.rs` may fail CI until iss-950 is fixed.
> 
> **Overview**
> Adds an **in-tree deterministic-simulation (DST) harness** (`cargo test -p omnigraph-engine --test [test] dst`) that runs seeded generative walks over a six-op alphabet, checks a **white-box invariant battery** after every step, and **reports matrix coverage**—tests only, no engine `src` changes.
> 
> The harness splits into modules for **ops + reference model**, **structured known-vs-novel classification** (allow-listed RC-1 / RC-X engine errors; logical structural findings always fail), **`StorageAdapter` CAS fault injection** via `open_with_storage`, and **embedded backend helpers**. It includes **three characterization regressions** (RC-1 delete combo, Lance #7230 scalar BTREE, dup-@key concurrency) plus clean and fault-injected walks that fail on novel violations.
> 
> Also adds **`async-trait` as a dev-dependency** for `FaultAdapter`, and a **RED `writes.rs` test** asserting `edge:Knows` manifest version equals Lance HEAD after deleting a node with no incident edges (zero-row cascade `delete_where` drift).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edb2771ab44ef1c030ae89f4e8b90d16dd19d641. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an in-tree white-box DST harness for the morphological matrix (iss-784): a seeded generative walk drives the real engine through a 6-op alphabet, runs a 4-invariant battery after every step, and classifies findings as known bugs (allow-listed) or novel (fail). It also adds a RED regression test to `writes.rs` that pins the zero-row-cascade `HEAD > manifest` drift bug at the engine boundary.

- **Generative walk** (`dst.rs`, `dst/` submodules): two seeds × 15 steps, clean and fault-injected variants; structured `Finding` classifier gates RC-1 on the `OmniError::Manifest` variant and RC-X on Lance's specific internal panic string; `Logical` findings are never allow-listed.
- **Three characterization regression tests**: `regression_rc1_stale_view_on_delete_combo`, `regression_rc_x_btree_from_sorted_iter`, `regression_dup_key_under_concurrency` — all assert current buggy behavior and are documented to flip when each upstream fix lands.
- **`writes.rs` RED test** (`node_delete_with_no_incident_edges_leaves_no_edge_table_drift`): directly opens Lance `Dataset` to verify `manifest version == on-disk HEAD` after a no-edge-cascade delete; expected to turn green once `delete` migrates to the staged two-phase path (iss-950).

<h3>Confidence Score: 4/5</h3>

Tests-only change with no engine source modifications; the RED test in writes.rs is intentionally expected to fail until iss-950 lands and is clearly documented as such.

The harness design is sound: structured classifier, Logical findings never allow-listed, fault injection via the StorageAdapter seam. A few smaller issues in the harness itself are worth addressing: the hardcoded `4` denominator in coverage.rs will silently go stale when invariants are added; `break 'walk` contradicts the "explores past it" docstring and could mislead a future contributor; and discarded JoinErrors in the concurrent regression tests could hide spurious task panics.

crates/omnigraph/tests/dst/coverage.rs (hardcoded denominator) and crates/omnigraph/tests/dst.rs (docstring accuracy and discarded join handles in the concurrent regression tests)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/omnigraph/tests/dst.rs | Main harness entry point: 3 characterization regression tests + 2 generative walk tests; `break 'walk` on known bugs terminates the seed walk rather than continuing, which is correct but contradicts the module docstring's "explores past it" claim |
| crates/omnigraph/tests/dst/coverage.rs | Coverage tracker: invariant denominator is hardcoded as the literal `4` in `report()` instead of being derived dynamically — will silently produce a wrong ratio if invariants are added to `run_battery` |
| crates/omnigraph/tests/dst/invariants.rs | Structured classifier + 4-invariant battery; RC-1 gated on OmniError::Manifest variant (not free-text), Logical findings are never allow-listed — design is sound |
| crates/omnigraph/tests/dst/fault.rs | FaultAdapter wraps StorageAdapter and injects seeded spurious CAS-lost on write_text_if_match; implementation is correct — only delegates to inner on the non-fault path |
| crates/omnigraph/tests/dst/model.rs | Reference model tracking Person/Doc key sets; model is updated only on op success keeping it consistent with engine state; check_counts issues Logical findings (never allow-listed) |
| crates/omnigraph/tests/dst/op.rs | D1 op alphabet with inline xorshift64* RNG; 6 OpKinds cover all major engine paths; DeletePerson targets ids from [0, next) which safely handles non-existent and Doc ids as no-ops |
| crates/omnigraph/tests/dst/backend.rs | Two open functions: clean and faulted; graph is initialized cleanly before fault injection so recovery sweep at open_with_storage sees an empty sidecar set |
| crates/omnigraph/tests/writes.rs | Adds RED regression test `node_delete_with_no_incident_edges_leaves_no_edge_table_drift` that directly opens Lance Dataset to check HEAD == manifest version; correctly marked to go GREEN when iss-950 is fixed |
| crates/omnigraph/Cargo.toml | Adds async-trait as a dev-dependency (workspace-pinned version); needed by FaultAdapter's #[async_trait] impl of StorageAdapter |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[run_walk start\nseed = 0..2] --> B[open_clean / open_faulted]
    B --> C[init Rng + Model]
    C --> D{for step_i in 0..15}
    D --> E[op::step\npick + execute op]
    E --> F{op result}
    F -- Err --> G{classify finding}
    G -- Some known bug --> H[record + break walk]
    G -- None + faults=true --> D
    G -- None + faults=false --> PANIC[panic NOVEL op error]
    F -- Ok --> I[run_battery\n4 invariants]
    I --> J{invariant result}
    J -- Err --> K{classify finding}
    K -- Some known bug --> H
    K -- None --> PANIC2[panic NOVEL invariant violation]
    J -- Ok --> D
    H --> L{more seeds?}
    D -- step_i==15 --> L
    L -- yes --> A
    L -- no --> M[print coverage report]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[run_walk start\nseed = 0..2] --> B[open_clean / open_faulted]
    B --> C[init Rng + Model]
    C --> D{for step_i in 0..15}
    D --> E[op::step\npick + execute op]
    E --> F{op result}
    F -- Err --> G{classify finding}
    G -- Some known bug --> H[record + break walk]
    G -- None + faults=true --> D
    G -- None + faults=false --> PANIC[panic NOVEL op error]
    F -- Ok --> I[run_battery\n4 invariants]
    I --> J{invariant result}
    J -- Err --> K{classify finding}
    K -- Some known bug --> H
    K -- None --> PANIC2[panic NOVEL invariant violation]
    J -- Ok --> D
    H --> L{more seeds?}
    D -- step_i==15 --> L
    L -- yes --> A
    L -- no --> M[print coverage report]
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Acrates%2Fomnigraph%2Ftests%2Fdst%2Fcoverage.rs%3A29-37%0AThe%20invariant%20denominator%20is%20hardcoded%20as%20the%20literal%20%604%60.%20When%20a%20fifth%20invariant%20is%20added%20to%20%60run_battery%60%2C%20this%20counter%20won't%20update%20and%20the%20coverage%20report%20will%20silently%20claim%20e.g.%20%22invariants%205%2F4%22%20%E2%80%94%20a%20number%20that%20doesn't%20make%20sense%20and%20can't%20alert%20a%20reviewer%20that%20the%20cap%20is%20stale.%20The%20denominator%20should%20come%20from%20a%20single%20authoritative%20source.%0A%0A%60%60%60suggestion%0A%20%20%20%20pub%20fn%20report%28%26self%2C%20total_invariants%3A%20usize%29%20-%3E%20String%20%7B%0A%20%20%20%20%20%20%20%20format!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%22ops%20%7B%7D%2F%7B%7D%2C%20invariants%20%7B%7D%2F%7Btotal_invariants%7D%2C%20known-bugs%20exercised%20%7B%7D%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20self.ops.len%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20OpKind%3A%3AALL.len%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20self.invariants.len%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20self.findings.len%28%29%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Acrates%2Fomnigraph%2Ftests%2Fdst.rs%3A19%0A**Module%20docstring%20contradicts%20the%20walk%20implementation.**%20The%20header%20says%20known%20bugs%20are%20%22allow-listed%20so%20the%20walk%20explores%20past%20it%2C%22%20but%20both%20the%20op-error%20path%20%28line%20~234%29%20and%20the%20invariant-violation%20path%20%28line%20~253%29%20issue%20%60break%20'walk%60%2C%20terminating%20the%20entire%20seed%20walk%20the%20moment%20a%20known%20bug%20is%20reproduced.%20The%20PR%20description%20is%20similarly%20worded.%20Breaking%20is%20the%20correct%20choice%20%E2%80%94%20continuing%20ops%20against%20a%20corrupted%20engine%20state%20would%20produce%20cascading%20spurious%20novel%20violations%20%E2%80%94%20but%20the%20documentation%20should%20say%20%22the%20seed%20walk%20terminates%20early%22%20rather%20than%20%22explores%20past%20it%2C%22%20so%20future%20contributors%20don't%20add%20%60continue%60%20in%20place%20of%20%60break%20'walk%60%20expecting%20that%20to%20be%20the%20intended%20behavior.%0A%0A%23%23%23%20Issue%203%20of%204%0Acrates%2Fomnigraph%2Ftests%2Fdst.rs%3A134-135%0A**Discarded%20%60JoinError%60%20can%20hide%20task%20panics.**%20%60let%20_%20%3D%20upd.await%60%20and%20%60let%20_%20%3D%20opt.await%60%20silently%20swallow%20any%20panic%20inside%20the%20spawned%20tasks.%20If%20the%20UPDATE%20loop%20hits%20an%20unexpected%20%60unwrap%60%20failure%2C%20the%20task%20terminates%20with%20a%20%60JoinError%3A%3APanic%60%20and%20this%20test%20continues%20straight%20to%20the%20%60db.query%28...%29%60%20assertion%2C%20potentially%20failing%20on%20an%20unrelated%20error%20or%20producing%20a%20confusing%20diagnostic.%20The%20same%20pattern%20appears%20in%20%60regression_dup_key_under_concurrency%60%20%28%60let%20_%20%3D%20h.await%60%29.%20Using%20%60.expect%28%22upd%20task%22%29%60%20%2F%20%60.expect%28%22opt%20task%22%29%60%20on%20the%20join%20handles%20would%20surface%20any%20spurious%20task%20panics%20immediately%20with%20a%20clear%20message.%0A%0A%23%23%23%20Issue%204%20of%204%0Acrates%2Fomnigraph%2Ftests%2Fdst.rs%3A192-197%0A**%60assert!%28total%20%3E%20keys%29%60%20gives%20a%20false%20%22FIXED%22%20signal%20when%20no%20inserts%20land.**%20If%20every%20worker's%2012%20retries%20all%20fail%20%28e.g.%20livelock%20from%20concurrent%20CAS%20conflicts%20on%20a%20slow%20CI%20host%29%2C%20%60total%20%3D%3D%200%20%3C%20keys%20%3D%3D%20500%60%2C%20so%20%60assert!%28total%20%3E%20keys%29%60%20panics%20with%20%22dup-%40key%20appears%20FIXED%22%20%E2%80%94%20incorrectly.%20A%20guard%20%60assert!%28total%20%3E%3D%20keys%2C%20%22expected%20at%20least%20%7Bkeys%7D%20rows%2C%20got%20%7Btotal%7D%20%E2%80%94%20workers%20may%20have%20all%20failed%22%29%60%20before%20the%20dup-check%20makes%20a%20zero-insert%20failure%20immediately%20distinguishable%20from%20a%20genuine%20fix.%0A%0A&repo=modernrelay%2Fomnigraph&pr=300&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["test(dst): modularize + structured class..."](https://github.com/modernrelay/omnigraph/commit/edb2771ab44ef1c030ae89f4e8b90d16dd19d641) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39605204)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->