### PR TITLE
Fix CI: make policy-load e2e overwrite self-consistent

### DIFF
--- a/crates/omnigraph-cli/tests/system_local.rs
+++ b/crates/omnigraph-cli/tests/system_local.rs
@@ -1295,9 +1295,17 @@ fn local_cli_load_enforces_engine_layer_policy() {
     );
     let temp = tempfile::tempdir().unwrap();
     let data = temp.path().join("policy-load.jsonl");
+    // The seeded graph (test.jsonl) has Knows/WorksAt edges over its Persons, so a
+    // per-table overwrite must be self-consistent: replacing node:Person also
+    // replaces the edge tables that referenced the old Persons, or the retained
+    // edges would strand against the new node image (a loud OrphanEdge). The data
+    // is incidental to this policy test; it just has to commit cleanly for the
+    // allowed actor. WorksAt points at Acme, a Company the overwrite retains.
     fs::write(
         &data,
-        r#"{"type":"Person","data":{"name":"LoadPolicy","age":11}}"#,
+        "{\"type\":\"Person\",\"data\":{\"name\":\"LoadPolicy\",\"age\":11}}\n\
+         {\"edge\":\"Knows\",\"from\":\"LoadPolicy\",\"to\":\"LoadPolicy\"}\n\
+         {\"edge\":\"WorksAt\",\"from\":\"LoadPolicy\",\"to\":\"Acme\"}\n",
     )
     .unwrap();
 


### PR DESCRIPTION
## Problem

CI on `main` is red after the validation-unification merge: the
`local_cli_load_enforces_engine_layer_policy` system e2e fails with
`src 'Alice' not found in Person`.

## Root cause

The seeded knowledge graph (`test.jsonl`) carries `Knows`/`WorksAt` edges over
its Persons. The test's allowed-actor step does `load --mode overwrite` with a
single `Person` row. Overwrite is per-table, so it replaces `node:Person`
(dropping the seeded Alice/Bob/...) while the `Knows`/`WorksAt` edge tables are
retained — and those retained edges now reference nodes that no longer exist.

The new overwrite referential-integrity validation correctly rejects this as an
orphan edge. The test had been relying on the prior behavior, where such an
overwrite silently published orphan edges.

## Fix

Make the overwrite self-consistent: the payload replaces the edge tables in the
same load (`Knows LoadPolicy->LoadPolicy`, `WorksAt LoadPolicy->Acme`, with Acme
a Company the overwrite retains). The test's subject — engine-layer policy
enforcement on a destructive overwrite — is unchanged; the loaded data was
always incidental.

## Why it escaped pre-merge

`cargo test --workspace` fail-fasts at the first failing test binary, and the
cli system suite is exercised only under the full workspace gate (not
`-p omnigraph-engine`). Swept the cli + server + cluster suites with
`--no-fail-fast`: this is the only affected test (629 pass otherwise).

## Verification

- `cargo test -p omnigraph-cli --test system_local` → 27 passed, 1 ignored
- `cargo test -p omnigraph-cli -p omnigraph-server -p omnigraph-cluster --no-fail-fast` → only this test was failing; green with the fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to fixture data and comments; no runtime or policy logic modified.
> 
> **Overview**
> Updates **`local_cli_load_enforces_engine_layer_policy`** so the allowed-actor **`load --mode overwrite`** step no longer fails after stricter overwrite referential-integrity checks.
> 
> The test still exercises **engine-layer policy** (Bruno denied, Ragnor allowed on protected `main`); only the incidental JSONL fixture changes. Instead of a single **`Person`** row—which replaced `node:Person` while leaving seeded **`Knows`/`WorksAt`** edges pointing at removed nodes—the payload now includes **`Knows`** (`LoadPolicy`→`LoadPolicy`) and **`WorksAt`** (`LoadPolicy`→**`Acme`**) so the overwrite is per-table self-consistent. Inline comments document why that matters (**`OrphanEdge`** / missing endpoint errors).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4533e70e12bb520e455a8e8ea237f8f50e8544fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the policy-load system test fixture. The main changes are:

- Adds edge rows to the overwrite payload used by the allowed actor.
- Keeps the replacement graph self-consistent with retained `Company` data.
- Documents why the test must overwrite edge tables with the `Person` table.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/omnigraph-cli/tests/system_local.rs | Updates one system test fixture so the destructive overwrite path replaces related edge tables consistently. |

<sub>Reviews (1): Last reviewed commit: ["test(cli): make policy-load overwrite se..."](https://github.com/modernrelay/omnigraph/commit/4533e70e12bb520e455a8e8ea237f8f50e8544fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40809463)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=59169be6-01cf-4bae-80fc-604b6a708098))
- Context used - CLAUDE.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=fba7c581-edb6-48b3-90ce-1db695f47e8b))

<!-- /greptile_comment -->