### PR TITLE
Fix CI: seed failpoints overwrite-recovery test edge-free

### DIFF
--- a/crates/omnigraph/tests/failpoints.rs
+++ b/crates/omnigraph/tests/failpoints.rs
@@ -1016,9 +1016,20 @@ async fn recovery_rolls_forward_load_overwrite() {
 
     {
         let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
-        load_jsonl(&mut db, helpers::TEST_DATA, LoadMode::Overwrite)
-            .await
-            .unwrap();
+        // Seed Persons only (no edges): the fault-injected step below overwrites
+        // node:Person down to a single row, and a per-table overwrite that drops
+        // Persons referenced by seeded Knows/WorksAt edges is now rejected as an
+        // orphan during validation — before it ever reaches the post-finalize
+        // failpoint this test drives. Keeping the seed edge-free makes the
+        // overwrite a clean single-table roll-forward, which is what's under test.
+        load_jsonl(
+            &mut db,
+            "{\"type\":\"Person\",\"data\":{\"name\":\"Alice\",\"age\":30}}\n\
+             {\"type\":\"Person\",\"data\":{\"name\":\"Bob\",\"age\":31}}\n",
+            LoadMode::Overwrite,
+        )
+        .await
+        .unwrap();
         parent_commit_id = branch_head_commit_id(dir.path(), "main").await.unwrap();
 
         let _failpoint = ScopedFailPoint::new(names::MUTATION_POST_FINALIZE_PRE_PUBLISHER, "return");


### PR DESCRIPTION
## Problem

`main` CI is red again after the previous fix (#317). The workspace test step
now passes, but the separate **failpoints** feature-gated step fails:
`recovery_rolls_forward_load_overwrite` panics with
`src 'Alice' not found in Person`.

## Root cause

Same class as #317. The test seeds the full `test.jsonl` (which carries
`Knows`/`WorksAt` edges) and then fault-injects a per-table `Overwrite` of
`node:Person` down to a single row. Overwrite referential-integrity validation
now correctly rejects that — dropping the seeded Persons strands the retained
edges — so the load fails during validation, *before* it reaches the
post-finalize failpoint the test drives. The recovery roll-forward it means to
exercise never runs.

## Fix

Seed Persons only (no edges), so the fault-injected overwrite is a clean
single-table roll-forward — which is exactly what the test asserts
(`RolledForward{node:Person}`). The overwrite still removes the seeded Persons,
so the overwrite-removed-ids path is still exercised, just without an orphan.

## Why it escaped (twice now)

The failpoints suite runs under `--features failpoints` as a **separate CI step**
from the workspace test run, so it's invisible to both the PR gate (which skips
`Test Workspace` entirely) and to `cargo test -p omnigraph-engine`. Only the
post-merge `main` run exercises it, and it runs *after* the workspace step, so
#317's green workspace run couldn't reveal it.

## Verification

- `cargo test -p omnigraph-engine --features failpoints --test failpoints` → 57 passed, 0 failed
- Audited every S3-gated overwrite site (s3_storage, server s3, cli s3 e2e, s3 failpoints) — all are either full-image seeds, `Append`/`Merge`, or edge-free schemas; none strand.
- Triggering a `workflow_dispatch` run on this branch to exercise the full gate (workspace + failpoints engine/cluster + RustFS S3) before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in the failpoints suite; no production loader or validation logic is modified.
> 
> **Overview**
> **Fixes red failpoints CI** for `recovery_rolls_forward_load_overwrite`, which was failing with `src 'Alice' not found in Person` after overwrite referential-integrity checks started rejecting per-table Person overwrites that drop nodes still referenced by seeded edges.
> 
> In `recovery_rolls_forward_load_overwrite`, the setup **stops loading full `test.jsonl`** (Persons plus `Knows`/`WorksAt`) and instead **seeds two inline Person records** via `load_jsonl` in `Overwrite` mode. The fault-injected Person overwrite and post-finalize recovery roll-forward behavior under test are unchanged; the seed is edge-free so validation reaches the failpoint instead of failing early as an orphan edge case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78262aa0b9610d60408192ffac05f9d0c0d8f980. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes the overwrite recovery failpoint test setup. The main changes are:

- Replaces the shared edge-bearing seed fixture with inline `Person` rows.
- Keeps the overwrite test focused on `node:Person` roll-forward recovery.
- Documents why edge-free seed data avoids orphan validation before the failpoint.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after a small test hardening cleanup.

- No blocking issues found in the changed code.
- The remaining issue is test coverage quality: the recovery assertion proves row count, but not recovered row identity or values.

crates/omnigraph/tests/failpoints.rs

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/omnigraph/tests/failpoints.rs | The test seed is narrowed to edge-free Person data, which fixes the orphan-validation setup but leaves the recovered row content unchecked. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acrates%2Fomnigraph%2Ftests%2Ffailpoints.rs%3A1026-1029%0A**Recovered%20Row%20Content%20Unchecked**%0A%0AWhen%20recovery%20publishes%20the%20staged%20overwrite%2C%20the%20test%20only%20checks%20that%20%60node%3APerson%60%20has%20one%20row%20before%20the%20follow-up%20insert.%20If%20roll-forward%20points%20the%20manifest%20at%20a%20corrupted%20or%20wrong%20one-row%20version%2C%20this%20still%20passes%20and%20the%20follow-up%20mutation%20can%20make%20the%20count%20become%20two%20without%20proving%20that%20the%20overwrite%20row%20survived%20correctly.%0A%0A&repo=modernrelay%2Fomnigraph&pr=319&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["test(engine): seed recovery\_rolls\_forwar..."](https://github.com/modernrelay/omnigraph/commit/78262aa0b9610d60408192ffac05f9d0c0d8f980) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41049740)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=59169be6-01cf-4bae-80fc-604b6a708098))
- Context used - CLAUDE.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=fba7c581-edb6-48b3-90ce-1db695f47e8b))

<!-- /greptile_comment -->