### PR TITLE
chore(release): bump version to 0.8.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Tools that support `@`-imports (Claude Code) auto-include all three files via th
 
 `CLAUDE.md` is a symlink to this file — there is exactly one source of truth. Edit `AGENTS.md`.
 
-**Version surveyed:** 0.7.2
+**Version surveyed:** 0.8.0
 **Workspace crates:** `omnigraph-compiler`, `omnigraph` (engine), `omnigraph-policy`, `omnigraph-api-types` (shared HTTP wire DTOs), `omnigraph-cluster`, `omnigraph-cli`, `omnigraph-server`
 **Storage substrate:** Lance 7.x (columnar, versioned, branchable)
 **License:** MIT

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4851,7 +4851,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-api-types"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "omnigraph-compiler",
  "omnigraph-engine",
@@ -4862,7 +4862,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-cli"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -4886,7 +4886,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-cluster"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "fail",
  "omnigraph-compiler",
@@ -4905,7 +4905,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-compiler"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -4924,7 +4924,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-engine"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -4969,7 +4969,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-policy"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "cedar-policy",
  "clap",
@@ -4982,7 +4982,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-server"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/crates/omnigraph-api-types/Cargo.toml
+++ b/crates/omnigraph-api-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-api-types"
-version = "0.7.2"
+version = "0.8.0"
 edition = "2024"
 description = "Shared HTTP wire DTOs for Omnigraph — request/response types and engine-result → DTO mappings used by both omnigraph-server and omnigraph-cli (RFC-009). Plain serde/utoipa types; no transport or server internals."
 license = "MIT"
@@ -9,8 +9,8 @@ homepage = "https://github.com/ModernRelay/omnigraph"
 documentation = "https://docs.rs/omnigraph-api-types"
 
 [dependencies]
-omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.7.2" }
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.2" }
+omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.8.0" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.8.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 utoipa = { workspace = true }

--- a/crates/omnigraph-cli/Cargo.toml
+++ b/crates/omnigraph-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-cli"
-version = "0.7.2"
+version = "0.8.0"
 edition = "2024"
 description = "CLI for the Omnigraph graph database."
 license = "MIT"
@@ -13,12 +13,12 @@ name = "omnigraph"
 path = "src/main.rs"
 
 [dependencies]
-omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.7.2" }
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.2" }
-omnigraph-api-types = { path = "../omnigraph-api-types", version = "0.7.2" }
-omnigraph-cluster = { path = "../omnigraph-cluster", version = "0.7.2" }
-omnigraph-policy = { path = "../omnigraph-policy", version = "0.7.2" }
-omnigraph-server = { path = "../omnigraph-server", version = "0.7.2" }
+omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.8.0" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.8.0" }
+omnigraph-api-types = { path = "../omnigraph-api-types", version = "0.8.0" }
+omnigraph-cluster = { path = "../omnigraph-cluster", version = "0.8.0" }
+omnigraph-policy = { path = "../omnigraph-policy", version = "0.8.0" }
+omnigraph-server = { path = "../omnigraph-server", version = "0.8.0" }
 clap = { workspace = true }
 color-eyre = { workspace = true }
 serde = { workspace = true }

--- a/crates/omnigraph-cluster/Cargo.toml
+++ b/crates/omnigraph-cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-cluster"
-version = "0.7.2"
+version = "0.8.0"
 edition = "2024"
 description = "Cluster configuration validation, planning, and config-only apply for Omnigraph."
 license = "MIT"
@@ -14,8 +14,8 @@ documentation = "https://docs.rs/omnigraph-cluster"
 failpoints = ["dep:fail", "fail/failpoints", "omnigraph/failpoints"]
 
 [dependencies]
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.2" }
-omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.7.2" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.8.0" }
+omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.8.0" }
 fail = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/omnigraph-compiler/Cargo.toml
+++ b/crates/omnigraph-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-compiler"
-version = "0.7.2"
+version = "0.8.0"
 edition = "2024"
 description = "Schema/query compiler for Omnigraph. Zero Lance dependency."
 license = "MIT"

--- a/crates/omnigraph-policy/Cargo.toml
+++ b/crates/omnigraph-policy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-policy"
-version = "0.7.2"
+version = "0.8.0"
 edition = "2024"
 description = "Policy / authorization layer for Omnigraph — Cedar-backed PolicyEngine, PolicyChecker trait, ResourceScope enum."
 license = "MIT"

--- a/crates/omnigraph-server/Cargo.toml
+++ b/crates/omnigraph-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-server"
-version = "0.7.2"
+version = "0.8.0"
 edition = "2024"
 description = "HTTP server for the Omnigraph graph database."
 license = "MIT"
@@ -19,11 +19,11 @@ default = []
 aws = ["dep:aws-config", "dep:aws-sdk-secretsmanager"]
 
 [dependencies]
-omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.7.2" }
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.2" }
-omnigraph-policy = { path = "../omnigraph-policy", version = "0.7.2" }
-omnigraph-api-types = { path = "../omnigraph-api-types", version = "0.7.2" }
-omnigraph-cluster = { path = "../omnigraph-cluster", version = "0.7.2" }
+omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.8.0" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.8.0" }
+omnigraph-policy = { path = "../omnigraph-policy", version = "0.8.0" }
+omnigraph-api-types = { path = "../omnigraph-api-types", version = "0.8.0" }
+omnigraph-cluster = { path = "../omnigraph-cluster", version = "0.8.0" }
 axum = { workspace = true }
 clap = { workspace = true }
 color-eyre = { workspace = true }

--- a/crates/omnigraph/Cargo.toml
+++ b/crates/omnigraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-engine"
-version = "0.7.2"
+version = "0.8.0"
 edition = "2024"
 description = "Runtime engine for the Omnigraph graph database."
 license = "MIT"
@@ -16,8 +16,8 @@ default = []
 failpoints = ["dep:fail", "fail/failpoints"]
 
 [dependencies]
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.2" }
-omnigraph-policy = { path = "../omnigraph-policy", version = "0.7.2" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.8.0" }
+omnigraph-policy = { path = "../omnigraph-policy", version = "0.8.0" }
 lance = { workspace = true }
 lance-core = { workspace = true }
 lance-datafusion = { workspace = true }
@@ -53,7 +53,7 @@ chrono = { workspace = true }
 arc-swap = { workspace = true }
 
 [dev-dependencies]
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.7.2" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.8.0" }
 tokio = { workspace = true }
 lance-namespace-impls = { workspace = true }
 # test-util gates IoStats.requests + assert_io_eq! (failure diagnostics only); dev-dep,

--- a/docs/releases/v0.8.0.md
+++ b/docs/releases/v0.8.0.md
@@ -1,8 +1,4 @@
-# Omnigraph v0.8.0 (in progress)
-
-> Draft release notes for the next minor. The version line in `AGENTS.md` and the
-> crate manifests are bumped when this release is cut — these notes track the
-> user-visible delta as the work lands.
+# Omnigraph v0.8.0
 
 This release moves the graph commit lineage into `__manifest` (RFC-013 Phase 7),
 retires the two legacy commit-graph datasets, and surfaces the storage-format

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "0.7.2"
+    "version": "0.8.0"
   },
   "paths": {
     "/graphs": {


### PR DESCRIPTION
## What & why

Cuts the 0.8.0 release: bumps every published crate manifest and internal path-dependency constraint from 0.7.2 to 0.8.0, refreshes `Cargo.lock` for the seven omnigraph crates, bumps `openapi.json` `info.version` and the surveyed-version line in `AGENTS.md`, and finalizes the already-authored `docs/releases/v0.8.0.md` by dropping its in-progress draft header. CLI and server version output flow from `env!("CARGO_PKG_VERSION")`, so `omnigraph version`, `omnigraph --version`, and `GET /healthz` report 0.8.0 once built — no source literal hardcodes the version.

## Backing issue / RFC

- [x] **Trivial fast-lane** (typo / docs / dependency bump / comment / one-line CI) — no issue/RFC required

## Checklist

- [x] Change is focused (one logical change)
- [x] Tests added/updated for behavior changes (or N/A) — N/A (mechanical version bump; the OpenAPI drift test covers `openapi.json`)
- [x] Public docs updated if user-facing surface changed (or N/A) — release notes finalized, surveyed version bumped
- [x] Reviewed against [docs/dev/invariants.md](../blob/main/docs/dev/invariants.md) — no Hard Invariant weakened, no deny-list item hit (or justified)

## Notes for reviewers

`loom 0.7.2` in `Cargo.lock` is an unrelated transitive dependency that coincidentally shared the old version number and was deliberately left untouched. `cargo metadata --locked` passes, confirming the lockfile is coherent with the bumped manifests. The release-notes content (lineage in `__manifest`, retired commit-graph tables, strict-single-version storage) landed in prior PRs; this change only cuts the version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation metadata only; no engine, storage, or API logic changes in this PR.
> 
> **Overview**
> **Release cut:** bumps the workspace from **0.7.2 → 0.8.0** with no runtime or API behavior changes in this diff.
> 
> All seven published crates get `version = "0.8.0"` and matching `0.8.0` path-dependency constraints; `Cargo.lock` is updated for those packages. **`openapi.json`** `info.version` and **`AGENTS.md`** “Version surveyed” move to 0.8.0. **`docs/releases/v0.8.0.md`** drops the in-progress draft header so the notes read as the shipped release (feature content was landed earlier).
> 
> CLI and server version strings still come from **`CARGO_PKG_VERSION`**, so builds from this branch report 0.8.0 without extra edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5074576b2fb26b03ea91cf24fa44dddd8f98c8f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR cuts the 0.8.0 release. The main changes are:

- Workspace crate versions bumped to 0.8.0.
- Internal path dependency constraints bumped to 0.8.0.
- Cargo.lock refreshed for the Omnigraph crates.
- OpenAPI metadata updated to 0.8.0.
- AGENTS/CLAUDE surveyed version updated to 0.8.0.
- v0.8.0 release notes finalized.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Cargo.lock | Updates the Omnigraph package entries to 0.8.0; no stale Omnigraph 0.7.2 lockfile entry was identified. |
| crates/omnigraph-api-types/Cargo.toml | Updates the API types crate version and local dependency constraints to 0.8.0. |
| crates/omnigraph-cli/Cargo.toml | Updates the CLI crate version and all local Omnigraph dependency constraints to 0.8.0. |
| crates/omnigraph-cluster/Cargo.toml | Updates the cluster crate version and local engine/compiler constraints to 0.8.0. |
| crates/omnigraph-compiler/Cargo.toml | Updates the compiler crate package version to 0.8.0. |
| crates/omnigraph-policy/Cargo.toml | Updates the policy crate package version to 0.8.0. |
| crates/omnigraph-server/Cargo.toml | Updates the server crate version and all local Omnigraph dependency constraints to 0.8.0. |
| crates/omnigraph/Cargo.toml | Updates the engine crate version and local dependency constraints to 0.8.0. |
| AGENTS.md | Updates the surveyed version line to 0.8.0. |
| docs/releases/v0.8.0.md | Removes the draft marker and finalizes the v0.8.0 release note title. |
| openapi.json | Updates the checked-in OpenAPI info.version to 0.8.0. |

<sub>Reviews (1): Last reviewed commit: ["chore(release): bump version to 0.8.0"](https://github.com/modernrelay/omnigraph/commit/5074576b2fb26b03ea91cf24fa44dddd8f98c8f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40480002)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=59169be6-01cf-4bae-80fc-604b6a708098))
- Context used - CLAUDE.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=fba7c581-edb6-48b3-90ce-1db695f47e8b))

<!-- /greptile_comment -->