### PR TITLE
bench(engine): append every run to a results log (ts + git_sha)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ demo/*.omni/
 /schema-issues.md
 /schema-prior-art.md
 mdrip/
+crates/omnigraph/benches/results.jsonl

--- a/crates/omnigraph/benches/scenarios.rs
+++ b/crates/omnigraph/benches/scenarios.rs
@@ -55,6 +55,8 @@ struct Args {
     /// ANN k (the query's `limit`) for nearest-prefilter.
     k: usize,
     memory_cap_mb: Option<u64>,
+    /// Results-log override; see `results_path`.
+    out: Option<String>,
     /// Run the identical workload but SKIP the measured operation; the
     /// peak-RSS delta between a normal run and a baseline run isolates the
     /// measured op's own memory contribution (ru_maxrss spans the whole
@@ -75,6 +77,7 @@ impl Args {
             selectivity: 0.05,
             k: 10,
             memory_cap_mb: None,
+            out: None,
             baseline: false,
             child: false,
         };
@@ -94,6 +97,7 @@ impl Args {
                     args.selectivity = take("--selectivity").parse().expect("--selectivity")
                 }
                 "--k" => args.k = take("--k").parse().expect("--k"),
+                "--out" => args.out = Some(take("--out")),
                 "--memory-cap-mb" => {
                     args.memory_cap_mb = Some(take("--memory-cap-mb").parse().expect("cap"))
                 }
@@ -162,10 +166,53 @@ fn main() {
     for run in 0..args.runs {
         let record = run_once(&args, run);
         println!("{record}");
+        append_result(&args, &record);
     }
 }
 
 #[cfg(unix)]
+/// Where run records accumulate: `--out <path>`, else `OMNIGRAPH_BENCH_RESULTS`,
+/// else `benches/results.jsonl` next to this crate (gitignored — results are
+/// host-specific; each record is self-describing via `host` + `params` +
+/// `git_sha`). Append-only JSON lines, the harness's system of record.
+fn results_path(args: &Args) -> std::path::PathBuf {
+    if let Some(ref out) = args.out {
+        return out.into();
+    }
+    if let Ok(env_path) = std::env::var("OMNIGRAPH_BENCH_RESULTS") {
+        if !env_path.trim().is_empty() {
+            return env_path.trim().into();
+        }
+    }
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("benches/results.jsonl")
+}
+
+fn append_result(args: &Args, record: &serde_json::Value) {
+    let path = results_path(args);
+    let appended = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .and_then(|mut f| {
+            use std::io::Write as _;
+            writeln!(f, "{record}")
+        });
+    if let Err(e) = appended {
+        eprintln!("WARNING: could not append to {}: {e}", path.display());
+    }
+}
+
+fn git_sha() -> Option<String> {
+    let out = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .ok()?;
+    out.status
+        .success()
+        .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
 fn run_once(args: &Args, run: usize) -> serde_json::Value {
     let exe = std::env::current_exe().expect("current_exe");
     let mut child = std::process::Command::new(exe)
@@ -200,6 +247,11 @@ fn run_once(args: &Args, run: usize) -> serde_json::Value {
     serde_json::json!({
         "scenario": args.scenario,
         "run": run,
+        "ts": std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0),
+        "git_sha": git_sha(),
         "params": {
             "rows": args.rows,
             "dims": args.dims,

--- a/crates/omnigraph/benches/scenarios.rs
+++ b/crates/omnigraph/benches/scenarios.rs
@@ -187,6 +187,7 @@ fn results_path(args: &Args) -> std::path::PathBuf {
     std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("benches/results.jsonl")
 }
 
+#[cfg(unix)]
 fn append_result(args: &Args, record: &serde_json::Value) {
     let path = results_path(args);
     let appended = std::fs::OpenOptions::new()
@@ -202,6 +203,7 @@ fn append_result(args: &Args, record: &serde_json::Value) {
     }
 }
 
+#[cfg(unix)]
 fn git_sha() -> Option<String> {
     let out = std::process::Command::new("git")
         .args(["rev-parse", "--short", "HEAD"])
@@ -213,6 +215,7 @@ fn git_sha() -> Option<String> {
         .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
 }
 
+#[cfg(unix)]
 fn run_once(args: &Args, run: usize) -> serde_json::Value {
     let exe = std::env::current_exe().expect("current_exe");
     let mut child = std::process::Command::new(exe)

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -114,8 +114,12 @@ The CLI system tests (`system_local.rs`) spawn the workspace-built `omnigraph` a
   merge-all-changed --rows 20000 --dims 256` (also `nearest-prefilter`;
   `--baseline` re-runs the identical workload minus the measured op so the
   peak-RSS delta isolates it; `--memory-cap-mb` applies `RLIMIT_AS` — enforced
-  on Linux, best-effort on macOS). Add new scenarios here rather than new
-  bench targets; keep the JSON-lines/no-assertions contract.
+  on Linux, best-effort on macOS). Every run appends its record (with `ts` +
+  `git_sha`) to a results log — `--out <path>`, else `OMNIGRAPH_BENCH_RESULTS`,
+  else `crates/omnigraph/benches/results.jsonl` (gitignored; host-specific) —
+  so baselines survive across sessions and substrate bumps. Add new scenarios
+  here rather than new bench targets; keep the JSON-lines/no-assertions
+  contract.
 - Add `benches/` per crate when you ship a perf-driven change, and include the motivating workload with the optimization.
 
 ## Coverage tooling — what's missing


### PR DESCRIPTION
Follow-up to #332: the harness printed JSON lines and discarded them — the numbers that justify decisions (the 6.9 GB merge crash, the prefilter recall 0.0→1.0 pair) had no system of record, and the lance-7 baselines are needed for before/after comparison across the Lance 9 migration.

Every run now appends its record — stamped with `ts` (unix secs) and `git_sha` — to a results log: `--out <path>`, else `OMNIGRAPH_BENCH_RESULTS`, else `crates/omnigraph/benches/results.jsonl` (gitignored: host-specific, self-describing via `host` + `params` + `git_sha`). A failed append warns on stderr rather than failing the run. Today's runs are backfilled into the local log (marked `"backfill": true`).

Verified: smoke run appends a well-formed line; `cargo test --workspace` untouched (bench outside the gate); testing.md updated in the same PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/modernrelay/omnigraph/pull/334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a persistent results log to the scenario bench harness. Every run now appends its JSON record — stamped with `ts` (Unix seconds) and `git_sha` (short) — to a configurable path: `--out <path>`, then `OMNIGRAPH_BENCH_RESULTS`, then the default `crates/omnigraph/benches/results.jsonl` (gitignored). A failed file write warns on stderr rather than aborting the run.

- Adds three new unix-only helpers (`results_path`, `append_result`, `git_sha`) each correctly guarded with `#[cfg(unix)]`, keeping the Windows inert-stub guarantee intact.
- Appending is done in the parent process after each `run_once` returns; the child process is not affected — `to_child_argv` correctly omits `--out` because the child never calls `append_result`.
- `docs/dev/testing.md` is updated in the same PR to document the new `--out` flag and env-var override, consistent with the AGENTS.md "update in the same PR" rule.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are confined to the bench harness, outside cargo test --workspace, with no production code touched.

All three new helpers carry correct #[cfg(unix)] guards, preserving the Windows inert-stub guarantee. Append logic is parent-only, error-tolerant, and correctly excluded from child invocations. The gitignore entry matches the default path. No CI gate or production path is affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/omnigraph/benches/scenarios.rs | Adds `results_path`, `append_result`, and `git_sha` — all correctly guarded with `#[cfg(unix)]`; `run_once` retains its guard; appending is parent-only and fails gracefully. |
| .gitignore | Adds `crates/omnigraph/benches/results.jsonl` to gitignore, matching the default output path in `results_path`. |
| docs/dev/testing.md | Updates the scenario harness description to document the new `--out`/env-var/default-path results log and `ts`+`git_sha` stamping. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User
    participant P as Parent (main)
    participant C as Child (run_child)
    participant F as results.jsonl

    U->>P: cargo bench -- --scenario merge-all-changed [--out path]
    loop for run in 0..args.runs
        P->>C: spawn(current_exe, to_child_argv())
        Note over C: runs scenario, prints metrics JSON to stdout
        C-->>P: stdout (metrics JSON) + exit status
        P->>P: wait4_rusage(pid) → peak_rss_bytes
        P->>P: "build record {ts, git_sha, params, exit_status, peak_rss_bytes, metrics}"
        P->>F: OpenOptions::append(true).open(results_path(args))
        F-->>P: Ok / Err (warn on stderr, never abort)
        P->>U: println!(record)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User
    participant P as Parent (main)
    participant C as Child (run_child)
    participant F as results.jsonl

    U->>P: cargo bench -- --scenario merge-all-changed [--out path]
    loop for run in 0..args.runs
        P->>C: spawn(current_exe, to_child_argv())
        Note over C: runs scenario, prints metrics JSON to stdout
        C-->>P: stdout (metrics JSON) + exit status
        P->>P: wait4_rusage(pid) → peak_rss_bytes
        P->>P: "build record {ts, git_sha, params, exit_status, peak_rss_bytes, metrics}"
        P->>F: OpenOptions::append(true).open(results_path(args))
        F-->>P: Ok / Err (warn on stderr, never abort)
        P->>U: println!(record)
    end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix(bench): restore the cfg(unix) gate d..."](https://github.com/modernrelay/omnigraph/commit/4aa7f23694277011c7899863191b3f09ed5c1a96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41918382)</sub>

<!-- /greptile_comment -->