### PR TITLE
test(dst): comprehensive DST harness on 0.7.2 + completeness-critic hardening (supersedes #300, #302)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4951,6 +4951,7 @@ dependencies = [
  "omnigraph-compiler",
  "omnigraph-policy",
  "proptest",
+ "proptest-state-machine",
  "regex",
  "reqwest 0.12.28",
  "serde",
@@ -5687,6 +5688,15 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "proptest-state-machine"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1675727965d66ff6f335e7d398e477184da08f4bed22f1a7f0dbf2f077f56f2e"
+dependencies = [
+ "proptest",
 ]
 
 [[package]]

--- a/crates/omnigraph/Cargo.toml
+++ b/crates/omnigraph/Cargo.toml
@@ -56,5 +56,10 @@ omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.2" }
 tokio = { workspace = true }
 lance-namespace-impls = { workspace = true }
 lance-io = "7.0.0"
+arrow-array = { workspace = true }
+futures = { workspace = true }
+serde_json = { workspace = true }
+async-trait = { workspace = true }
 serial_test = "3"
 proptest = "1"
+proptest-state-machine = "0.8"

--- a/crates/omnigraph/tests/dst.rs
+++ b/crates/omnigraph/tests/dst.rs
@@ -1,0 +1,580 @@
+//! Deterministic-simulation / morphological-matrix test harness (iss-784 / epc-783).
+//!
+//! A seeded generative walk drives the real engine through the op alphabet
+//! (`op`), runs the white-box invariant battery (`invariants`) against a
+//! reference `model` after every op, and classifies each finding as a KNOWN
+//! open bug (allow-listed so the walk explores past it) or NOVEL (fails). The
+//! `FaultAdapter` (`fault`) injects manifest-layer faults; `coverage` records
+//! which matrix cells were touched.
+//!
+//! Layout: `op` (D1 alphabet) · `model` (D4 reference + count==model) ·
+//! `invariants` (D4 battery + structured classifier) · `fault` (StorageAdapter
+//! fault injection) · `backend` (D5 embedded context) · `coverage`.
+//!
+//! Run: `cargo test -p omnigraph-engine --test dst -- --nocapture`
+//!
+//! The three named regressions ASSERT current buggy behavior on the edge build
+//! (Lance 7.0.0) — characterization guards that break (forcing review) when each
+//! bug is fixed: RC-X → Lance #7230 (Lance v8.0.0); RC-1 → stale-view manifest
+//! CAS on delete op-class combos; dup-@key → MR-714.
+
+use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
+
+use futures::FutureExt;
+use omnigraph::db::ReadTarget;
+use omnigraph::loader::{LoadMode, load_jsonl};
+use omnigraph_compiler::ir::ParamMap;
+
+#[path = "dst/op.rs"]
+mod op;
+#[path = "dst/model.rs"]
+mod model;
+#[path = "dst/fault.rs"]
+mod fault;
+#[path = "dst/invariants.rs"]
+mod invariants;
+#[path = "dst/coverage.rs"]
+mod coverage;
+#[path = "dst/backend.rs"]
+mod backend;
+#[path = "dst/readshape.rs"]
+mod readshape;
+#[path = "dst/statemachine.rs"]
+mod statemachine;
+
+use coverage::Coverage;
+use invariants::{Finding, classify, run_battery};
+use model::Model;
+use op::{Rng, doc, knows, person};
+
+// ═══════════════════════════ named regressions ════════════════════════════
+
+/// RC-1 — multi-statement `delete Person + delete Knows` fails with a spurious
+/// stale-view manifest-CAS error (the node-delete cascade bumps edge:Knows
+/// under the explicit edge-delete's pinned version).
+#[tokio::test]
+async fn regression_rc1_stale_view_on_delete_combo() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = backend::open_clean(dir.path().to_str().unwrap()).await;
+    let mut seed = String::new();
+    for i in 0..50 {
+        seed.push_str(&person(&format!("p{i}")));
+    }
+    for i in 0..50 {
+        seed.push_str(&knows(&format!("p{i}"), &format!("p{}", (i + 1) % 50)));
+    }
+    load_jsonl(&db, &seed, LoadMode::Merge).await.unwrap();
+
+    let q = "query m() { delete Person where slug = \"p30\" delete Knows where from = \"p30\" }";
+    match db.mutate("main", q, "m", &ParamMap::new()).await {
+        Err(e) => assert_eq!(
+            classify(&Finding::Engine(e)),
+            Some("RC-1 stale-view"),
+            "RC-1: expected a stale-view manifest error"
+        ),
+        Ok(_) => panic!("RC-1 appears FIXED — flip this regression to expect Ok"),
+    }
+}
+
+/// RC-X — Lance #7230: scalar BTREE corruption (duplicate row addresses) under
+/// UPDATE racing optimize; the indexed read crashes with `from_sorted_iter`.
+#[tokio::test]
+async fn regression_rc_x_btree_from_sorted_iter() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = Arc::new(backend::open_clean(dir.path().to_str().unwrap()).await);
+    const FRAGS: usize = 3;
+    const PER: usize = 600;
+    for frag in 0..FRAGS {
+        let mut data = String::new();
+        for i in 0..PER {
+            let s = if i % 12 == 0 { "email" } else { "whatsapp" };
+            data.push_str(&doc(&format!("d{frag}-{i}"), s));
+        }
+        load_jsonl(&db, &data, LoadMode::Merge).await.unwrap();
+    }
+    let _ = db.optimize().await;
+
+    let upd = {
+        let db = db.clone();
+        tokio::spawn(async move {
+            for round in 0..3 {
+                for frag in 0..FRAGS {
+                    for i in (0..PER).step_by(40) {
+                        let q = format!(
+                            "query u() {{ update Doc set {{ body: \"r{round} needle\" }} where slug = \"d{frag}-{i}\" }}"
+                        );
+                        for _ in 0..4 {
+                            if db.mutate("main", &q, "u", &ParamMap::new()).await.is_ok() {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    };
+    let opt = {
+        let db = db.clone();
+        tokio::spawn(async move {
+            for _ in 0..4 {
+                let _ = db.optimize().await;
+            }
+        })
+    };
+    let _ = upd.await;
+    let _ = opt.await;
+
+    match db
+        .query(
+            ReadTarget::branch("main"),
+            "query w() { match { $d: Doc { source: \"whatsapp\" } } return { $d.slug } }",
+            "w",
+            &ParamMap::new(),
+        )
+        .await
+    {
+        Err(e) => assert_eq!(
+            classify(&Finding::Engine(e)),
+            Some("RC-X/#7230 scalar-BTREE"),
+            "RC-X: expected a from_sorted_iter error"
+        ),
+        Ok(res) => panic!(
+            "RC-X appears FIXED ({} rows) — flip to expect Ok (Lance >= 8.0.0)",
+            res.num_rows()
+        ),
+    }
+}
+
+/// dup-@key (MR-714) — concurrent same-key merge-upserts produce duplicate rows.
+#[tokio::test]
+async fn regression_dup_key_under_concurrency() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = Arc::new(backend::open_clean(dir.path().to_str().unwrap()).await);
+    let workers = 4usize;
+    let keys = 500usize;
+    let mut handles = Vec::new();
+    for _ in 0..workers {
+        let db = db.clone();
+        handles.push(tokio::spawn(async move {
+            let mut data = String::new();
+            for k in 0..keys {
+                data.push_str(&person(&format!("hot-{k}")));
+            }
+            for _ in 0..12 {
+                if load_jsonl(&db, &data, LoadMode::Merge).await.is_ok() {
+                    break;
+                }
+            }
+        }));
+    }
+    for h in handles {
+        let _ = h.await;
+    }
+    let total = db
+        .query(
+            ReadTarget::branch("main"),
+            "query q() { match { $x: Person } return { $x.slug } }",
+            "q",
+            &ParamMap::new(),
+        )
+        .await
+        .unwrap()
+        .num_rows();
+    assert!(
+        total > keys,
+        "dup-@key appears FIXED: total={total} == distinct keys={keys}; flip this regression"
+    );
+}
+
+/// FINDING (harness-surfaced, distinct from the 3 above): a `Knows` SELF-LOOP is
+/// committed to the edge table but is NOT returned by `$a knows $b` traversal —
+/// durable across optimize and reopen, and the CSR build keeps it (so the drop
+/// is in Expand). `proptest_equivalence` can't catch it: it only asserts
+/// CSR-vs-indexed MODE equivalence, and both modes drop the self-loop alike. The
+/// model-based edges==model oracle caught it; self-loops are kept out of the
+/// generic generator so that oracle stays unambiguous. This characterization
+/// guard breaks (forcing review) when self-loops become traversable.
+#[tokio::test]
+async fn regression_self_loop_not_traversable() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = backend::open_clean(dir.path().to_str().unwrap()).await;
+    load_jsonl(&db, &person("s0"), LoadMode::Merge).await.unwrap();
+    load_jsonl(&db, &knows("s0", "s0"), LoadMode::Merge).await.unwrap();
+
+    // The self-loop row is durably committed to the edge table.
+    let snap = db.snapshot_of(ReadTarget::branch("main")).await.unwrap();
+    let mut raw = 0;
+    for entry in snap.entries() {
+        if entry.table_key == "edge:Knows" {
+            raw = snap
+                .open(&entry.table_key)
+                .await
+                .unwrap()
+                .count_rows(None)
+                .await
+                .unwrap();
+        }
+    }
+    assert_eq!(raw, 1, "self-loop edge row should be committed");
+
+    // ...but traversal does not return it (the finding).
+    let trav = db
+        .query(
+            ReadTarget::branch("main"),
+            "query e() { match { $a: Person $a knows $b } return { $a.slug, $b.slug } }",
+            "e",
+            &ParamMap::new(),
+        )
+        .await
+        .unwrap()
+        .num_rows();
+    assert_eq!(
+        trav, 0,
+        "self-loop appears FIXED (traversable={trav}) — flip this regression to expect 1"
+    );
+}
+
+// ═══════════════════════ concurrency (multi-actor) ════════════════════════
+
+/// Seeded N-actor concurrent walk over a SHARED graph, with an OVERLAPPING key
+/// space so same-key upserts race. Under concurrency the sequential reference
+/// model doesn't apply, so the oracle is the interleaving-INVARIANT subset:
+/// unique live row-ids, `Dataset::validate`, HEAD==manifest, and `@key`
+/// uniqueness. dup-`@key` (MR-714) and RC-1 drift are allow-listed knowns; any
+/// other divergence is a novel concurrency bug and fails. A Lance panic inside
+/// an actor is contained by `tokio::spawn` (surfaces as a JoinError we ignore),
+/// so the harness stays up — the post-join battery is the judge.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_walk_structural_invariants() {
+    let mut reproduced: Vec<String> = Vec::new();
+    for seed in 0..3u64 {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Arc::new(backend::open_clean(dir.path().to_str().unwrap()).await);
+        let actors = 4usize;
+        let mut handles = Vec::new();
+        for a in 0..actors {
+            let db = db.clone();
+            handles.push(tokio::spawn(async move {
+                let mut rng = Rng::new(seed.wrapping_mul(131) + a as u64);
+                for _ in 0..20 {
+                    let k = rng.below(30); // shared 0..30 key space → races
+                    match rng.below(5) {
+                        0 | 1 => {
+                            let _ = load_jsonl(&db, &person(&format!("h{k}")), LoadMode::Merge).await;
+                        }
+                        2 => {
+                            let q = format!(
+                                "query u() {{ update Person set {{ name: \"x{k}\" }} where slug = \"h{k}\" }}"
+                            );
+                            let _ = db.mutate("main", &q, "u", &ParamMap::new()).await;
+                        }
+                        3 => {
+                            let q = format!("query d() {{ delete Person where slug = \"h{k}\" }}");
+                            let _ = db.mutate("main", &q, "d", &ParamMap::new()).await;
+                        }
+                        _ => {
+                            let _ = db.optimize().await;
+                        }
+                    }
+                }
+            }));
+        }
+        for h in handles {
+            let _ = h.await; // ignore JoinError: a contained actor panic is judged by the battery
+        }
+
+        let checks: Vec<(&str, Result<(), Finding>)> = vec![
+            ("row-id-unique", invariants::no_duplicate_live_row_ids(&db).await),
+            ("dataset.validate", invariants::dataset_validate(&db).await),
+            ("head==manifest", invariants::head_eq_manifest(&db).await),
+            ("no-dup-@key", invariants::no_duplicate_keys(&db, "Person", "main").await),
+        ];
+        for (name, res) in checks {
+            if let Err(f) = res {
+                match classify(&f) {
+                    Some(bug) => reproduced.push(format!("seed={seed} [{name}] -> {bug}")),
+                    None => panic!(
+                        "seed={seed}: NOVEL concurrent violation [{name}]: {}",
+                        f.message()
+                    ),
+                }
+            }
+        }
+    }
+    eprintln!(
+        "[dst] concurrent walk: {} known-bug instance(s), 0 novel violations",
+        reproduced.len()
+    );
+    for r in &reproduced {
+        eprintln!("  - {r}");
+    }
+}
+
+// ═══════════════════════ branch isolation + merge ═════════════════════════
+
+async fn count_persons(db: &omnigraph::db::Omnigraph, branch: &str) -> usize {
+    db.query(
+        ReadTarget::branch(branch),
+        "query q() { match { $x: Person } return { $x.slug } }",
+        "q",
+        &ParamMap::new(),
+    )
+    .await
+    .unwrap()
+    .num_rows()
+}
+
+async fn person_exists(db: &omnigraph::db::Omnigraph, branch: &str, slug: &str) -> usize {
+    let q =
+        format!("query p() {{ match {{ $x: Person {{ slug: \"{slug}\" }} }} return {{ $x.slug }} }}");
+    db.query(ReadTarget::branch(branch), &q, "p", &ParamMap::new())
+        .await
+        .unwrap()
+        .num_rows()
+}
+
+/// D4 oracles for the branch subsystem (the deferred B2 branch_isolation +
+/// merge_correctness): a branch must not observe `main` writes made after it
+/// forked, `main` must not observe branch-only writes, and a merge must produce
+/// the row-level union. Kept as a focused scenario (not the generic per-op walk)
+/// so the reference model stays single-branch and unambiguous.
+#[tokio::test]
+async fn branch_isolation_and_merge() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = backend::open_clean(dir.path().to_str().unwrap()).await;
+    let mut seed = String::new();
+    for i in 0..5 {
+        seed.push_str(&person(&format!("p{i}")));
+    }
+    load_jsonl(&db, &seed, LoadMode::Merge).await.unwrap();
+
+    db.branch_create("feature").await.unwrap();
+
+    // Diverge: a post-fork write on each side.
+    db.mutate(
+        "main",
+        "query i() { insert Person { slug: \"m-only\", name: \"n\" } }",
+        "i",
+        &ParamMap::new(),
+    )
+    .await
+    .unwrap();
+    db.mutate(
+        "feature",
+        "query i() { insert Person { slug: \"f-only\", name: \"n\" } }",
+        "i",
+        &ParamMap::new(),
+    )
+    .await
+    .unwrap();
+
+    // branch_isolation: neither side sees the other's post-fork write.
+    assert_eq!(
+        person_exists(&db, "feature", "m-only").await,
+        0,
+        "isolation: feature observed a post-fork main write"
+    );
+    assert_eq!(
+        person_exists(&db, "main", "f-only").await,
+        0,
+        "isolation: main observed a feature-only write"
+    );
+    assert_eq!(person_exists(&db, "feature", "f-only").await, 1);
+    assert_eq!(person_exists(&db, "main", "m-only").await, 1);
+
+    // merge_correctness: main converges to the row-level union (p0..p4 + both).
+    let outcome = db.branch_merge("feature", "main").await.unwrap();
+    let total = count_persons(&db, "main").await;
+    assert_eq!(
+        total, 7,
+        "merge: expected the 7-person union, got {total} (outcome {outcome:?})"
+    );
+    assert_eq!(
+        person_exists(&db, "main", "f-only").await,
+        1,
+        "merge: feature's row was not merged into main"
+    );
+}
+
+// ═══════════════════════ D3 read shapes × D2 morphology ═══════════════════
+
+/// Every read shape must execute (no engine error / panic) against every table
+/// morphology — the D2×D3 cell sweep — plus the morphology-invariant counts
+/// (full-scan == live persons, zero-match == 0) must hold, and the shapes must
+/// run against a forked branch too.
+#[tokio::test]
+async fn read_shape_battery_across_morphologies() {
+    for morph in readshape::Morph::ALL {
+        let dir = tempfile::tempdir().unwrap();
+        let db = omnigraph::db::Omnigraph::init(dir.path().to_str().unwrap(), readshape::SCHEMA)
+            .await
+            .unwrap();
+        let expected_persons = readshape::build(&db, morph).await;
+        for (name, res) in readshape::run(&db, "main").await {
+            let rows =
+                res.unwrap_or_else(|e| panic!("morph {morph:?} shape [{name}] errored: {e}"));
+            if name == "full-scan" {
+                assert_eq!(rows, expected_persons, "morph {morph:?} full-scan count");
+            }
+            if name == "zero-match" {
+                assert_eq!(rows, 0, "morph {morph:?} zero-match must be empty");
+            }
+        }
+    }
+
+    // on-branch morphology: every shape must execute against a forked branch.
+    let dir = tempfile::tempdir().unwrap();
+    let db = omnigraph::db::Omnigraph::init(dir.path().to_str().unwrap(), readshape::SCHEMA)
+        .await
+        .unwrap();
+    readshape::build(&db, readshape::Morph::MultiFragment).await;
+    db.branch_create("feature").await.unwrap();
+    for (name, res) in readshape::run(&db, "feature").await {
+        res.unwrap_or_else(|e| panic!("on-branch shape [{name}] errored: {e}"));
+    }
+}
+
+// ═══════════════════════════ generative walk ══════════════════════════════
+
+/// Clean walk: full white-box battery after every op; novel violations fail.
+#[tokio::test]
+async fn seeded_op_loop_invariants_hold() {
+    run_walk(false).await;
+}
+
+/// Phase 2: same walk under injected manifest CAS-lost faults. The engine must
+/// surface/retry them (never silently lose a write) — count==model catches loss.
+#[tokio::test]
+async fn seeded_op_loop_with_cas_faults() {
+    run_walk(true).await;
+}
+
+async fn run_walk(faults: bool) {
+    let mut cov = Coverage::new();
+    let mut reproduced: Vec<String> = Vec::new();
+    for seed in 0..4u64 {
+        let dir = tempfile::tempdir().unwrap();
+        let uri = dir.path().to_str().unwrap();
+        let mut db = if faults {
+            backend::open_faulted(uri, seed, 8).await
+        } else {
+            backend::open_clean(uri).await
+        };
+        let mut rng = Rng::new(seed);
+        let mut model = Model::new();
+
+        'walk: for step_i in 0..25 {
+            // Reopen op (walk-driven): drop + reopen the handle so the recovery
+            // sweep / coordinator re-resolution runs against the current table
+            // state; the op + battery below then execute on the reopened handle,
+            // so the existing checks validate post-reopen. (A clean reopen, so a
+            // faulted walk continues fault-free after it — acceptable.)
+            if step_i > 0 && rng.below(100) < 15 {
+                drop(db);
+                db = backend::reopen(uri).await;
+                cov.op(op::OpKind::Reopen);
+            }
+            // A fault-injection / depth DST harness must treat a substrate PANIC
+            // (a Lance `unwrap`/index crash unwinding through the engine) as a
+            // finding, not a suite abort — so the op and the battery run under
+            // catch_unwind, and a known crash signature is classified like any
+            // other known bug (record + break); a novel panic re-raises.
+            let stepped = AssertUnwindSafe(op::step(&db, &mut rng, &mut model))
+                .catch_unwind()
+                .await;
+            let (kind, res) = match stepped {
+                Ok(kr) => kr,
+                Err(p) => {
+                    let msg = invariants::panic_message(&*p);
+                    match invariants::classify_panic(&msg) {
+                        Some(bug) => {
+                            cov.finding(bug);
+                            reproduced.push(format!("seed={seed} step={step_i} PANIC -> {bug}"));
+                            break 'walk;
+                        }
+                        None => panic!("seed={seed} step={step_i}: NOVEL panic: {msg}"),
+                    }
+                }
+            };
+            cov.op(kind);
+            if let Err(e) = res {
+                let f = Finding::Engine(e);
+                match classify(&f) {
+                    Some(bug) => {
+                        cov.finding(bug);
+                        reproduced.push(format!("seed={seed} step={step_i} op[{kind:?}] -> {bug}"));
+                        break 'walk;
+                    }
+                    // Fault injection legitimately fails writes in varied ways;
+                    // the INVARIANT checks below stay strict.
+                    None if faults => {}
+                    None => panic!("seed={seed} step={step_i}: NOVEL op error: {}", f.message()),
+                }
+            }
+            let battery = match AssertUnwindSafe(run_battery(&db, &model)).catch_unwind().await {
+                Ok(b) => b,
+                Err(p) => {
+                    let msg = invariants::panic_message(&*p);
+                    match invariants::classify_panic(&msg) {
+                        Some(bug) => {
+                            cov.finding(bug);
+                            reproduced.push(format!("seed={seed} step={step_i} battery PANIC -> {bug}"));
+                            break 'walk;
+                        }
+                        None => panic!("seed={seed} step={step_i}: NOVEL battery panic: {msg}"),
+                    }
+                }
+            };
+            for (name, res) in battery {
+                cov.invariant(name);
+                if let Err(f) = res {
+                    match classify(&f) {
+                        Some(bug) => {
+                            cov.finding(bug);
+                            reproduced.push(format!("seed={seed} step={step_i} [{name}] -> {bug}"));
+                            break 'walk;
+                        }
+                        None => panic!(
+                            "seed={seed} step={step_i}: NOVEL invariant violation [{name}]: {}",
+                            f.message()
+                        ),
+                    }
+                }
+            }
+        }
+
+        // ── reopen==pre_state: durability oracle ──
+        // A fresh handle on the same bytes (clean adapter; the open-time recovery
+        // sweep runs) must agree with the model the walk built. count==model /
+        // content==model prove the data survived; head==manifest / row-id-disjoint
+        // prove the sweep left no residual drift. Reuses the same battery at
+        // durability time, so no separate coverage cell.
+        drop(db);
+        let reopened = backend::reopen(uri).await;
+        for (name, res) in run_battery(&reopened, &model).await {
+            if let Err(f) = res {
+                match classify(&f) {
+                    Some(bug) => {
+                        cov.finding(bug);
+                        reproduced.push(format!("seed={seed} [reopen/{name}] -> {bug}"));
+                    }
+                    None => panic!(
+                        "seed={seed}: NOVEL post-reopen violation [{name}]: {}",
+                        f.message()
+                    ),
+                }
+            }
+        }
+    }
+    eprintln!(
+        "[dst] walk(faults={faults}): coverage [{}]; {} known-bug instance(s), 0 novel violations (+reopen durability gate)",
+        cov.report(),
+        reproduced.len()
+    );
+    for r in &reproduced {
+        eprintln!("  - {r}");
+    }
+}
+
+

--- a/crates/omnigraph/tests/dst.rs
+++ b/crates/omnigraph/tests/dst.rs
@@ -42,6 +42,9 @@ mod backend;
 mod readshape;
 #[path = "dst/statemachine.rs"]
 mod statemachine;
+// NOTE: the failpoint-gated recovery cells live in their OWN binary
+// (`tests/dst_recovery.rs`), not here — the process-global `fail` registry would
+// otherwise leak armed failpoints into these (non-serial, parallel) walks.
 
 use coverage::Coverage;
 use invariants::{Finding, classify, run_battery};

--- a/crates/omnigraph/tests/dst/MATRIX.md
+++ b/crates/omnigraph/tests/dst/MATRIX.md
@@ -1,0 +1,131 @@
+# DST coverage ledger (completeness-critic output)
+
+This is the harness's honest self-assessment: which cells of the morphological
+matrix it actually samples, which it does not, and — most importantly — which
+**dimensions it had not named** until a bug found by other means forced them
+into view.
+
+> **Read this first:** "comprehensive" is always *relative to the dimensions
+> below*. A 100% mark here means "100% of the distinctions we thought to draw."
+> The only way to find an *unnamed* dimension is to check the harness against a
+> bug it didn't catch (see the `#296` row). Re-run this critic whenever that
+> happens. This ledger is a process artifact, never a proof.
+
+## Why exhaustive sampling is impossible (so this ledger exists instead)
+
+1. **Cells are path-spaces, several unbounded.** A "cell" is reached by a
+   *sequence* of ops; sequence count grows exponentially with length, and
+   length, history depth, data values, and fragment/version morphology are all
+   unbounded. The grid is a projection of an infinite tree.
+2. **Concurrency is non-enumerable.** A concurrent bug lives in a *schedule*
+   (interleaving + timing), not a cell. You sample schedules or steer toward a
+   named hazard; you never cover them.
+3. **The model is open-world.** You can only sample dimensions you've named, and
+   you can't prove you've named them all (`#296` was a dimension we hadn't).
+
+So the goal is not coverage; it's **maximize bugs-found per unit cost** —
+sample with novelty bias, steer to named hazards, and run this critic to surface
+new dimensions.
+
+## Dimension ledger
+
+Legend: ✅ sampled · 🟡 partial · ❌ unsampled · ⏸️ deferred-by-plan (PR-C/PR-D)
+
+### D1 — operations
+| op | status | where |
+|----|--------|-------|
+| insert node (Person/Doc) | ✅ | walk, statemachine |
+| insert/delete edge (Knows) | ✅ | walk (`InsertKnows`/`DeleteKnows`) |
+| update | ✅ | walk, statemachine |
+| delete node (cascade) | ✅ | walk (`DeletePerson`) |
+| optimize | ✅ | walk |
+| repair | ✅ | walk (`Repair`) |
+| read | ✅ | walk, readshape |
+| branch create/write/merge | 🟡 | `branch_isolation_and_merge` (scenario, not generic walk) |
+| **`open` / recovery sweep** | ❌ | **only a fixture step (`reopen`), never a generated op — the `#296` gap** |
+| cleanup (version GC) | ❌ | needs `&mut self`; deferred |
+| apply-schema mid-sequence | ❌ | forks the single-branch model; deferred |
+| overwrite (`LoadMode::Overwrite`) | ❌ | deferred |
+
+### D2 — latent table morphology
+| morphology | status | where |
+|------------|--------|-------|
+| 1 vs ≥2 fragments | ✅ | readshape (`Single`/`MultiFragment`), walk |
+| deletion vectors | ✅ | readshape (`WithDeletions`), walk |
+| compacted/reindexed | ✅ | readshape (`Optimized`), walk |
+| on-branch | 🟡 | readshape on-branch + branch scenario |
+| HEAD>manifest drift | 🟡 | produced by RC-1; not deliberately steered |
+| overlapping row-id ranges | ✅ (as invariant target) | `no_duplicate_live_row_ids` |
+
+### D3 — read shapes
+| shape | status | where |
+|-------|--------|-------|
+| scan · @key · indexed · non-indexed · range · order+limit · count · numeric-agg · 1-hop · var-hop · negation · zero-match | ✅ | `readshape::shapes()` × 4 morphologies × on-branch |
+| **vector (`nearest`)** | ⏸️ | needs vector data |
+| **FTS (`bm25`/`search`/`fuzzy`) / `rrf`** | ⏸️ | needs the inverted index whose builder OOB-panics (finding #5) |
+
+### D4 — oracles
+| oracle | status |
+|--------|--------|
+| HEAD==manifest · `Dataset::validate` · row-id-unique · index-probe · count==model · content==model · edges==model (RI) · @key-unique | ✅ |
+| branch isolation · merge correctness · reopen==pre_state | ✅ |
+| **replay-equality (bit-identical)** | ⏸️ — blocked on PR-C determinism (Lance internal parallelism unseeded) |
+| **linearizability (porcupine)** | ⏸️ |
+
+### D5 — context  *(the dimension with the biggest blind spots)*
+| context | status | note |
+|---------|--------|------|
+| embedded backend | ✅ | the only backend |
+| **CLI / long-lived server backend** | ⏸️ | PR-D |
+| local FS | ✅ | |
+| **S3 (RustFS/MinIO)** | ⏸️ | PR-D |
+| single writer | ✅ | |
+| concurrent writers (one handle) | ✅ | `concurrent_walk_structural_invariants` |
+| **concurrent *opens* / ≥2 recovery sweeps** | ❌ | **the `#296` cell — see below** |
+| **cross-process writers/opens** | ❌ | documented engine known-gap; harness can't reach it yet |
+| cold vs warm coordinator | 🟡 | reopen exercises cold; not steered |
+
+### Hidden dimensions (named only after a miss)
+| dimension | how we learned it | status |
+|-----------|-------------------|--------|
+| **handle/process multiplicity** | `#296` (concurrent recovery sweeps on one sidecar) | ❌ being closed |
+| **`open`/recovery as a first-class op** | `#296` (the sweep is a hidden op) | 🟡 — `Reopen` op added to the walk; concurrent/cross-process still ❌ |
+| **schedule/interleaving precision** | `#296` needs one exact classify→publish-CAS race | 🟡 — sampled stochastically (multi-thread), not steered; failpoints would steer it |
+
+### ⚠️ Fault-injection seam is narrower than documented (critic finding)
+The Phase-2 `FaultAdapter` wraps `StorageAdapter::write_text_if_match` claiming to
+fault "the conditional manifest write." It does **not**: the `__manifest` publish
+is a Lance `MergeInsertBuilder` row-level CAS on `object_id`
+(`db/manifest/publisher.rs:377`), which never flows through the StorageAdapter.
+Verified empirically — a write under `cas_conflict_pct = 100` **succeeds and
+leaves no sidecar**. So `seeded_op_loop_with_cas_faults` injects into a *cold*
+text-CAS path (schema staging / `omnigraph.rs:2380,2441`), not the manifest hot
+path, which is why faults≈no-faults in the walk. **Real manifest-CAS / publish
+fault injection needs either (a) wrapping Lance's `object_store` at dataset open
+(the deferred "Lance-internal-I/O" seam) or (b) the engine's failpoints**
+(`recovery.before_roll_forward_publish`, the per-writer Phase-B publisher
+failpoints). This is the prerequisite for the `#296` cell — the StorageAdapter
+seam cannot induce a `RolledPastExpected` sidecar.
+
+## Prioritized gap-closure backlog
+1. **Widen the fault seam (prerequisite for everything below).** The StorageAdapter
+   wrapper misses the manifest publish (see the critic finding above). Add a
+   `--features failpoints` harness variant using `recovery.before_roll_forward_publish`
+   + the per-writer Phase-B publisher failpoints, and/or wrap Lance's `object_store`
+   at dataset open. Until this lands, manifest-CAS / sidecar faults are not reachable.
+2. **`#296` cell — concurrent `open` under a fault-induced pending sidecar** (needs #1):
+   induce a `RolledPastExpected` sidecar (failpoint at Phase-B publish), then spawn N
+   concurrent `Omnigraph::open` + a rendezvous so two sweeps race one sidecar; assert
+   every open converges (none returns `ExpectedVersionMismatch`). Caught `#296` on
+   0.7.1; guards 0.7.2.
+3. **`open`/recovery as a generated op** — ✅ DONE (the `Reopen` op): the walk now
+   drops + reopens mid-sequence, sampling the recovery sweep across walk states (not
+   only at the end). Concurrent/cross-process variants remain (needs #1/#4).
+4. **cross-process** writer/open scenarios (subprocess backend) — the documented
+   one-winner-CAS territory.
+5. **vector/FTS/rrf read shapes** + **determinism/replay-equality** (PR-C) + **CLI/server/S3 backends** (PR-D).
+
+## The standing rule
+When a bug is found *outside* this harness, before closing it: add its row to the
+Hidden-dimensions table if it names a new dimension, then add a sampling cell.
+That is the only mechanism that grows the model. The ledger is never "done."

--- a/crates/omnigraph/tests/dst/MATRIX.md
+++ b/crates/omnigraph/tests/dst/MATRIX.md
@@ -108,22 +108,27 @@ failpoints). This is the prerequisite for the `#296` cell — the StorageAdapter
 seam cannot induce a `RolledPastExpected` sidecar.
 
 ## Prioritized gap-closure backlog
-1. **Widen the fault seam (prerequisite for everything below).** The StorageAdapter
-   wrapper misses the manifest publish (see the critic finding above). Add a
-   `--features failpoints` harness variant using `recovery.before_roll_forward_publish`
-   + the per-writer Phase-B publisher failpoints, and/or wrap Lance's `object_store`
-   at dataset open. Until this lands, manifest-CAS / sidecar faults are not reachable.
-2. **`#296` cell — concurrent `open` under a fault-induced pending sidecar** (needs #1):
-   induce a `RolledPastExpected` sidecar (failpoint at Phase-B publish), then spawn N
-   concurrent `Omnigraph::open` + a rendezvous so two sweeps race one sidecar; assert
-   every open converges (none returns `ExpectedVersionMismatch`). Caught `#296` on
-   0.7.1; guards 0.7.2.
-3. **`open`/recovery as a generated op** — ✅ DONE (the `Reopen` op): the walk now
-   drops + reopens mid-sequence, sampling the recovery sweep across walk states (not
-   only at the end). Concurrent/cross-process variants remain (needs #1/#4).
+1. **Widen the fault seam** — ✅ DONE via the `--features failpoints` variant
+   (`tests/dst_recovery.rs`, own binary so the process-global `fail` registry can't
+   leak into the main walks). `mutation.post_finalize_pre_publisher` now induces a
+   real `RolledPastExpected` sidecar — the thing the StorageAdapter wrapper could
+   not. *(The StorageAdapter seam is still off the manifest publish; failpoints are
+   the reach. A Lance `object_store` wrapper remains the option for generative —
+   not hand-armed — manifest-CAS faults.)*
+2. **`#296` cell — concurrent `open` under a pending sidecar** — ✅ DONE
+   (`concurrent_opens_converge_on_pending_sidecar`): an inline park-first rendezvous
+   at `recovery.before_roll_forward_publish` forces two sweeps to race one sidecar;
+   the CAS-loser must converge (not `ExpectedVersionMismatch`). Non-vacuous (the
+   rendezvous panics if the race never fires) + the white-box battery as oracle.
+   Guards 0.7.2 (the failpoint instrumentation was added *with* the #296 fix, so it
+   can't run against true 0.7.1).
+3. **`open`/recovery as a generated op** — ✅ DONE (the `Reopen` op): the walk drops
+   + reopens mid-sequence, sampling the sweep across walk states.
 4. **cross-process** writer/open scenarios (subprocess backend) — the documented
-   one-winner-CAS territory.
-5. **vector/FTS/rrf read shapes** + **determinism/replay-equality** (PR-C) + **CLI/server/S3 backends** (PR-D).
+   one-winner-CAS territory. ❌ remaining.
+5. **generative** (not hand-armed) recovery faults — wrap Lance's `object_store` so
+   the walk *discovers* sidecar/CAS bugs instead of the cells being scripted. ❌
+6. **vector/FTS/rrf read shapes** + **determinism/replay-equality** (PR-C) + **CLI/server/S3 backends** (PR-D). ⏸️
 
 ## The standing rule
 When a bug is found *outside* this harness, before closing it: add its row to the

--- a/crates/omnigraph/tests/dst/backend.rs
+++ b/crates/omnigraph/tests/dst/backend.rs
@@ -1,0 +1,31 @@
+//! D5 (embedded context) — graph construction. A `Backend` trait abstraction
+//! (CLI / long-lived server) is the Phase-5 extension point; today there is one
+//! in-process embedded backend, exposed as two open functions.
+
+use omnigraph::db::Omnigraph;
+
+use crate::op::SCHEMA;
+
+/// A clean graph (no fault injection).
+pub async fn open_clean(uri: &str) -> Omnigraph {
+    Omnigraph::init(uri, SCHEMA).await.expect("init")
+}
+
+/// Reopen an EXISTING graph from its bytes on disk (runs the open-time recovery
+/// sweep in read-write mode). Backs the reopen==pre_state durability oracle: a
+/// fresh handle must agree with the model the walk built.
+pub async fn reopen(uri: &str) -> Omnigraph {
+    Omnigraph::open(uri).await.expect("reopen")
+}
+
+/// A graph whose storage injects seeded manifest-layer faults (CAS-lost). The
+/// graph + schema are created cleanly first, then reopened through the
+/// `FaultAdapter` so only the op workload runs under faults.
+pub async fn open_faulted(uri: &str, seed: u64, cas_pct: u8) -> Omnigraph {
+    Omnigraph::init(uri, SCHEMA).await.expect("init");
+    let base = omnigraph::storage::storage_for_uri(uri).expect("storage_for_uri");
+    let faulted = crate::fault::FaultAdapter::new(base, seed, cas_pct);
+    Omnigraph::open_with_storage(uri, faulted)
+        .await
+        .expect("open_with_storage")
+}

--- a/crates/omnigraph/tests/dst/coverage.rs
+++ b/crates/omnigraph/tests/dst/coverage.rs
@@ -1,0 +1,38 @@
+//! Coverage capture: which matrix cells the generative walk actually touched.
+//! Turns "comprehensive" from a claim into a number (hit / total).
+
+use std::collections::HashSet;
+
+use crate::op::OpKind;
+
+#[derive(Default)]
+pub struct Coverage {
+    ops: HashSet<OpKind>,
+    invariants: HashSet<&'static str>,
+    /// op-error and invariant-violation signatures actually exercised.
+    findings: HashSet<&'static str>,
+}
+
+impl Coverage {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    pub fn op(&mut self, k: OpKind) {
+        self.ops.insert(k);
+    }
+    pub fn invariant(&mut self, name: &'static str) {
+        self.invariants.insert(name);
+    }
+    pub fn finding(&mut self, name: &'static str) {
+        self.findings.insert(name);
+    }
+    pub fn report(&self) -> String {
+        format!(
+            "ops {}/{}, invariants {}/7, known-bugs exercised {}",
+            self.ops.len(),
+            OpKind::ALL.len(),
+            self.invariants.len(),
+            self.findings.len()
+        )
+    }
+}

--- a/crates/omnigraph/tests/dst/fault.rs
+++ b/crates/omnigraph/tests/dst/fault.rs
@@ -1,0 +1,95 @@
+//! Phase 2: a fault-injecting `StorageAdapter` wrapper (SlateDB-style), mirrors
+//! `omnigraph::instrumentation::CountingStorageAdapter`. Wrap the base adapter
+//! and inject seeded faults on the manifest/commit/CAS layer, then open the
+//! graph via `Omnigraph::open_with_storage`.
+//!
+//! The high-value fault is a spurious CAS-lost on `write_text_if_match` (the
+//! conditional manifest write): the engine MUST surface it (retry / fence),
+//! never silently lose the write. If a write is lost, `check_counts` (count==
+//! model) catches it as a NOVEL violation. Optional latency exercises timing.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use omnigraph::error::Result;
+use omnigraph::storage::StorageAdapter;
+
+#[derive(Debug)]
+pub struct FaultAdapter {
+    inner: Arc<dyn StorageAdapter>,
+    cas_conflict_pct: u8,
+    rng: Mutex<u64>,
+}
+
+impl FaultAdapter {
+    /// Wrap `inner` (e.g. `storage_for_uri(uri)?`). `cas_conflict_pct` is the
+    /// percentage of conditional writes that spuriously report CAS-lost.
+    pub fn new(
+        inner: Arc<dyn StorageAdapter>,
+        seed: u64,
+        cas_conflict_pct: u8,
+    ) -> Arc<dyn StorageAdapter> {
+        Arc::new(Self {
+            inner,
+            cas_conflict_pct,
+            rng: Mutex::new(seed ^ 0x9E37_79B9_7F4A_7C15),
+        })
+    }
+
+    fn roll(&self, pct: u8) -> bool {
+        let mut g = self.rng.lock().unwrap();
+        let mut x = *g;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        *g = x;
+        (x.wrapping_mul(0x2545_F491_4F6C_DD1D) % 100) < pct as u64
+    }
+}
+
+#[async_trait]
+impl StorageAdapter for FaultAdapter {
+    async fn read_text(&self, uri: &str) -> Result<String> {
+        self.inner.read_text(uri).await
+    }
+    async fn write_text(&self, uri: &str, contents: &str) -> Result<()> {
+        self.inner.write_text(uri, contents).await
+    }
+    async fn write_text_if_absent(&self, uri: &str, contents: &str) -> Result<bool> {
+        self.inner.write_text_if_absent(uri, contents).await
+    }
+    async fn exists(&self, uri: &str) -> Result<bool> {
+        self.inner.exists(uri).await
+    }
+    async fn rename_text(&self, from_uri: &str, to_uri: &str) -> Result<()> {
+        self.inner.rename_text(from_uri, to_uri).await
+    }
+    async fn delete(&self, uri: &str) -> Result<()> {
+        self.inner.delete(uri).await
+    }
+    async fn list_dir(&self, dir_uri: &str) -> Result<Vec<String>> {
+        self.inner.list_dir(dir_uri).await
+    }
+    async fn read_text_versioned(&self, uri: &str) -> Result<(String, String)> {
+        self.inner.read_text_versioned(uri).await
+    }
+    async fn write_text_if_match(
+        &self,
+        uri: &str,
+        contents: &str,
+        expected_version: &str,
+    ) -> Result<Option<String>> {
+        // Inject a spurious CAS-lost (precondition failed) — a concurrent-writer
+        // illusion. The engine must surface/retry this; a swallowed loss is
+        // caught downstream by count==model.
+        if self.roll(self.cas_conflict_pct) {
+            return Ok(None);
+        }
+        self.inner
+            .write_text_if_match(uri, contents, expected_version)
+            .await
+    }
+    async fn delete_prefix(&self, prefix_uri: &str) -> Result<()> {
+        self.inner.delete_prefix(prefix_uri).await
+    }
+}

--- a/crates/omnigraph/tests/dst/invariants.rs
+++ b/crates/omnigraph/tests/dst/invariants.rs
@@ -1,0 +1,249 @@
+//! D4: the white-box invariant battery + the structured known/novel classifier.
+//!
+//! A `Finding` is either an `Engine(OmniError)` (an op/query returned an engine
+//! error) or a `Logical(String)` (a harness-computed structural mismatch:
+//! HEAD!=manifest, count!=model, orphan edge). Classification is structured —
+//! NOT free-text substring matching over arbitrary messages:
+//!   * Engine errors are allow-listed only for the two known bugs, each gated on
+//!     a narrow signal (RC-1 on the `OmniError::Manifest` variant; RC-X on
+//!     Lance's specific internal string).
+//!   * Logical findings are NEVER allow-listed — a structural divergence is
+//!     always a real finding (the named regressions cover the known concurrency
+//!     cases separately).
+
+use std::collections::HashSet;
+
+use arrow_array::{RecordBatch, UInt64Array};
+use futures::TryStreamExt;
+use omnigraph::db::{Omnigraph, ReadTarget};
+use omnigraph::error::OmniError;
+use omnigraph_compiler::ir::ParamMap;
+
+#[derive(Debug)]
+pub enum Finding {
+    /// An engine-returned error (variant preserved for structured classification).
+    Engine(OmniError),
+    /// A harness-computed structural violation — always novel.
+    Logical(String),
+}
+
+impl Finding {
+    pub fn message(&self) -> String {
+        match self {
+            Finding::Engine(e) => e.to_string(),
+            Finding::Logical(s) => s.clone(),
+        }
+    }
+}
+
+/// Returns `Some(known-bug-name)` if the finding matches a known open bug we
+/// allow-list (so the walk explores past it), else `None` (= NOVEL → fail).
+pub fn classify(f: &Finding) -> Option<&'static str> {
+    match f {
+        Finding::Engine(e) => {
+            let s = e.to_string();
+            // RC-1: edge-table HEAD/manifest drift from the node-delete cascade.
+            // Gated on the Manifest variant so a coincidental substring elsewhere
+            // can't mask it. Two surfaces of the same root: the write-time CAS
+            // "stale view", and a LATER write's precondition refusing the
+            // uncovered drift ("ahead of manifest ... run omnigraph repair").
+            if matches!(e, OmniError::Manifest(_))
+                && (s.contains("stale view")
+                    || (s.contains("expected") && s.contains("current"))
+                    || s.contains("ahead of manifest version"))
+            {
+                return Some("RC-1 stale-view");
+            }
+            // RC-X / Lance #7230: scalar-BTREE duplicate row addresses. The Lance
+            // internal panic string is highly specific (near-zero false positive).
+            if s.contains("from_sorted_iter") || s.contains("non-sorted input") {
+                return Some("RC-X/#7230 scalar-BTREE");
+            }
+            None
+        }
+        // Structural divergences are novel by default, with ONE narrow
+        // exception: dup-`@key` (MR-714) is a known open bug, so a finding whose
+        // message carries the `dup-@key` marker is allow-listed like the engine
+        // known-bugs above. Every other structural divergence stays novel.
+        Finding::Logical(s) => {
+            if s.contains("dup-@key") {
+                return Some("dup-@key MR-714");
+            }
+            None
+        }
+    }
+}
+
+/// Extract a readable message from a caught panic payload.
+pub fn panic_message(p: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = p.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = p.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "<non-string panic payload>".to_string()
+    }
+}
+
+/// Classify a caught panic (a Lance-internal `unwrap`/index crash that unwinds
+/// through the engine) the same KNOWN-vs-NOVEL way as `classify`. Under fault
+/// injection and at walk depth the substrate WILL crash, so the harness must
+/// treat a panic as a finding, not let it abort the suite. NONE → re-raise.
+///
+/// Note on `index out of bounds`: in THIS harness the only source of that panic
+/// is Lance's inverted (FTS) index builder — the harness's own code uses checked
+/// loops and returns `Logical` findings, never an OOB panic — so the broad match
+/// is safe here and would not mask a harness bug.
+pub fn classify_panic(msg: &str) -> Option<&'static str> {
+    if msg.contains("from_sorted_iter") || msg.contains("non-sorted input") {
+        return Some("RC-X/#7230 scalar-BTREE");
+    }
+    if msg.contains("index out of bounds") {
+        return Some("Lance FTS inverted-builder OOB");
+    }
+    None
+}
+
+// ── INVARIANT #1: Lance HEAD == manifest table version, per table ──
+pub async fn head_eq_manifest(db: &Omnigraph) -> Result<(), Finding> {
+    let snap = db
+        .snapshot_of(ReadTarget::branch("main"))
+        .await
+        .map_err(Finding::Engine)?;
+    for entry in snap.entries() {
+        let ds = snap.open(&entry.table_key).await.map_err(Finding::Engine)?;
+        let lance_head = ds.version().version;
+        if lance_head != entry.table_version {
+            return Err(Finding::Logical(format!(
+                "HEAD!=manifest on {}: lance_head={lance_head} manifest_pin={}",
+                entry.table_key, entry.table_version
+            )));
+        }
+    }
+    Ok(())
+}
+
+// ── INVARIANT #2: Lance Dataset::validate() per table (general corruption) ──
+pub async fn dataset_validate(db: &Omnigraph) -> Result<(), Finding> {
+    let snap = db
+        .snapshot_of(ReadTarget::branch("main"))
+        .await
+        .map_err(Finding::Engine)?;
+    for entry in snap.entries() {
+        let ds = snap.open(&entry.table_key).await.map_err(Finding::Engine)?;
+        // Dataset::validate returns a Lance error; a validation failure IS a
+        // structural corruption finding (always novel).
+        ds.validate()
+            .await
+            .map_err(|e| Finding::Logical(format!("Dataset::validate {}: {e}", entry.table_key)))?;
+    }
+    Ok(())
+}
+
+// ── INVARIANT #3a: no duplicate LIVE stable row-id within a table ──
+// A stable row id uniquely identifies one live row for the dataset's lifetime;
+// the same id appearing on two live rows is exactly the duplicate-row-address
+// corruption class behind RC-X / Lance #7230. We read the truth deletion-vector-
+// correctly by scanning each table with `with_row_id()` (Lance's `_rowid`
+// projection returns only LIVE rows, so a tombstoned id masked by an UPDATE or
+// compaction never counts) and asserting the live `_rowid`s are unique. Unlike
+// `index_probe` (which only surfaces a bad scalar-BTREE page when a filtered
+// READ loads it), this is a direct structural check on every committed row.
+//
+// (An earlier version compared raw `row_id_meta` fragment ranges, but those
+// ranges include tombstoned ids — after an UPDATE+compaction an old fragment's
+// range legitimately overlaps the new fragment's, so that check false-positived.
+// Scanning live `_rowid`s is the deletion-vector-aware form.)
+pub async fn no_duplicate_live_row_ids(db: &Omnigraph) -> Result<(), Finding> {
+    let snap = db
+        .snapshot_of(ReadTarget::branch("main"))
+        .await
+        .map_err(Finding::Engine)?;
+    for entry in snap.entries() {
+        let ds = snap.open(&entry.table_key).await.map_err(Finding::Engine)?;
+        let mut scanner = ds.scan();
+        scanner.with_row_id();
+        let batches: Vec<RecordBatch> = scanner
+            .try_into_stream()
+            .await
+            .map_err(|e| Finding::Logical(format!("scan {}: {e}", entry.table_key)))?
+            .try_collect()
+            .await
+            .map_err(|e| Finding::Logical(format!("scan collect {}: {e}", entry.table_key)))?;
+        let mut seen: HashSet<u64> = HashSet::new();
+        for batch in &batches {
+            let col = batch
+                .column_by_name("_rowid")
+                .ok_or_else(|| Finding::Logical(format!("no _rowid column on {}", entry.table_key)))?
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .ok_or_else(|| Finding::Logical(format!("_rowid not u64 on {}", entry.table_key)))?;
+            for i in 0..col.len() {
+                let id = col.value(i);
+                if !seen.insert(id) {
+                    return Err(Finding::Logical(format!(
+                        "duplicate live stable row-id {id} in {} (RC-X-class duplicate row address)",
+                        entry.table_key
+                    )));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+// ── INVARIANT #3: scalar-index probe (catches RC-X at creation) ──
+// Force-loads the Doc.source BTREE flat pages by filtering each enum value.
+pub async fn index_probe(db: &Omnigraph) -> Result<(), Finding> {
+    for src in ["whatsapp", "email", "linkedin", "slack", "telegram"] {
+        let q = format!("query w() {{ match {{ $d: Doc {{ source: \"{src}\" }} }} return {{ $d.slug }} }}");
+        db.query(ReadTarget::branch("main"), &q, "w", &ParamMap::new())
+            .await
+            .map_err(Finding::Engine)?;
+    }
+    Ok(())
+}
+
+// ── @key uniqueness (no sequential model — for the concurrent oracle) ──
+// Every `@key` value may appear on at most one live row. Concurrent same-key
+// upserts that produce duplicates are MR-714 (dup-`@key`); `classify` allow-
+// lists the `dup-@key` marker as that known bug.
+pub async fn no_duplicate_keys(db: &Omnigraph, ty: &str, branch: &str) -> Result<(), Finding> {
+    let q = format!("query q() {{ match {{ $x: {ty} }} return {{ $x.slug }} }}");
+    let res = db
+        .query(ReadTarget::branch(branch), &q, "q", &ParamMap::new())
+        .await
+        .map_err(Finding::Engine)?;
+    let json = res.to_rust_json();
+    let rows = json
+        .as_array()
+        .ok_or_else(|| Finding::Logical(format!("{ty} key scan not an array")))?;
+    let total = rows.len();
+    let mut seen: HashSet<String> = HashSet::new();
+    for row in rows {
+        let slug = row["x.slug"]
+            .as_str()
+            .ok_or_else(|| Finding::Logical(format!("missing x.slug in {ty}")))?;
+        if !seen.insert(slug.to_string()) {
+            return Err(Finding::Logical(format!(
+                "duplicate @key {slug:?} in {ty} ({total} rows, {} distinct) — dup-@key",
+                seen.len()
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// The full battery as a registry: `(name, result)` per invariant. Adding an
+/// invariant is one line here; the walk iterates and the coverage map records.
+pub async fn run_battery(db: &Omnigraph, model: &crate::model::Model) -> Vec<(&'static str, Result<(), Finding>)> {
+    vec![
+        ("head==manifest", head_eq_manifest(db).await),
+        ("dataset.validate", dataset_validate(db).await),
+        ("row-id-unique", no_duplicate_live_row_ids(db).await),
+        ("index-probe", index_probe(db).await),
+        ("count==model", crate::model::check_counts(db, model).await),
+        ("content==model", crate::model::check_content(db, model).await),
+        ("edges==model", crate::model::check_edges(db, model).await),
+    ]
+}

--- a/crates/omnigraph/tests/dst/model.rs
+++ b/crates/omnigraph/tests/dst/model.rs
@@ -1,0 +1,235 @@
+//! Reference model (D4 oracle source of truth) + the count==model invariant.
+//!
+//! Tracks the SET of live Person/Doc keys the harness believes should exist.
+//! Updated only AFTER an op succeeds, so a failed op (e.g. RC-1 stale-view, or
+//! a FaultAdapter-injected CAS loss) leaves the model consistent with reality.
+//! A divergence means a lost write (count<model) or a duplicate key
+//! (count>model) — both real bugs.
+
+use std::collections::{HashMap, HashSet};
+
+use omnigraph::db::{Omnigraph, ReadTarget};
+use omnigraph_compiler::ir::ParamMap;
+
+use crate::invariants::Finding;
+
+#[derive(Default)]
+pub struct Model {
+    persons: HashSet<usize>,
+    docs: HashSet<usize>,
+    /// Expected `body` value per live Doc id — the source of truth for the
+    /// content==model oracle (a lost UPDATE shows up here even when counts match).
+    doc_body: HashMap<usize, String>,
+    /// Live `Knows` edges as `from -> to` (the map enforces the schema's
+    /// `@card(0..1)`: a `from` has at most one outgoing edge). Every endpoint is
+    /// a live Person by construction — `del_person` cascades both directions, so
+    /// the model never holds an orphan and the engine producing one is a finding.
+    knows: HashMap<usize, usize>,
+    next: usize,
+}
+
+impl Model {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    /// A never-before-used id (so generated inserts never collide).
+    pub fn fresh_id(&mut self) -> usize {
+        let i = self.next;
+        self.next += 1;
+        i
+    }
+    /// Upper bound for picking an existing-ish id for delete/update targets.
+    pub fn id_high(&self) -> usize {
+        self.next.max(1)
+    }
+    pub fn add_person(&mut self, id: usize) {
+        self.persons.insert(id);
+    }
+    pub fn add_doc(&mut self, id: usize, body: String) {
+        self.docs.insert(id);
+        self.doc_body.insert(id, body);
+    }
+    /// Record an UPDATE's new body — only for a Doc the model believes exists,
+    /// so a no-op update (0 rows matched) doesn't desync the model.
+    pub fn update_doc_body(&mut self, id: usize, body: String) {
+        if self.docs.contains(&id) {
+            self.doc_body.insert(id, body);
+        }
+    }
+    pub fn del_person(&mut self, id: usize) {
+        self.persons.remove(&id);
+        // Node delete cascades to incident edges, BOTH directions — mirror it so
+        // the model never references a deleted Person (this is the RC-1 surface).
+        self.knows.remove(&id);
+        self.knows.retain(|_, &mut to| to != id);
+    }
+    pub fn persons(&self) -> usize {
+        self.persons.len()
+    }
+    pub fn docs(&self) -> usize {
+        self.docs.len()
+    }
+    pub fn doc_bodies(&self) -> &HashMap<usize, String> {
+        &self.doc_body
+    }
+
+    // ── edges ──
+    /// Live person ids (for picking an edge endpoint).
+    pub fn persons_vec(&self) -> Vec<usize> {
+        self.persons.iter().copied().collect()
+    }
+    /// Persons with no outgoing `Knows` — the only legal `from` for a new edge
+    /// under `@card(0..1)`, so every generated InsertKnows is a valid op.
+    pub fn free_froms(&self) -> Vec<usize> {
+        self.persons
+            .iter()
+            .copied()
+            .filter(|p| !self.knows.contains_key(p))
+            .collect()
+    }
+    /// Persons that currently have an outgoing edge (legal DeleteKnows targets).
+    pub fn knows_froms(&self) -> Vec<usize> {
+        self.knows.keys().copied().collect()
+    }
+    pub fn add_edge(&mut self, from: usize, to: usize) {
+        self.knows.insert(from, to);
+    }
+    pub fn del_edge(&mut self, from: usize) {
+        self.knows.remove(&from);
+    }
+    pub fn edges(&self) -> usize {
+        self.knows.len()
+    }
+}
+
+async fn count(db: &Omnigraph, ty: &str) -> Result<usize, Finding> {
+    let q = format!("query q() {{ match {{ $x: {ty} }} return {{ $x.slug }} }}");
+    db.query(ReadTarget::branch("main"), &q, "q", &ParamMap::new())
+        .await
+        .map(|r| r.num_rows())
+        .map_err(Finding::Engine)
+}
+
+/// count==model: live row counts must equal the model. A divergence is a
+/// structural (Logical) finding — lost-write (count<model — e.g. a swallowed
+/// CAS conflict) or duplicate-key (count>model — MR-714).
+pub async fn check_counts(db: &Omnigraph, model: &Model) -> Result<(), Finding> {
+    let p = count(db, "Person").await?;
+    if p != model.persons() {
+        return Err(Finding::Logical(format!(
+            "count Person={p} != model={} (lost-write or dup-@key)",
+            model.persons()
+        )));
+    }
+    let d = count(db, "Doc").await?;
+    if d != model.docs() {
+        return Err(Finding::Logical(format!(
+            "count Doc={d} != model={}",
+            model.docs()
+        )));
+    }
+    Ok(())
+}
+
+/// content==model: every live Doc's `body` must equal the model's expected
+/// value, and no `@key` may appear twice. A count check passes through a
+/// lost UPDATE (the row is still there, just stale) or a silent dup-`@key`
+/// (a value-level duplicate the row count would only catch if it changed the
+/// total) — this is the oracle that catches both. Slugs are `g{id}`.
+pub async fn check_content(db: &Omnigraph, model: &Model) -> Result<(), Finding> {
+    let res = db
+        .query(
+            ReadTarget::branch("main"),
+            "query c() { match { $d: Doc } return { $d.slug, $d.body } }",
+            "c",
+            &ParamMap::new(),
+        )
+        .await
+        .map_err(Finding::Engine)?;
+    let json = res.to_rust_json();
+    let rows = json
+        .as_array()
+        .ok_or_else(|| Finding::Logical("Doc content query did not return an array".into()))?;
+
+    let mut seen: HashMap<usize, String> = HashMap::new();
+    for row in rows {
+        let slug = row["d.slug"]
+            .as_str()
+            .ok_or_else(|| Finding::Logical(format!("missing d.slug in {row}")))?;
+        let body = row["d.body"]
+            .as_str()
+            .ok_or_else(|| Finding::Logical(format!("missing d.body in {row}")))?;
+        let id: usize = slug
+            .strip_prefix('g')
+            .and_then(|s| s.parse().ok())
+            .ok_or_else(|| Finding::Logical(format!("unexpected Doc slug {slug}")))?;
+        if let Some(prev) = seen.insert(id, body.to_string()) {
+            return Err(Finding::Logical(format!(
+                "duplicate Doc @key g{id} (dup-@key): {prev:?} and {body:?}"
+            )));
+        }
+    }
+
+    for (id, expected) in model.doc_bodies() {
+        match seen.get(id) {
+            None => {
+                return Err(Finding::Logical(format!(
+                    "Doc g{id} missing from engine (model body {expected:?})"
+                )));
+            }
+            Some(actual) if actual != expected => {
+                return Err(Finding::Logical(format!(
+                    "Doc g{id} body mismatch: engine {actual:?} != model {expected:?} (lost update)"
+                )));
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// edges==model (referential integrity): two complementary counts must both
+/// equal the model's live-edge count. The RAW `edge:Knows` row count (read
+/// white-box via the snapshot, so it sees orphans too) catches a lost
+/// node-delete cascade that strands an edge pointing at a deleted Person; the
+/// TRAVERSAL count (`$a knows $b`, which only matches live endpoints) catches a
+/// lost edge write. Raw > traversal means an orphan exists.
+pub async fn check_edges(db: &Omnigraph, model: &Model) -> Result<(), Finding> {
+    let snap = db
+        .snapshot_of(ReadTarget::branch("main"))
+        .await
+        .map_err(Finding::Engine)?;
+    let mut raw: usize = 0;
+    for entry in snap.entries() {
+        if entry.table_key == "edge:Knows" {
+            let ds = snap.open(&entry.table_key).await.map_err(Finding::Engine)?;
+            raw = ds
+                .count_rows(None)
+                .await
+                .map_err(|e| Finding::Logical(format!("edge:Knows count_rows: {e}")))?;
+        }
+    }
+    if raw != model.edges() {
+        return Err(Finding::Logical(format!(
+            "raw edge:Knows rows={raw} != model={} (orphan edge / lost cascade / dup edge)",
+            model.edges()
+        )));
+    }
+    let res = db
+        .query(
+            ReadTarget::branch("main"),
+            "query e() { match { $a: Person $a knows $b } return { $a.slug, $b.slug } }",
+            "e",
+            &ParamMap::new(),
+        )
+        .await
+        .map_err(Finding::Engine)?;
+    if res.num_rows() != model.edges() {
+        return Err(Finding::Logical(format!(
+            "traversable Knows edges={} != model={} (orphan endpoint / lost edge)",
+            res.num_rows(),
+            model.edges()
+        )));
+    }
+    Ok(())
+}

--- a/crates/omnigraph/tests/dst/op.rs
+++ b/crates/omnigraph/tests/dst/op.rs
@@ -1,0 +1,236 @@
+//! D1: the operation alphabet, as data. `step` picks an op, executes it against
+//! the real engine, and updates the reference `Model` on success. Returns the
+//! `OpKind` (for coverage) and the raw `OmniError` (for structured
+//! classification — never stringified here).
+
+use omnigraph::db::{Omnigraph, ReadTarget, RepairOptions};
+use omnigraph::error::OmniError;
+use omnigraph::loader::{LoadMode, load_jsonl};
+use omnigraph_compiler::ir::ParamMap;
+
+use crate::model::Model;
+
+/// One schema exercising both bug surfaces: Person+Knows(@card) for the
+/// delete-cascade / stale-view path, and Doc.source (low-cardinality enum
+/// @index → scalar BTREE) for the index-corruption path.
+pub const SCHEMA: &str = r#"
+node Person {
+    slug: String @key
+    name: String
+}
+node Doc {
+    slug: String @key
+    source: enum(whatsapp, email, linkedin, slack, telegram) @index
+    body: String
+}
+edge Knows: Person -> Person @card(0..1)
+"#;
+
+/// Inline deterministic RNG (xorshift64*, no `rand` dep).
+pub struct Rng(u64);
+impl Rng {
+    pub fn new(seed: u64) -> Self {
+        Rng(seed ^ 0x9E37_79B9_7F4A_7C15)
+    }
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+    pub fn below(&mut self, n: usize) -> usize {
+        (self.next() % n as u64) as usize
+    }
+}
+
+pub fn person(slug: &str) -> String {
+    format!("{{\"type\":\"Person\",\"data\":{{\"slug\":\"{slug}\",\"name\":\"n\"}}}}\n")
+}
+pub fn doc(slug: &str, source: &str) -> String {
+    format!("{{\"type\":\"Doc\",\"data\":{{\"slug\":\"{slug}\",\"source\":\"{source}\",\"body\":\"needle filler\"}}}}\n")
+}
+pub fn knows(from: &str, to: &str) -> String {
+    format!("{{\"edge\":\"Knows\",\"from\":\"{from}\",\"to\":\"{to}\",\"data\":{{}}}}\n")
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum OpKind {
+    InsertPerson,
+    InsertDoc,
+    Optimize,
+    DeletePerson,
+    UpdateDoc,
+    InsertKnows,
+    DeleteKnows,
+    Repair,
+    /// Drop + reopen the handle mid-walk (driven by the walk, not `step`): makes
+    /// the recovery sweep / coordinator re-resolution a first-class op, sampled
+    /// across varied table states instead of only at the end.
+    Reopen,
+    Read,
+}
+
+impl OpKind {
+    pub const ALL: [OpKind; 10] = [
+        OpKind::InsertPerson,
+        OpKind::InsertDoc,
+        OpKind::Optimize,
+        OpKind::DeletePerson,
+        OpKind::UpdateDoc,
+        OpKind::InsertKnows,
+        OpKind::DeleteKnows,
+        OpKind::Repair,
+        OpKind::Reopen,
+        OpKind::Read,
+    ];
+}
+
+/// Pick and run one op. The model is updated only on success.
+pub async fn step(db: &Omnigraph, rng: &mut Rng, model: &mut Model) -> (OpKind, Result<(), OmniError>) {
+    match rng.below(9) {
+        0 => {
+            let mut ids = Vec::new();
+            let mut data = String::new();
+            for _ in 0..(1 + rng.below(10)) {
+                let id = model.fresh_id();
+                ids.push(id);
+                data.push_str(&person(&format!("g{id}")));
+            }
+            let res = match load_jsonl(db, &data, LoadMode::Merge).await {
+                Ok(_) => {
+                    for id in ids {
+                        model.add_person(id);
+                    }
+                    Ok(())
+                }
+                Err(e) => Err(e),
+            };
+            (OpKind::InsertPerson, res)
+        }
+        1 => {
+            let mut ids = Vec::new();
+            let mut data = String::new();
+            for _ in 0..(1 + rng.below(10)) {
+                let id = model.fresh_id();
+                ids.push(id);
+                let s = if rng.below(100) < 85 { "whatsapp" } else { "email" };
+                data.push_str(&doc(&format!("g{id}"), s));
+            }
+            let res = match load_jsonl(db, &data, LoadMode::Merge).await {
+                Ok(_) => {
+                    // `doc()` writes body "needle filler" — track it for content==model.
+                    for id in ids {
+                        model.add_doc(id, "needle filler".to_string());
+                    }
+                    Ok(())
+                }
+                Err(e) => Err(e),
+            };
+            (OpKind::InsertDoc, res)
+        }
+        2 => (OpKind::Optimize, db.optimize().await.map(|_| ())),
+        3 => {
+            let id = rng.below(model.id_high());
+            let q = format!("query d() {{ delete Person where slug = \"g{id}\" }}");
+            let res = match db.mutate("main", &q, "d", &ParamMap::new()).await {
+                Ok(_) => {
+                    model.del_person(id);
+                    Ok(())
+                }
+                Err(e) => Err(e),
+            };
+            (OpKind::DeletePerson, res)
+        }
+        4 => {
+            // UPDATE moves the whole row → scalar-index remap (RC-X morphology).
+            let id = rng.below(model.id_high());
+            let body = format!("u{id} needle");
+            let q = format!("query u() {{ update Doc set {{ body: \"{body}\" }} where slug = \"g{id}\" }}");
+            let res = match db.mutate("main", &q, "u", &ParamMap::new()).await {
+                Ok(_) => {
+                    // Only mutates the model for a Doc it believes exists, so a
+                    // no-op update (0 rows matched) can't desync content==model.
+                    model.update_doc_body(id, body);
+                    Ok(())
+                }
+                Err(e) => Err(e),
+            };
+            (OpKind::UpdateDoc, res)
+        }
+        5 => {
+            // InsertKnows — pick a `from` with no outgoing edge (so the @card(0..1)
+            // insert is always legal) and any live `to`; both endpoints exist, so
+            // the engine producing an orphan/dup is a finding, not a generated one.
+            let froms = model.free_froms();
+            let persons = model.persons_vec();
+            if froms.is_empty() || persons.is_empty() {
+                // No legal edge to add yet — a no-op (still counts for coverage).
+                (OpKind::InsertKnows, Ok(()))
+            } else {
+                let from = froms[rng.below(froms.len())];
+                // Exclude self-loops: a Knows self-loop is committed to the edge
+                // table but is NOT returned by `$a knows $b` traversal (durable
+                // across optimize+reopen; the CSR build keeps it, so the drop is
+                // in Expand). That stored-but-not-traversable divergence is a real
+                // finding the harness surfaced — kept out of the generic generator
+                // so the edges==model oracle stays unambiguous; see B3 notes.
+                let others: Vec<usize> = persons.iter().copied().filter(|p| *p != from).collect();
+                if others.is_empty() {
+                    return (OpKind::InsertKnows, Ok(()));
+                }
+                let to = others[rng.below(others.len())];
+                let data = knows(&format!("g{from}"), &format!("g{to}"));
+                let res = match load_jsonl(db, &data, LoadMode::Merge).await {
+                    Ok(_) => {
+                        model.add_edge(from, to);
+                        Ok(())
+                    }
+                    Err(e) => Err(e),
+                };
+                (OpKind::InsertKnows, res)
+            }
+        }
+        6 => {
+            // DeleteKnows — remove an existing edge by its `from`.
+            let froms = model.knows_froms();
+            if froms.is_empty() {
+                (OpKind::DeleteKnows, Ok(()))
+            } else {
+                let from = froms[rng.below(froms.len())];
+                let q = format!("query dk() {{ delete Knows where from = \"g{from}\" }}");
+                let res = match db.mutate("main", &q, "dk", &ParamMap::new()).await {
+                    Ok(_) => {
+                        model.del_edge(from);
+                        Ok(())
+                    }
+                    Err(e) => Err(e),
+                };
+                (OpKind::DeleteKnows, res)
+            }
+        }
+        7 => {
+            // Repair in confirm (not force) mode — heals VERIFIED maintenance
+            // drift but leaves suspicious/semantic drift (e.g. RC-1's) for
+            // head_eq_manifest to still catch. A no-op on a clean graph; must
+            // never change logical data, so the model is untouched.
+            let opts = RepairOptions {
+                confirm: true,
+                force: false,
+            };
+            (OpKind::Repair, db.repair(opts).await.map(|_| ()))
+        }
+        _ => (
+            OpKind::Read,
+            db.query(
+                ReadTarget::branch("main"),
+                "query w() { match { $d: Doc { source: \"whatsapp\" } } return { $d.slug } }",
+                "w",
+                &ParamMap::new(),
+            )
+            .await
+            .map(|_| ()),
+        ),
+    }
+}

--- a/crates/omnigraph/tests/dst/readshape.rs
+++ b/crates/omnigraph/tests/dst/readshape.rs
@@ -1,0 +1,169 @@
+//! D3 × D2: the read-shape battery run against deliberately-built table
+//! morphologies. The oracle is primarily NO-CRASH — every query shape must
+//! execute without an engine error or panic across each latent layout (single
+//! fragment, ≥2 fragments, deletion vectors, compacted, on-branch) — plus exact
+//! count checks where the answer is morphology-invariant. This is the D2×D3
+//! cell sweep: a planner/execution regression that only bites a specific
+//! fragment layout shows up here, where the generic walk's main-branch oracles
+//! would miss it.
+//!
+//! Scope: the non-vector/non-FTS shapes (scan · @key · indexed · non-indexed ·
+//! range · order+limit · count · numeric aggregates · 1-hop · var-hop ·
+//! negation · zero-match). Vector (`nearest`) and FTS (`bm25`/`search`) shapes
+//! are deferred — they need vector data and the inverted index whose builder
+//! OOB-panics at depth (see `regression`-adjacent finding in dst.rs).
+
+use omnigraph::db::{Omnigraph, ReadTarget};
+use omnigraph::loader::{LoadMode, load_jsonl};
+use omnigraph_compiler::ir::ParamMap;
+
+/// Richer than the walk schema: `age: I64` unlocks range + numeric aggregates.
+pub const SCHEMA: &str = r#"
+node Person {
+    slug: String @key
+    name: String
+    age: I64
+}
+node Doc {
+    slug: String @key
+    source: enum(whatsapp, email, linkedin, slack, telegram) @index
+    body: String
+}
+edge Knows: Person -> Person @card(0..1)
+"#;
+
+fn person(slug: &str, age: i64) -> String {
+    format!("{{\"type\":\"Person\",\"data\":{{\"slug\":\"{slug}\",\"name\":\"n\",\"age\":{age}}}}}\n")
+}
+fn doc(slug: &str, source: &str) -> String {
+    format!("{{\"type\":\"Doc\",\"data\":{{\"slug\":\"{slug}\",\"source\":\"{source}\",\"body\":\"needle filler\"}}}}\n")
+}
+fn knows(from: &str, to: &str) -> String {
+    format!("{{\"edge\":\"Knows\",\"from\":\"{from}\",\"to\":\"{to}\",\"data\":{{}}}}\n")
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum Morph {
+    /// One load batch → one fragment.
+    Single,
+    /// Each row group in its own `Merge` batch → ≥2 fragments.
+    MultiFragment,
+    /// Multi-fragment, then a delete → deletion vectors over live rows.
+    WithDeletions,
+    /// Multi-fragment, then `optimize` → compacted + reindexed.
+    Optimized,
+}
+
+impl Morph {
+    pub const ALL: [Morph; 4] = [
+        Morph::Single,
+        Morph::MultiFragment,
+        Morph::WithDeletions,
+        Morph::Optimized,
+    ];
+}
+
+/// The base population (before morphology-specific shaping): 10 persons p0..p9
+/// with ages 0..9, a `knows` chain p0→p1→…→p8, and 10 docs cycling 4 of the 5
+/// enum sources (never `telegram`, so zero-match is deterministic).
+fn base_rows() -> (Vec<String>, Vec<String>) {
+    let sources = ["whatsapp", "email", "linkedin", "slack"];
+    let mut persons = Vec::new();
+    let mut docs = Vec::new();
+    for i in 0..10 {
+        persons.push(person(&format!("p{i}"), i as i64));
+        docs.push(doc(&format!("d{i}"), sources[i % 4]));
+    }
+    (persons, docs)
+}
+
+/// Build the requested morphology on a fresh graph; returns the live Person
+/// count after shaping (the only count the read battery asserts exactly).
+pub async fn build(db: &Omnigraph, morph: Morph) -> usize {
+    let (persons, docs) = base_rows();
+    match morph {
+        Morph::Single => {
+            let mut all = persons.concat();
+            all.push_str(&docs.concat());
+            for i in 0..9 {
+                all.push_str(&knows(&format!("p{i}"), &format!("p{}", i + 1)));
+            }
+            load_jsonl(db, &all, LoadMode::Merge).await.unwrap();
+            10
+        }
+        Morph::MultiFragment | Morph::Optimized => {
+            // Each person + its doc in its own batch → 10 fragments.
+            for i in 0..10 {
+                load_jsonl(db, &format!("{}{}", persons[i], docs[i]), LoadMode::Merge)
+                    .await
+                    .unwrap();
+            }
+            for i in 0..9 {
+                load_jsonl(db, &knows(&format!("p{i}"), &format!("p{}", i + 1)), LoadMode::Merge)
+                    .await
+                    .unwrap();
+            }
+            if matches!(morph, Morph::Optimized) {
+                db.optimize().await.unwrap();
+            }
+            10
+        }
+        Morph::WithDeletions => {
+            for i in 0..10 {
+                load_jsonl(db, &format!("{}{}", persons[i], docs[i]), LoadMode::Merge)
+                    .await
+                    .unwrap();
+            }
+            for i in 0..9 {
+                load_jsonl(db, &knows(&format!("p{i}"), &format!("p{}", i + 1)), LoadMode::Merge)
+                    .await
+                    .unwrap();
+            }
+            // Delete p0..p2 → deletion vectors + cascaded edges.
+            for i in 0..3 {
+                db.mutate(
+                    "main",
+                    &format!("query d() {{ delete Person where slug = \"p{i}\" }}"),
+                    "d",
+                    &ParamMap::new(),
+                )
+                .await
+                .unwrap();
+            }
+            7
+        }
+    }
+}
+
+/// Every read shape as `(name, query)`. Each must execute without an engine
+/// error against every morphology.
+pub fn shapes() -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("full-scan", "query q() { match { $p: Person } return { $p.slug } }"),
+        ("key-filter", "query q() { match { $p: Person { slug: \"p5\" } } return { $p.slug } }"),
+        ("indexed-filter", "query q() { match { $d: Doc { source: \"whatsapp\" } } return { $d.slug } }"),
+        ("nonindexed-filter", "query q() { match { $p: Person $p.age >= 5 } return { $p.slug } }"),
+        ("range", "query q() { match { $p: Person $p.age >= 3 $p.age <= 6 } return { $p.slug } }"),
+        ("order-limit", "query q() { match { $p: Person } return { $p.slug, $p.age } order { $p.age desc } limit 3 }"),
+        ("count", "query q() { match { $p: Person } return { count($p) as n } }"),
+        ("aggregate", "query q() { match { $p: Person } return { sum($p.age) as s, avg($p.age) as a, min($p.age) as mn, max($p.age) as mx } }"),
+        ("traversal-1hop", "query q() { match { $a: Person $a knows $b } return { $a.slug, $b.slug } }"),
+        ("var-hop", "query q() { match { $a: Person { slug: \"p3\" } $a knows{1,3} $b } return { $b.slug } }"),
+        ("negation", "query q() { match { $p: Person not { $p knows $_ } } return { $p.slug } }"),
+        ("zero-match", "query q() { match { $d: Doc { source: \"telegram\" } } return { $d.slug } }"),
+    ]
+}
+
+/// Run the whole battery against `branch`; returns `(shape, Result<rows,error>)`.
+pub async fn run(db: &Omnigraph, branch: &str) -> Vec<(&'static str, Result<usize, String>)> {
+    let mut out = Vec::new();
+    for (name, q) in shapes() {
+        let r = db
+            .query(ReadTarget::branch(branch), q, "q", &ParamMap::new())
+            .await
+            .map(|res| res.num_rows())
+            .map_err(|e| e.to_string());
+        out.push((name, r));
+    }
+    out
+}

--- a/crates/omnigraph/tests/dst/recovery_walk.rs
+++ b/crates/omnigraph/tests/dst/recovery_walk.rs
@@ -1,0 +1,185 @@
+//! Closes the fault-seam gap (see MATRIX.md). The Phase-2 `FaultAdapter` wraps
+//! `StorageAdapter::write_text_if_match`, which is OFF the manifest-publish hot
+//! path (the publish is a Lance `MergeInsertBuilder` CAS), so it cannot induce a
+//! pending recovery sidecar. **Failpoints can** — `mutation.post_finalize_pre_publisher`
+//! fires after Lance HEAD advances (and the `__recovery/{ulid}.json` sidecar is
+//! written) but before the manifest publish, leaving a `RolledPastExpected`
+//! sidecar.
+//!
+//! Gated on `--features failpoints` (the `fail` registry is process-global, so
+//! every test here is `#[serial]`). Two cells:
+//!  1. recovery rolls forward under a finalize failure — judged by the harness's
+//!     WHITE-BOX structural battery (additive vs the engine's count-only test).
+//!  2. the **#296 cell** — concurrent `Omnigraph::open` racing one pending
+//!     sidecar must all converge, never `ExpectedVersionMismatch`. This is the
+//!     named blind spot from MATRIX.md, now sampled.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering::SeqCst};
+use std::time::Duration;
+
+use fail::FailScenario;
+use omnigraph::db::{Omnigraph, ReadTarget};
+use omnigraph::failpoints::{ScopedFailPoint, names};
+use omnigraph_compiler::ir::ParamMap;
+use serial_test::serial;
+
+use crate::backend;
+use crate::invariants::{self, Finding, classify};
+
+/// The structural (model-free) battery — valid even after a roll-forward
+/// changes the visible state, unlike count==model.
+async fn structural_battery(db: &Omnigraph) -> Vec<(&'static str, Result<(), Finding>)> {
+    vec![
+        ("row-id-unique", invariants::no_duplicate_live_row_ids(db).await),
+        ("dataset.validate", invariants::dataset_validate(db).await),
+        ("head==manifest", invariants::head_eq_manifest(db).await),
+        ("no-dup-@key", invariants::no_duplicate_keys(db, "Person", "main").await),
+    ]
+}
+
+fn judge(findings: Vec<(&'static str, Result<(), Finding>)>, ctx: &str) {
+    for (name, res) in findings {
+        if let Err(f) = res {
+            match classify(&f) {
+                Some(_bug) => {} // known open bug — allow-listed
+                None => panic!("{ctx}: NOVEL violation [{name}]: {}", f.message()),
+            }
+        }
+    }
+}
+
+/// Arm `mutation.post_finalize_pre_publisher`, run one insert that fails after
+/// Phase B, and confirm exactly one sidecar persists. Returns having left the
+/// graph at `uri` with a pending `RolledPastExpected` sidecar.
+async fn induce_pending_sidecar(uri: &str, slug: &str) {
+    let db = backend::reopen(uri).await;
+    let _fp = ScopedFailPoint::new(names::MUTATION_POST_FINALIZE_PRE_PUBLISHER, "return");
+    let q = format!("query i() {{ insert Person {{ slug: \"{slug}\", name: \"n\" }} }}");
+    let err = db.mutate("main", &q, "i", &ParamMap::new()).await.unwrap_err();
+    assert!(
+        err.to_string().contains("mutation.post_finalize_pre_publisher"),
+        "expected the finalize failpoint, got: {err}"
+    );
+    // sidecar dropped with `_fp` + `db` at scope end (handle freed for reopen)
+}
+
+fn sidecar_count(uri: &str) -> usize {
+    let recov = std::path::Path::new(uri).join("__recovery");
+    std::fs::read_dir(&recov)
+        .map(|rd| rd.filter_map(|e| e.ok()).count())
+        .unwrap_or(0)
+}
+
+/// Cell 1: a finalize failure leaves a sidecar; the next open rolls it forward,
+/// and the white-box structural battery holds afterward.
+#[tokio::test]
+#[serial]
+async fn recovery_rolls_forward_under_finalize_failure() {
+    let _scenario = FailScenario::setup();
+    let dir = tempfile::tempdir().unwrap();
+    let uri = dir.path().to_str().unwrap().to_string();
+    drop(backend::open_clean(&uri).await); // init the graph
+
+    induce_pending_sidecar(&uri, "eve").await;
+    assert_eq!(sidecar_count(&uri), 1, "a sidecar must persist for recovery");
+
+    // Reopen runs the sweep → rolls forward → converges.
+    let db = backend::reopen(&uri).await;
+    assert_eq!(sidecar_count(&uri), 0, "sweep must delete the sidecar");
+    let n = db
+        .query(
+            ReadTarget::branch("main"),
+            "query q() { match { $x: Person } return { $x.slug } }",
+            "q",
+            &ParamMap::new(),
+        )
+        .await
+        .unwrap()
+        .num_rows();
+    assert_eq!(n, 1, "the rolled-forward insert must be visible");
+    judge(structural_battery(&db).await, "post-roll-forward");
+}
+
+/// Minimal park-first rendezvous (inlined from `tests/helpers/failpoint.rs` so
+/// the dst binary doesn't pull the whole helpers module): the FIRST thread to
+/// hit `name` parks until `release()`; later arrivals fall through. Bounded so a
+/// bug can't hang the suite.
+struct Rendezvous {
+    reached: Arc<AtomicBool>,
+    release: Arc<AtomicBool>,
+    _fp: ScopedFailPoint,
+}
+impl Rendezvous {
+    fn park_first(name: &str) -> Self {
+        let reached = Arc::new(AtomicBool::new(false));
+        let release = Arc::new(AtomicBool::new(false));
+        let (r, rl) = (Arc::clone(&reached), Arc::clone(&release));
+        let _fp = ScopedFailPoint::with_callback(name, move || {
+            if r.compare_exchange(false, true, SeqCst, SeqCst).is_ok() {
+                for _ in 0..6000 {
+                    if rl.load(SeqCst) {
+                        return;
+                    }
+                    std::thread::sleep(Duration::from_millis(5));
+                }
+            }
+        });
+        Self { reached, release, _fp }
+    }
+    async fn wait_until_reached(&self) {
+        for _ in 0..2400 {
+            if self.reached.load(SeqCst) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        panic!("rendezvous: failpoint was never reached");
+    }
+    fn release(&self) {
+        self.release.store(true, SeqCst);
+    }
+}
+
+/// Cell 2 (the #296 blind spot), forced DETERMINISTICALLY: two concurrent
+/// `Omnigraph::open` sweeps race ONE pending sidecar. The first parks at the
+/// publish window (after classifying `RolledPastExpected`); the second falls
+/// through, rolls the sidecar forward (manifest v→v+1), deletes it. Released,
+/// the parked sweep's publish CAS finds the manifest already at goal — it must
+/// CONVERGE, not fail the open with `ExpectedVersionMismatch`. This is the
+/// generative shape of #296: it fails the open on 0.7.1, converges on 0.7.2.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial]
+async fn concurrent_opens_converge_on_pending_sidecar() {
+    let _scenario = FailScenario::setup();
+    let dir = tempfile::tempdir().unwrap();
+    let uri = dir.path().to_str().unwrap().to_string();
+    drop(backend::open_clean(&uri).await);
+
+    induce_pending_sidecar(&uri, "race").await;
+    assert_eq!(sidecar_count(&uri), 1);
+
+    let rv = Rendezvous::park_first(names::RECOVERY_BEFORE_ROLL_FORWARD_PUBLISH);
+
+    let uri_parked = uri.clone();
+    let parked = tokio::spawn(async move { Omnigraph::open(&uri_parked).await.map(|_| ()) });
+    rv.wait_until_reached().await;
+
+    // The second open converges the sidecar, advancing the manifest past the
+    // parked sweep's pin.
+    Omnigraph::open(&uri)
+        .await
+        .expect("the converging open must roll the sidecar forward and succeed");
+
+    // Release the parked sweep: its CAS loses at a now-stale expected version and
+    // must converge, not crash the open.
+    rv.release();
+    parked
+        .await
+        .expect("parked open task must not panic")
+        .expect("the parked sweep must CONVERGE on CAS-loss, not ExpectedVersionMismatch (#296)");
+
+    assert_eq!(sidecar_count(&uri), 0, "sidecar gone after both converge");
+    let db = backend::reopen(&uri).await;
+    judge(structural_battery(&db).await, "post-concurrent-converge");
+}

--- a/crates/omnigraph/tests/dst/statemachine.rs
+++ b/crates/omnigraph/tests/dst/statemachine.rs
@@ -1,0 +1,229 @@
+//! B5: proptest-state-machine campaign with automatic SHRINKING + regression
+//! persistence, over the CLEAN op subset.
+//!
+//! proptest-state-machine fails and minimizes on ANY reference↔SUT divergence,
+//! so it runs over the ops that have no known open bug — insert-person,
+//! insert-doc, update-doc, read (no delete/optimize/edge/concurrency, which
+//! trigger RC-1 / RC-X / FTS-OOB / dup-`@key`). Over that subset reference and
+//! engine must agree exactly; a regression that breaks a clean op auto-minimizes
+//! to the shortest failing op sequence and persists its seed under
+//! `proptest-regressions/`. The generative walk + the named regressions cover
+//! the buggy ops; this layer adds the shrinking machinery.
+//!
+//! The async engine is bridged the canonical sync way (`proptest_equivalence.rs`
+//! pattern): the SUT owns a current-thread `Runtime` and every engine call is a
+//! `rt.block_on(...)` — the whole campaign is a plain `#[test]`, no ambient
+//! runtime, so `block_on` is legal.
+
+use std::collections::BTreeMap;
+
+use proptest::prelude::*;
+use proptest::strategy::Union;
+use proptest::test_runner::Config;
+use proptest_state_machine::{ReferenceStateMachine, StateMachineTest};
+use tokio::runtime::Runtime;
+
+use omnigraph::db::{Omnigraph, ReadTarget};
+use omnigraph::loader::{LoadMode, load_jsonl};
+use omnigraph_compiler::ir::ParamMap;
+
+use crate::backend;
+use crate::op::{doc, person};
+
+/// The reference model (also the state-machine `State`): the keys that must
+/// exist and each Doc's expected body. `BTreeMap`/`u32` keep `Debug` output
+/// stable, which keeps shrink reports deterministic.
+#[derive(Clone, Debug, Default)]
+pub struct RefModel {
+    persons: BTreeMap<u32, ()>,
+    docs: BTreeMap<u32, String>,
+    next: u32,
+}
+
+/// The clean transitions. Ids are explicit so the reference is a pure function.
+#[derive(Clone, Debug)]
+pub enum Tr {
+    InsertPerson(u32),
+    InsertDoc(u32),
+    /// (existing doc id, tag) → body `u{id}-{tag}`.
+    UpdateDoc(u32, u32),
+    Read,
+}
+
+impl ReferenceStateMachine for RefModel {
+    type State = RefModel;
+    type Transition = Tr;
+
+    fn init_state() -> BoxedStrategy<RefModel> {
+        Just(RefModel::default()).boxed()
+    }
+
+    fn transitions(state: &RefModel) -> BoxedStrategy<Tr> {
+        let next = state.next;
+        let mut options: Vec<BoxedStrategy<Tr>> = vec![
+            Just(Tr::InsertPerson(next)).boxed(),
+            Just(Tr::InsertDoc(next)).boxed(),
+            Just(Tr::Read).boxed(),
+        ];
+        if !state.docs.is_empty() {
+            let ids: Vec<u32> = state.docs.keys().copied().collect();
+            options.push(
+                (proptest::sample::select(ids), any::<u16>())
+                    .prop_map(|(id, tag)| Tr::UpdateDoc(id, tag as u32))
+                    .boxed(),
+            );
+        }
+        Union::new(options).boxed()
+    }
+
+    fn apply(mut state: RefModel, transition: &Tr) -> RefModel {
+        match transition {
+            Tr::InsertPerson(id) => {
+                state.persons.insert(*id, ());
+                state.next = state.next.max(id + 1);
+            }
+            Tr::InsertDoc(id) => {
+                state.docs.insert(*id, "needle filler".to_string());
+                state.next = state.next.max(id + 1);
+            }
+            Tr::UpdateDoc(id, tag) => {
+                // Mirror engine no-op semantics: only an existing doc changes.
+                if state.docs.contains_key(id) {
+                    state.docs.insert(*id, format!("u{id}-{tag}"));
+                }
+            }
+            Tr::Read => {}
+        }
+        state
+    }
+}
+
+/// The system under test: a real graph plus the runtime that drives it.
+pub struct Sut {
+    rt: Runtime,
+    db: Omnigraph,
+    _dir: tempfile::TempDir,
+}
+
+pub struct DstMachine;
+
+impl Sut {
+    fn person_count(&self) -> usize {
+        self.rt.block_on(async {
+            self.db
+                .query(
+                    ReadTarget::branch("main"),
+                    "query q() { match { $x: Person } return { $x.slug } }",
+                    "q",
+                    &ParamMap::new(),
+                )
+                .await
+                .unwrap()
+                .num_rows()
+        })
+    }
+
+    /// id → body for every live Doc.
+    fn doc_bodies(&self) -> BTreeMap<u32, String> {
+        self.rt.block_on(async {
+            let res = self
+                .db
+                .query(
+                    ReadTarget::branch("main"),
+                    "query c() { match { $d: Doc } return { $d.slug, $d.body } }",
+                    "c",
+                    &ParamMap::new(),
+                )
+                .await
+                .unwrap();
+            let json = res.to_rust_json();
+            let mut out = BTreeMap::new();
+            for row in json.as_array().unwrap() {
+                let slug = row["d.slug"].as_str().unwrap();
+                let body = row["d.body"].as_str().unwrap().to_string();
+                let id: u32 = slug.strip_prefix('g').unwrap().parse().unwrap();
+                out.insert(id, body);
+            }
+            out
+        })
+    }
+}
+
+impl StateMachineTest for DstMachine {
+    type SystemUnderTest = Sut;
+    type Reference = RefModel;
+
+    fn init_test(_ref_state: &RefModel) -> Sut {
+        let rt = Runtime::new().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let uri = dir.path().to_str().unwrap().to_string();
+        let db = rt.block_on(backend::open_clean(&uri));
+        Sut {
+            rt,
+            db,
+            _dir: dir,
+        }
+    }
+
+    fn apply(sut: Sut, _ref_state: &RefModel, transition: Tr) -> Sut {
+        sut.rt.block_on(async {
+            match transition {
+                Tr::InsertPerson(id) => {
+                    load_jsonl(&sut.db, &person(&format!("g{id}")), LoadMode::Merge)
+                        .await
+                        .unwrap();
+                }
+                Tr::InsertDoc(id) => {
+                    load_jsonl(&sut.db, &doc(&format!("g{id}"), "whatsapp"), LoadMode::Merge)
+                        .await
+                        .unwrap();
+                }
+                Tr::UpdateDoc(id, tag) => {
+                    let q = format!(
+                        "query u() {{ update Doc set {{ body: \"u{id}-{tag}\" }} where slug = \"g{id}\" }}"
+                    );
+                    sut.db.mutate("main", &q, "u", &ParamMap::new()).await.unwrap();
+                }
+                Tr::Read => {
+                    sut.db
+                        .query(
+                            ReadTarget::branch("main"),
+                            "query w() { match { $d: Doc { source: \"whatsapp\" } } return { $d.slug } }",
+                            "w",
+                            &ParamMap::new(),
+                        )
+                        .await
+                        .unwrap();
+                }
+            }
+        });
+        sut
+    }
+
+    fn check_invariants(sut: &Sut, ref_state: &RefModel) {
+        // count==model and content==model against the reference, plus structural
+        // row-id uniqueness — all must hold exactly over the clean op subset.
+        assert_eq!(
+            sut.person_count(),
+            ref_state.persons.len(),
+            "Person count diverged from reference"
+        );
+        assert_eq!(
+            sut.doc_bodies(),
+            ref_state.docs,
+            "Doc id→body diverged from reference (lost/dup/stale write)"
+        );
+        sut.rt
+            .block_on(crate::invariants::no_duplicate_live_row_ids(&sut.db))
+            .expect("duplicate live stable row-id");
+    }
+}
+
+proptest_state_machine::prop_state_machine! {
+    #![proptest_config(Config { cases: 24, .. Config::default() })]
+
+    /// Over the clean op subset, the engine must track the reference for any
+    /// generated sequence of 1..30 ops; a divergence auto-shrinks + persists.
+    #[test]
+    fn clean_ops_track_reference(sequential 1..30 => DstMachine);
+}

--- a/crates/omnigraph/tests/dst_recovery.rs
+++ b/crates/omnigraph/tests/dst_recovery.rs
@@ -1,0 +1,23 @@
+//! Failpoint-gated DST cells, in their OWN binary so the process-global `fail`
+//! registry cannot leak armed failpoints into the main `dst` suite's (parallel,
+//! non-serial) generative walks. Run with `--features failpoints`; empty
+//! otherwise. Shares the harness's `dst/` modules via `#[path]` (compiled per
+//! binary — hence `allow(dead_code)` for the helpers this binary doesn't call).
+//!
+//! See `dst/recovery_walk.rs` for the cells; see `dst/MATRIX.md` for why this
+//! closes the fault-seam gap.
+#![cfg(feature = "failpoints")]
+#![allow(dead_code)]
+
+#[path = "dst/op.rs"]
+mod op;
+#[path = "dst/model.rs"]
+mod model;
+#[path = "dst/invariants.rs"]
+mod invariants;
+#[path = "dst/fault.rs"]
+mod fault;
+#[path = "dst/backend.rs"]
+mod backend;
+#[path = "dst/recovery_walk.rs"]
+mod recovery_walk;


### PR DESCRIPTION
**Supersedes #300 and #302** — consolidates the full DST harness onto current `main` (0.7.2) in one PR, plus the completeness-critic hardening pass. Tests-only (no engine `src` changes).

## The harness (B1–B6, was #300 + #302)
A seeded, model-based DST harness over the morphological matrix (D1 ops · D2 fragment morphology · D3 read shapes · D4 oracles · D5 context):
- White-box invariant battery after every op: HEAD==manifest, `Dataset::validate`, **unique live `_rowid`** (RC-X corruption class, deletion-vector-correct), index-probe, count==model, content==model, edges==model (RI), @key-unique.
- Generative walk (panic-robust via `catch_unwind` + `classify_panic`), branch isolation/merge scenario, read-shape battery × 4 morphologies, concurrent multi-actor walk, and a **proptest-state-machine** shrinking campaign over the clean op subset.

### Bugs guarded (5)
Reproduced/pinned as characterization tests, **all still present on 0.7.2** (verified):
| | layer | guard |
|---|---|---|
| RC-X / Lance #7230 (scalar-BTREE dup row addr) | Lance (fixed v8.0.0) | `regression_rc_x_…` + index-probe |
| RC-1 stale-view manifest CAS on delete combos | Omnigraph | `regression_rc1_…` + HEAD==manifest |
| dup-`@key` (MR-714) | Omnigraph | `regression_dup_key_…` + concurrent walk |
| **self-loop `Knows` not traversable** (NEW) | Omnigraph (Expand) | `regression_self_loop_…` + edges==model |
| **Lance FTS inverted-builder OOB panic** (NEW) | Lance | caught + classified by the walk |

## Hardening (completeness-critic pass)
- **`dst/MATRIX.md`** — a coverage ledger: D1–D5 sampled/unsampled cells, the **hidden dimensions** found only after a miss, and why exhaustive sampling is impossible. A living artifact, re-run when an external bug slips through.
- **`Reopen` op** — the recovery sweep is now a first-class walk op.
- **Critic finding:** the Phase-2 `FaultAdapter` wraps `StorageAdapter::write_text_if_match`, which is **off** the manifest-publish path (a Lance `MergeInsertBuilder` CAS) — so it couldn't induce a recovery sidecar.
- **Fault-seam closed** via a `--features failpoints` variant in its **own binary** (`tests/dst_recovery.rs`): induces a real `RolledPastExpected` sidecar, and a rendezvous-forced **concurrent-open race** (the `#296` blind spot) asserting the CAS-loser converges. Run: `cargo test -p omnigraph-engine --features failpoints --test dst_recovery`.

## Why 0.7.2
The only fix between 0.7.1 and 0.7.2 (#296, recovery roll-forward convergence) fixes a *different* recovery bug than any the harness catches — confirmed by running the harness against 0.7.2 (all 5 guards stay green). The `#296` cell is now sampled so its class can't slip again.

## Run
- `cargo test -p omnigraph-engine --test dst` (10 tests)
- `cargo test -p omnigraph-engine --features failpoints --test dst_recovery` (2 cells)

New test-only dev-deps: `arrow-array`, `futures`, `serde_json`, `async-trait`, `proptest-state-machine`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions and dev-dependencies; no production engine code paths change.
> 
> **Overview**
> **Tests-only** — adds a deterministic-simulation / morphological-matrix (DST) harness under `crates/omnigraph/tests/dst/` with entrypoints `tests/dst.rs` and `tests/dst_recovery.rs` (no engine `src` changes).
> 
> The harness drives the real **omnigraph-engine** through a seeded op alphabet, a reference **model**, and a white-box **invariant battery** after each step (HEAD==manifest, `Dataset::validate`, unique live `_rowid`, index probe, count/content/edges vs model, @key checks). Findings are classified as **known open bugs** (allow-listed) vs **novel** (fail). Coverage is tracked; **`dst/MATRIX.md`** documents sampled vs gap matrix dimensions and critic findings (e.g. `FaultAdapter` CAS seam vs manifest publish path).
> 
> **New scenarios:** named characterization regressions (RC-1, RC-X, dup-@key, self-loop traversal, etc.); generative walks with optional **`FaultAdapter`** CAS faults, mid-walk **`Reopen`**, and panic containment; concurrent multi-actor structural walk; branch isolation/merge; read-shape battery × table morphologies; **proptest-state-machine** shrinking on clean ops.
> 
> **Failpoint binary** (`--features failpoints --test dst_recovery`): real pending recovery sidecars and deterministic concurrent-open race (#296), isolated from parallel main DST runs.
> 
> **Dev-deps:** `proptest-state-machine`, plus `arrow-array`, `futures`, `serde_json`, `async-trait` for the harness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76fa48f35c58b2fa7435b71438129aec1696b3fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a test-only DST harness for Omnigraph. The main changes are:

- Seeded operation walks with model and invariant checks.
- Regression guards for known Lance and Omnigraph bugs.
- Read-shape and morphology coverage tests.
- Failpoint-gated recovery race tests.
- A coverage ledger for sampled and deferred cells.

<h3>Confidence Score: 4/5</h3>

The DST harness needs a small correctness fix before merging.

- A generic Person count mismatch can be classified as the known duplicate-key bug.
- That can hide lost-write failures in the new walk.
- The new build and failpoint test surfaces otherwise look consistent.

crates/omnigraph/tests/dst/model.rs

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/omnigraph/tests/dst.rs | Adds the main DST test binary with seeded walks, regression guards, read-shape coverage, and durability checks. |
| crates/omnigraph/tests/dst/model.rs | Adds the reference model and invariant checks, with one count-mismatch message that can be over-allow-listed. |
| crates/omnigraph/tests/dst/invariants.rs | Adds known-bug classification and the invariant battery used by the walk. |
| crates/omnigraph/tests/dst/op.rs | Defines the generated operation alphabet and model update rules. |
| crates/omnigraph/tests/dst/recovery_walk.rs | Adds failpoint-driven recovery and concurrent-open race coverage. |
| crates/omnigraph/tests/dst/statemachine.rs | Adds a proptest-state-machine campaign over the clean operation subset. |
| crates/omnigraph/tests/dst/MATRIX.md | Documents DST coverage and remaining gaps, with one stale recovery row. |
| crates/omnigraph/Cargo.toml | Adds the test-support dependencies used by the new harness. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Seeded DST walk] --> B[Run engine op]
  B --> C{Op succeeds?}
  C -->|yes| D[Update model]
  C -->|no| E[Classify error]
  D --> F[Run invariant battery]
  E --> F
  F --> G{Finding?}
  G -->|known| H[Record known bug]
  G -->|novel| I[Fail test]
  G -->|none| A
  A --> J[Reopen durability check]
  J --> F
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
  A[Seeded DST walk] --> B[Run engine op]
  B --> C{Op succeeds?}
  C -->|yes| D[Update model]
  C -->|no| E[Classify error]
  D --> F[Run invariant battery]
  E --> F
  F --> G{Finding?}
  G -->|known| H[Record known bug]
  G -->|novel| I[Fail test]
  G -->|none| A
  A --> J[Reopen durability check]
  J --> F
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acrates%2Fomnigraph%2Ftests%2Fdst%2Fmodel.rs%3A119-122%0A**Lost%20Writes%20Become%20Known%20Bugs**%0A%0AWhen%20%60count%20Person%60%20differs%20from%20the%20model%20for%20any%20reason%2C%20this%20message%20includes%20the%20%60dup-%40key%60%20token%20that%20%60classify%28%29%60%20allow-lists.%20A%20lost%20write%20after%20a%20faulted%20op%2C%20repair%2C%20or%20reopen%20can%20therefore%20be%20recorded%20as%20the%20known%20duplicate-key%20bug%20instead%20of%20failing%20the%20DST%20walk.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20return%20Err%28Finding%3A%3ALogical%28format!%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%22count%20Person%3D%7Bp%7D%20!%3D%20model%3D%7B%7D%20%28lost-write%20or%20unexpected%20duplicate%20row%29%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20model.persons%28%29%0A%20%20%20%20%20%20%20%20%29%29%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acrates%2Fomnigraph%2Ftests%2Fdst%2FMATRIX.md%3A45%0A**Recovery%20Coverage%20Row%20Is%20Stale**%0A%0AThis%20row%20still%20marks%20%60open%60%20%2F%20recovery%20as%20unsampled%2C%20while%20the%20same%20PR%20adds%20%60Reopen%60%20to%20the%20walk%20and%20marks%20the%20failpoint%20recovery%20cells%20done%20later%20in%20the%20file.%20The%20ledger%20now%20contradicts%20the%20harness%20and%20can%20mislead%20future%20gap-closure%20work.%0A%0A%60%60%60suggestion%0A%7C%20**%60open%60%20%2F%20recovery%20sweep**%20%7C%20%E2%9C%85%20%7C%20walk%20%28%60Reopen%60%29%20%2B%20failpoint%20recovery%20cells%20%28%60dst_recovery%60%29%20%7C%0A%60%60%60%0A%0A&repo=modernrelay%2Fomnigraph&pr=303&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["chore: lock new test-only dev-deps (arro..."](https://github.com/modernrelay/omnigraph/commit/76fa48f35c58b2fa7435b71438129aec1696b3fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39801799)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=59169be6-01cf-4bae-80fc-604b6a708098))
- Context used - CLAUDE.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=fba7c581-edb6-48b3-90ce-1db695f47e8b))

<!-- /greptile_comment -->