### PR TITLE
release: v0.7.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Tools that support `@`-imports (Claude Code) auto-include all three files via th
 
 `CLAUDE.md` is a symlink to this file — there is exactly one source of truth. Edit `AGENTS.md`.
 
-**Version surveyed:** 0.7.1
+**Version surveyed:** 0.7.2
 **Workspace crates:** `omnigraph-compiler`, `omnigraph` (engine), `omnigraph-policy`, `omnigraph-api-types` (shared HTTP wire DTOs), `omnigraph-cluster`, `omnigraph-cli`, `omnigraph-server`
 **Storage substrate:** Lance 7.x (columnar, versioned, branchable)
 **License:** MIT

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4851,7 +4851,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-api-types"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "omnigraph-compiler",
  "omnigraph-engine",
@@ -4862,7 +4862,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-cli"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -4886,7 +4886,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-cluster"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "fail",
  "omnigraph-compiler",
@@ -4905,7 +4905,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-compiler"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -4924,7 +4924,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-engine"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -4968,7 +4968,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-policy"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "cedar-policy",
  "clap",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-server"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/crates/omnigraph-api-types/Cargo.toml
+++ b/crates/omnigraph-api-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-api-types"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 description = "Shared HTTP wire DTOs for Omnigraph — request/response types and engine-result → DTO mappings used by both omnigraph-server and omnigraph-cli (RFC-009). Plain serde/utoipa types; no transport or server internals."
 license = "MIT"
@@ -9,8 +9,8 @@ homepage = "https://github.com/ModernRelay/omnigraph"
 documentation = "https://docs.rs/omnigraph-api-types"
 
 [dependencies]
-omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.7.1" }
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.1" }
+omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.7.2" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.2" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 utoipa = { workspace = true }

--- a/crates/omnigraph-cli/Cargo.toml
+++ b/crates/omnigraph-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-cli"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 description = "CLI for the Omnigraph graph database."
 license = "MIT"
@@ -13,12 +13,12 @@ name = "omnigraph"
 path = "src/main.rs"
 
 [dependencies]
-omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.7.1" }
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.1" }
-omnigraph-api-types = { path = "../omnigraph-api-types", version = "0.7.1" }
-omnigraph-cluster = { path = "../omnigraph-cluster", version = "0.7.1" }
-omnigraph-policy = { path = "../omnigraph-policy", version = "0.7.1" }
-omnigraph-server = { path = "../omnigraph-server", version = "0.7.1" }
+omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.7.2" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.2" }
+omnigraph-api-types = { path = "../omnigraph-api-types", version = "0.7.2" }
+omnigraph-cluster = { path = "../omnigraph-cluster", version = "0.7.2" }
+omnigraph-policy = { path = "../omnigraph-policy", version = "0.7.2" }
+omnigraph-server = { path = "../omnigraph-server", version = "0.7.2" }
 clap = { workspace = true }
 color-eyre = { workspace = true }
 serde = { workspace = true }

--- a/crates/omnigraph-cluster/Cargo.toml
+++ b/crates/omnigraph-cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-cluster"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 description = "Cluster configuration validation, planning, and config-only apply for Omnigraph."
 license = "MIT"
@@ -14,8 +14,8 @@ documentation = "https://docs.rs/omnigraph-cluster"
 failpoints = ["dep:fail", "fail/failpoints", "omnigraph/failpoints"]
 
 [dependencies]
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.1" }
-omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.7.1" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.2" }
+omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.7.2" }
 fail = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/omnigraph-compiler/Cargo.toml
+++ b/crates/omnigraph-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-compiler"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 description = "Schema/query compiler for Omnigraph. Zero Lance dependency."
 license = "MIT"

--- a/crates/omnigraph-policy/Cargo.toml
+++ b/crates/omnigraph-policy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-policy"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 description = "Policy / authorization layer for Omnigraph — Cedar-backed PolicyEngine, PolicyChecker trait, ResourceScope enum."
 license = "MIT"

--- a/crates/omnigraph-server/Cargo.toml
+++ b/crates/omnigraph-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-server"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 description = "HTTP server for the Omnigraph graph database."
 license = "MIT"
@@ -19,11 +19,11 @@ default = []
 aws = ["dep:aws-config", "dep:aws-sdk-secretsmanager"]
 
 [dependencies]
-omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.7.1" }
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.1" }
-omnigraph-policy = { path = "../omnigraph-policy", version = "0.7.1" }
-omnigraph-api-types = { path = "../omnigraph-api-types", version = "0.7.1" }
-omnigraph-cluster = { path = "../omnigraph-cluster", version = "0.7.1" }
+omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.7.2" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.2" }
+omnigraph-policy = { path = "../omnigraph-policy", version = "0.7.2" }
+omnigraph-api-types = { path = "../omnigraph-api-types", version = "0.7.2" }
+omnigraph-cluster = { path = "../omnigraph-cluster", version = "0.7.2" }
 axum = { workspace = true }
 clap = { workspace = true }
 color-eyre = { workspace = true }

--- a/crates/omnigraph/Cargo.toml
+++ b/crates/omnigraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-engine"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 description = "Runtime engine for the Omnigraph graph database."
 license = "MIT"
@@ -16,8 +16,8 @@ default = []
 failpoints = ["dep:fail", "fail/failpoints"]
 
 [dependencies]
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.1" }
-omnigraph-policy = { path = "../omnigraph-policy", version = "0.7.1" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.2" }
+omnigraph-policy = { path = "../omnigraph-policy", version = "0.7.2" }
 lance = { workspace = true }
 lance-datafusion = { workspace = true }
 datafusion = { workspace = true }
@@ -52,7 +52,7 @@ chrono = { workspace = true }
 arc-swap = { workspace = true }
 
 [dev-dependencies]
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.1" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.2" }
 tokio = { workspace = true }
 lance-namespace-impls = { workspace = true }
 lance-io = "7.0.0"

--- a/docs/releases/v0.7.2.md
+++ b/docs/releases/v0.7.2.md
@@ -1,0 +1,60 @@
+# Omnigraph v0.7.2
+
+A patch release over v0.7.1: write-path latency reductions plus three
+correctness fixes on the maintenance and recovery paths. No breaking changes, no
+on-disk format change, and no migration — drop-in over v0.7.1.
+
+## Performance
+
+- **Write opens go direct, schema validates once (#288, #298).** Write opens
+  used to route through the per-table Lance namespace catalog, which re-opened
+  the dataset just to read its location and re-resolved the latest version on
+  every table open — an O(commit-depth) double resolution that dominated write
+  latency on object stores (~70%). Writes now open each touched data table
+  directly by its manifest-recorded location (Lance's O(1) version-hint path),
+  validate the schema contract once per write instead of ~4×, and open each
+  touched table once instead of 4×.
+
+- **`optimize` compacts the internal metadata tables (#291).** `optimize`
+  previously iterated only node/edge tables, so the internal `__manifest`,
+  `_graph_commits`, and `_graph_commit_actors` tables accumulated one fragment
+  per commit and were never compacted — making every write's metadata scan grow
+  with commit history. `optimize` now compacts all three, so a periodically
+  optimized long-lived graph keeps its per-write metadata scan flat in history.
+
+## Fixes
+
+- **`optimize` survives a cross-process write race (#297).** A CLI `optimize`
+  racing a served write on the same table could fail: the in-process write queue
+  doesn't serialize across processes, so a concurrent insert/delete advancing the
+  manifest between optimize's compaction and its publish broke the strict
+  equality CAS. Optimize now reopens-and-replans on a genuine Lance conflict and
+  fast-forwards its publish monotonically, so a maintenance compaction never
+  fails a live write. Bounded retry; sustained contention surfaces a loud
+  conflict rather than dropping work.
+
+- **`optimize` is non-destructive on upgraded graphs (#291).** A graph created by
+  a pre-0.7.0 binary carries an on-by-default Lance auto-cleanup config; under it,
+  optimize's compaction commit could fire Lance's version-GC hook and prune
+  `__manifest`-pinned versions (breaking snapshots and time travel). Optimize now
+  strips any stale `lance.auto_cleanup.*` config off every table — data and
+  internal — before its HEAD-advancing commits, so compaction can never GC pinned
+  versions.
+
+- **Recovery converges instead of failing `open` under a concurrent manifest
+  advance (#296).** The open-time recovery sweep published its roll-forward at the
+  sidecar's pinned expected version; if another writer advanced the manifest
+  during the classify→publish window, the CAS failed and aborted the whole
+  `Omnigraph::open`. The sweep now treats roll-forward as "the manifest reflects
+  the sidecar's committed state," not "this sweep won the CAS": on a CAS loss it
+  re-reads the live manifest and, when the sidecar's intent is already satisfied,
+  records the recovery and deletes the sidecar idempotently — so a concurrent
+  advance no longer fails the open. (The destructive roll-back twin still defers
+  to a cross-process lease, as documented.)
+
+## Upgrade notes
+
+Drop-in over v0.7.1 — no configuration, schema, or data changes. Upgrade the
+server and CLI together as usual. Graphs created on v0.7.1 read and write
+identically on v0.7.2; the optimize non-destructive fix additionally protects
+graphs created by pre-0.7.0 binaries from version GC during compaction.

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "0.7.1"
+    "version": "0.7.2"
   },
   "paths": {
     "/graphs": {


### PR DESCRIPTION
Patch release over v0.7.1. No breaking changes, no on-disk format change, no migration — drop-in over v0.7.1.

## Performance
- **Write opens go direct, schema validates once (#288, #298).** Writes open each touched data table directly by its manifest-recorded location (Lance's O(1) version-hint path), validate the schema contract once per write instead of ~4×, and open each touched table once instead of 4× — removing the O(commit-depth) namespace-catalog double-resolution that dominated write latency on object stores (~70%).
- **`optimize` compacts the internal metadata tables (#291).** `__manifest`, `_graph_commits`, and `_graph_commit_actors` are now compacted, so a periodically optimized long-lived graph keeps its per-write metadata scan flat in history.

## Fixes
- **`optimize` survives a cross-process write race (#297).** Reopen-and-replan on a genuine Lance conflict + monotonic publish fast-forward, so a maintenance compaction never fails a live write (invariant 7); bounded retry, loud on sustained contention.
- **`optimize` is non-destructive on upgraded graphs (#291).** Strips any stale `lance.auto_cleanup.*` config off every table before HEAD-advancing commits, so compaction can never GC `__manifest`-pinned versions.
- **Recovery converges instead of failing `open` under a concurrent manifest advance (#296).** On a CAS loss the sweep re-reads the live manifest and, when the sidecar's intent is already satisfied, records the recovery and deletes the sidecar idempotently.

## Coherence
All 7 crate manifests + path-dep constraints, `Cargo.lock`, `openapi.json`, and the AGENTS.md surveyed version bumped `0.7.1 → 0.7.2`. New `docs/releases/v0.7.2.md`. Build green under `--locked`; OpenAPI drift check green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and metadata bumps only; no application logic changes in the diff. Operational risk is limited to deploying the tagged binaries that include the documented engine fixes from prior merges.
> 
> **Overview**
> **Release packaging for v0.7.2** — bumps every published crate (`omnigraph-engine`, `omnigraph-compiler`, `omnigraph-policy`, `omnigraph-api-types`, `omnigraph-cluster`, `omnigraph-cli`, `omnigraph-server`) and their path dependency constraints from **0.7.1 → 0.7.2**, updates `Cargo.lock`, sets `openapi.json` `info.version` to **0.7.2**, and changes the surveyed version in `AGENTS.md`.
> 
> Adds **`docs/releases/v0.7.2.md`**, which documents the user-visible delta for this patch (write-path performance, `optimize` behavior, recovery-on-open) that landed in earlier PRs — this PR does not include those engine changes in the diff.
> 
> Drop-in over v0.7.1 per the release notes: no breaking changes, format change, or migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fa86f02682dcd7a72764be5d1604e1efa2b0873. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prepares the v0.7.2 release. The main changes are:

- Bumps all workspace crate versions and local path dependency constraints to 0.7.2.
- Updates Cargo.lock, AGENTS.md, and OpenAPI metadata for the release.
- Adds v0.7.2 release notes covering performance fixes and recovery behavior.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Surveyed version updated to 0.7.2. |
| Cargo.lock | Workspace omnigraph packages updated to 0.7.2. |
| crates/omnigraph-api-types/Cargo.toml | Package version and local dependency constraints updated to 0.7.2. |
| crates/omnigraph-cli/Cargo.toml | CLI package version and local omnigraph dependency constraints updated to 0.7.2. |
| crates/omnigraph-cluster/Cargo.toml | Cluster package version and local dependency constraints updated to 0.7.2. |
| crates/omnigraph-compiler/Cargo.toml | Compiler package version updated to 0.7.2. |
| crates/omnigraph-policy/Cargo.toml | Policy package version updated to 0.7.2. |
| crates/omnigraph-server/Cargo.toml | Server package version and local omnigraph dependency constraints updated to 0.7.2. |
| crates/omnigraph/Cargo.toml | Engine package version and local dependency constraints updated to 0.7.2. |
| docs/releases/v0.7.2.md | New release notes describe the v0.7.2 patch release and upgrade expectations. |
| openapi.json | OpenAPI info version updated to 0.7.2. |

<sub>Reviews (1): Last reviewed commit: ["release: v0.7.2"](https://github.com/modernrelay/omnigraph/commit/5fa86f02682dcd7a72764be5d1604e1efa2b0873) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39767674)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=59169be6-01cf-4bae-80fc-604b6a708098))
- Context used - CLAUDE.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=fba7c581-edb6-48b3-90ce-1db695f47e8b))

<!-- /greptile_comment -->