### PR TITLE
fix(engine): embedding fixes slice 1 — prefilter, finiteness, loader parity, mock warning

### DIFF
--- a/crates/omnigraph/src/embedding.rs
+++ b/crates/omnigraph/src/embedding.rs
@@ -781,6 +781,24 @@ mod tests {
     }
 
     #[test]
+    fn validate_and_normalize_embedding_rejects_non_finite_and_zero() {
+        // iss-embedding-nan-validation: a NaN component must be rejected —
+        // not silently returned un-normalized (NaN > EPSILON is false, so the
+        // normalize guard inverts and the raw NaN vector came back Ok).
+        let err = validate_and_normalize_embedding(vec![f32::NAN, 1.0], 2).unwrap_err();
+        assert!(err.contains("finite"), "NaN must be rejected, got: {err}");
+        // An Inf component must be rejected — not normalized into 0s + NaN.
+        let err = validate_and_normalize_embedding(vec![f32::INFINITY, 1.0], 2).unwrap_err();
+        assert!(err.contains("finite"), "Inf must be rejected, got: {err}");
+        let err =
+            validate_and_normalize_embedding(vec![1.0, f32::NEG_INFINITY], 2).unwrap_err();
+        assert!(err.contains("finite"), "-Inf must be rejected, got: {err}");
+        // An all-zero vector has no direction — undefined under cosine/ANN.
+        let err = validate_and_normalize_embedding(vec![0.0, 0.0], 2).unwrap_err();
+        assert!(err.contains("zero"), "zero vector must be rejected, got: {err}");
+    }
+
+    #[test]
     fn validate_and_normalize_embedding_enforces_dimension() {
         let normalized = validate_and_normalize_embedding(vec![3.0, 4.0], 2).unwrap();
         assert!((normalized[0] - 0.6).abs() < 1e-6);

--- a/crates/omnigraph/src/embedding.rs
+++ b/crates/omnigraph/src/embedding.rs
@@ -542,6 +542,25 @@ fn validate_and_normalize_embedding(
             values.len()
         ));
     }
+    // Reject poisoned vectors BEFORE normalizing: a NaN component makes the
+    // norm NaN (whose `> EPSILON` comparison is false, silently skipping
+    // normalization), an Inf component normalizes the rest to 0s and itself
+    // to NaN, and a zero vector has no direction — all three would persist
+    // as "successful" embeddings and degrade ANN/IVF for unrelated rows.
+    if let Some(idx) = values.iter().position(|v| !v.is_finite()) {
+        return Err(format!(
+            "embedding component {} is not finite ({})",
+            idx, values[idx]
+        ));
+    }
+    let norm = values
+        .iter()
+        .map(|v| (*v as f64) * (*v as f64))
+        .sum::<f64>()
+        .sqrt() as f32;
+    if norm <= f32::EPSILON {
+        return Err("embedding has zero norm (no direction)".to_string());
+    }
     Ok(normalize_vector(values))
 }
 

--- a/crates/omnigraph/src/embedding.rs
+++ b/crates/omnigraph/src/embedding.rs
@@ -70,6 +70,24 @@ impl EmbeddingConfig {
     /// 5. provider api-key env (`OPENROUTER_API_KEY`/`OPENAI_API_KEY`, or `GEMINI_API_KEY`).
     pub fn from_env() -> Result<Self> {
         if env_flag("OMNIGRAPH_EMBEDDINGS_MOCK") {
+            // The mock flag deliberately wins (pinned by
+            // from_env_mock_flag_wins) — but overriding an EXPLICITLY
+            // configured real provider must be loud: mock vectors are
+            // indistinguishable from real ones (correct dimension, unit
+            // norm), so a leaked test env var would otherwise silently
+            // poison persisted embeds and query-time nearest().
+            if let Some(provider) = env_string("OMNIGRAPH_EMBED_PROVIDER")
+                && provider != "mock"
+            {
+                tracing::warn!(
+                    target: "omnigraph::embedding",
+                    overridden_provider = %provider,
+                    "OMNIGRAPH_EMBEDDINGS_MOCK is set and overrides the \
+                     explicitly configured OMNIGRAPH_EMBED_PROVIDER — all \
+                     embeddings in this process are deterministic mock \
+                     vectors, not real ones"
+                );
+            }
             return Ok(Self::mock());
         }
 

--- a/crates/omnigraph/src/embedding.rs
+++ b/crates/omnigraph/src/embedding.rs
@@ -579,7 +579,14 @@ fn validate_and_normalize_embedding(
     if norm <= f32::EPSILON {
         return Err("embedding has zero norm (no direction)".to_string());
     }
-    Ok(normalize_vector(values))
+    // Normalize in place with the norm just computed — `normalize_vector`
+    // would recompute it (and its zero guard is unreachable here, since a
+    // zero norm already returned Err above).
+    let mut values = values;
+    for value in &mut values {
+        *value /= norm;
+    }
+    Ok(values)
 }
 
 fn normalize_vector(mut values: Vec<f32>) -> Vec<f32> {

--- a/crates/omnigraph/src/exec/query.rs
+++ b/crates/omnigraph/src/exec/query.rs
@@ -1923,6 +1923,18 @@ async fn execute_node_scan(
             // Apply the structured IR filter via Lance's Expr pushdown.
             if let Some(ref expr) = filter_expr {
                 scanner.filter_expr(expr.clone());
+                // The filter must run BEFORE any ANN/FTS search on this
+                // scanner. Lance defaults to prefilter=false, which applies
+                // the filter to the search's top-k results — "you may get
+                // back fewer results than you ask for (or none at all)"
+                // (lance scanner.rs) — i.e. `limit k` would mean top-k of
+                // the whole table, silently starved by a selective filter.
+                // One flag governs both the vector and FTS sources, and it
+                // is unused by plain scans, so setting it whenever a filter
+                // is present is safe. Prefiltering also re-enables scalar-
+                // index acceleration for the predicate (Lance gates
+                // use_scalar_index on prefilter when a nearest is present).
+                scanner.prefilter(true);
             }
 
             // Apply FTS queries from hoisted search filters (search/fuzzy/match_text in match clause)

--- a/crates/omnigraph/src/loader/mod.rs
+++ b/crates/omnigraph/src/loader/mod.rs
@@ -907,9 +907,18 @@ fn build_column_from_json(
                         )));
                     }
                     for val in arr {
-                        builder
-                            .values()
-                            .append_value(val.as_f64().unwrap_or(0.0) as f32);
+                        // Parity with the mutation path: non-numeric elements
+                        // (null — what json! emits for a non-finite float —
+                        // strings, bools) are rejected loudly, never coerced
+                        // to 0.0, which would silently corrupt the vector's
+                        // direction while passing every dimension check.
+                        let Some(v) = val.as_f64() else {
+                            return Err(OmniError::manifest(format!(
+                                "vector property '{}' elements must be numeric, got {}",
+                                name, val
+                            )));
+                        };
+                        builder.values().append_value(v as f32);
                     }
                     builder.append(true);
                 } else if nullable {

--- a/crates/omnigraph/tests/search.rs
+++ b/crates/omnigraph/tests/search.rs
@@ -387,6 +387,75 @@ async fn phrase_search_is_documented_fts_fallback() {
 
 // ─── Vector search (nearest) ────────────────────────────────────────────────
 
+/// iss-nearest-postfilter-starves-results: a scalar `match` predicate combined
+/// with `nearest` must return the top-k of the MATCHING rows. Lance's default
+/// is post-filtering (filter applied AFTER the ANN top-k), under which this
+/// fixture — where every filter-matching doc sits far from the query vector,
+/// so the global top-k is entirely non-matching — returns 0 rows despite 3
+/// matches existing. The engine must set prefilter(true) whenever a filter
+/// rides the same scanner as a search.
+#[tokio::test]
+#[serial]
+async fn filtered_nearest_returns_matching_rows_not_postfiltered_topk() {
+    const SCHEMA: &str = r#"
+node Doc {
+    slug: String @key
+    status: String
+    embedding: Vector(4)
+}
+"#;
+    // Query vector is +e1. The three status="miss" docs cluster around +e1
+    // (global top-3); the three status="hit" docs cluster around -e1.
+    const DATA: &str = r#"{"type":"Doc","data":{"slug":"miss-1","status":"miss","embedding":[1.0,0.01,0.0,0.0]}}
+{"type":"Doc","data":{"slug":"miss-2","status":"miss","embedding":[1.0,0.0,0.02,0.0]}}
+{"type":"Doc","data":{"slug":"miss-3","status":"miss","embedding":[1.0,0.0,0.0,0.03]}}
+{"type":"Doc","data":{"slug":"hit-1","status":"hit","embedding":[-1.0,0.01,0.0,0.0]}}
+{"type":"Doc","data":{"slug":"hit-2","status":"hit","embedding":[-1.0,0.0,0.02,0.0]}}
+{"type":"Doc","data":{"slug":"hit-3","status":"hit","embedding":[-1.0,0.0,0.0,0.03]}}
+"#;
+    const QUERIES: &str = r#"
+query filtered_nearest($q: Vector(4)) {
+    match { $d: Doc { status: "hit" } }
+    return { $d.slug }
+    order { nearest($d.embedding, $q) }
+    limit 3
+}
+"#;
+    let dir = tempfile::tempdir().unwrap();
+    let uri = dir.path().to_str().unwrap();
+    let mut db = Omnigraph::init(uri, SCHEMA).await.unwrap();
+    load_jsonl(&mut db, DATA, LoadMode::Overwrite).await.unwrap();
+
+    let result = query_main(
+        &mut db,
+        QUERIES,
+        "filtered_nearest",
+        &vector_param("$q", &[1.0, 0.0, 0.0, 0.0]),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        result.num_rows(),
+        3,
+        "filtered nearest must return the top-k of MATCHING rows (3 hits exist), \
+         not the post-filtered remainder of the global top-k"
+    );
+    let batch = result.concat_batches().unwrap();
+    let slugs = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    for i in 0..slugs.len() {
+        assert!(
+            slugs.value(i).starts_with("hit-"),
+            "only matching docs may appear, got {}",
+            slugs.value(i)
+        );
+    }
+}
+
 #[tokio::test]
 #[serial]
 async fn nearest_returns_k_closest() {

--- a/crates/omnigraph/tests/validators.rs
+++ b/crates/omnigraph/tests/validators.rs
@@ -112,6 +112,63 @@ async fn init_with(schema: &str, data: &str) -> (tempfile::TempDir, Omnigraph) {
     (dir, db)
 }
 
+// ─── Vector element validation (loader surface) ─────────────────────────────
+
+const VECTOR_SCHEMA: &str = r#"
+node Doc {
+    slug: String @key
+    embedding: Vector(3)
+}
+"#;
+
+/// iss-loader-vector-element-coercion: the loader must reject non-numeric
+/// vector elements loudly (parity with the mutation path's "vector elements
+/// must be numeric"), never coerce them to 0.0 — a NaN serialized as JSON
+/// null (JSON has no NaN) or a string element silently zeroed the vector's
+/// direction while passing every dimension check.
+#[tokio::test]
+async fn non_numeric_vector_element_rejected_on_jsonl_load() {
+    let (_dir, mut db) = init_with(VECTOR_SCHEMA, "").await;
+
+    // A null element (what json! produces for a non-finite float).
+    let bad_null = r#"{"type":"Doc","data":{"slug":"d1","embedding":[0.1,null,0.3]}}"#;
+    let err = load_jsonl(&mut db, bad_null, LoadMode::Overwrite)
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("elements must be numeric"),
+        "null element must be rejected, got: {}",
+        err
+    );
+
+    // A string element.
+    let bad_str = r#"{"type":"Doc","data":{"slug":"d2","embedding":[0.1,"0.2",0.3]}}"#;
+    let err = load_jsonl(&mut db, bad_str, LoadMode::Overwrite)
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("elements must be numeric"),
+        "string element must be rejected, got: {}",
+        err
+    );
+
+    // Pin the adjacent (existing) dimension check while we are here — no
+    // loader vector validation had any coverage before this test.
+    let bad_dim = r#"{"type":"Doc","data":{"slug":"d3","embedding":[0.1,0.2]}}"#;
+    let err = load_jsonl(&mut db, bad_dim, LoadMode::Overwrite)
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("expects 3 dimensions, got 2"),
+        "dimension mismatch must be rejected, got: {}",
+        err
+    );
+
+    // A valid row still loads.
+    let good = r#"{"type":"Doc","data":{"slug":"d4","embedding":[0.1,0.2,0.3]}}"#;
+    load_jsonl(&mut db, good, LoadMode::Overwrite).await.unwrap();
+}
+
 // ─── Enum validation ─────────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/docs/user/search/embeddings.md
+++ b/docs/user/search/embeddings.md
@@ -13,7 +13,10 @@ query vectors and document vectors share one model and one vector space.
 | `gemini` | `POST {base}/models/{model}:embedContent`, `x-goog-api-key`, with `RETRIEVAL_QUERY` / `RETRIEVAL_DOCUMENT` task types | Reaching Google's `generativelanguage` API directly |
 | `mock` | none — deterministic offline vectors | Tests and local dev without a key |
 
-Vectors are stored L2-normalized as `FixedSizeList(Float32, dim)`; the requested output dimension is driven by
+Vectors are stored L2-normalized as `FixedSizeList(Float32, dim)`. Embedding
+values must be finite — a vector containing NaN/Inf, or an all-zero vector
+(no direction under cosine distance), is rejected at the client boundary
+rather than persisted; the requested output dimension is driven by
 the target column width and sent as Gemini `outputDimensionality` / OpenAI `dimensions`.
 
 ## Configuration (cluster)

--- a/docs/user/search/embeddings.md
+++ b/docs/user/search/embeddings.md
@@ -61,7 +61,7 @@ Direct (`--store`) access, embedded callers, and the offline
 | `OMNIGRAPH_EMBED_DEADLINE_MS` | total wall-clock budget for one embed call across all retries (default `60000`; `0` = unbounded) |
 | `OMNIGRAPH_EMBED_TIMEOUT_MS` | per-request HTTP timeout (default `30000`) |
 | `OMNIGRAPH_EMBED_RETRY_ATTEMPTS` / `OMNIGRAPH_EMBED_RETRY_BACKOFF_MS` | retry policy (defaults `4` / `200`) |
-| `OMNIGRAPH_EMBEDDINGS_MOCK` | set truthy to force the deterministic mock provider |
+| `OMNIGRAPH_EMBEDDINGS_MOCK` | set truthy to force the deterministic mock provider. Takes precedence over an explicitly configured `OMNIGRAPH_EMBED_PROVIDER` — the override is logged as a warning (`omnigraph::embedding` target), since mock vectors are indistinguishable from real ones (correct dimension, unit norm) |
 
 The default zero-config path is OpenRouter: set `OPENROUTER_API_KEY` and run. Reaching Gemini takes
 `OMNIGRAPH_EMBED_PROVIDER=gemini` plus `GEMINI_API_KEY`.

--- a/docs/user/search/index.md
+++ b/docs/user/search/index.md
@@ -20,6 +20,10 @@ rank).
 - `nearest()` requires a `limit`. The query vector is resolved from the param map,
   or embedded from a text input at runtime via the configured
   [embedding client](embeddings.md).
+- Match filters apply **before** the search: combining a `match` predicate with
+  `nearest()` (or `bm25()`) returns the top-`limit` of the *matching* rows —
+  never a post-filtered remainder of the global top-k. A selective filter
+  narrows the candidate set; it cannot starve the result count.
 - Scores and ranks propagate as ordinary columns, so you can `return` a score and
   `order` by it.
 


### PR DESCRIPTION
First slice of the embeddings code-review findings: the four surgical, adversarially-verified bugs. Each fix lands as a rule-12 red→green pair (red commit fails with the predicted symptom, quoted in its message); the design-level findings (text↔vector staleness contract, per-row provenance, lance#7230 BTREE remediation, merge streaming) are tracked separately.

## Fix 1 — `prefilter(true)` for filtered vector/FTS search (P0)

Lance's scanner defaults to post-filtering: a `match` predicate riding the same scanner as `nearest()`/`bm25()` was applied AFTER the ANN/FTS top-k, so `limit k` meant top-k of the whole table — a selective filter silently starved results (deny-list: silent partial result), and `rrf` hybrids inherited it. Now `prefilter(true)` is set whenever a structured filter is pushed; one flag governs both the vector and FTS sources, plain scans ignore it, and it re-enables scalar-index acceleration for the predicate.

Measured with the #332 bench scenario (20k rows, s=0.05, k=10): **recall 0.0 → 1.0** (0 of 10 returned before, 10/10 after; 1,000 matching rows existed all along), mean query latency 0.10 ms → 0.15 ms. Docs now state the contract: filters apply **before** the search.

## Fix 2 — reject non-finite / zero-norm embeddings (P1)

`validate_and_normalize_embedding` checked only dimension; the normalize guard (`norm > f32::EPSILON`) inverts on NaN — a NaN vector returned Ok un-normalized, Inf normalized to 0s+NaN, all-zero passed. Poisoned vectors persisted as success and degrade IVF training for unrelated rows. Now: every component must be finite (error names the index), zero-norm rejected — through the existing error channel, no new plumbing.

## Fix 3 — loud warning when `OMNIGRAPH_EMBEDDINGS_MOCK` overrides an explicit provider (P1)

Precedence unchanged (deliberate, pinned by `from_env_mock_flag_wins`) — but the override was silent, and mock vectors are indistinguishable from real ones (correct dim, unit norm), silently poisoning CLI embeds and server query-time `nearest()` for graphs without a bound cluster embedding profile. Now a `tracing::warn` names the overridden provider; the env-var table documents it.

## Fix 4 — loader rejects non-numeric vector elements (P1)

The loader's `FixedSizeList` arm coerced non-numeric elements to `0.0` (`as_f64().unwrap_or(0.0)`) while the mutation path rejects loudly — a `null` (exactly what `json!` emits for a non-finite float) silently zeroed the vector's direction. Now a loud per-row error in the loader's own style. The red test also pins the previously-untested dimension check.

## Verification

- Four red→green pairs visible in `git log` (each red commit quotes its predicted failure).
- `cargo test --workspace --locked` green (the one observed failure was the known concurrency-flake in `change_concurrent_updates_same_key_serialize_via_publisher_cas`, 3/3 green on re-run, untouched by this diff).
- Dev-graph issues: `iss-nearest-postfilter-starves-results`, `iss-embedding-nan-validation`, `iss-embeddings-mock-override-silent`, `iss-loader-vector-element-coercion`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/modernrelay/omnigraph/pull/333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes four independently-verified correctness bugs in the embeddings and vector-search stack. Each fix ships with a red→green test pair following the project's rule-12 discipline.

- **Fix 1 (prefilter)**: Adds `scanner.prefilter(true)` whenever a structured filter is present, ensuring Lance applies the predicate before the ANN/FTS top-k rather than after — eliminating the silent result starvation on filtered `nearest()`/`bm25()` queries.
- **Fix 2 (validation)**: `validate_and_normalize_embedding` now checks finiteness of every component and zero-norm before normalizing, then normalizes in-place with the already-computed norm (avoiding the previous double computation and the now-unreachable guard in `normalize_vector`).
- **Fix 3 (mock warning)**: Emits a `tracing::warn` when `OMNIGRAPH_EMBEDDINGS_MOCK` overrides an explicitly configured real provider, making a previously silent env-var precedence rule observable.
- **Fix 4 (loader parity)**: The bulk-loader's `FixedSizeList` arm now rejects non-numeric JSON elements loudly instead of silently coercing `null`/strings to `0.0`, matching the mutation path's behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge — four targeted bug fixes, each with a red→green regression test, no regressions visible in changed or related code paths.

All four changes are surgical and well-bounded: the prefilter flag is set inside the existing filter_expr guard and is a documented no-op for plain scans; the embedding validation changes close a class of poisoned-vector bugs without affecting the mock path or normalize_vector (still live in mock_embedding); the loader fix is a one-line replacement with identical happy-path behavior; the warning is conditional and additive. Tests cover each failure mode end-to-end. No related-repo interfaces are affected.

No files require special attention — all changes are well-scoped and covered by regression tests.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/omnigraph/src/exec/query.rs | Adds scanner.prefilter(true) inside the existing filter_expr block; safe for plain scans (no-op without nearest/bm25) and correct for filtered ANN/FTS queries. |
| crates/omnigraph/src/embedding.rs | Finiteness + zero-norm guards added before normalization; inline normalization avoids double norm computation; mock warning is correctly conditional on provider != "mock". |
| crates/omnigraph/src/loader/mod.rs | Non-numeric vector elements now rejected with a clear error rather than silently coerced to 0.0, matching the mutation path. |
| crates/omnigraph/tests/search.rs | New filtered_nearest test correctly constructs a scenario where post-filtering returns 0 rows (all miss-docs in global top-3) while pre-filtering returns all 3 hit-docs. |
| crates/omnigraph/tests/validators.rs | New test covers null elements, string elements, dimension mismatch, and a valid load for the loader's FixedSizeList path — first coverage of this surface. |
| docs/user/search/embeddings.md | Documents the new finiteness contract and clarifies the OMNIGRAPH_EMBEDDINGS_MOCK warning; update is in-sync with the code change per rule-1. |
| docs/user/search/index.md | Adds the prefilter contract ("filters apply before the search") to the search docs, matching the new behavior. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Query: nearest + filter"] --> B{filter_expr present?}
    B -- Yes --> C[scanner.filter_expr]
    C --> D["scanner.prefilter(true) NEW"]
    D --> E{search configured?}
    E -- nearest --> F["scanner.nearest(prop, vec, k)"]
    E -- bm25 --> G["scanner.full_text_search"]
    E -- neither --> H["Plain scan — no-op"]
    B -- No --> E
    F --> I["Lance: filter candidates FIRST"]
    G --> I
    I --> J["Return top-k of MATCHING rows"]

    K["Loader: vector element"] --> L{val.as_f64 succeeds?}
    L -- No --> M["Error: elements must be numeric NEW"]
    L -- Yes --> N["append_value as f32"]

    O["validate_and_normalize_embedding"] --> R{any component non-finite?}
    R -- Yes --> S["Err: component N not finite NEW"]
    R -- No --> T{norm le EPSILON?}
    T -- Yes --> U["Err: zero norm NEW"]
    T -- No --> V["normalize in-place with pre-computed norm"]
    V --> W["Ok normalized vec"]

    X["from_env: MOCK flag set"] --> Y{real provider also set?}
    Y -- Yes --> Z["tracing::warn overridden_provider NEW"]
    Z --> AA["return Self::mock()"]
    Y -- No --> AA
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Query: nearest + filter"] --> B{filter_expr present?}
    B -- Yes --> C[scanner.filter_expr]
    C --> D["scanner.prefilter(true) NEW"]
    D --> E{search configured?}
    E -- nearest --> F["scanner.nearest(prop, vec, k)"]
    E -- bm25 --> G["scanner.full_text_search"]
    E -- neither --> H["Plain scan — no-op"]
    B -- No --> E
    F --> I["Lance: filter candidates FIRST"]
    G --> I
    I --> J["Return top-k of MATCHING rows"]

    K["Loader: vector element"] --> L{val.as_f64 succeeds?}
    L -- No --> M["Error: elements must be numeric NEW"]
    L -- Yes --> N["append_value as f32"]

    O["validate_and_normalize_embedding"] --> R{any component non-finite?}
    R -- Yes --> S["Err: component N not finite NEW"]
    R -- No --> T{norm le EPSILON?}
    T -- Yes --> U["Err: zero norm NEW"]
    T -- No --> V["normalize in-place with pre-computed norm"]
    V --> W["Ok normalized vec"]

    X["from_env: MOCK flag set"] --> Y{real provider also set?}
    Y -- Yes --> Z["tracing::warn overridden_provider NEW"]
    Z --> AA["return Self::mock()"]
    Y -- No --> AA
```

</a>

<sub>Reviews (2): Last reviewed commit: ["perf(engine): normalize with the already..."](https://github.com/modernrelay/omnigraph/commit/ecbf247fd7251b52567024b52de8a279dff4c4e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41870295)</sub>

<!-- /greptile_comment -->