### PR TITLE
feat(dst): deterministic-replay seam + replay-equality oracle (PR-C, stacked on #303)

### DIFF
--- a/crates/omnigraph/Cargo.toml
+++ b/crates/omnigraph/Cargo.toml
@@ -14,6 +14,9 @@ name = "omnigraph"
 [features]
 default = []
 failpoints = ["dep:fail", "fail/failpoints"]
+# Deterministic-replay seam for the DST test harness (seeds the engine's
+# observable ULID/timestamp sites via a task-local). Zero cost when off.
+dst = []
 
 [dependencies]
 omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.2" }

--- a/crates/omnigraph/src/db/commit_graph.rs
+++ b/crates/omnigraph/src/db/commit_graph.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use arrow_array::{
     Array, RecordBatch, RecordBatchIterator, StringArray, TimestampMicrosecondArray, UInt64Array,
@@ -42,7 +41,7 @@ impl CommitGraph {
         let root = root_uri.trim_end_matches('/');
         let uri = graph_commits_uri(root);
         let genesis = GraphCommit {
-            graph_commit_id: ulid::Ulid::new().to_string(),
+            graph_commit_id: crate::dst::next_ulid().to_string(),
             manifest_branch: None,
             manifest_version,
             parent_commit_id: None,
@@ -259,7 +258,7 @@ impl CommitGraph {
         merged_parent_commit_id: Option<&str>,
         actor_id: Option<&str>,
     ) -> Result<String> {
-        let graph_commit_id = ulid::Ulid::new().to_string();
+        let graph_commit_id = crate::dst::next_ulid().to_string();
         let commit = GraphCommit {
             graph_commit_id: graph_commit_id.clone(),
             manifest_branch: manifest_branch.map(|s| s.to_string()),
@@ -695,10 +694,9 @@ async fn open_for_branch(root_uri: &str, branch: Option<&str>) -> Result<CommitG
 }
 
 fn now_micros() -> Result<i64> {
-    let duration = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|e| OmniError::manifest(format!("system clock before UNIX_EPOCH: {}", e)))?;
-    Ok(duration.as_micros() as i64)
+    // Routed through the DST seam (deterministic under the `dst` feature; the
+    // real clock otherwise). Covers all commit-graph timestamp callers.
+    Ok(crate::dst::now_micros())
 }
 
 #[cfg(test)]

--- a/crates/omnigraph/src/db/commit_graph.rs
+++ b/crates/omnigraph/src/db/commit_graph.rs
@@ -695,8 +695,10 @@ async fn open_for_branch(root_uri: &str, branch: Option<&str>) -> Result<CommitG
 
 fn now_micros() -> Result<i64> {
     // Routed through the DST seam (deterministic under the `dst` feature; the
-    // real clock otherwise). Covers all commit-graph timestamp callers.
-    Ok(crate::dst::now_micros())
+    // real clock otherwise). The `_result` variant PROPAGATES a clock-before-
+    // epoch error (the pre-seam contract) instead of persisting a 0 timestamp.
+    // Covers all commit-graph timestamp callers.
+    crate::dst::now_micros_result()
 }
 
 #[cfg(test)]

--- a/crates/omnigraph/src/db/manifest/recovery.rs
+++ b/crates/omnigraph/src/db/manifest/recovery.rs
@@ -1920,12 +1920,9 @@ pub(crate) fn new_sidecar(
     actor_id: Option<String>,
     tables: Vec<SidecarTablePin>,
 ) -> RecoverySidecar {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let operation_id = ulid::Ulid::new().to_string();
-    let started_at = match SystemTime::now().duration_since(UNIX_EPOCH) {
-        Ok(d) => format!("{}", d.as_micros()),
-        Err(_) => "0".to_string(),
-    };
+    let operation_id = crate::dst::next_ulid().to_string();
+    // Routed through the DST seam (deterministic under the `dst` feature).
+    let started_at = format!("{}", crate::dst::now_micros());
     RecoverySidecar {
         schema_version: SIDECAR_SCHEMA_VERSION,
         operation_id,

--- a/crates/omnigraph/src/db/recovery_audit.rs
+++ b/crates/omnigraph/src/db/recovery_audit.rs
@@ -22,7 +22,6 @@
 //! audit append is retried).
 
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use arrow_array::{
     Array, RecordBatch, RecordBatchIterator, StringArray, TimestampMicrosecondArray,
@@ -277,10 +276,8 @@ fn decode_row(batch: &RecordBatch, row: usize) -> Result<RecoveryAuditRecord> {
 }
 
 pub(crate) fn now_micros() -> Result<i64> {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_micros() as i64)
-        .map_err(|e| OmniError::manifest_internal(format!("system clock before unix epoch: {}", e)))
+    // Routed through the DST seam (deterministic under the `dst` feature).
+    Ok(crate::dst::now_micros())
 }
 
 #[cfg(test)]

--- a/crates/omnigraph/src/db/recovery_audit.rs
+++ b/crates/omnigraph/src/db/recovery_audit.rs
@@ -276,8 +276,10 @@ fn decode_row(batch: &RecordBatch, row: usize) -> Result<RecoveryAuditRecord> {
 }
 
 pub(crate) fn now_micros() -> Result<i64> {
-    // Routed through the DST seam (deterministic under the `dst` feature).
-    Ok(crate::dst::now_micros())
+    // Routed through the DST seam (deterministic under the `dst` feature). The
+    // `_result` variant PROPAGATES a clock-before-epoch error (the pre-seam
+    // contract) instead of persisting a 0 timestamp.
+    crate::dst::now_micros_result()
 }
 
 #[cfg(test)]

--- a/crates/omnigraph/src/dst.rs
+++ b/crates/omnigraph/src/dst.rs
@@ -14,13 +14,22 @@
 
 use ulid::Ulid;
 
-/// Production fallback: real micros since the Unix epoch.
-fn real_now_micros() -> i64 {
+/// Production fallback: real micros since the Unix epoch, propagating a
+/// clock-before-epoch failure (mirrors the pre-seam helper's `OmniError`).
+fn real_now_micros_result() -> crate::error::Result<i64> {
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_micros() as i64)
-        .unwrap_or(0)
+        .map_err(|e| crate::error::OmniError::manifest(format!("system clock before UNIX_EPOCH: {e}")))
+}
+
+/// Infallible variant: a clock-before-epoch failure collapses to `0`. Only for
+/// callers that aren't fallible (the sidecar `started_at` diagnostic string and
+/// the seeded ULID clock); the fallible timestamp helpers use
+/// [`now_micros_result`] so a bad clock still surfaces, never persists as `0`.
+fn real_now_micros() -> i64 {
+    real_now_micros_result().unwrap_or(0)
 }
 
 /// A ULID for an observable id. Deterministic under [`with_seed`]; otherwise a
@@ -45,6 +54,21 @@ pub(crate) fn now_micros() -> i64 {
         }
     }
     real_now_micros()
+}
+
+/// Fallible timestamp for the production write path: deterministic + monotonic
+/// under [`with_seed`]; otherwise the real clock, PROPAGATING a clock-before-
+/// epoch error (the pre-seam contract). Use this — not [`now_micros`] — wherever
+/// the caller is `Result`-returning, so a broken clock fails loudly (deny-list:
+/// no silent failures) instead of persisting a `0` timestamp.
+pub(crate) fn now_micros_result() -> crate::error::Result<i64> {
+    #[cfg(feature = "dst")]
+    {
+        if let Ok(t) = imp::DST.try_with(|s| s.now_micros()) {
+            return Ok(t);
+        }
+    }
+    real_now_micros_result()
 }
 
 #[cfg(feature = "dst")]
@@ -76,8 +100,14 @@ mod imp {
                 seed,
                 ids: AtomicU64::new(0),
                 // Fixed seed-derived epoch (~2023 in micros), advanced
-                // monotonically so ULID timestamps stay sortable.
-                clock_micros: AtomicI64::new(1_700_000_000_000_000 + (seed as i64) * 1_000_000),
+                // monotonically so ULID timestamps stay sortable. The seed-
+                // derived offset is bounded to < 1 day (86_400_000_000 micros)
+                // via splitmix64 so an arbitrary u64 seed (e.g. a fuzzer seed)
+                // can't overflow i64 — `(seed as i64) * 1_000_000` would panic in
+                // debug / wrap in release for large seeds and mint bogus times.
+                clock_micros: AtomicI64::new(
+                    1_700_000_000_000_000 + (splitmix64(seed) % 86_400_000_000) as i64,
+                ),
                 fingerprint: AtomicU64::new(splitmix64(seed)),
             })
         }

--- a/crates/omnigraph/src/dst.rs
+++ b/crates/omnigraph/src/dst.rs
@@ -1,0 +1,125 @@
+//! Deterministic-replay seam for the DST test harness (Cargo feature `dst`).
+//!
+//! The engine mints ULIDs and microsecond timestamps at scattered, OBSERVABLE
+//! sites (commit-graph ids/timestamps, keyless node/edge ids, recovery sidecar
+//! op-ids). For a seeded harness run to be bit-reproducible, those sites call
+//! [`next_ulid`] / [`now_micros`] here instead of `Ulid::new()` /
+//! `SystemTime::now()`.
+//!
+//! Mirrors `failpoints.rs`: WITHOUT the `dst` feature (or with no provider in
+//! scope) both functions fall back to the real source, and the feature block
+//! compiles away — **zero production cost**. Under the feature, a per-task
+//! seeded provider (`with_seed`) makes ids/timestamps deterministic and exposes
+//! a rolling fingerprint for the replay-equality oracle.
+
+use ulid::Ulid;
+
+/// Production fallback: real micros since the Unix epoch.
+fn real_now_micros() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_micros() as i64)
+        .unwrap_or(0)
+}
+
+/// A ULID for an observable id. Deterministic under [`with_seed`]; otherwise a
+/// real `Ulid::new()`.
+pub(crate) fn next_ulid() -> Ulid {
+    #[cfg(feature = "dst")]
+    {
+        if let Ok(u) = imp::DST.try_with(|s| s.next_ulid()) {
+            return u;
+        }
+    }
+    Ulid::new()
+}
+
+/// Micros since the epoch for an observable timestamp. Deterministic +
+/// monotonic under [`with_seed`]; otherwise the real clock.
+pub(crate) fn now_micros() -> i64 {
+    #[cfg(feature = "dst")]
+    {
+        if let Ok(t) = imp::DST.try_with(|s| s.now_micros()) {
+            return t;
+        }
+    }
+    real_now_micros()
+}
+
+#[cfg(feature = "dst")]
+mod imp {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicI64, AtomicU64, Ordering::SeqCst};
+
+    use ulid::Ulid;
+
+    pub(super) fn splitmix64(mut x: u64) -> u64 {
+        x = x.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        x = (x ^ (x >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        x = (x ^ (x >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        x ^ (x >> 31)
+    }
+
+    /// Seeded, monotonic id/clock source + a rolling fingerprint of everything
+    /// it has minted — the replay-equality signal.
+    pub struct DstState {
+        seed: u64,
+        ids: AtomicU64,
+        clock_micros: AtomicI64,
+        fingerprint: AtomicU64,
+    }
+
+    impl DstState {
+        pub fn new(seed: u64) -> Arc<Self> {
+            Arc::new(Self {
+                seed,
+                ids: AtomicU64::new(0),
+                // Fixed seed-derived epoch (~2023 in micros), advanced
+                // monotonically so ULID timestamps stay sortable.
+                clock_micros: AtomicI64::new(1_700_000_000_000_000 + (seed as i64) * 1_000_000),
+                fingerprint: AtomicU64::new(splitmix64(seed)),
+            })
+        }
+        fn mix(&self, v: u64) {
+            let cur = self.fingerprint.load(SeqCst);
+            self.fingerprint.store(splitmix64(cur ^ v), SeqCst);
+        }
+        pub fn next_ulid(&self) -> Ulid {
+            let n = self.ids.fetch_add(1, SeqCst);
+            let ms = (self.clock_micros.load(SeqCst) / 1000) as u64;
+            // 80-bit random part derived from (seed, counter) — unique + deterministic.
+            let random = ((splitmix64(self.seed ^ n) as u128) << 16) | (n as u128 & 0xFFFF);
+            self.mix(n ^ ms);
+            Ulid::from_parts(ms, random)
+        }
+        pub fn now_micros(&self) -> i64 {
+            // 1ms per call → monotonic, deterministic.
+            let t = self.clock_micros.fetch_add(1000, SeqCst);
+            self.mix(t as u64);
+            t
+        }
+        pub fn fingerprint(&self) -> u64 {
+            self.fingerprint.load(SeqCst)
+        }
+    }
+
+    tokio::task_local! {
+        pub static DST: Arc<DstState>;
+    }
+}
+
+/// Run `fut` with a seeded deterministic id/clock provider in scope; returns the
+/// future's output and the engine's id/clock FINGERPRINT for that run. Two runs
+/// of the same seeded workload must produce the same fingerprint — the
+/// replay-equality oracle. Only available under the `dst` feature.
+#[cfg(feature = "dst")]
+pub async fn with_seed<F>(seed: u64, fut: F) -> (F::Output, u64)
+where
+    F: std::future::Future,
+{
+    let state = imp::DstState::new(seed);
+    let handle = std::sync::Arc::clone(&state);
+    let out = imp::DST.scope(state, fut).await;
+    (out, handle.fingerprint())
+}

--- a/crates/omnigraph/src/exec/mutation.rs
+++ b/crates/omnigraph/src/exec/mutation.rs
@@ -1086,7 +1086,7 @@ impl Omnigraph {
                     }
                 }
             } else {
-                ulid::Ulid::new().to_string()
+                crate::dst::next_ulid().to_string()
             };
 
             let batch = build_insert_batch(&schema, &id, &resolved, &blob_props)?;
@@ -1132,7 +1132,7 @@ impl Omnigraph {
             let edge_type = &self.catalog().edge_types[type_name];
             let schema = edge_type.arrow_schema.clone();
             let blob_props = edge_type.blob_properties.clone();
-            let id = ulid::Ulid::new().to_string();
+            let id = crate::dst::next_ulid().to_string();
 
             let batch = build_insert_batch(&schema, &id, &resolved, &blob_props)?;
             validate_edge_insert_endpoints(self, staging, branch, type_name, &resolved).await?;

--- a/crates/omnigraph/src/lib.rs
+++ b/crates/omnigraph/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod changes;
 pub mod db;
+pub mod dst;
 pub mod embedding;
 pub mod error;
 mod exec;

--- a/crates/omnigraph/src/loader/mod.rs
+++ b/crates/omnigraph/src/loader/mod.rs
@@ -1177,7 +1177,7 @@ fn load_write_concurrency() -> usize {
 }
 
 fn generate_id() -> String {
-    ulid::Ulid::new().to_string()
+    crate::dst::next_ulid().to_string()
 }
 
 pub(crate) fn parse_date32_literal(value: &str) -> Result<i32> {

--- a/crates/omnigraph/tests/dst.rs
+++ b/crates/omnigraph/tests/dst.rs
@@ -581,3 +581,59 @@ async fn run_walk(faults: bool) {
 }
 
 
+
+// ═══════════════════════════ determinism (PR-C) ═══════════════════════════
+
+/// Replay-equality oracle (feature `dst`): the same seeded clean op sequence,
+/// run twice under the same DST seed, must mint the IDENTICAL engine id/clock
+/// fingerprint AND produce the identical outcome — a determinism tripwire (green
+/// while the engine is reproducible, red the moment non-determinism leaks into
+/// the id/timestamp seam). Uses insert/read only (no optimize/delete), so
+/// neither the Lance FTS-builder non-determinism nor RC-1 perturbs the
+/// comparison; the engine still mints a commit id + timestamp per load, so the
+/// seam IS exercised. A different seed must diverge (proves seed-sensitivity).
+#[cfg(feature = "dst")]
+#[tokio::test]
+async fn replay_equality_same_seed() {
+    async fn run(seed: u64) -> (usize, usize) {
+        let dir = tempfile::tempdir().unwrap();
+        let db = backend::open_clean(dir.path().to_str().unwrap()).await;
+        let mut rng = Rng::new(seed);
+        let (mut np, mut nd) = (0usize, 0usize);
+        for i in 0..15 {
+            match rng.below(3) {
+                0 => {
+                    load_jsonl(&db, &person(&format!("p{i}")), LoadMode::Merge)
+                        .await
+                        .unwrap();
+                    np += 1;
+                }
+                1 => {
+                    load_jsonl(&db, &doc(&format!("d{i}"), "whatsapp"), LoadMode::Merge)
+                        .await
+                        .unwrap();
+                    nd += 1;
+                }
+                _ => {
+                    let _ = db
+                        .query(
+                            ReadTarget::branch("main"),
+                            "query q() { match { $x: Person } return { $x.slug } }",
+                            "q",
+                            &ParamMap::new(),
+                        )
+                        .await;
+                }
+            }
+        }
+        (np, nd)
+    }
+
+    let (out1, fp1) = omnigraph::dst::with_seed(7, run(7)).await;
+    let (out2, fp2) = omnigraph::dst::with_seed(7, run(7)).await;
+    assert_eq!(fp1, fp2, "engine id/clock fingerprint must match for the same seed");
+    assert_eq!(out1, out2, "harness outcome must match for the same seed");
+
+    let (_out3, fp3) = omnigraph::dst::with_seed(99, run(99)).await;
+    assert_ne!(fp1, fp3, "different seeds should yield different fingerprints");
+}


### PR DESCRIPTION
**Stacked on #303** (base `dst-harness-harden`). The one engine change of the DST plan (PR-C) — a feature-gated deterministic-replay seam. **Zero production cost.**

## What
The engine mints observable ULIDs/timestamps at scattered sites (commit-graph ids/timestamps, keyless node/edge ids, recovery sidecar op-ids), so a seeded harness run was not bit-reproducible. New `src/dst.rs` (mirrors `failpoints.rs`'s no-op-fallback shape):
- `next_ulid()` / `now_micros()` consult a `tokio::task_local` provider **when the `dst` feature is on AND a provider is in scope**, else fall back to real `Ulid::new()` / `SystemTime::now()`. Without the feature the `#[cfg(feature="dst")]` block compiles away.
- `with_seed(seed, fut) -> (Output, fingerprint)` scopes a seeded provider and returns a rolling id/clock fingerprint.

## Sites routed (OBSERVABLE only)
6 ULID + the timestamp seam: `exec/mutation.rs` (×2), `loader/mod.rs` (`generate_id`), `db/commit_graph.rs` (genesis+append, and the `now_micros` helper covering all its callers), `db/manifest/recovery.rs` (sidecar op_id + `started_at`), `db/recovery_audit.rs` (`now_micros` helper). Skipped ephemeral cleanup-cutoff / metrics sites.

## Oracle
`replay_equality_same_seed` (`--features dst`): the same seeded clean op sequence run twice yields an identical engine fingerprint + outcome; a different seed diverges. A determinism tripwire — green while the engine is reproducible, red if non-determinism leaks into the seam.

## Verification
- `cargo test -p omnigraph-engine --test dst` — **10 passed, no warnings** (production/behaviour byte-unchanged).
- `cargo test -p omnigraph-engine --features dst --test dst` — **11 passed** (incl. the oracle).

## Honest scope
Bit-identical replay at the **engine** layer only. Lance internals (compaction/index ids, threadpool scheduling) stay non-deterministic — full on-disk byte-equality is out of scope, and the flaky Lance FTS-builder panic is **not** fixed by this. The main generative walks aren't yet wrapped in `with_seed` (follow-up); the dedicated oracle is the determinism guard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Production builds without `dst` compile the seam away and keep real IDs/clocks; fallible timestamp helpers preserve the prior error contract. Residual risk is only mis-routing a mint site or enabling `dst` in production by mistake.
> 
> **Overview**
> Introduces Cargo feature **`dst`** and module **`dst.rs`** (same no-op-when-off pattern as failpoints): **`next_ulid`**, **`now_micros`**, and fallible **`now_micros_result`** consult a per-task seeded provider when the feature is on and **`with_seed`** is in scope; otherwise behavior stays **`Ulid::new()`** / the real clock.
> 
> **Observable mint sites** are rewired to the seam: commit-graph ids and **`now_micros`** helpers, recovery sidecar **`operation_id`** / **`started_at`**, keyless node/edge inserts, and loader **`generate_id`**. Persisted timestamps on error paths still use **`now_micros_result`** so pre-seam clock-before-epoch errors propagate instead of writing **`0`**.
> 
> Under **`--features dst`**, **`replay_equality_same_seed`** runs the same seeded load/query workload twice and asserts matching id/clock **fingerprints** and outcomes; a different seed must diverge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 626ca8de810e443be5e0fcb28fe904af73596491. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a deterministic replay seam for engine-visible IDs and timestamps. The main changes are:

- A new `dst` feature with seeded ULID and clock helpers.
- Commit, recovery, mutation, and loader ID/time sites routed through the seam.
- A replay-equality test that compares same-seed fingerprints and outcomes.
- Fallible timestamp helpers preserved for commit and recovery audit writes.

<h3>Confidence Score: 4/5</h3>

This is close, but the seeded replay path should handle spawned work before merging.

- The clock-error and large-seed fixes look addressed.
- The seeded provider can be lost across spawned tasks, which can let nondeterministic IDs bypass the replay fingerprint.

crates/omnigraph/src/dst.rs

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/omnigraph/src/dst.rs | Adds the seeded provider, production fallbacks, fallible timestamp helper, and replay fingerprint state. |
| crates/omnigraph/src/db/commit_graph.rs | Routes commit IDs and commit timestamps through the DST seam while preserving fallible clock behavior. |
| crates/omnigraph/src/db/recovery_audit.rs | Routes recovery audit timestamps through the fallible DST timestamp helper. |
| crates/omnigraph/src/db/manifest/recovery.rs | Routes recovery sidecar IDs and diagnostic start times through the DST seam. |
| crates/omnigraph/src/exec/mutation.rs | Routes generated keyless node and edge IDs through the DST seam. |
| crates/omnigraph/src/loader/mod.rs | Routes loader-generated IDs through the DST seam. |
| crates/omnigraph/src/lib.rs | Exports the new DST module. |
| crates/omnigraph/Cargo.toml | Adds the opt-in `dst` feature. |
| crates/omnigraph/tests/dst.rs | Adds the feature-gated replay-equality oracle. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Engine ID or timestamp call] --> B{dst provider in task scope}
  B -- yes --> C[Seeded DstState]
  C --> D[Deterministic ULID or micros]
  C --> E[Replay fingerprint]
  B -- no --> F[Real ULID or clock fallback]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
  A[Engine ID or timestamp call] --> B{dst provider in task scope}
  B -- yes --> C[Seeded DstState]
  C --> D[Deterministic ULID or micros]
  C --> E[Replay fingerprint]
  B -- no --> F[Real ULID or clock fallback]
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fomnigraph%2Fsrc%2Fdst.rs%3A40-44%0A**Spawned%20Tasks%20Escape**%0A%0A%60with_seed%60%20only%20scopes%20a%20Tokio%20task-local%20provider%2C%20and%20this%20branch%20silently%20falls%20back%20to%20%60Ulid%3A%3Anew%28%29%60%20when%20no%20provider%20is%20present.%20If%20a%20seeded%20replay%20wraps%20a%20workload%20that%20calls%20the%20engine%20from%20a%20spawned%20task%2C%20that%20task%20does%20not%20have%20this%20task-local%20provider%2C%20so%20generated%20commit%20IDs%2C%20sidecar%20IDs%2C%20or%20keyless%20row%20IDs%20come%20from%20the%20real%20clock%2Frandom%20source%20and%20are%20not%20included%20in%20the%20fingerprint.%20The%20replay%20can%20then%20contain%20nondeterministic%20persisted%20IDs%20while%20the%20oracle%20misses%20those%20calls.%20Consider%20making%20the%20seeded%20path%20fail%20loudly%20when%20the%20feature%20is%20enabled%20and%20deterministic%20mode%20was%20expected%2C%20or%20providing%20a%20way%20to%20propagate%20the%20seeded%20provider%20into%20spawned%20work.%0A%0A&repo=modernrelay%2Fomnigraph&pr=304&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(dst): bound seeded clock init; keep ..."](https://github.com/modernrelay/omnigraph/commit/626ca8de810e443be5e0fcb28fe904af73596491) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39812033)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=59169be6-01cf-4bae-80fc-604b6a708098))
- Context used - CLAUDE.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=fba7c581-edb6-48b3-90ce-1db695f47e8b))

<!-- /greptile_comment -->