### PR TITLE
docs(release): cover #314 stricter validation + #316 linux-arm64 in v0.8.0 notes

### DIFF
--- a/docs/releases/v0.8.0.md
+++ b/docs/releases/v0.8.0.md
@@ -80,8 +80,8 @@ commit:
 - **Enum constraints are enforced on the merge path** (previously a gap: merge
   validated `@range`/`@check` but not enum).
 - **Cross-version uniqueness is enforced.** A write or load whose `@unique` value
-  collides with an already-committed *different* row is now rejected. Re-upserting an
-  existing `@key` still upserts as before.
+  collides with an already-committed *different* row visible to that write is now
+  rejected. Re-upserting an existing `@key` still upserts as before.
 - **Duplicate-key semantics are precise.** A `@key` that appears twice as two
   distinct records *within one input batch* (e.g. a bulk load listing the same key
   twice) is rejected; the *same* id reappearing *across* batches (e.g. an

--- a/docs/releases/v0.8.0.md
+++ b/docs/releases/v0.8.0.md
@@ -1,11 +1,12 @@
 # Omnigraph v0.8.0
 
 This release moves the graph commit lineage into `__manifest` (RFC-013 Phase 7),
-retires the two legacy commit-graph datasets, and surfaces the storage-format
+retires the two legacy commit-graph datasets, unifies constraint validation across
+every write surface (stricter in a few cases), and surfaces the storage-format
 version to operators. It is the first release with an internal-schema change since
 v0.4.0, and storage is **strict-single-version**: there is no in-place migration —
 a graph from an older release is rebuilt via export/import. Read the upgrade notes
-before rolling it out.
+and the stricter-validation notes before rolling it out.
 
 ## Graph lineage now lives in `__manifest` (internal schema v4)
 
@@ -59,6 +60,50 @@ it through a refusal:
 - `omnigraph snapshot` reports the opened graph's on-disk `internal_schema_version`.
 - The server `GET /healthz` response includes `internal_schema_version` (the
   binary's served version).
+
+## Stricter, unified constraint validation (#314)
+
+Constraint enforcement — value/range/`@check`, enum, `@unique`, edge referential
+integrity, and cardinality — was previously implemented separately in the bulk
+loader, the mutation executor, and the branch-merge path, and had drifted. All three
+write surfaces now route through one catalog-derived evaluator, so they can no longer
+diverge. The evaluator is delta-scoped (it checks only the change set) and
+index-backed (it probes committed state through the `@key`/`@unique`/`src`/`dst`
+BTREEs instead of scanning every catalog table), so a one-row merge opens ~3 data
+tables instead of 6+ and validation cost is flat in graph size rather than O(V+E).
+
+The unification closes real gaps. **These behavior changes are all stricter — none
+relax an existing check** — so a graph that already satisfies its schema is
+unaffected, but inputs that previously slipped through are now rejected before the
+commit:
+
+- **Enum constraints are enforced on the merge path** (previously a gap: merge
+  validated `@range`/`@check` but not enum).
+- **Cross-version uniqueness is enforced.** A write or load whose `@unique` value
+  collides with an already-committed *different* row is now rejected. Re-upserting an
+  existing `@key` still upserts as before.
+- **Duplicate-key semantics are precise.** A `@key` that appears twice as two
+  distinct records *within one input batch* (e.g. a bulk load listing the same key
+  twice) is rejected; the *same* id reappearing *across* batches (e.g. an
+  insert-then-update in one mutation) is coalesced as ordered supersession of one
+  logical row.
+- **Overwrite loads validate per touched table.** A table in the overwrite batch is
+  validated against its replacement image (an empty committed view); a table absent
+  from the batch keeps its committed rows, so an edges-only overwrite still resolves
+  referential integrity against the retained nodes.
+
+If an ingestion pipeline unknowingly relied on one of these gaps — a duplicate
+`@unique` value, or an enum violation reaching a branch through merge — it will now
+fail loudly at write time. Validate load inputs against the schema before upgrading
+if in doubt.
+
+## New prebuilt platform: linux-arm64 (#316)
+
+Tagged releases now ship an `omnigraph-linux-arm64` (aarch64) archive alongside the
+existing Linux x86_64, macOS arm64, and Windows x86_64 builds, and the Homebrew
+formula carries a matching `on_linux`/`on_arm` bottle. The install script maps
+Linux/aarch64 to the new asset, so aarch64 Linux is now a first-class prebuilt
+target instead of build-from-source.
 
 ## Upgrade order
 


### PR DESCRIPTION
The v0.8.0 release notes (`docs/releases/v0.8.0.md`) were written in the
version-bump commit (#313). Two user-relevant changes landed on `main` **after**
that commit, so they are currently undocumented in the notes:

- **#314 — unify constraint validation across all write surfaces.** The behavior
  changes are all stricter (none relaxed): enum now enforced on the merge path,
  cross-version `@unique` collisions now rejected, precise within-batch vs
  across-batch duplicate-`@key` semantics, and per-table overwrite validation.
  These are user-visible and can newly reject inputs that previously slipped
  through, so they get a dedicated "Stricter, unified constraint validation"
  section.
- **#316 — linux-arm64 (aarch64) prebuilt target.** Now a first-class prebuilt
  archive + Homebrew bottle; documented as a new platform.

Also adds a one-clause mention of the stricter validation to the release intro.

Docs-only; no code changes. This is the last content gap before cutting the
`v0.8.0` tag from the current `main` tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the v0.8.0 release notes. The main changes are:

- Added a stricter validation section for constraint checks across write paths.
- Clarified duplicate key and uniqueness behavior in the release notes.
- Added linux-arm64 as a documented prebuilt platform.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/releases/v0.8.0.md | Adds release-note coverage for stricter validation and linux-arm64 prebuilts. |

<sub>Reviews (2): Last reviewed commit: ["docs(release): scope cross-version uniqu..."](https://github.com/modernrelay/omnigraph/commit/36eabbee7f7d2605046c1e98b97534cdfc6db69b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41106195)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=59169be6-01cf-4bae-80fc-604b6a708098))
- Context used - CLAUDE.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=fba7c581-edb6-48b3-90ce-1db695f47e8b))

<!-- /greptile_comment -->