### PR TITLE
test(dst): comprehensive DST harness — D2/D3 matrix, more oracles, shrinking, concurrency

### DIFF
--- a/crates/omnigraph/Cargo.toml
+++ b/crates/omnigraph/Cargo.toml
@@ -56,7 +56,8 @@ omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.1" }
 tokio = { workspace = true }
 lance-namespace-impls = { workspace = true }
 lance-io = "7.0.0"
-lance-table = { workspace = true }
+arrow-array = { workspace = true }
+futures = { workspace = true }
 serde_json = { workspace = true }
 serial_test = "3"
 proptest = "1"

--- a/crates/omnigraph/Cargo.toml
+++ b/crates/omnigraph/Cargo.toml
@@ -61,4 +61,5 @@ futures = { workspace = true }
 serde_json = { workspace = true }
 serial_test = "3"
 proptest = "1"
+proptest-state-machine = "0.8"
 async-trait = { workspace = true }

--- a/crates/omnigraph/Cargo.toml
+++ b/crates/omnigraph/Cargo.toml
@@ -57,6 +57,7 @@ tokio = { workspace = true }
 lance-namespace-impls = { workspace = true }
 lance-io = "7.0.0"
 lance-table = { workspace = true }
+serde_json = { workspace = true }
 serial_test = "3"
 proptest = "1"
 async-trait = { workspace = true }

--- a/crates/omnigraph/Cargo.toml
+++ b/crates/omnigraph/Cargo.toml
@@ -56,6 +56,7 @@ omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.1" }
 tokio = { workspace = true }
 lance-namespace-impls = { workspace = true }
 lance-io = "7.0.0"
+lance-table = { workspace = true }
 serial_test = "3"
 proptest = "1"
 async-trait = { workspace = true }

--- a/crates/omnigraph/tests/dst.rs
+++ b/crates/omnigraph/tests/dst.rs
@@ -38,6 +38,8 @@ mod invariants;
 mod coverage;
 #[path = "dst/backend.rs"]
 mod backend;
+#[path = "dst/readshape.rs"]
+mod readshape;
 
 use coverage::Coverage;
 use invariants::{Finding, classify, run_battery};
@@ -315,6 +317,44 @@ async fn branch_isolation_and_merge() {
         1,
         "merge: feature's row was not merged into main"
     );
+}
+
+// ═══════════════════════ D3 read shapes × D2 morphology ═══════════════════
+
+/// Every read shape must execute (no engine error / panic) against every table
+/// morphology — the D2×D3 cell sweep — plus the morphology-invariant counts
+/// (full-scan == live persons, zero-match == 0) must hold, and the shapes must
+/// run against a forked branch too.
+#[tokio::test]
+async fn read_shape_battery_across_morphologies() {
+    for morph in readshape::Morph::ALL {
+        let dir = tempfile::tempdir().unwrap();
+        let db = omnigraph::db::Omnigraph::init(dir.path().to_str().unwrap(), readshape::SCHEMA)
+            .await
+            .unwrap();
+        let expected_persons = readshape::build(&db, morph).await;
+        for (name, res) in readshape::run(&db, "main").await {
+            let rows =
+                res.unwrap_or_else(|e| panic!("morph {morph:?} shape [{name}] errored: {e}"));
+            if name == "full-scan" {
+                assert_eq!(rows, expected_persons, "morph {morph:?} full-scan count");
+            }
+            if name == "zero-match" {
+                assert_eq!(rows, 0, "morph {morph:?} zero-match must be empty");
+            }
+        }
+    }
+
+    // on-branch morphology: every shape must execute against a forked branch.
+    let dir = tempfile::tempdir().unwrap();
+    let db = omnigraph::db::Omnigraph::init(dir.path().to_str().unwrap(), readshape::SCHEMA)
+        .await
+        .unwrap();
+    readshape::build(&db, readshape::Morph::MultiFragment).await;
+    db.branch_create("feature").await.unwrap();
+    for (name, res) in readshape::run(&db, "feature").await {
+        res.unwrap_or_else(|e| panic!("on-branch shape [{name}] errored: {e}"));
+    }
 }
 
 // ═══════════════════════════ generative walk ══════════════════════════════

--- a/crates/omnigraph/tests/dst.rs
+++ b/crates/omnigraph/tests/dst.rs
@@ -40,6 +40,8 @@ mod coverage;
 mod backend;
 #[path = "dst/readshape.rs"]
 mod readshape;
+#[path = "dst/statemachine.rs"]
+mod statemachine;
 
 use coverage::Coverage;
 use invariants::{Finding, classify, run_battery};

--- a/crates/omnigraph/tests/dst.rs
+++ b/crates/omnigraph/tests/dst.rs
@@ -181,6 +181,54 @@ async fn regression_dup_key_under_concurrency() {
     );
 }
 
+/// FINDING (harness-surfaced, distinct from the 3 above): a `Knows` SELF-LOOP is
+/// committed to the edge table but is NOT returned by `$a knows $b` traversal —
+/// durable across optimize and reopen, and the CSR build keeps it (so the drop
+/// is in Expand). `proptest_equivalence` can't catch it: it only asserts
+/// CSR-vs-indexed MODE equivalence, and both modes drop the self-loop alike. The
+/// model-based edges==model oracle caught it; self-loops are kept out of the
+/// generic generator so that oracle stays unambiguous. This characterization
+/// guard breaks (forcing review) when self-loops become traversable.
+#[tokio::test]
+async fn regression_self_loop_not_traversable() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = backend::open_clean(dir.path().to_str().unwrap()).await;
+    load_jsonl(&db, &person("s0"), LoadMode::Merge).await.unwrap();
+    load_jsonl(&db, &knows("s0", "s0"), LoadMode::Merge).await.unwrap();
+
+    // The self-loop row is durably committed to the edge table.
+    let snap = db.snapshot_of(ReadTarget::branch("main")).await.unwrap();
+    let mut raw = 0;
+    for entry in snap.entries() {
+        if entry.table_key == "edge:Knows" {
+            raw = snap
+                .open(&entry.table_key)
+                .await
+                .unwrap()
+                .count_rows(None)
+                .await
+                .unwrap();
+        }
+    }
+    assert_eq!(raw, 1, "self-loop edge row should be committed");
+
+    // ...but traversal does not return it (the finding).
+    let trav = db
+        .query(
+            ReadTarget::branch("main"),
+            "query e() { match { $a: Person $a knows $b } return { $a.slug, $b.slug } }",
+            "e",
+            &ParamMap::new(),
+        )
+        .await
+        .unwrap()
+        .num_rows();
+    assert_eq!(
+        trav, 0,
+        "self-loop appears FIXED (traversable={trav}) — flip this regression to expect 1"
+    );
+}
+
 // ═══════════════════════════ generative walk ══════════════════════════════
 
 /// Clean walk: full white-box battery after every op; novel violations fail.

--- a/crates/omnigraph/tests/dst.rs
+++ b/crates/omnigraph/tests/dst.rs
@@ -231,6 +231,92 @@ async fn regression_self_loop_not_traversable() {
     );
 }
 
+// ═══════════════════════ branch isolation + merge ═════════════════════════
+
+async fn count_persons(db: &omnigraph::db::Omnigraph, branch: &str) -> usize {
+    db.query(
+        ReadTarget::branch(branch),
+        "query q() { match { $x: Person } return { $x.slug } }",
+        "q",
+        &ParamMap::new(),
+    )
+    .await
+    .unwrap()
+    .num_rows()
+}
+
+async fn person_exists(db: &omnigraph::db::Omnigraph, branch: &str, slug: &str) -> usize {
+    let q =
+        format!("query p() {{ match {{ $x: Person {{ slug: \"{slug}\" }} }} return {{ $x.slug }} }}");
+    db.query(ReadTarget::branch(branch), &q, "p", &ParamMap::new())
+        .await
+        .unwrap()
+        .num_rows()
+}
+
+/// D4 oracles for the branch subsystem (the deferred B2 branch_isolation +
+/// merge_correctness): a branch must not observe `main` writes made after it
+/// forked, `main` must not observe branch-only writes, and a merge must produce
+/// the row-level union. Kept as a focused scenario (not the generic per-op walk)
+/// so the reference model stays single-branch and unambiguous.
+#[tokio::test]
+async fn branch_isolation_and_merge() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = backend::open_clean(dir.path().to_str().unwrap()).await;
+    let mut seed = String::new();
+    for i in 0..5 {
+        seed.push_str(&person(&format!("p{i}")));
+    }
+    load_jsonl(&db, &seed, LoadMode::Merge).await.unwrap();
+
+    db.branch_create("feature").await.unwrap();
+
+    // Diverge: a post-fork write on each side.
+    db.mutate(
+        "main",
+        "query i() { insert Person { slug: \"m-only\", name: \"n\" } }",
+        "i",
+        &ParamMap::new(),
+    )
+    .await
+    .unwrap();
+    db.mutate(
+        "feature",
+        "query i() { insert Person { slug: \"f-only\", name: \"n\" } }",
+        "i",
+        &ParamMap::new(),
+    )
+    .await
+    .unwrap();
+
+    // branch_isolation: neither side sees the other's post-fork write.
+    assert_eq!(
+        person_exists(&db, "feature", "m-only").await,
+        0,
+        "isolation: feature observed a post-fork main write"
+    );
+    assert_eq!(
+        person_exists(&db, "main", "f-only").await,
+        0,
+        "isolation: main observed a feature-only write"
+    );
+    assert_eq!(person_exists(&db, "feature", "f-only").await, 1);
+    assert_eq!(person_exists(&db, "main", "m-only").await, 1);
+
+    // merge_correctness: main converges to the row-level union (p0..p4 + both).
+    let outcome = db.branch_merge("feature", "main").await.unwrap();
+    let total = count_persons(&db, "main").await;
+    assert_eq!(
+        total, 7,
+        "merge: expected the 7-person union, got {total} (outcome {outcome:?})"
+    );
+    assert_eq!(
+        person_exists(&db, "main", "f-only").await,
+        1,
+        "merge: feature's row was not merged into main"
+    );
+}
+
 // ═══════════════════════════ generative walk ══════════════════════════════
 
 /// Clean walk: full white-box battery after every op; novel violations fail.

--- a/crates/omnigraph/tests/dst.rs
+++ b/crates/omnigraph/tests/dst.rs
@@ -233,6 +233,82 @@ async fn regression_self_loop_not_traversable() {
     );
 }
 
+// ═══════════════════════ concurrency (multi-actor) ════════════════════════
+
+/// Seeded N-actor concurrent walk over a SHARED graph, with an OVERLAPPING key
+/// space so same-key upserts race. Under concurrency the sequential reference
+/// model doesn't apply, so the oracle is the interleaving-INVARIANT subset:
+/// unique live row-ids, `Dataset::validate`, HEAD==manifest, and `@key`
+/// uniqueness. dup-`@key` (MR-714) and RC-1 drift are allow-listed knowns; any
+/// other divergence is a novel concurrency bug and fails. A Lance panic inside
+/// an actor is contained by `tokio::spawn` (surfaces as a JoinError we ignore),
+/// so the harness stays up — the post-join battery is the judge.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_walk_structural_invariants() {
+    let mut reproduced: Vec<String> = Vec::new();
+    for seed in 0..3u64 {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Arc::new(backend::open_clean(dir.path().to_str().unwrap()).await);
+        let actors = 4usize;
+        let mut handles = Vec::new();
+        for a in 0..actors {
+            let db = db.clone();
+            handles.push(tokio::spawn(async move {
+                let mut rng = Rng::new(seed.wrapping_mul(131) + a as u64);
+                for _ in 0..20 {
+                    let k = rng.below(30); // shared 0..30 key space → races
+                    match rng.below(5) {
+                        0 | 1 => {
+                            let _ = load_jsonl(&db, &person(&format!("h{k}")), LoadMode::Merge).await;
+                        }
+                        2 => {
+                            let q = format!(
+                                "query u() {{ update Person set {{ name: \"x{k}\" }} where slug = \"h{k}\" }}"
+                            );
+                            let _ = db.mutate("main", &q, "u", &ParamMap::new()).await;
+                        }
+                        3 => {
+                            let q = format!("query d() {{ delete Person where slug = \"h{k}\" }}");
+                            let _ = db.mutate("main", &q, "d", &ParamMap::new()).await;
+                        }
+                        _ => {
+                            let _ = db.optimize().await;
+                        }
+                    }
+                }
+            }));
+        }
+        for h in handles {
+            let _ = h.await; // ignore JoinError: a contained actor panic is judged by the battery
+        }
+
+        let checks: Vec<(&str, Result<(), Finding>)> = vec![
+            ("row-id-unique", invariants::no_duplicate_live_row_ids(&db).await),
+            ("dataset.validate", invariants::dataset_validate(&db).await),
+            ("head==manifest", invariants::head_eq_manifest(&db).await),
+            ("no-dup-@key", invariants::no_duplicate_keys(&db, "Person", "main").await),
+        ];
+        for (name, res) in checks {
+            if let Err(f) = res {
+                match classify(&f) {
+                    Some(bug) => reproduced.push(format!("seed={seed} [{name}] -> {bug}")),
+                    None => panic!(
+                        "seed={seed}: NOVEL concurrent violation [{name}]: {}",
+                        f.message()
+                    ),
+                }
+            }
+        }
+    }
+    eprintln!(
+        "[dst] concurrent walk: {} known-bug instance(s), 0 novel violations",
+        reproduced.len()
+    );
+    for r in &reproduced {
+        eprintln!("  - {r}");
+    }
+}
+
 // ═══════════════════════ branch isolation + merge ═════════════════════════
 
 async fn count_persons(db: &omnigraph::db::Omnigraph, branch: &str) -> usize {

--- a/crates/omnigraph/tests/dst.rs
+++ b/crates/omnigraph/tests/dst.rs
@@ -244,9 +244,32 @@ async fn run_walk(faults: bool) {
                 }
             }
         }
+
+        // ── reopen==pre_state: durability oracle ──
+        // A fresh handle on the same bytes (clean adapter; the open-time recovery
+        // sweep runs) must agree with the model the walk built. count==model /
+        // content==model prove the data survived; head==manifest / row-id-disjoint
+        // prove the sweep left no residual drift. Reuses the same battery at
+        // durability time, so no separate coverage cell.
+        drop(db);
+        let reopened = backend::reopen(uri).await;
+        for (name, res) in run_battery(&reopened, &model).await {
+            if let Err(f) = res {
+                match classify(&f) {
+                    Some(bug) => {
+                        cov.finding(bug);
+                        reproduced.push(format!("seed={seed} [reopen/{name}] -> {bug}"));
+                    }
+                    None => panic!(
+                        "seed={seed}: NOVEL post-reopen violation [{name}]: {}",
+                        f.message()
+                    ),
+                }
+            }
+        }
     }
     eprintln!(
-        "[dst] walk(faults={faults}): coverage [{}]; {} known-bug instance(s), 0 novel violations",
+        "[dst] walk(faults={faults}): coverage [{}]; {} known-bug instance(s), 0 novel violations (+reopen durability gate)",
         cov.report(),
         reproduced.len()
     );

--- a/crates/omnigraph/tests/dst.rs
+++ b/crates/omnigraph/tests/dst.rs
@@ -18,8 +18,10 @@
 //! bug is fixed: RC-X → Lance #7230 (Lance v8.0.0); RC-1 → stale-view manifest
 //! CAS on delete op-class combos; dup-@key → MR-714.
 
+use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 
+use futures::FutureExt;
 use omnigraph::db::ReadTarget;
 use omnigraph::loader::{LoadMode, load_jsonl};
 use omnigraph_compiler::ir::ParamMap;
@@ -247,7 +249,7 @@ async fn seeded_op_loop_with_cas_faults() {
 async fn run_walk(faults: bool) {
     let mut cov = Coverage::new();
     let mut reproduced: Vec<String> = Vec::new();
-    for seed in 0..2u64 {
+    for seed in 0..4u64 {
         let dir = tempfile::tempdir().unwrap();
         let uri = dir.path().to_str().unwrap();
         let db = if faults {
@@ -258,8 +260,29 @@ async fn run_walk(faults: bool) {
         let mut rng = Rng::new(seed);
         let mut model = Model::new();
 
-        'walk: for step_i in 0..15 {
-            let (kind, res) = op::step(&db, &mut rng, &mut model).await;
+        'walk: for step_i in 0..25 {
+            // A fault-injection / depth DST harness must treat a substrate PANIC
+            // (a Lance `unwrap`/index crash unwinding through the engine) as a
+            // finding, not a suite abort — so the op and the battery run under
+            // catch_unwind, and a known crash signature is classified like any
+            // other known bug (record + break); a novel panic re-raises.
+            let stepped = AssertUnwindSafe(op::step(&db, &mut rng, &mut model))
+                .catch_unwind()
+                .await;
+            let (kind, res) = match stepped {
+                Ok(kr) => kr,
+                Err(p) => {
+                    let msg = invariants::panic_message(&*p);
+                    match invariants::classify_panic(&msg) {
+                        Some(bug) => {
+                            cov.finding(bug);
+                            reproduced.push(format!("seed={seed} step={step_i} PANIC -> {bug}"));
+                            break 'walk;
+                        }
+                        None => panic!("seed={seed} step={step_i}: NOVEL panic: {msg}"),
+                    }
+                }
+            };
             cov.op(kind);
             if let Err(e) = res {
                 let f = Finding::Engine(e);
@@ -275,7 +298,21 @@ async fn run_walk(faults: bool) {
                     None => panic!("seed={seed} step={step_i}: NOVEL op error: {}", f.message()),
                 }
             }
-            for (name, res) in run_battery(&db, &model).await {
+            let battery = match AssertUnwindSafe(run_battery(&db, &model)).catch_unwind().await {
+                Ok(b) => b,
+                Err(p) => {
+                    let msg = invariants::panic_message(&*p);
+                    match invariants::classify_panic(&msg) {
+                        Some(bug) => {
+                            cov.finding(bug);
+                            reproduced.push(format!("seed={seed} step={step_i} battery PANIC -> {bug}"));
+                            break 'walk;
+                        }
+                        None => panic!("seed={seed} step={step_i}: NOVEL battery panic: {msg}"),
+                    }
+                }
+            };
+            for (name, res) in battery {
                 cov.invariant(name);
                 if let Err(f) = res {
                     match classify(&f) {
@@ -325,3 +362,4 @@ async fn run_walk(faults: bool) {
         eprintln!("  - {r}");
     }
 }
+

--- a/crates/omnigraph/tests/dst/backend.rs
+++ b/crates/omnigraph/tests/dst/backend.rs
@@ -11,6 +11,13 @@ pub async fn open_clean(uri: &str) -> Omnigraph {
     Omnigraph::init(uri, SCHEMA).await.expect("init")
 }
 
+/// Reopen an EXISTING graph from its bytes on disk (runs the open-time recovery
+/// sweep in read-write mode). Backs the reopen==pre_state durability oracle: a
+/// fresh handle must agree with the model the walk built.
+pub async fn reopen(uri: &str) -> Omnigraph {
+    Omnigraph::open(uri).await.expect("reopen")
+}
+
 /// A graph whose storage injects seeded manifest-layer faults (CAS-lost). The
 /// graph + schema are created cleanly first, then reopened through the
 /// `FaultAdapter` so only the op workload runs under faults.

--- a/crates/omnigraph/tests/dst/coverage.rs
+++ b/crates/omnigraph/tests/dst/coverage.rs
@@ -28,7 +28,7 @@ impl Coverage {
     }
     pub fn report(&self) -> String {
         format!(
-            "ops {}/{}, invariants {}/4, known-bugs exercised {}",
+            "ops {}/{}, invariants {}/5, known-bugs exercised {}",
             self.ops.len(),
             OpKind::ALL.len(),
             self.invariants.len(),

--- a/crates/omnigraph/tests/dst/coverage.rs
+++ b/crates/omnigraph/tests/dst/coverage.rs
@@ -28,7 +28,7 @@ impl Coverage {
     }
     pub fn report(&self) -> String {
         format!(
-            "ops {}/{}, invariants {}/5, known-bugs exercised {}",
+            "ops {}/{}, invariants {}/6, known-bugs exercised {}",
             self.ops.len(),
             OpKind::ALL.len(),
             self.invariants.len(),

--- a/crates/omnigraph/tests/dst/coverage.rs
+++ b/crates/omnigraph/tests/dst/coverage.rs
@@ -28,7 +28,7 @@ impl Coverage {
     }
     pub fn report(&self) -> String {
         format!(
-            "ops {}/{}, invariants {}/6, known-bugs exercised {}",
+            "ops {}/{}, invariants {}/7, known-bugs exercised {}",
             self.ops.len(),
             OpKind::ALL.len(),
             self.invariants.len(),

--- a/crates/omnigraph/tests/dst/invariants.rs
+++ b/crates/omnigraph/tests/dst/invariants.rs
@@ -11,8 +11,10 @@
 //!     always a real finding (the named regressions cover the known concurrency
 //!     cases separately).
 
-use lance_table::format::RowIdMeta;
-use lance_table::rowids::read_row_ids;
+use std::collections::HashSet;
+
+use arrow_array::{RecordBatch, UInt64Array};
+use futures::TryStreamExt;
 use omnigraph::db::{Omnigraph, ReadTarget};
 use omnigraph::error::OmniError;
 use omnigraph_compiler::ir::ParamMap;
@@ -39,10 +41,15 @@ pub fn classify(f: &Finding) -> Option<&'static str> {
     match f {
         Finding::Engine(e) => {
             let s = e.to_string();
-            // RC-1: stale-view manifest CAS — gated on the Manifest variant so a
-            // coincidental substring in another subsystem cannot mask it.
+            // RC-1: edge-table HEAD/manifest drift from the node-delete cascade.
+            // Gated on the Manifest variant so a coincidental substring elsewhere
+            // can't mask it. Two surfaces of the same root: the write-time CAS
+            // "stale view", and a LATER write's precondition refusing the
+            // uncovered drift ("ahead of manifest ... run omnigraph repair").
             if matches!(e, OmniError::Manifest(_))
-                && (s.contains("stale view") || (s.contains("expected") && s.contains("current")))
+                && (s.contains("stale view")
+                    || (s.contains("expected") && s.contains("current"))
+                    || s.contains("ahead of manifest version"))
             {
                 return Some("RC-1 stale-view");
             }
@@ -56,6 +63,36 @@ pub fn classify(f: &Finding) -> Option<&'static str> {
         // Structural divergences are never allow-listed.
         Finding::Logical(_) => None,
     }
+}
+
+/// Extract a readable message from a caught panic payload.
+pub fn panic_message(p: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = p.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = p.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "<non-string panic payload>".to_string()
+    }
+}
+
+/// Classify a caught panic (a Lance-internal `unwrap`/index crash that unwinds
+/// through the engine) the same KNOWN-vs-NOVEL way as `classify`. Under fault
+/// injection and at walk depth the substrate WILL crash, so the harness must
+/// treat a panic as a finding, not let it abort the suite. NONE → re-raise.
+///
+/// Note on `index out of bounds`: in THIS harness the only source of that panic
+/// is Lance's inverted (FTS) index builder — the harness's own code uses checked
+/// loops and returns `Logical` findings, never an OOB panic — so the broad match
+/// is safe here and would not mask a harness bug.
+pub fn classify_panic(msg: &str) -> Option<&'static str> {
+    if msg.contains("from_sorted_iter") || msg.contains("non-sorted input") {
+        return Some("RC-X/#7230 scalar-BTREE");
+    }
+    if msg.contains("index out of bounds") {
+        return Some("Lance FTS inverted-builder OOB");
+    }
+    None
 }
 
 // ── INVARIANT #1: Lance HEAD == manifest table version, per table ──
@@ -94,48 +131,49 @@ pub async fn dataset_validate(db: &Omnigraph) -> Result<(), Finding> {
     Ok(())
 }
 
-// ── INVARIANT #3a: no overlapping stable row-id ranges across fragments ──
-// A structural integrity check decoded from each fragment's `row_id_meta`
-// (`RowIdMeta::Inline` → `read_row_ids` → `row_id_range`): in a stable-row-id
-// dataset every fragment owns a DISJOINT range of stable row ids, so any two
-// fragments whose `[start..=end]` ranges intersect is corruption — a double-
-// allocated / re-used row-id range. Unlike `index_probe` (which only surfaces a
-// bad scalar-BTREE page when a filtered READ loads it), this fires the moment
-// the bad fragment metadata is committed, before any read. Reaches Lance only
-// through public surfaces: `Snapshot::open → Dataset::fragments()` +
-// `lance_table::rowids::read_row_ids`. `RowIdMeta::External` and `None` (legacy
-// assign-by-position) fragments carry no inline range and are skipped.
-pub async fn no_overlapping_row_ids(db: &Omnigraph) -> Result<(), Finding> {
+// ── INVARIANT #3a: no duplicate LIVE stable row-id within a table ──
+// A stable row id uniquely identifies one live row for the dataset's lifetime;
+// the same id appearing on two live rows is exactly the duplicate-row-address
+// corruption class behind RC-X / Lance #7230. We read the truth deletion-vector-
+// correctly by scanning each table with `with_row_id()` (Lance's `_rowid`
+// projection returns only LIVE rows, so a tombstoned id masked by an UPDATE or
+// compaction never counts) and asserting the live `_rowid`s are unique. Unlike
+// `index_probe` (which only surfaces a bad scalar-BTREE page when a filtered
+// READ loads it), this is a direct structural check on every committed row.
+//
+// (An earlier version compared raw `row_id_meta` fragment ranges, but those
+// ranges include tombstoned ids — after an UPDATE+compaction an old fragment's
+// range legitimately overlaps the new fragment's, so that check false-positived.
+// Scanning live `_rowid`s is the deletion-vector-aware form.)
+pub async fn no_duplicate_live_row_ids(db: &Omnigraph) -> Result<(), Finding> {
     let snap = db
         .snapshot_of(ReadTarget::branch("main"))
         .await
         .map_err(Finding::Engine)?;
     for entry in snap.entries() {
         let ds = snap.open(&entry.table_key).await.map_err(Finding::Engine)?;
-        // (frag_id, start, end) for every fragment carrying an inline row-id range.
-        let mut ranges: Vec<(u64, u64, u64)> = Vec::new();
-        for frag in ds.fragments().iter() {
-            if let Some(RowIdMeta::Inline(bytes)) = &frag.row_id_meta {
-                let seq = read_row_ids(bytes).map_err(|e| {
-                    Finding::Logical(format!(
-                        "row_id_meta decode failed on {} frag {}: {e}",
-                        entry.table_key, frag.id
-                    ))
-                })?;
-                if let Some(r) = seq.row_id_range() {
-                    ranges.push((frag.id, *r.start(), *r.end()));
-                }
-            }
-        }
-        // Fragment counts per table are small; an O(n²) pairwise scan is fine and
-        // reports the exact colliding pair.
-        for i in 0..ranges.len() {
-            for j in (i + 1)..ranges.len() {
-                let (ai, a0, a1) = ranges[i];
-                let (bj, b0, b1) = ranges[j];
-                if a0 <= b1 && b0 <= a1 {
+        let mut scanner = ds.scan();
+        scanner.with_row_id();
+        let batches: Vec<RecordBatch> = scanner
+            .try_into_stream()
+            .await
+            .map_err(|e| Finding::Logical(format!("scan {}: {e}", entry.table_key)))?
+            .try_collect()
+            .await
+            .map_err(|e| Finding::Logical(format!("scan collect {}: {e}", entry.table_key)))?;
+        let mut seen: HashSet<u64> = HashSet::new();
+        for batch in &batches {
+            let col = batch
+                .column_by_name("_rowid")
+                .ok_or_else(|| Finding::Logical(format!("no _rowid column on {}", entry.table_key)))?
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .ok_or_else(|| Finding::Logical(format!("_rowid not u64 on {}", entry.table_key)))?;
+            for i in 0..col.len() {
+                let id = col.value(i);
+                if !seen.insert(id) {
                     return Err(Finding::Logical(format!(
-                        "overlapping stable row-id ranges on {}: frag {ai} [{a0}..={a1}] ∩ frag {bj} [{b0}..={b1}]",
+                        "duplicate live stable row-id {id} in {} (RC-X-class duplicate row address)",
                         entry.table_key
                     )));
                 }
@@ -163,7 +201,7 @@ pub async fn run_battery(db: &Omnigraph, model: &crate::model::Model) -> Vec<(&'
     vec![
         ("head==manifest", head_eq_manifest(db).await),
         ("dataset.validate", dataset_validate(db).await),
-        ("row-id-disjoint", no_overlapping_row_ids(db).await),
+        ("row-id-unique", no_duplicate_live_row_ids(db).await),
         ("index-probe", index_probe(db).await),
         ("count==model", crate::model::check_counts(db, model).await),
         ("content==model", crate::model::check_content(db, model).await),

--- a/crates/omnigraph/tests/dst/invariants.rs
+++ b/crates/omnigraph/tests/dst/invariants.rs
@@ -167,5 +167,6 @@ pub async fn run_battery(db: &Omnigraph, model: &crate::model::Model) -> Vec<(&'
         ("index-probe", index_probe(db).await),
         ("count==model", crate::model::check_counts(db, model).await),
         ("content==model", crate::model::check_content(db, model).await),
+        ("edges==model", crate::model::check_edges(db, model).await),
     ]
 }

--- a/crates/omnigraph/tests/dst/invariants.rs
+++ b/crates/omnigraph/tests/dst/invariants.rs
@@ -11,6 +11,8 @@
 //!     always a real finding (the named regressions cover the known concurrency
 //!     cases separately).
 
+use lance_table::format::RowIdMeta;
+use lance_table::rowids::read_row_ids;
 use omnigraph::db::{Omnigraph, ReadTarget};
 use omnigraph::error::OmniError;
 use omnigraph_compiler::ir::ParamMap;
@@ -92,6 +94,57 @@ pub async fn dataset_validate(db: &Omnigraph) -> Result<(), Finding> {
     Ok(())
 }
 
+// ── INVARIANT #3a: no overlapping stable row-id ranges across fragments ──
+// A structural integrity check decoded from each fragment's `row_id_meta`
+// (`RowIdMeta::Inline` → `read_row_ids` → `row_id_range`): in a stable-row-id
+// dataset every fragment owns a DISJOINT range of stable row ids, so any two
+// fragments whose `[start..=end]` ranges intersect is corruption — a double-
+// allocated / re-used row-id range. Unlike `index_probe` (which only surfaces a
+// bad scalar-BTREE page when a filtered READ loads it), this fires the moment
+// the bad fragment metadata is committed, before any read. Reaches Lance only
+// through public surfaces: `Snapshot::open → Dataset::fragments()` +
+// `lance_table::rowids::read_row_ids`. `RowIdMeta::External` and `None` (legacy
+// assign-by-position) fragments carry no inline range and are skipped.
+pub async fn no_overlapping_row_ids(db: &Omnigraph) -> Result<(), Finding> {
+    let snap = db
+        .snapshot_of(ReadTarget::branch("main"))
+        .await
+        .map_err(Finding::Engine)?;
+    for entry in snap.entries() {
+        let ds = snap.open(&entry.table_key).await.map_err(Finding::Engine)?;
+        // (frag_id, start, end) for every fragment carrying an inline row-id range.
+        let mut ranges: Vec<(u64, u64, u64)> = Vec::new();
+        for frag in ds.fragments().iter() {
+            if let Some(RowIdMeta::Inline(bytes)) = &frag.row_id_meta {
+                let seq = read_row_ids(bytes).map_err(|e| {
+                    Finding::Logical(format!(
+                        "row_id_meta decode failed on {} frag {}: {e}",
+                        entry.table_key, frag.id
+                    ))
+                })?;
+                if let Some(r) = seq.row_id_range() {
+                    ranges.push((frag.id, *r.start(), *r.end()));
+                }
+            }
+        }
+        // Fragment counts per table are small; an O(n²) pairwise scan is fine and
+        // reports the exact colliding pair.
+        for i in 0..ranges.len() {
+            for j in (i + 1)..ranges.len() {
+                let (ai, a0, a1) = ranges[i];
+                let (bj, b0, b1) = ranges[j];
+                if a0 <= b1 && b0 <= a1 {
+                    return Err(Finding::Logical(format!(
+                        "overlapping stable row-id ranges on {}: frag {ai} [{a0}..={a1}] ∩ frag {bj} [{b0}..={b1}]",
+                        entry.table_key
+                    )));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 // ── INVARIANT #3: scalar-index probe (catches RC-X at creation) ──
 // Force-loads the Doc.source BTREE flat pages by filtering each enum value.
 pub async fn index_probe(db: &Omnigraph) -> Result<(), Finding> {
@@ -110,6 +163,7 @@ pub async fn run_battery(db: &Omnigraph, model: &crate::model::Model) -> Vec<(&'
     vec![
         ("head==manifest", head_eq_manifest(db).await),
         ("dataset.validate", dataset_validate(db).await),
+        ("row-id-disjoint", no_overlapping_row_ids(db).await),
         ("index-probe", index_probe(db).await),
         ("count==model", crate::model::check_counts(db, model).await),
     ]

--- a/crates/omnigraph/tests/dst/invariants.rs
+++ b/crates/omnigraph/tests/dst/invariants.rs
@@ -166,5 +166,6 @@ pub async fn run_battery(db: &Omnigraph, model: &crate::model::Model) -> Vec<(&'
         ("row-id-disjoint", no_overlapping_row_ids(db).await),
         ("index-probe", index_probe(db).await),
         ("count==model", crate::model::check_counts(db, model).await),
+        ("content==model", crate::model::check_content(db, model).await),
     ]
 }

--- a/crates/omnigraph/tests/dst/invariants.rs
+++ b/crates/omnigraph/tests/dst/invariants.rs
@@ -19,6 +19,7 @@ use omnigraph::db::{Omnigraph, ReadTarget};
 use omnigraph::error::OmniError;
 use omnigraph_compiler::ir::ParamMap;
 
+#[derive(Debug)]
 pub enum Finding {
     /// An engine-returned error (variant preserved for structured classification).
     Engine(OmniError),

--- a/crates/omnigraph/tests/dst/invariants.rs
+++ b/crates/omnigraph/tests/dst/invariants.rs
@@ -60,8 +60,16 @@ pub fn classify(f: &Finding) -> Option<&'static str> {
             }
             None
         }
-        // Structural divergences are never allow-listed.
-        Finding::Logical(_) => None,
+        // Structural divergences are novel by default, with ONE narrow
+        // exception: dup-`@key` (MR-714) is a known open bug, so a finding whose
+        // message carries the `dup-@key` marker is allow-listed like the engine
+        // known-bugs above. Every other structural divergence stays novel.
+        Finding::Logical(s) => {
+            if s.contains("dup-@key") {
+                return Some("dup-@key MR-714");
+            }
+            None
+        }
     }
 }
 
@@ -191,6 +199,36 @@ pub async fn index_probe(db: &Omnigraph) -> Result<(), Finding> {
         db.query(ReadTarget::branch("main"), &q, "w", &ParamMap::new())
             .await
             .map_err(Finding::Engine)?;
+    }
+    Ok(())
+}
+
+// ── @key uniqueness (no sequential model — for the concurrent oracle) ──
+// Every `@key` value may appear on at most one live row. Concurrent same-key
+// upserts that produce duplicates are MR-714 (dup-`@key`); `classify` allow-
+// lists the `dup-@key` marker as that known bug.
+pub async fn no_duplicate_keys(db: &Omnigraph, ty: &str, branch: &str) -> Result<(), Finding> {
+    let q = format!("query q() {{ match {{ $x: {ty} }} return {{ $x.slug }} }}");
+    let res = db
+        .query(ReadTarget::branch(branch), &q, "q", &ParamMap::new())
+        .await
+        .map_err(Finding::Engine)?;
+    let json = res.to_rust_json();
+    let rows = json
+        .as_array()
+        .ok_or_else(|| Finding::Logical(format!("{ty} key scan not an array")))?;
+    let total = rows.len();
+    let mut seen: HashSet<String> = HashSet::new();
+    for row in rows {
+        let slug = row["x.slug"]
+            .as_str()
+            .ok_or_else(|| Finding::Logical(format!("missing x.slug in {ty}")))?;
+        if !seen.insert(slug.to_string()) {
+            return Err(Finding::Logical(format!(
+                "duplicate @key {slug:?} in {ty} ({total} rows, {} distinct) — dup-@key",
+                seen.len()
+            )));
+        }
     }
     Ok(())
 }

--- a/crates/omnigraph/tests/dst/model.rs
+++ b/crates/omnigraph/tests/dst/model.rs
@@ -6,7 +6,7 @@
 //! A divergence means a lost write (count<model) or a duplicate key
 //! (count>model) — both real bugs.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use omnigraph::db::{Omnigraph, ReadTarget};
 use omnigraph_compiler::ir::ParamMap;
@@ -17,6 +17,9 @@ use crate::invariants::Finding;
 pub struct Model {
     persons: HashSet<usize>,
     docs: HashSet<usize>,
+    /// Expected `body` value per live Doc id — the source of truth for the
+    /// content==model oracle (a lost UPDATE shows up here even when counts match).
+    doc_body: HashMap<usize, String>,
     next: usize,
 }
 
@@ -37,8 +40,16 @@ impl Model {
     pub fn add_person(&mut self, id: usize) {
         self.persons.insert(id);
     }
-    pub fn add_doc(&mut self, id: usize) {
+    pub fn add_doc(&mut self, id: usize, body: String) {
         self.docs.insert(id);
+        self.doc_body.insert(id, body);
+    }
+    /// Record an UPDATE's new body — only for a Doc the model believes exists,
+    /// so a no-op update (0 rows matched) doesn't desync the model.
+    pub fn update_doc_body(&mut self, id: usize, body: String) {
+        if self.docs.contains(&id) {
+            self.doc_body.insert(id, body);
+        }
     }
     pub fn del_person(&mut self, id: usize) {
         self.persons.remove(&id);
@@ -48,6 +59,9 @@ impl Model {
     }
     pub fn docs(&self) -> usize {
         self.docs.len()
+    }
+    pub fn doc_bodies(&self) -> &HashMap<usize, String> {
+        &self.doc_body
     }
 }
 
@@ -76,6 +90,63 @@ pub async fn check_counts(db: &Omnigraph, model: &Model) -> Result<(), Finding> 
             "count Doc={d} != model={}",
             model.docs()
         )));
+    }
+    Ok(())
+}
+
+/// content==model: every live Doc's `body` must equal the model's expected
+/// value, and no `@key` may appear twice. A count check passes through a
+/// lost UPDATE (the row is still there, just stale) or a silent dup-`@key`
+/// (a value-level duplicate the row count would only catch if it changed the
+/// total) — this is the oracle that catches both. Slugs are `g{id}`.
+pub async fn check_content(db: &Omnigraph, model: &Model) -> Result<(), Finding> {
+    let res = db
+        .query(
+            ReadTarget::branch("main"),
+            "query c() { match { $d: Doc } return { $d.slug, $d.body } }",
+            "c",
+            &ParamMap::new(),
+        )
+        .await
+        .map_err(Finding::Engine)?;
+    let json = res.to_rust_json();
+    let rows = json
+        .as_array()
+        .ok_or_else(|| Finding::Logical("Doc content query did not return an array".into()))?;
+
+    let mut seen: HashMap<usize, String> = HashMap::new();
+    for row in rows {
+        let slug = row["d.slug"]
+            .as_str()
+            .ok_or_else(|| Finding::Logical(format!("missing d.slug in {row}")))?;
+        let body = row["d.body"]
+            .as_str()
+            .ok_or_else(|| Finding::Logical(format!("missing d.body in {row}")))?;
+        let id: usize = slug
+            .strip_prefix('g')
+            .and_then(|s| s.parse().ok())
+            .ok_or_else(|| Finding::Logical(format!("unexpected Doc slug {slug}")))?;
+        if let Some(prev) = seen.insert(id, body.to_string()) {
+            return Err(Finding::Logical(format!(
+                "duplicate Doc @key g{id} (dup-@key): {prev:?} and {body:?}"
+            )));
+        }
+    }
+
+    for (id, expected) in model.doc_bodies() {
+        match seen.get(id) {
+            None => {
+                return Err(Finding::Logical(format!(
+                    "Doc g{id} missing from engine (model body {expected:?})"
+                )));
+            }
+            Some(actual) if actual != expected => {
+                return Err(Finding::Logical(format!(
+                    "Doc g{id} body mismatch: engine {actual:?} != model {expected:?} (lost update)"
+                )));
+            }
+            _ => {}
+        }
     }
     Ok(())
 }

--- a/crates/omnigraph/tests/dst/model.rs
+++ b/crates/omnigraph/tests/dst/model.rs
@@ -20,6 +20,11 @@ pub struct Model {
     /// Expected `body` value per live Doc id — the source of truth for the
     /// content==model oracle (a lost UPDATE shows up here even when counts match).
     doc_body: HashMap<usize, String>,
+    /// Live `Knows` edges as `from -> to` (the map enforces the schema's
+    /// `@card(0..1)`: a `from` has at most one outgoing edge). Every endpoint is
+    /// a live Person by construction — `del_person` cascades both directions, so
+    /// the model never holds an orphan and the engine producing one is a finding.
+    knows: HashMap<usize, usize>,
     next: usize,
 }
 
@@ -53,6 +58,10 @@ impl Model {
     }
     pub fn del_person(&mut self, id: usize) {
         self.persons.remove(&id);
+        // Node delete cascades to incident edges, BOTH directions — mirror it so
+        // the model never references a deleted Person (this is the RC-1 surface).
+        self.knows.remove(&id);
+        self.knows.retain(|_, &mut to| to != id);
     }
     pub fn persons(&self) -> usize {
         self.persons.len()
@@ -62,6 +71,38 @@ impl Model {
     }
     pub fn doc_bodies(&self) -> &HashMap<usize, String> {
         &self.doc_body
+    }
+
+    // ── edges ──
+    /// Live person ids (for picking an edge endpoint).
+    pub fn persons_vec(&self) -> Vec<usize> {
+        self.persons.iter().copied().collect()
+    }
+    /// Persons with no outgoing `Knows` — the only legal `from` for a new edge
+    /// under `@card(0..1)`, so every generated InsertKnows is a valid op.
+    pub fn free_froms(&self) -> Vec<usize> {
+        self.persons
+            .iter()
+            .copied()
+            .filter(|p| !self.knows.contains_key(p))
+            .collect()
+    }
+    /// Persons that currently have an outgoing edge (legal DeleteKnows targets).
+    pub fn knows_froms(&self) -> Vec<usize> {
+        self.knows.keys().copied().collect()
+    }
+    pub fn add_edge(&mut self, from: usize, to: usize) {
+        self.knows.insert(from, to);
+    }
+    pub fn del_edge(&mut self, from: usize) {
+        self.knows.remove(&from);
+    }
+    pub fn edges(&self) -> usize {
+        self.knows.len()
+    }
+    /// Debug-only: the live edges as (from,to) pairs.
+    pub fn knows_pairs(&self) -> Vec<(usize, usize)> {
+        self.knows.iter().map(|(&f, &t)| (f, t)).collect()
     }
 }
 
@@ -147,6 +188,52 @@ pub async fn check_content(db: &Omnigraph, model: &Model) -> Result<(), Finding>
             }
             _ => {}
         }
+    }
+    Ok(())
+}
+
+/// edges==model (referential integrity): two complementary counts must both
+/// equal the model's live-edge count. The RAW `edge:Knows` row count (read
+/// white-box via the snapshot, so it sees orphans too) catches a lost
+/// node-delete cascade that strands an edge pointing at a deleted Person; the
+/// TRAVERSAL count (`$a knows $b`, which only matches live endpoints) catches a
+/// lost edge write. Raw > traversal means an orphan exists.
+pub async fn check_edges(db: &Omnigraph, model: &Model) -> Result<(), Finding> {
+    let snap = db
+        .snapshot_of(ReadTarget::branch("main"))
+        .await
+        .map_err(Finding::Engine)?;
+    let mut raw: usize = 0;
+    for entry in snap.entries() {
+        if entry.table_key == "edge:Knows" {
+            let ds = snap.open(&entry.table_key).await.map_err(Finding::Engine)?;
+            raw = ds
+                .count_rows(None)
+                .await
+                .map_err(|e| Finding::Logical(format!("edge:Knows count_rows: {e}")))?;
+        }
+    }
+    if raw != model.edges() {
+        return Err(Finding::Logical(format!(
+            "raw edge:Knows rows={raw} != model={} (orphan edge / lost cascade / dup edge)",
+            model.edges()
+        )));
+    }
+    let res = db
+        .query(
+            ReadTarget::branch("main"),
+            "query e() { match { $a: Person $a knows $b } return { $a.slug, $b.slug } }",
+            "e",
+            &ParamMap::new(),
+        )
+        .await
+        .map_err(Finding::Engine)?;
+    if res.num_rows() != model.edges() {
+        return Err(Finding::Logical(format!(
+            "traversable Knows edges={} != model={} (orphan endpoint / lost edge)",
+            res.num_rows(),
+            model.edges()
+        )));
     }
     Ok(())
 }

--- a/crates/omnigraph/tests/dst/model.rs
+++ b/crates/omnigraph/tests/dst/model.rs
@@ -100,10 +100,6 @@ impl Model {
     pub fn edges(&self) -> usize {
         self.knows.len()
     }
-    /// Debug-only: the live edges as (from,to) pairs.
-    pub fn knows_pairs(&self) -> Vec<(usize, usize)> {
-        self.knows.iter().map(|(&f, &t)| (f, t)).collect()
-    }
 }
 
 async fn count(db: &Omnigraph, ty: &str) -> Result<usize, Finding> {

--- a/crates/omnigraph/tests/dst/op.rs
+++ b/crates/omnigraph/tests/dst/op.rs
@@ -62,23 +62,27 @@ pub enum OpKind {
     Optimize,
     DeletePerson,
     UpdateDoc,
+    InsertKnows,
+    DeleteKnows,
     Read,
 }
 
 impl OpKind {
-    pub const ALL: [OpKind; 6] = [
+    pub const ALL: [OpKind; 8] = [
         OpKind::InsertPerson,
         OpKind::InsertDoc,
         OpKind::Optimize,
         OpKind::DeletePerson,
         OpKind::UpdateDoc,
+        OpKind::InsertKnows,
+        OpKind::DeleteKnows,
         OpKind::Read,
     ];
 }
 
 /// Pick and run one op. The model is updated only on success.
 pub async fn step(db: &Omnigraph, rng: &mut Rng, model: &mut Model) -> (OpKind, Result<(), OmniError>) {
-    match rng.below(6) {
+    match rng.below(8) {
         0 => {
             let mut ids = Vec::new();
             let mut data = String::new();
@@ -147,6 +151,57 @@ pub async fn step(db: &Omnigraph, rng: &mut Rng, model: &mut Model) -> (OpKind, 
                 Err(e) => Err(e),
             };
             (OpKind::UpdateDoc, res)
+        }
+        5 => {
+            // InsertKnows — pick a `from` with no outgoing edge (so the @card(0..1)
+            // insert is always legal) and any live `to`; both endpoints exist, so
+            // the engine producing an orphan/dup is a finding, not a generated one.
+            let froms = model.free_froms();
+            let persons = model.persons_vec();
+            if froms.is_empty() || persons.is_empty() {
+                // No legal edge to add yet — a no-op (still counts for coverage).
+                (OpKind::InsertKnows, Ok(()))
+            } else {
+                let from = froms[rng.below(froms.len())];
+                // Exclude self-loops: a Knows self-loop is committed to the edge
+                // table but is NOT returned by `$a knows $b` traversal (durable
+                // across optimize+reopen; the CSR build keeps it, so the drop is
+                // in Expand). That stored-but-not-traversable divergence is a real
+                // finding the harness surfaced — kept out of the generic generator
+                // so the edges==model oracle stays unambiguous; see B3 notes.
+                let others: Vec<usize> = persons.iter().copied().filter(|p| *p != from).collect();
+                if others.is_empty() {
+                    return (OpKind::InsertKnows, Ok(()));
+                }
+                let to = others[rng.below(others.len())];
+                let data = knows(&format!("g{from}"), &format!("g{to}"));
+                let res = match load_jsonl(db, &data, LoadMode::Merge).await {
+                    Ok(_) => {
+                        model.add_edge(from, to);
+                        Ok(())
+                    }
+                    Err(e) => Err(e),
+                };
+                (OpKind::InsertKnows, res)
+            }
+        }
+        6 => {
+            // DeleteKnows — remove an existing edge by its `from`.
+            let froms = model.knows_froms();
+            if froms.is_empty() {
+                (OpKind::DeleteKnows, Ok(()))
+            } else {
+                let from = froms[rng.below(froms.len())];
+                let q = format!("query dk() {{ delete Knows where from = \"g{from}\" }}");
+                let res = match db.mutate("main", &q, "dk", &ParamMap::new()).await {
+                    Ok(_) => {
+                        model.del_edge(from);
+                        Ok(())
+                    }
+                    Err(e) => Err(e),
+                };
+                (OpKind::DeleteKnows, res)
+            }
         }
         _ => (
             OpKind::Read,

--- a/crates/omnigraph/tests/dst/op.rs
+++ b/crates/omnigraph/tests/dst/op.rs
@@ -3,7 +3,7 @@
 //! `OpKind` (for coverage) and the raw `OmniError` (for structured
 //! classification — never stringified here).
 
-use omnigraph::db::{Omnigraph, ReadTarget};
+use omnigraph::db::{Omnigraph, ReadTarget, RepairOptions};
 use omnigraph::error::OmniError;
 use omnigraph::loader::{LoadMode, load_jsonl};
 use omnigraph_compiler::ir::ParamMap;
@@ -64,11 +64,12 @@ pub enum OpKind {
     UpdateDoc,
     InsertKnows,
     DeleteKnows,
+    Repair,
     Read,
 }
 
 impl OpKind {
-    pub const ALL: [OpKind; 8] = [
+    pub const ALL: [OpKind; 9] = [
         OpKind::InsertPerson,
         OpKind::InsertDoc,
         OpKind::Optimize,
@@ -76,13 +77,14 @@ impl OpKind {
         OpKind::UpdateDoc,
         OpKind::InsertKnows,
         OpKind::DeleteKnows,
+        OpKind::Repair,
         OpKind::Read,
     ];
 }
 
 /// Pick and run one op. The model is updated only on success.
 pub async fn step(db: &Omnigraph, rng: &mut Rng, model: &mut Model) -> (OpKind, Result<(), OmniError>) {
-    match rng.below(8) {
+    match rng.below(9) {
         0 => {
             let mut ids = Vec::new();
             let mut data = String::new();
@@ -202,6 +204,17 @@ pub async fn step(db: &Omnigraph, rng: &mut Rng, model: &mut Model) -> (OpKind, 
                 };
                 (OpKind::DeleteKnows, res)
             }
+        }
+        7 => {
+            // Repair in confirm (not force) mode — heals VERIFIED maintenance
+            // drift but leaves suspicious/semantic drift (e.g. RC-1's) for
+            // head_eq_manifest to still catch. A no-op on a clean graph; must
+            // never change logical data, so the model is untouched.
+            let opts = RepairOptions {
+                confirm: true,
+                force: false,
+            };
+            (OpKind::Repair, db.repair(opts).await.map(|_| ()))
         }
         _ => (
             OpKind::Read,

--- a/crates/omnigraph/tests/dst/op.rs
+++ b/crates/omnigraph/tests/dst/op.rs
@@ -109,8 +109,9 @@ pub async fn step(db: &Omnigraph, rng: &mut Rng, model: &mut Model) -> (OpKind, 
             }
             let res = match load_jsonl(db, &data, LoadMode::Merge).await {
                 Ok(_) => {
+                    // `doc()` writes body "needle filler" — track it for content==model.
                     for id in ids {
-                        model.add_doc(id);
+                        model.add_doc(id, "needle filler".to_string());
                     }
                     Ok(())
                 }
@@ -134,8 +135,18 @@ pub async fn step(db: &Omnigraph, rng: &mut Rng, model: &mut Model) -> (OpKind, 
         4 => {
             // UPDATE moves the whole row → scalar-index remap (RC-X morphology).
             let id = rng.below(model.id_high());
-            let q = format!("query u() {{ update Doc set {{ body: \"u{id} needle\" }} where slug = \"g{id}\" }}");
-            (OpKind::UpdateDoc, db.mutate("main", &q, "u", &ParamMap::new()).await.map(|_| ()))
+            let body = format!("u{id} needle");
+            let q = format!("query u() {{ update Doc set {{ body: \"{body}\" }} where slug = \"g{id}\" }}");
+            let res = match db.mutate("main", &q, "u", &ParamMap::new()).await {
+                Ok(_) => {
+                    // Only mutates the model for a Doc it believes exists, so a
+                    // no-op update (0 rows matched) can't desync content==model.
+                    model.update_doc_body(id, body);
+                    Ok(())
+                }
+                Err(e) => Err(e),
+            };
+            (OpKind::UpdateDoc, res)
         }
         _ => (
             OpKind::Read,

--- a/crates/omnigraph/tests/dst/readshape.rs
+++ b/crates/omnigraph/tests/dst/readshape.rs
@@ -1,0 +1,169 @@
+//! D3 × D2: the read-shape battery run against deliberately-built table
+//! morphologies. The oracle is primarily NO-CRASH — every query shape must
+//! execute without an engine error or panic across each latent layout (single
+//! fragment, ≥2 fragments, deletion vectors, compacted, on-branch) — plus exact
+//! count checks where the answer is morphology-invariant. This is the D2×D3
+//! cell sweep: a planner/execution regression that only bites a specific
+//! fragment layout shows up here, where the generic walk's main-branch oracles
+//! would miss it.
+//!
+//! Scope: the non-vector/non-FTS shapes (scan · @key · indexed · non-indexed ·
+//! range · order+limit · count · numeric aggregates · 1-hop · var-hop ·
+//! negation · zero-match). Vector (`nearest`) and FTS (`bm25`/`search`) shapes
+//! are deferred — they need vector data and the inverted index whose builder
+//! OOB-panics at depth (see `regression`-adjacent finding in dst.rs).
+
+use omnigraph::db::{Omnigraph, ReadTarget};
+use omnigraph::loader::{LoadMode, load_jsonl};
+use omnigraph_compiler::ir::ParamMap;
+
+/// Richer than the walk schema: `age: I64` unlocks range + numeric aggregates.
+pub const SCHEMA: &str = r#"
+node Person {
+    slug: String @key
+    name: String
+    age: I64
+}
+node Doc {
+    slug: String @key
+    source: enum(whatsapp, email, linkedin, slack, telegram) @index
+    body: String
+}
+edge Knows: Person -> Person @card(0..1)
+"#;
+
+fn person(slug: &str, age: i64) -> String {
+    format!("{{\"type\":\"Person\",\"data\":{{\"slug\":\"{slug}\",\"name\":\"n\",\"age\":{age}}}}}\n")
+}
+fn doc(slug: &str, source: &str) -> String {
+    format!("{{\"type\":\"Doc\",\"data\":{{\"slug\":\"{slug}\",\"source\":\"{source}\",\"body\":\"needle filler\"}}}}\n")
+}
+fn knows(from: &str, to: &str) -> String {
+    format!("{{\"edge\":\"Knows\",\"from\":\"{from}\",\"to\":\"{to}\",\"data\":{{}}}}\n")
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum Morph {
+    /// One load batch → one fragment.
+    Single,
+    /// Each row group in its own `Merge` batch → ≥2 fragments.
+    MultiFragment,
+    /// Multi-fragment, then a delete → deletion vectors over live rows.
+    WithDeletions,
+    /// Multi-fragment, then `optimize` → compacted + reindexed.
+    Optimized,
+}
+
+impl Morph {
+    pub const ALL: [Morph; 4] = [
+        Morph::Single,
+        Morph::MultiFragment,
+        Morph::WithDeletions,
+        Morph::Optimized,
+    ];
+}
+
+/// The base population (before morphology-specific shaping): 10 persons p0..p9
+/// with ages 0..9, a `knows` chain p0→p1→…→p8, and 10 docs cycling 4 of the 5
+/// enum sources (never `telegram`, so zero-match is deterministic).
+fn base_rows() -> (Vec<String>, Vec<String>) {
+    let sources = ["whatsapp", "email", "linkedin", "slack"];
+    let mut persons = Vec::new();
+    let mut docs = Vec::new();
+    for i in 0..10 {
+        persons.push(person(&format!("p{i}"), i as i64));
+        docs.push(doc(&format!("d{i}"), sources[i % 4]));
+    }
+    (persons, docs)
+}
+
+/// Build the requested morphology on a fresh graph; returns the live Person
+/// count after shaping (the only count the read battery asserts exactly).
+pub async fn build(db: &Omnigraph, morph: Morph) -> usize {
+    let (persons, docs) = base_rows();
+    match morph {
+        Morph::Single => {
+            let mut all = persons.concat();
+            all.push_str(&docs.concat());
+            for i in 0..9 {
+                all.push_str(&knows(&format!("p{i}"), &format!("p{}", i + 1)));
+            }
+            load_jsonl(db, &all, LoadMode::Merge).await.unwrap();
+            10
+        }
+        Morph::MultiFragment | Morph::Optimized => {
+            // Each person + its doc in its own batch → 10 fragments.
+            for i in 0..10 {
+                load_jsonl(db, &format!("{}{}", persons[i], docs[i]), LoadMode::Merge)
+                    .await
+                    .unwrap();
+            }
+            for i in 0..9 {
+                load_jsonl(db, &knows(&format!("p{i}"), &format!("p{}", i + 1)), LoadMode::Merge)
+                    .await
+                    .unwrap();
+            }
+            if matches!(morph, Morph::Optimized) {
+                db.optimize().await.unwrap();
+            }
+            10
+        }
+        Morph::WithDeletions => {
+            for i in 0..10 {
+                load_jsonl(db, &format!("{}{}", persons[i], docs[i]), LoadMode::Merge)
+                    .await
+                    .unwrap();
+            }
+            for i in 0..9 {
+                load_jsonl(db, &knows(&format!("p{i}"), &format!("p{}", i + 1)), LoadMode::Merge)
+                    .await
+                    .unwrap();
+            }
+            // Delete p0..p2 → deletion vectors + cascaded edges.
+            for i in 0..3 {
+                db.mutate(
+                    "main",
+                    &format!("query d() {{ delete Person where slug = \"p{i}\" }}"),
+                    "d",
+                    &ParamMap::new(),
+                )
+                .await
+                .unwrap();
+            }
+            7
+        }
+    }
+}
+
+/// Every read shape as `(name, query)`. Each must execute without an engine
+/// error against every morphology.
+pub fn shapes() -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("full-scan", "query q() { match { $p: Person } return { $p.slug } }"),
+        ("key-filter", "query q() { match { $p: Person { slug: \"p5\" } } return { $p.slug } }"),
+        ("indexed-filter", "query q() { match { $d: Doc { source: \"whatsapp\" } } return { $d.slug } }"),
+        ("nonindexed-filter", "query q() { match { $p: Person $p.age >= 5 } return { $p.slug } }"),
+        ("range", "query q() { match { $p: Person $p.age >= 3 $p.age <= 6 } return { $p.slug } }"),
+        ("order-limit", "query q() { match { $p: Person } return { $p.slug, $p.age } order { $p.age desc } limit 3 }"),
+        ("count", "query q() { match { $p: Person } return { count($p) as n } }"),
+        ("aggregate", "query q() { match { $p: Person } return { sum($p.age) as s, avg($p.age) as a, min($p.age) as mn, max($p.age) as mx } }"),
+        ("traversal-1hop", "query q() { match { $a: Person $a knows $b } return { $a.slug, $b.slug } }"),
+        ("var-hop", "query q() { match { $a: Person { slug: \"p3\" } $a knows{1,3} $b } return { $b.slug } }"),
+        ("negation", "query q() { match { $p: Person not { $p knows $_ } } return { $p.slug } }"),
+        ("zero-match", "query q() { match { $d: Doc { source: \"telegram\" } } return { $d.slug } }"),
+    ]
+}
+
+/// Run the whole battery against `branch`; returns `(shape, Result<rows,error>)`.
+pub async fn run(db: &Omnigraph, branch: &str) -> Vec<(&'static str, Result<usize, String>)> {
+    let mut out = Vec::new();
+    for (name, q) in shapes() {
+        let r = db
+            .query(ReadTarget::branch(branch), q, "q", &ParamMap::new())
+            .await
+            .map(|res| res.num_rows())
+            .map_err(|e| e.to_string());
+        out.push((name, r));
+    }
+    out
+}

--- a/crates/omnigraph/tests/dst/statemachine.rs
+++ b/crates/omnigraph/tests/dst/statemachine.rs
@@ -1,0 +1,229 @@
+//! B5: proptest-state-machine campaign with automatic SHRINKING + regression
+//! persistence, over the CLEAN op subset.
+//!
+//! proptest-state-machine fails and minimizes on ANY reference↔SUT divergence,
+//! so it runs over the ops that have no known open bug — insert-person,
+//! insert-doc, update-doc, read (no delete/optimize/edge/concurrency, which
+//! trigger RC-1 / RC-X / FTS-OOB / dup-`@key`). Over that subset reference and
+//! engine must agree exactly; a regression that breaks a clean op auto-minimizes
+//! to the shortest failing op sequence and persists its seed under
+//! `proptest-regressions/`. The generative walk + the named regressions cover
+//! the buggy ops; this layer adds the shrinking machinery.
+//!
+//! The async engine is bridged the canonical sync way (`proptest_equivalence.rs`
+//! pattern): the SUT owns a current-thread `Runtime` and every engine call is a
+//! `rt.block_on(...)` — the whole campaign is a plain `#[test]`, no ambient
+//! runtime, so `block_on` is legal.
+
+use std::collections::BTreeMap;
+
+use proptest::prelude::*;
+use proptest::strategy::Union;
+use proptest::test_runner::Config;
+use proptest_state_machine::{ReferenceStateMachine, StateMachineTest};
+use tokio::runtime::Runtime;
+
+use omnigraph::db::{Omnigraph, ReadTarget};
+use omnigraph::loader::{LoadMode, load_jsonl};
+use omnigraph_compiler::ir::ParamMap;
+
+use crate::backend;
+use crate::op::{doc, person};
+
+/// The reference model (also the state-machine `State`): the keys that must
+/// exist and each Doc's expected body. `BTreeMap`/`u32` keep `Debug` output
+/// stable, which keeps shrink reports deterministic.
+#[derive(Clone, Debug, Default)]
+pub struct RefModel {
+    persons: BTreeMap<u32, ()>,
+    docs: BTreeMap<u32, String>,
+    next: u32,
+}
+
+/// The clean transitions. Ids are explicit so the reference is a pure function.
+#[derive(Clone, Debug)]
+pub enum Tr {
+    InsertPerson(u32),
+    InsertDoc(u32),
+    /// (existing doc id, tag) → body `u{id}-{tag}`.
+    UpdateDoc(u32, u32),
+    Read,
+}
+
+impl ReferenceStateMachine for RefModel {
+    type State = RefModel;
+    type Transition = Tr;
+
+    fn init_state() -> BoxedStrategy<RefModel> {
+        Just(RefModel::default()).boxed()
+    }
+
+    fn transitions(state: &RefModel) -> BoxedStrategy<Tr> {
+        let next = state.next;
+        let mut options: Vec<BoxedStrategy<Tr>> = vec![
+            Just(Tr::InsertPerson(next)).boxed(),
+            Just(Tr::InsertDoc(next)).boxed(),
+            Just(Tr::Read).boxed(),
+        ];
+        if !state.docs.is_empty() {
+            let ids: Vec<u32> = state.docs.keys().copied().collect();
+            options.push(
+                (proptest::sample::select(ids), any::<u16>())
+                    .prop_map(|(id, tag)| Tr::UpdateDoc(id, tag as u32))
+                    .boxed(),
+            );
+        }
+        Union::new(options).boxed()
+    }
+
+    fn apply(mut state: RefModel, transition: &Tr) -> RefModel {
+        match transition {
+            Tr::InsertPerson(id) => {
+                state.persons.insert(*id, ());
+                state.next = state.next.max(id + 1);
+            }
+            Tr::InsertDoc(id) => {
+                state.docs.insert(*id, "needle filler".to_string());
+                state.next = state.next.max(id + 1);
+            }
+            Tr::UpdateDoc(id, tag) => {
+                // Mirror engine no-op semantics: only an existing doc changes.
+                if state.docs.contains_key(id) {
+                    state.docs.insert(*id, format!("u{id}-{tag}"));
+                }
+            }
+            Tr::Read => {}
+        }
+        state
+    }
+}
+
+/// The system under test: a real graph plus the runtime that drives it.
+pub struct Sut {
+    rt: Runtime,
+    db: Omnigraph,
+    _dir: tempfile::TempDir,
+}
+
+pub struct DstMachine;
+
+impl Sut {
+    fn person_count(&self) -> usize {
+        self.rt.block_on(async {
+            self.db
+                .query(
+                    ReadTarget::branch("main"),
+                    "query q() { match { $x: Person } return { $x.slug } }",
+                    "q",
+                    &ParamMap::new(),
+                )
+                .await
+                .unwrap()
+                .num_rows()
+        })
+    }
+
+    /// id → body for every live Doc.
+    fn doc_bodies(&self) -> BTreeMap<u32, String> {
+        self.rt.block_on(async {
+            let res = self
+                .db
+                .query(
+                    ReadTarget::branch("main"),
+                    "query c() { match { $d: Doc } return { $d.slug, $d.body } }",
+                    "c",
+                    &ParamMap::new(),
+                )
+                .await
+                .unwrap();
+            let json = res.to_rust_json();
+            let mut out = BTreeMap::new();
+            for row in json.as_array().unwrap() {
+                let slug = row["d.slug"].as_str().unwrap();
+                let body = row["d.body"].as_str().unwrap().to_string();
+                let id: u32 = slug.strip_prefix('g').unwrap().parse().unwrap();
+                out.insert(id, body);
+            }
+            out
+        })
+    }
+}
+
+impl StateMachineTest for DstMachine {
+    type SystemUnderTest = Sut;
+    type Reference = RefModel;
+
+    fn init_test(_ref_state: &RefModel) -> Sut {
+        let rt = Runtime::new().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let uri = dir.path().to_str().unwrap().to_string();
+        let db = rt.block_on(backend::open_clean(&uri));
+        Sut {
+            rt,
+            db,
+            _dir: dir,
+        }
+    }
+
+    fn apply(sut: Sut, _ref_state: &RefModel, transition: Tr) -> Sut {
+        sut.rt.block_on(async {
+            match transition {
+                Tr::InsertPerson(id) => {
+                    load_jsonl(&sut.db, &person(&format!("g{id}")), LoadMode::Merge)
+                        .await
+                        .unwrap();
+                }
+                Tr::InsertDoc(id) => {
+                    load_jsonl(&sut.db, &doc(&format!("g{id}"), "whatsapp"), LoadMode::Merge)
+                        .await
+                        .unwrap();
+                }
+                Tr::UpdateDoc(id, tag) => {
+                    let q = format!(
+                        "query u() {{ update Doc set {{ body: \"u{id}-{tag}\" }} where slug = \"g{id}\" }}"
+                    );
+                    sut.db.mutate("main", &q, "u", &ParamMap::new()).await.unwrap();
+                }
+                Tr::Read => {
+                    sut.db
+                        .query(
+                            ReadTarget::branch("main"),
+                            "query w() { match { $d: Doc { source: \"whatsapp\" } } return { $d.slug } }",
+                            "w",
+                            &ParamMap::new(),
+                        )
+                        .await
+                        .unwrap();
+                }
+            }
+        });
+        sut
+    }
+
+    fn check_invariants(sut: &Sut, ref_state: &RefModel) {
+        // count==model and content==model against the reference, plus structural
+        // row-id uniqueness — all must hold exactly over the clean op subset.
+        assert_eq!(
+            sut.person_count(),
+            ref_state.persons.len(),
+            "Person count diverged from reference"
+        );
+        assert_eq!(
+            sut.doc_bodies(),
+            ref_state.docs,
+            "Doc id→body diverged from reference (lost/dup/stale write)"
+        );
+        sut.rt
+            .block_on(crate::invariants::no_duplicate_live_row_ids(&sut.db))
+            .expect("duplicate live stable row-id");
+    }
+}
+
+proptest_state_machine::prop_state_machine! {
+    #![proptest_config(Config { cases: 24, .. Config::default() })]
+
+    /// Over the clean op subset, the engine must track the reference for any
+    /// generated sequence of 1..30 ops; a divergence auto-shrinks + persists.
+    #[test]
+    fn clean_ops_track_reference(sequential 1..30 => DstMachine);
+}


### PR DESCRIPTION
Stacked on #300 (base `dst-harness-iss784`). Tests-only — **0 engine `src` changes**, 10 tests green.

Takes the shipped DST spine (#300) to the comprehensive harness: completes the D2/D3 matrix, adds the remaining D4 oracles, shrinking, and real concurrency.

## What's added
- **B1** — live-`_rowid` uniqueness invariant (the RC-X duplicate-row-address corruption class), deletion-vector-correct.
- **B2** — `content==model` (per-key Doc body) + `reopen==pre_state` durability gate.
- **B3** — `Knows` edges + `edges==model` RI oracle; `Repair` op; `branch_isolation` + `merge_correctness` scenario.
- **B4** — `readshape.rs`: 12 read shapes × 4 fragment morphologies × on-branch (no-crash + count oracles).
- **B5** — `statemachine.rs`: proptest-state-machine **auto-shrinking** + `proptest-regressions/` persistence over the clean op subset.
- **B6** — concurrent multi-actor walk + interleaving-invariant oracle (reproduces dup-`@key` MR-714 generically).

The generative walk is now **panic-robust** (`catch_unwind` + `classify_panic`): a substrate crash is classified like any finding, not a suite abort.

## Two NEW findings surfaced by the harness (beyond the 3 known bugs)
1. **Self-loop `Knows` not traversable** — a self-loop is committed to `edge:Knows` (raw count 1) but `$a knows $b` returns 0, durable across optimize+reopen. The CSR build keeps it, so the drop is in **Expand**. `proptest_equivalence` misses it (it only checks CSR-vs-indexed *mode* equivalence; both drop self-loops alike). Captured as `regression_self_loop_not_traversable`.
2. **Lance FTS inverted-builder OOB panic** — at depth, rebuilding the FTS index after delete+optimize panics in `lance-index inverted/builder.rs:856`. The FTS index is auto-built on the **`String @key` column** (`node_prop_index_kind` maps String-non-enum → FTS; the `@key → BTREE` note in `docs/dev/lance.md` is **stale**). Non-deterministic (Lance's index-build parallelism isn't seeded); caught + classified by the walk.

## Notes
- B1 was corrected mid-development: the initial raw `row_id_meta`-range form false-positived after UPDATE+compaction (tombstoned ids legitimately overlap); the shipped form scans live `_rowid`.
- New dev-deps (test target only): `arrow-array`, `futures`, `serde_json`, `proptest-state-machine`.
- Out of scope (separate PRs): determinism/`cfg(dst)` (the one engine change) and D5 fan-out / `cargo-fuzz`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test code and dev-dependencies; they do not alter production engine behavior, though CI runtime may increase.
> 
> **Overview**
> **Tests-only** expansion of the omnigraph DST harness (no engine `src` changes). It deepens D4 oracles, widens the op alphabet, and adds several new integration scenarios while keeping known-bug allow-listing so walks can explore past RC-1, RC-X, and dup-`@key`.
> 
> The generative walk now runs longer (more seeds/steps), wraps ops and the invariant battery in **`catch_unwind`** with **`classify_panic`** (Lance FTS OOB, RC-X strings), and gates durability with **`reopen`** plus the full battery after drop. New invariants include **live `_rowid` uniqueness**, **`content==model`** / **`edges==model`**, **`no_duplicate_keys`**, extended RC-1 manifest matching, and dup-`@key` allow-list on logical findings. **`Model`** and **`op::step`** add Knows insert/delete, **Repair**, doc-body tracking, and cascade-aware edge state.
> 
> New modules/tests: **`readshape`** (12 query shapes × 4 fragment morphologies + branch), **`statemachine`** (proptest-state-machine shrinking on clean ops), **multi-actor concurrent walk**, **branch isolation + merge**, and characterization regressions for **self-loop Knows not traversable** and existing known bugs.
> 
> Dev-deps added for tests: `arrow-array`, `futures`, `serde_json`, `proptest-state-machine`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f504f0f5d798b3cc78f6a960190713c3f4725ac3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands the DST harness for deeper engine coverage. The main changes are:

- New structural, content, row-id, and edge invariants.
- More generated operations, including Knows edges and repair.
- Read-shape coverage across fragment morphologies.
- Reopen durability checks and panic classification.
- Concurrent actor walks and state-machine shrinking tests.

<h3>Confidence Score: 4/5</h3>

The test harness changes need fixes before merging.

- The locked workspace test command can fail because the new dependency is not reflected in the lockfile.
- The concurrent DST path can hide actor panics and report success after a crash.

crates/omnigraph/Cargo.toml and crates/omnigraph/tests/dst.rs

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/omnigraph/Cargo.toml | Adds test-only dependencies, but the new state-machine dependency also needs the lockfile updated. |
| crates/omnigraph/tests/dst.rs | Adds regression, concurrency, read-shape, reopen, and panic-handling coverage; the concurrent join path currently hides actor panics. |
| crates/omnigraph/tests/dst/invariants.rs | Adds panic classification plus row-id, key, and structural invariant checks. |
| crates/omnigraph/tests/dst/model.rs | Extends the reference model with Doc bodies and Knows edges. |
| crates/omnigraph/tests/dst/op.rs | Adds generated Knows operations and repair to the DST walk. |
| crates/omnigraph/tests/dst/readshape.rs | Adds read-shape queries over single-fragment, multi-fragment, deleted, optimized, and branch cases. |
| crates/omnigraph/tests/dst/statemachine.rs | Adds a proptest-state-machine campaign over the clean operation subset. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[DST harness] --> B[Sequential walk]
  A --> C[Concurrent actor walk]
  A --> D[Read-shape battery]
  A --> E[State-machine campaign]
  B --> F[Model invariants]
  C --> G[Structural invariants]
  D --> H[Fragment morphology matrix]
  E --> I[Shrunk clean-op failures]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
  A[DST harness] --> B[Sequential walk]
  A --> C[Concurrent actor walk]
  A --> D[Read-shape battery]
  A --> E[State-machine campaign]
  B --> F[Model invariants]
  C --> G[Structural invariants]
  D --> H[Fragment morphology matrix]
  E --> I[Shrunk clean-op failures]
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fomnigraph%2FCargo.toml%3A64%0A**Locked%20Test%20Build%20Breaks**%0A%0AThis%20adds%20%60proptest-state-machine%60%20without%20updating%20%60Cargo.lock%60.%20The%20repo's%20documented%20test%20gate%20uses%20%60cargo%20test%20--workspace%20--locked%60%2C%20so%20the%20first%20locked%20build%20of%20this%20test%20target%20will%20fail%20before%20any%20DST%20tests%20run.%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fomnigraph%2Ftests%2Fdst.rs%3A283-285%0A**Actor%20Panics%20Are%20Hidden**%0A%0AWhen%20a%20spawned%20actor%20panics%20during%20%60load_jsonl%60%2C%20%60mutate%60%2C%20or%20%60optimize%60%2C%20%60h.await%60%20returns%20a%20%60JoinError%60%20and%20this%20loop%20discards%20it.%20If%20the%20panic%20leaves%20no%20persistent%20drift%20for%20the%20post-join%20battery%20to%20observe%2C%20the%20concurrency%20test%20reports%20success%20while%20losing%20the%20crash%20finding%20it%20was%20meant%20to%20surface.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20for%20h%20in%20handles%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20h.await.expect%28%22concurrent%20actor%20panicked%22%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=modernrelay%2Fomnigraph&pr=302&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["test(dst): B5 — proptest-state-machine s..."](https://github.com/modernrelay/omnigraph/commit/f504f0f5d798b3cc78f6a960190713c3f4725ac3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39785445)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=59169be6-01cf-4bae-80fc-604b6a708098))
- Context used - CLAUDE.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=fba7c581-edb6-48b3-90ce-1db695f47e8b))

<!-- /greptile_comment -->