### PR TITLE
docs(upgrade): v0.8.0 migration section — manifest changes + stricter-validation pre-flight

### DIFF
--- a/docs/user/operations/upgrade.md
+++ b/docs/user/operations/upgrade.md
@@ -82,3 +82,73 @@ new graph verifies.
   re-embed after loading.
 - **Server deployments**: take the graph out of the serving set, rebuild it offline
   with the CLI, then point the cluster at the rebuilt graph (`cluster apply`).
+
+## Migrating to v0.8.0
+
+v0.8.0 is the first release with a storage-format change since v0.4.0. Any graph
+created by an earlier release must be rebuilt with the recipe above. Beyond the
+rebuild, v0.8.0 changes two things to plan for: the on-disk layout, and
+write-time validation strictness.
+
+### What changed on disk (internal schema v4)
+
+- **Graph commit lineage now lives in the `__manifest` table.** Commits, parents,
+  merge parents, per-branch heads, and the authoring actor are stored as
+  `graph_commit` / `graph_head` rows, written in the **same atomic commit** as the
+  table-version rows of a graph publish. Previously a crash in a narrow window
+  could leave a published version with no matching history entry; that window no
+  longer exists.
+- **Two internal datasets are retired.** `_graph_commits.lance` and
+  `_graph_commit_actors.lance` are no longer created, read, or written — a graph
+  created by v0.8.0 has neither. If backup scripts, disk-usage tooling, or
+  monitoring reference those paths inside a graph directory, update them.
+- **The version gate is enforced in both directions, including read-only opens.**
+  A v0.8.0 binary refuses a pre-v0.8.0 graph with the rebuild message above; a
+  pre-v0.8.0 binary refuses a v0.8.0 graph with an
+  `upgrade omnigraph before opening this graph` error. There is no mixed-version
+  window: upgrade every binary that touches a graph together, then rebuild.
+
+If you have tooling that inspects `__manifest` directly, note that it now holds
+three kinds of rows (table versions, commits, branch heads) rather than one —
+filter by row kind instead of assuming every row is a table version.
+
+### Stricter validation — pre-flight your pipelines
+
+Independently of the storage change, v0.8.0 unifies constraint validation across
+all three write surfaces (load, mutation, branch merge). Every change is stricter;
+none relaxes an existing check. A pipeline that unknowingly relied on one of these
+gaps will now fail loudly at write time:
+
+- **Enum constraints are enforced on branch merge** (previously only on load and
+  mutation).
+- **Cross-version uniqueness**: inserting a `@unique` value that collides with a
+  different, already-committed row is rejected on load and mutation (previously
+  only merges caught it). Re-upserting the *same* row — same key — is still an
+  update, not a violation.
+- **Duplicate keys within one input batch are rejected**: the same `@key` value
+  twice in one load file is an error. The same id across *separate* batches or
+  statements still coalesces (last write wins).
+- **Overwrite loads validate the new image per table**: an edges-only overwrite
+  resolves referential integrity against the retained node tables, and orphan
+  edges are rejected.
+
+Pre-flight recipe: before upgrading a production writer, run your ingest with a
+v0.8.0 binary against a **branch** of a rebuilt copy, using the **same `--mode`
+your pipeline uses in production** (`--mode` is always required; `overwrite` is
+the mode whose validation changed most):
+
+```bash
+omnigraph load --data batch.jsonl --mode merge \
+  --branch preflight --from main s3://bucket/graph-v2.omni
+```
+
+Rows violating the stricter checks fail the load with a typed error naming the
+constraint; fix the data (or the constraint) and re-run. Nothing is partially
+applied — a failed load publishes no commit.
+
+### Verifying versions
+
+The two CLI checks are listed in
+[How you know you need this](#how-you-know-you-need-this) (`omnigraph version`,
+`omnigraph snapshot`). New in v0.8.0, the server's `GET /healthz` response also
+reports `internal_schema_version`.


### PR DESCRIPTION
The upgrade guide is deliberately version-generic, but v0.8.0 is the first storage-format change since v0.4.0 and there was no single user-facing place describing what it breaks. Adds a **Migrating to v0.8.0** section to `docs/user/operations/upgrade.md`:

- **On-disk deltas (internal schema v4):** lineage as `graph_commit`/`graph_head` rows in `__manifest` (atomic with the publish), the retired `_graph_commits.lance`/`_graph_commit_actors.lance` datasets (update backup/monitoring paths), the both-direction version gate incl. read-only opens, and a note for tooling that reads `__manifest` directly (three row kinds now).
- **Stricter unified validation pre-flight:** the four behavior changes from #314 that can fail existing pipelines at write time (enum-on-merge, cross-version `@unique`, intra-batch duplicate keys, overwrite RI against the new image), with a branch-based pre-flight recipe.
- **Version verification:** `omnigraph version` / `snapshot` / `GET /healthz`.

Docs only. `check-agents-md.sh` green.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This docs-only PR adds a **Migrating to v0.8.0** section to the upgrade guide, covering the three on-disk changes (lineage in `__manifest`, retired lance datasets, bidirectional version gate) and the four stricter validation behaviors introduced in #314, plus a pre-flight recipe and version-verification subsection.

- **On-disk changes** are accurately described and consistent with `docs/user/concepts/storage.md` and `docs/releases/v0.8.0.md`; the previous-comment fix for the missing `--mode` flag is present in the snippet.
- **Pre-flight recipe** uses `--mode merge` in its code example while the surrounding prose explicitly identifies `overwrite` as the mode whose validation changed most — an overwrite-pipeline user who copies the snippet will not exercise the new RI validation.
- **`__manifest` row-kind note** says the manifest held "one" kind of row before v0.8.0; `storage.md` shows three pre-existing `object_type` values (`table`, `table_version`, `table_tombstone`), making the "rather than one" claim imprecise for tooling authors.

<h3>Confidence Score: 4/5</h3>

Docs-only change; no runtime code is touched. The one substantive issue is a misleading code example that could cause overwrite-pipeline users to run the wrong pre-flight test and miss the most impactful validation change.

The pre-flight snippet hardcodes --mode merge while the prose explicitly names overwrite as the mode most affected by the v0.8.0 validation changes. An overwrite-pipeline user who copies the snippet will complete the pre-flight without exercising the new per-table RI validation, potentially hitting the error in production after a clean pre-flight. The rest of the added content is accurate and consistent with storage.md and the v0.8.0 release notes.

docs/user/operations/upgrade.md — specifically the pre-flight bash snippet at lines 140–143 and the __manifest row-kind note at lines 111–113.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/user/operations/upgrade.md | Adds a Migrating to v0.8.0 section covering on-disk schema v4 changes, stricter validation behavior, and version verification. The pre-flight code snippet hardcodes --mode merge while the prose singles out overwrite as the highest-risk mode, which can give false confidence to overwrite-pipeline users. A secondary doc accuracy issue: the manifest "three kinds rather than one" claim understates the pre-v4 row type count. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User on pre-v0.8.0] --> B{Has existing graphs?}
    B -- Yes --> C[Export with OLD binary\nomnigraph export]
    C --> D[Init with NEW binary\nomnigraph init]
    D --> E[Load with NEW binary\nomnigraph load --mode overwrite]
    B -- No --> F[Init + Load fresh]

    E --> G[Pre-flight validation\nomnigraph load --mode YOUR_MODE\n--branch preflight --from main]
    F --> G

    G --> H{Validation errors?}
    H -- Yes --> I[Fix data or schema\nRe-run pre-flight]
    I --> G
    H -- No --> J[Upgrade production writer\nto v0.8.0]

    J --> K[Verify versions\nomnigraph version\nomnigraph snapshot\nGET /healthz]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User on pre-v0.8.0] --> B{Has existing graphs?}
    B -- Yes --> C[Export with OLD binary\nomnigraph export]
    C --> D[Init with NEW binary\nomnigraph init]
    D --> E[Load with NEW binary\nomnigraph load --mode overwrite]
    B -- No --> F[Init + Load fresh]

    E --> G[Pre-flight validation\nomnigraph load --mode YOUR_MODE\n--branch preflight --from main]
    F --> G

    G --> H{Validation errors?}
    H -- Yes --> I[Fix data or schema\nRe-run pre-flight]
    I --> G
    H -- No --> J[Upgrade production writer\nto v0.8.0]

    J --> K[Verify versions\nomnigraph version\nomnigraph snapshot\nGET /healthz]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["docs(upgrade): add a v0.8.0 migration se..."](https://github.com/modernrelay/omnigraph/commit/a4d35d71d791fde61899b81dd0e530718303ec53) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41521435)</sub>

<!-- /greptile_comment -->