### PR TITLE
release: v0.8.1

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -36,6 +36,7 @@ jobs:
           echo "CARGO_REGISTRY_TOKEN is not set; skipping crates.io publish."
           echo "CARGO_PUBLISH_SKIP=1" >> "$GITHUB_ENV"
 
+
       - name: Resolve ref
         if: env.CARGO_PUBLISH_SKIP != '1'
         id: ref
@@ -49,6 +50,20 @@ jobs:
         uses: actions/checkout@v5.0.1
         with:
           ref: ${{ steps.ref.outputs.ref }}
+
+      # crates.io rejects git dependencies, so while the storage substrate is
+      # rev-pinned to a Lance pre-release (git dep in the workspace manifest)
+      # registry publication is deliberately deferred — binaries/Homebrew still
+      # ship from release.yml. This self-heals: the step stops matching the
+      # moment the dependency returns to a crates.io version (Lance 9 stable),
+      # and a workflow_dispatch catch-up run can then publish the skipped tag.
+      - name: Skip while the storage substrate is git-pinned
+        if: env.CARGO_PUBLISH_SKIP != '1'
+        run: |
+          if grep -qE '^lance = \{ git' Cargo.toml; then
+            echo "lance is git-pinned (pre-release substrate); deferring crates.io publish for this tag."
+            echo "CARGO_PUBLISH_SKIP=1" >> "$GITHUB_ENV"
+          fi
 
       - name: Install Linux dependencies
         if: env.CARGO_PUBLISH_SKIP != '1'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Tools that support `@`-imports (Claude Code) auto-include all three files via th
 
 `CLAUDE.md` is a symlink to this file — there is exactly one source of truth. Edit `AGENTS.md`.
 
-**Version surveyed:** 0.8.0
+**Version surveyed:** 0.8.1
 **Workspace crates:** `omnigraph-compiler`, `omnigraph` (engine), `omnigraph-policy`, `omnigraph-api-types` (shared HTTP wire DTOs), `omnigraph-cluster`, `omnigraph-cli`, `omnigraph-server`
 **Storage substrate:** Lance 9.x (columnar, versioned, branchable; 9.0.0-beta.15 git-rev pin until 9.0.0 stable)
 **License:** MIT
@@ -106,6 +106,7 @@ Full diagram and concurrency model: [docs/dev/architecture.md](docs/dev/architec
 | CI / release workflows | [docs/dev/ci.md](docs/dev/ci.md) |
 | Branch protection policy (declarative, applied via `scripts/apply-branch-protection.sh`) | [docs/dev/branch-protection.md](docs/dev/branch-protection.md) |
 | Constants & tunables cheat sheet | [docs/user/reference/constants.md](docs/user/reference/constants.md) |
+| RFC process — public contribution track (substantial / irreversible changes) | [docs/rfcs/README.md](docs/rfcs/README.md) |
 | Per-version release notes | [docs/releases/](docs/releases/) |
 
 ---

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-api-types"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "omnigraph-compiler",
  "omnigraph-engine",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -4997,7 +4997,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-cluster"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "fail",
  "omnigraph-compiler",
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-compiler"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -5035,7 +5035,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-engine"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "arc-swap",
  "arrow-array",
@@ -5082,7 +5082,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-policy"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "cedar-policy",
  "clap",
@@ -5095,7 +5095,7 @@ dependencies = [
 
 [[package]]
 name = "omnigraph-server"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/crates/omnigraph-api-types/Cargo.toml
+++ b/crates/omnigraph-api-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-api-types"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 description = "Shared HTTP wire DTOs for Omnigraph — request/response types and engine-result → DTO mappings used by both omnigraph-server and omnigraph-cli (RFC-009). Plain serde/utoipa types; no transport or server internals."
 license = "MIT"
@@ -9,8 +9,8 @@ homepage = "https://github.com/ModernRelay/omnigraph"
 documentation = "https://docs.rs/omnigraph-api-types"
 
 [dependencies]
-omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.8.0" }
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.8.0" }
+omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.8.1" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.8.1" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 utoipa = { workspace = true }

--- a/crates/omnigraph-cli/Cargo.toml
+++ b/crates/omnigraph-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-cli"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 description = "CLI for the Omnigraph graph database."
 license = "MIT"
@@ -13,12 +13,12 @@ name = "omnigraph"
 path = "src/main.rs"
 
 [dependencies]
-omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.8.0" }
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.8.0" }
-omnigraph-api-types = { path = "../omnigraph-api-types", version = "0.8.0" }
-omnigraph-cluster = { path = "../omnigraph-cluster", version = "0.8.0" }
-omnigraph-policy = { path = "../omnigraph-policy", version = "0.8.0" }
-omnigraph-server = { path = "../omnigraph-server", version = "0.8.0" }
+omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.8.1" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.8.1" }
+omnigraph-api-types = { path = "../omnigraph-api-types", version = "0.8.1" }
+omnigraph-cluster = { path = "../omnigraph-cluster", version = "0.8.1" }
+omnigraph-policy = { path = "../omnigraph-policy", version = "0.8.1" }
+omnigraph-server = { path = "../omnigraph-server", version = "0.8.1" }
 clap = { workspace = true }
 color-eyre = { workspace = true }
 serde = { workspace = true }

--- a/crates/omnigraph-cluster/Cargo.toml
+++ b/crates/omnigraph-cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-cluster"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 description = "Cluster configuration validation, planning, and config-only apply for Omnigraph."
 license = "MIT"
@@ -14,8 +14,8 @@ documentation = "https://docs.rs/omnigraph-cluster"
 failpoints = ["dep:fail", "fail/failpoints", "omnigraph/failpoints"]
 
 [dependencies]
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.8.0" }
-omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.8.0" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.8.1" }
+omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.8.1" }
 fail = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/omnigraph-compiler/Cargo.toml
+++ b/crates/omnigraph-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-compiler"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 description = "Schema/query compiler for Omnigraph. Zero Lance dependency."
 license = "MIT"

--- a/crates/omnigraph-policy/Cargo.toml
+++ b/crates/omnigraph-policy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-policy"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 description = "Policy / authorization layer for Omnigraph — Cedar-backed PolicyEngine, PolicyChecker trait, ResourceScope enum."
 license = "MIT"

--- a/crates/omnigraph-server/Cargo.toml
+++ b/crates/omnigraph-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-server"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 description = "HTTP server for the Omnigraph graph database."
 license = "MIT"
@@ -19,11 +19,11 @@ default = []
 aws = ["dep:aws-config", "dep:aws-sdk-secretsmanager"]
 
 [dependencies]
-omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.8.0" }
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.8.0" }
-omnigraph-policy = { path = "../omnigraph-policy", version = "0.8.0" }
-omnigraph-api-types = { path = "../omnigraph-api-types", version = "0.8.0" }
-omnigraph-cluster = { path = "../omnigraph-cluster", version = "0.8.0" }
+omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.8.1" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.8.1" }
+omnigraph-policy = { path = "../omnigraph-policy", version = "0.8.1" }
+omnigraph-api-types = { path = "../omnigraph-api-types", version = "0.8.1" }
+omnigraph-cluster = { path = "../omnigraph-cluster", version = "0.8.1" }
 axum = { workspace = true }
 clap = { workspace = true }
 color-eyre = { workspace = true }

--- a/crates/omnigraph/Cargo.toml
+++ b/crates/omnigraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnigraph-engine"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 description = "Runtime engine for the Omnigraph graph database."
 license = "MIT"
@@ -16,8 +16,8 @@ default = []
 failpoints = ["dep:fail", "fail/failpoints"]
 
 [dependencies]
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.8.0" }
-omnigraph-policy = { path = "../omnigraph-policy", version = "0.8.0" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.8.1" }
+omnigraph-policy = { path = "../omnigraph-policy", version = "0.8.1" }
 lance = { workspace = true }
 lance-core = { workspace = true }
 lance-select = { workspace = true }
@@ -54,7 +54,7 @@ chrono = { workspace = true }
 arc-swap = { workspace = true }
 
 [dev-dependencies]
-omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.8.0" }
+omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.8.1" }
 tokio = { workspace = true }
 lance-namespace-impls = { workspace = true }
 # test-util gates IoStats.requests + assert_io_eq! (failure diagnostics only); dev-dep,

--- a/docs/releases/v0.8.1.md
+++ b/docs/releases/v0.8.1.md
@@ -1,0 +1,98 @@
+# Omnigraph v0.8.1
+
+A reliability and features release. The storage substrate moves to Lance
+9.0.0-beta.15, adopting two upstream fixes that matter for embedding-heavy
+workloads; filtered vector search now applies filters before the search;
+schema migration learns enum widening; and the query language gains
+undirected edge traversal. **The on-disk format is unchanged (internal schema
+v4)** — v0.8.0 graphs are served as-is, no rebuild.
+
+**Channel note:** this release ships as binaries, Homebrew, and the
+installer. crates.io publication is deferred for one release: the substrate
+is pinned to a Lance pre-release, which exists as a git tag rather than a
+registry version, and published crates can only reference registry versions.
+`cargo install` users can build the tag directly —
+`cargo install --git https://github.com/ModernRelay/omnigraph --tag v0.8.1 omnigraph-cli`
+— or use the installer. Registry publication resumes at v0.9.0 with Lance
+9.0.0 stable.
+
+## Highlights
+
+- **Storage substrate: Lance 9.0.0-beta.15.** The Lance team resolved two
+  issues upstream that this release adopts (lance#7480, lance#7320); both
+  could surface on embedding-heavy graphs under routine write-then-maintain
+  patterns. If you have seen filtered reads fail with a record-batch length
+  error after refresh-style updates and deletes, or keyed lookups fail after
+  `optimize` on a recently-updated table, upgrading the binary resolves both
+  — **the data on disk was always intact, and no repair step is needed.**
+  The interim vendored patch omnigraph carried for the first issue is
+  retired now that the fix is upstream. The bump was validated against a
+  full review of the upstream changes (382 commits) plus the complete local
+  and CI test matrix, including S3 integration.
+
+- **Filtered vector search returns what it should.** Combining a `match`
+  filter with `nearest()` (or `bm25()`) previously applied the filter after
+  the ANN top-k, so a selective filter could return far fewer rows than
+  requested. Filters now apply *before* the search: `limit k` means the
+  top-k of *matching* rows. Filtered search results will change — they are
+  now correct.
+
+- **Undirected edge traversal.** `$a <edgeName> $b` matches an edge in either
+  direction with set semantics (a pair connected both ways appears once), for
+  same-endpoint-type edges (e.g. `Related: Issue -> Issue`); asymmetric edges
+  are rejected at typecheck (T22). Composes with hop bounds
+  (`$a <knows>{1,3} $b`) and `not { }` ("no edge in either direction"). One
+  pattern replaces the query-both-directions-and-merge workaround.
+
+- **Enum widening in schema migration.** Adding variants to an `enum(...)`
+  property is now a supported, metadata-only migration step — `schema plan`
+  shows `extend enum`, `apply` touches no table data, and the new variants
+  are accepted immediately on every write surface. Narrowing, variant
+  renames, and enum↔String conversions still refuse (OG-MF-106).
+
+- **Embedding validation hardened.** Non-finite embeddings (NaN/Inf) and
+  zero vectors are rejected at the client boundary instead of being stored;
+  the JSONL loader rejects non-numeric vector elements (previously coerced
+  to 0.0); and forcing the mock embedding provider over an explicitly
+  configured real one now logs a warning.
+
+- **Blob-bearing tables rejoin maintenance.** With Lance 9's blob-column
+  compaction support, `optimize` now includes tables with `Blob` properties
+  — fragment reclamation and index folding cover them like any other table.
+
+- **Self-service upgrade refusals.** Opening a graph from an older storage
+  format now names the release line that wrote it (e.g. "created by omnigraph
+  0.6.2 to 0.7.2") and the exact export → init → load commands, instead of
+  asking the operator to identify the right binary themselves.
+
+## Behavior changes
+
+- Filtered `nearest()`/`bm25()` result sets change (see above) — previously
+  missing results now appear.
+- New inverted indexes are written in Lance's FTS v2 format (readable by
+  omnigraph ≥ 0.8.0 binaries), and text-search `AND` semantics were refined
+  upstream, so `match_text`/`bm25` rankings may shift slightly.
+- Loads that previously succeeded with non-numeric vector elements or
+  non-finite embeddings now fail loudly at write time.
+
+## Upgrade notes
+
+- **No storage-format change.** v0.8.0 graphs open unchanged; downgrade to
+  v0.8.0 remains possible (same internal schema v4).
+- Upgrading the binary is the complete fix for the two substrate issues
+  above — no data repair, no rebuild.
+- The substrate is a rev-pinned Lance pre-release (9.0.0-beta.15), adopted
+  ahead of the stable release to deliver the fixes above promptly. v0.9.0
+  moves to Lance 9.0.0 stable.
+
+## Developer-facing
+
+- Scenario benchmark harness (`cargo bench -p omnigraph-engine --bench
+  scenarios`): cold subprocess runs measuring wall-clock + peak RSS, JSON-line
+  results with a persistent log — a decision instrument, never a CI gate.
+- A gated cross-version upgrade test (`OMNIGRAPH_OLD_BIN`) proves a genuine
+  v3-format graph is refused with the release-named message and rebuilds via
+  the documented path; run on demand, not in CI.
+- One dataset-open chokepoint (`instrumentation::open_dataset`) with the
+  shared per-graph Lance `Session` attached to write-side opens — the local
+  merge-scan cost term is now flat in commit history.

--- a/openapi.json
+++ b/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "0.8.0"
+    "version": "0.8.1"
   },
   "paths": {
     "/graphs": {


### PR DESCRIPTION
Release commit for v0.8.1 — see `docs/releases/v0.8.1.md` for the user-facing notes.

- Version 0.8.1 across all seven crates + path-dep constraints, `Cargo.lock`, `openapi.json`, AGENTS.md surveyed version.
- **Channel decision**: binaries/Homebrew/installer only; crates.io deferred until Lance 9.0.0 stable (the substrate git-pin cannot be published). `publish-crates.yml` gains a self-healing guard: skips cleanly while `lance` is a git dependency, resumes automatically when it returns to a registry version; skipped tags are recoverable via `workflow_dispatch`.
- Content since v0.8.0 (all previously merged & CI-validated): Lance 9.0.0-beta.15 substrate (adopts upstream fixes lance#7480/#7320), filtered-search prefilter fix, embedding validation hardening, enum widening, undirected traversal, blob tables in maintenance, self-service upgrade refusals, bench harness.
- On-disk format unchanged (internal schema v4) — no rebuild, downgrade to 0.8.0 possible.
- `cargo test --workspace --locked` green on the release commit; `omnigraph version` smoke: `0.8.1 / internal-schema 4`.

After merge: annotated tag `v0.8.1` on the merge commit → `release.yml` builds the binary matrix + updates the Homebrew tap.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/modernrelay/omnigraph/pull/338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is the v0.8.1 release commit. It bumps all seven workspace crates from 0.8.0 to 0.8.1, regenerates `Cargo.lock` and `openapi.json`, updates `AGENTS.md`'s surveyed version, adds the release notes, and wires a self-healing skip guard into `publish-crates.yml` that defers crates.io publication while `lance` is git-pinned to a pre-release.

- All version strings (crate manifests, path-dep constraints, `Cargo.lock`, `openapi.json`) are updated consistently; on-disk format is unchanged at schema v4 so downgrade to 0.8.0 remains possible.
- The new `publish-crates.yml` step correctly runs after checkout, detects the `lance = { git … }` entry in the workspace manifest, and propagates the `CARGO_PUBLISH_SKIP` flag that gates every subsequent step; the guard self-heals when `lance` returns to a registry version.
- The [`omnigraph-ts` SDK](https://github.com/modernrelay/omnigraph-ts/blob/HEAD/package.json) still declares `serverVersion: 0.8.0`, but since the OpenAPI surface is unchanged (only `info.version` changed), this is not a compatibility break — the `check-drift` script will continue to pass against the still-valid v0.8.0 tag.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all version strings are updated consistently, the on-disk format is unchanged, and the new workflow guard behaves correctly for the git-pinned lance dependency.

The change is a coordinated version bump with a well-scoped workflow addition. Version strings are consistent across all seven crate manifests, Cargo.lock, and openapi.json. The publish-crates.yml guard runs after checkout, correctly detects the git pin, and propagates the skip flag through all downstream steps. The only finding is a stale Lance 7.x label in the AGENTS.md architecture diagram, which is cosmetic and pre-existing.

AGENTS.md — the architecture diagram's Lance 7.x label is a one-line fix; everything else looks correct.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/publish-crates.yml | Adds self-healing guard to skip crates.io publication while lance is git-pinned; guard runs after checkout so Cargo.toml is available, and the existing skip-flag idiom carries through to all downstream steps correctly. |
| AGENTS.md | Version surveyed bumped to 0.8.1 and RFC process entry added to the topic table; however the architecture at a glance ASCII diagram still shows Lance 7.x while the substrate is now Lance 9.x. |
| Cargo.lock | All seven workspace crate entries bumped from 0.8.0 to 0.8.1; no other dependency changes detected. |
| crates/omnigraph-cli/Cargo.toml | Package version and all six internal path-dependency version constraints bumped from 0.8.0 to 0.8.1; consistent with the workspace-wide release bump. |
| crates/omnigraph-server/Cargo.toml | Package version and all five internal path-dependency constraints bumped consistently to 0.8.1. |
| openapi.json | Info.version field updated from 0.8.0 to 0.8.1; no API surface changes, consistent with the patch release scope. |
| docs/releases/v0.8.1.md | New release notes file covering all user-visible changes, behavior changes, upgrade notes, and the crates.io deferral rationale; follows OSS-facing style requirements from AGENTS.md. |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[push v* tag / workflow_dispatch] --> B{CARGO_REGISTRY_TOKEN set?}
    B -- No --> SKIP1[Set CARGO_PUBLISH_SKIP=1\nAll remaining steps skipped]
    B -- Yes --> C[Resolve ref]
    C --> D[Checkout source at tag]
    D --> E{lance = git in Cargo.toml?}
    E -- Yes\nLance pre-release --> SKIP2[Set CARGO_PUBLISH_SKIP=1\nDefer until Lance stable]
    E -- No\nLance registry version --> F[Install deps + Rust stable]
    F --> G[publish_if_new omnigraph-compiler]
    G --> H[publish_if_new omnigraph-policy]
    H --> I[publish_if_new omnigraph-engine]
    I --> J[publish_if_new omnigraph-api-types]
    J --> K[publish_if_new omnigraph-cluster]
    K --> L[publish_if_new omnigraph-server]
    L --> M[publish_if_new omnigraph-cli]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[push v* tag / workflow_dispatch] --> B{CARGO_REGISTRY_TOKEN set?}
    B -- No --> SKIP1[Set CARGO_PUBLISH_SKIP=1\nAll remaining steps skipped]
    B -- Yes --> C[Resolve ref]
    C --> D[Checkout source at tag]
    D --> E{lance = git in Cargo.toml?}
    E -- Yes\nLance pre-release --> SKIP2[Set CARGO_PUBLISH_SKIP=1\nDefer until Lance stable]
    E -- No\nLance registry version --> F[Install deps + Rust stable]
    F --> G[publish_if_new omnigraph-compiler]
    G --> H[publish_if_new omnigraph-policy]
    H --> I[publish_if_new omnigraph-engine]
    I --> J[publish_if_new omnigraph-api-types]
    J --> K[publish_if_new omnigraph-cluster]
    K --> L[publish_if_new omnigraph-server]
    L --> M[publish_if_new omnigraph-cli]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `AGENTS.md`, line 56 ([link](https://github.com/modernrelay/omnigraph/blob/2e8e034c19585ccdebb5f107c92e8b3d77c94463/AGENTS.md#L56)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The architecture diagram still labels the storage layer as `Lance 7.x` while the rest of this file (and the workspace manifest) describe the substrate as Lance 9.x. AGENTS.md rule 6 ("Don't lie") applies here since the file is being modified in this PR.

   **Context Used:** AGENTS.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=59169be6-01cf-4bae-80fc-604b6a708098))
   
   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20AGENTS.md%0ALine%3A%2056%0A%0AComment%3A%0AThe%20architecture%20diagram%20still%20labels%20the%20storage%20layer%20as%20%60Lance%207.x%60%20while%20the%20rest%20of%20this%20file%20%28and%20the%20workspace%20manifest%29%20describe%20the%20substrate%20as%20Lance%209.x.%20AGENTS.md%20rule%206%20%28%22Don't%20lie%22%29%20applies%20here%20since%20the%20file%20is%20being%20modified%20in%20this%20PR.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20Lance%209.x%20%20%20%20%20%20%20%20%20%E2%94%80%E2%94%80%20columnar%20Arrow%2C%20fragments%2C%20per-dataset%20versions%2Fbranches%2C%20indexes%0A%60%60%60%0A%0A**Context%20Used%3A**%20AGENTS.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fmodernrelay%2Fgithub%2FModernRelay%2Fomnigraph%2F-%2Fcustom-context%3Fmemory%3D59169be6-01cf-4bae-80fc-604b6a708098%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modernrelay%2Fomnigraph&pr=338&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AAGENTS.md%3A56%0AThe%20architecture%20diagram%20still%20labels%20the%20storage%20layer%20as%20%60Lance%207.x%60%20while%20the%20rest%20of%20this%20file%20%28and%20the%20workspace%20manifest%29%20describe%20the%20substrate%20as%20Lance%209.x.%20AGENTS.md%20rule%206%20%28%22Don't%20lie%22%29%20applies%20here%20since%20the%20file%20is%20being%20modified%20in%20this%20PR.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20Lance%209.x%20%20%20%20%20%20%20%20%20%E2%94%80%E2%94%80%20columnar%20Arrow%2C%20fragments%2C%20per-dataset%20versions%2Fbranches%2C%20indexes%0A%60%60%60%0A%0A&repo=modernrelay%2Fomnigraph&pr=338&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["release: v0.8.1"](https://github.com/modernrelay/omnigraph/commit/2e8e034c19585ccdebb5f107c92e8b3d77c94463) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42166916)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=59169be6-01cf-4bae-80fc-604b6a708098))

<!-- /greptile_comment -->