### PR TITLE
ci: add linux-arm64 (aarch64) prebuilt release target

### DIFF
--- a/.github/workflows/release-edge.yml
+++ b/.github/workflows/release-edge.yml
@@ -41,6 +41,8 @@ jobs:
         include:
           - runner: ubuntu-latest
             asset_name: omnigraph-linux-x86_64
+          - runner: ubuntu-24.04-arm
+            asset_name: omnigraph-linux-arm64
           - runner: macos-14
             asset_name: omnigraph-macos-arm64
           - runner: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
         include:
           - runner: ubuntu-latest
             asset_name: omnigraph-linux-x86_64
+          - runner: ubuntu-24.04-arm
+            asset_name: omnigraph-linux-arm64
           - runner: macos-14
             asset_name: omnigraph-macos-arm64
           - runner: windows-latest

--- a/docs/dev/ci.md
+++ b/docs/dev/ci.md
@@ -9,6 +9,6 @@
 - **AWS feature build job**: `cargo build/test -p omnigraph-server --features aws` on ubuntu-latest.
 - **Windows binary build job**: `cargo build --release --locked -p omnigraph-cli -p omnigraph-server` on windows-latest with smoke checks for `omnigraph.exe version`, `omnigraph-server.exe --help`, and PowerShell installer syntax.
 - **RustFS S3 integration**: spins up RustFS in Docker, runs `s3_storage`, `server_opens_s3_graph_directly_and_serves_snapshot_and_read`, and `local_cli_s3_end_to_end_init_load_read_flow`.
-- **release-edge.yml**: on every push to main, retags `edge`, builds Linux x86_64 / macOS arm64 archives and Windows x86_64 zip + sha256, publishes a rolling prerelease, then smoke-tests the Windows PowerShell installer against `edge`.
-- **release.yml**: on `v*` tags, builds the Linux x86_64 / macOS arm64 archives and Windows x86_64 zip release matrix, updates the Homebrew tap (`scripts/update-homebrew-formula.sh`) by pushing the regenerated formula to `ModernRelay/homebrew-tap`, and smoke-tests the Windows PowerShell installer against the tag.
+- **release-edge.yml**: on every push to main, retags `edge`, builds Linux x86_64 / Linux arm64 / macOS arm64 archives and Windows x86_64 zip + sha256, publishes a rolling prerelease, then smoke-tests the Windows PowerShell installer against `edge`.
+- **release.yml**: on `v*` tags, builds the Linux x86_64 / Linux arm64 / macOS arm64 archives and Windows x86_64 zip release matrix, updates the Homebrew tap (`scripts/update-homebrew-formula.sh`) by pushing the regenerated formula to `ModernRelay/homebrew-tap`, and smoke-tests the Windows PowerShell installer against the tag.
 - **package.yml**: manual ECR image build; emits two image tags per commit (`<sha>`, `<sha>-aws`) via CodeBuild.

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -121,6 +121,7 @@ Copy-Item target\release\omnigraph-server.exe "$env:USERPROFILE\.local\bin\omnig
 Tagged releases are expected to publish:
 
 - `omnigraph-linux-x86_64.tar.gz`
+- `omnigraph-linux-arm64.tar.gz`
 - `omnigraph-macos-arm64.tar.gz`
 - `omnigraph-windows-x86_64.zip`
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -35,6 +35,9 @@ platform_asset_name() {
     Linux/x86_64)
       printf 'omnigraph-linux-x86_64.tar.gz\n'
       ;;
+    Linux/aarch64)
+      printf 'omnigraph-linux-arm64.tar.gz\n'
+      ;;
     Darwin/arm64)
       printf 'omnigraph-macos-arm64.tar.gz\n'
       ;;

--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -47,11 +47,13 @@ RELEASE_JSON="$(gh release view "$TAG" --repo "$REPO_SLUG" --json assets)"
 
 MACOS_ARM_URL="https://github.com/${REPO_SLUG}/releases/download/${TAG}/omnigraph-macos-arm64.tar.gz"
 LINUX_X86_URL="https://github.com/${REPO_SLUG}/releases/download/${TAG}/omnigraph-linux-x86_64.tar.gz"
+LINUX_ARM_URL="https://github.com/${REPO_SLUG}/releases/download/${TAG}/omnigraph-linux-arm64.tar.gz"
 
 MACOS_ARM_SHA="$(asset_digest "$RELEASE_JSON" "omnigraph-macos-arm64.tar.gz")"
 LINUX_X86_SHA="$(asset_digest "$RELEASE_JSON" "omnigraph-linux-x86_64.tar.gz")"
+LINUX_ARM_SHA="$(asset_digest "$RELEASE_JSON" "omnigraph-linux-arm64.tar.gz")"
 
-for value in "$MACOS_ARM_SHA" "$LINUX_X86_SHA"; do
+for value in "$MACOS_ARM_SHA" "$LINUX_X86_SHA" "$LINUX_ARM_SHA"; do
   if [[ -z "$value" ]]; then
     printf 'error: failed to resolve one or more release asset digests for %s\n' "$TAG" >&2
     exit 1
@@ -85,6 +87,10 @@ class Omnigraph < Formula
     on_intel do
       url "${LINUX_X86_URL}"
       sha256 "${LINUX_X86_SHA}"
+    end
+    on_arm do
+      url "${LINUX_ARM_URL}"
+      sha256 "${LINUX_ARM_SHA}"
     end
   end
 


### PR DESCRIPTION
## What & why

aarch64 Linux previously hit the install-script arch guard ("no prebuilt binary is available for Linux/aarch64") and could only build from source. This adds an `omnigraph-linux-arm64` archive to the tagged-release and edge-release matrices (built on `ubuntu-24.04-arm`) and maps `Linux/aarch64` to it in `scripts/install.sh`, making it a first-class prebuilt target.

## Backing issue / RFC

- [x] **Trivial fast-lane** (additive CI matrix row + install-script case arm + docs) — no issue/RFC required

## Checklist

- [x] Change is focused (one logical change)
- [ ] Tests added/updated for behavior changes (N/A — release/install packaging only)
- [x] Public docs updated if user-facing surface changed (`docs/user/install.md`, `docs/dev/ci.md`)
- [x] Reviewed against docs/dev/invariants.md — no Hard Invariant weakened, no deny-list item hit

## Notes for reviewers

The new row uses GitHub's hosted `ubuntu-24.04-arm` runner — free for public repos and on Team/Enterprise; if this repo is private on the Free plan it would need a self-hosted ARM runner or cross-compilation instead. The new asset only becomes installable from the next tagged release (edge picks it up on next push to main); until then aarch64 still uses `scripts/install-source.sh`. No engine source changes — the code already compiles on aarch64.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive release-matrix row and install mapping only; no changes to application logic or existing platform paths.
> 
> **Overview**
> **Linux aarch64** gets a first-class prebuilt path: `omnigraph-linux-arm64.tar.gz` is built on `ubuntu-24.04-arm` in both **release** and **release-edge** workflow matrices, alongside the existing x86_64, macOS arm64, and Windows assets.
> 
> **`scripts/install.sh`** now maps `Linux/aarch64` to that archive so the curl installer no longer fails with “no prebuilt binary.” **`scripts/update-homebrew-formula.sh`** adds an `on_linux` / `on_arm` stanza with the new URL and digest. User and CI docs list the extra asset in the expected release set.
> 
> No runtime or engine code changes; packaging and distribution only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 646b73cbb9c039a564fc3748b74759252c227cb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR promotes Linux arm64 (aarch64) to a first-class prebuilt install target by adding an `ubuntu-24.04-arm` matrix row to both the tagged-release and edge-release CI workflows, wiring `scripts/install.sh` to map `Linux/aarch64` to the new archive, and updating the Homebrew formula generator to include an `on_arm` block inside `on_linux`.

- **CI**: Both `release.yml` and `release-edge.yml` gain a `ubuntu-24.04-arm` / `omnigraph-linux-arm64` matrix entry; `release.yml` correctly funnels the new artifact through the existing single-writer `publish_release` job, avoiding any race with other matrix jobs.
- **`scripts/install.sh`**: Adds `Linux/aarch64` → `omnigraph-linux-arm64.tar.gz` — `uname -m` on Linux arm64 always returns `aarch64`, so the case match is correct; checksum download and verification paths are consistent with CI-generated `.sha256` files.
- **`scripts/update-homebrew-formula.sh`**: Adds `LINUX_ARM_URL`/`LINUX_ARM_SHA` and an `on_arm` block inside `on_linux`; the digest guard loop is extended to cover the new asset, so a missing arm64 artifact during re-publish correctly aborts formula generation.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely additive CI matrix and packaging change with no application logic touched.

Every changed file is CI infrastructure, a shell installer case, or documentation. The arm64 build row integrates cleanly into the existing single-writer publish pattern in release.yml; install.sh correctly uses the Linux aarch64 uname output; the Homebrew formula generator properly extends its digest guard to cover the new asset. No pre-existing invariants are weakened.

No files require special attention. release-edge.yml has a pre-existing concurrent-write pattern that this PR extends to four jobs, but that race was already present and noted in earlier review threads.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Adds ubuntu-24.04-arm matrix row for omnigraph-linux-arm64; follows the existing single-writer publish_release pattern correctly — no race risk introduced. |
| .github/workflows/release-edge.yml | Adds ubuntu-24.04-arm matrix row for omnigraph-linux-arm64; extends the pre-existing concurrent softprops write race (each matrix job calls action-gh-release independently) but introduces no new structural issues beyond what was already present. |
| scripts/install.sh | Adds Linux/aarch64 → omnigraph-linux-arm64.tar.gz case; uname -m on Linux arm64 always returns aarch64 so the match is correct, and checksum/download paths are consistent with CI artifacts. |
| scripts/update-homebrew-formula.sh | Adds LINUX_ARM_URL/SHA variables and on_arm block inside on_linux; Homebrew DSL is correct and the digest guard loop covers the new asset. |
| docs/user/install.md | Adds omnigraph-linux-arm64.tar.gz to the expected release asset list; accurate and complete. |
| docs/dev/ci.md | Updates ci.md descriptions for both release workflows to mention Linux arm64; accurate reflection of the new matrix rows. |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph release.yml ["release.yml (tagged)"]
        B1[build: ubuntu-latest\nomnigraph-linux-x86_64]
        B2[build: ubuntu-24.04-arm\nomnigraph-linux-arm64 ✨]
        B3[build: macos-14\nomnigraph-macos-arm64]
        B4[build: windows-latest\nomnigraph-windows-x86_64]
        PUB[publish_release\nsingle writer]
        HB[update_homebrew_tap]
        SW[smoke_windows_installer]
        B1 & B2 & B3 & B4 --> PUB
        PUB --> HB
        PUB --> SW
    end

    subgraph release-edge.yml ["release-edge.yml (edge)"]
        E1[build: ubuntu-latest\nomnigraph-linux-x86_64]
        E2[build: ubuntu-24.04-arm\nomnigraph-linux-arm64 ✨]
        E3[build: macos-14\nomnigraph-macos-arm64]
        E4[build: windows-latest\nomnigraph-windows-x86_64]
        ER[softprops/action-gh-release\nper job — concurrent writes]
        ESW[smoke_windows_installer]
        E1 & E2 & E3 & E4 --> ER
        E1 & E2 & E3 & E4 --> ESW
    end

    subgraph install.sh
        OS{uname -s / uname -m}
        OS -->|Linux/x86_64| A1[omnigraph-linux-x86_64.tar.gz]
        OS -->|Linux/aarch64 ✨| A2[omnigraph-linux-arm64.tar.gz]
        OS -->|Darwin/arm64| A3[omnigraph-macos-arm64.tar.gz]
        OS -->|other| FAIL[exit — no prebuilt binary]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph release.yml ["release.yml (tagged)"]
        B1[build: ubuntu-latest\nomnigraph-linux-x86_64]
        B2[build: ubuntu-24.04-arm\nomnigraph-linux-arm64 ✨]
        B3[build: macos-14\nomnigraph-macos-arm64]
        B4[build: windows-latest\nomnigraph-windows-x86_64]
        PUB[publish_release\nsingle writer]
        HB[update_homebrew_tap]
        SW[smoke_windows_installer]
        B1 & B2 & B3 & B4 --> PUB
        PUB --> HB
        PUB --> SW
    end

    subgraph release-edge.yml ["release-edge.yml (edge)"]
        E1[build: ubuntu-latest\nomnigraph-linux-x86_64]
        E2[build: ubuntu-24.04-arm\nomnigraph-linux-arm64 ✨]
        E3[build: macos-14\nomnigraph-macos-arm64]
        E4[build: windows-latest\nomnigraph-windows-x86_64]
        ER[softprops/action-gh-release\nper job — concurrent writes]
        ESW[smoke_windows_installer]
        E1 & E2 & E3 & E4 --> ER
        E1 & E2 & E3 & E4 --> ESW
    end

    subgraph install.sh
        OS{uname -s / uname -m}
        OS -->|Linux/x86_64| A1[omnigraph-linux-x86_64.tar.gz]
        OS -->|Linux/aarch64 ✨| A2[omnigraph-linux-arm64.tar.gz]
        OS -->|Darwin/arm64| A3[omnigraph-macos-arm64.tar.gz]
        OS -->|other| FAIL[exit — no prebuilt binary]
    end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/release-edge.yml`, line 109-119 ([link](https://github.com/modernrelay/omnigraph/blob/6068529a91c4f875da2a55ae61f6a476f43be266/.github/workflows/release-edge.yml#L109-L119)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Concurrent release writers on every matrix job**

   Each of the four matrix jobs (now including `omnigraph-linux-arm64`) calls `softprops/action-gh-release` independently and simultaneously, so they race to create/update the same `edge` release. The tagged `release.yml` avoids this with a dedicated `publish_release` job that is the sole writer; `release-edge.yml` does not follow that pattern. In practice the race is usually benign since each job uploads distinct files, but `softprops` also updates the release description on every call, meaning three or four jobs fight over the body text simultaneously. This was a pre-existing three-way race that this PR extends to four. Aligning `release-edge.yml` to the same single-writer pattern used in `release.yml` would eliminate it cleanly.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Frelease-edge.yml%0ALine%3A%20109-119%0A%0AComment%3A%0A**Concurrent%20release%20writers%20on%20every%20matrix%20job**%0A%0AEach%20of%20the%20four%20matrix%20jobs%20%28now%20including%20%60omnigraph-linux-arm64%60%29%20calls%20%60softprops%2Faction-gh-release%60%20independently%20and%20simultaneously%2C%20so%20they%20race%20to%20create%2Fupdate%20the%20same%20%60edge%60%20release.%20The%20tagged%20%60release.yml%60%20avoids%20this%20with%20a%20dedicated%20%60publish_release%60%20job%20that%20is%20the%20sole%20writer%3B%20%60release-edge.yml%60%20does%20not%20follow%20that%20pattern.%20In%20practice%20the%20race%20is%20usually%20benign%20since%20each%20job%20uploads%20distinct%20files%2C%20but%20%60softprops%60%20also%20updates%20the%20release%20description%20on%20every%20call%2C%20meaning%20three%20or%20four%20jobs%20fight%20over%20the%20body%20text%20simultaneously.%20This%20was%20a%20pre-existing%20three-way%20race%20that%20this%20PR%20extends%20to%20four.%20Aligning%20%60release-edge.yml%60%20to%20the%20same%20single-writer%20pattern%20used%20in%20%60release.yml%60%20would%20eliminate%20it%20cleanly.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modernrelay%2Fomnigraph&pr=316&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["ci: emit a linux-arm64 bottle in the Hom..."](https://github.com/modernrelay/omnigraph/commit/646b73cbb9c039a564fc3748b74759252c227cb1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40630243)</sub>

<!-- /greptile_comment -->