### PR TITLE
docs(skill): align the omnigraph skill with 0.8.1

### DIFF
--- a/skills/omnigraph/SKILL.md
+++ b/skills/omnigraph/SKILL.md
@@ -2,10 +2,10 @@
 name: omnigraph
 description: Store, retrieve, and query knowledge, memory, and relationships in an Omnigraph graph, and operate a local or remote Omnigraph deployment. Use when the user wants to capture or recall facts, notes, or entities, build or query a knowledge graph or agent memory, or run Omnigraph — and whenever you see Omnigraph CLI commands (omnigraph init/query/mutate/load/schema/lint/embed/branch/commit/login/profile/cluster), .pg schema or .gq query files, s3:// graph URIs, bearer-authed graph endpoints, 504 errors, or a cluster.yaml / omnigraph.yaml / ~/.omnigraph/config.yaml. Covers cluster-mode deployments (cluster.yaml plan/apply, omnigraph-server --cluster), the two config surfaces (cluster.yaml + ~/.omnigraph/config.yaml), schema evolution, query linting, data writes (mutate; load needs --mode/--from), branches, embeddings, Cedar policy, and remote ops. Especially important before schema apply (plan first), any load (--mode required), any .gq/.pg edit (lint after), or any remote write (verify via commit list).
 license: MIT (see LICENSE at repo root)
-compatibility: Requires omnigraph CLI >= 0.7.0 — the unified `load`, the two config surfaces (cluster.yaml + ~/.omnigraph/config.yaml), and cluster apply/serve all require 0.7.0.
+compatibility: Requires omnigraph CLI >= 0.7.0 — the unified `load`, the two config surfaces (cluster.yaml + ~/.omnigraph/config.yaml), and cluster apply/serve all require 0.7.0. Version-gated features are marked inline (undirected traversal `<edge>` and enum widening in `schema apply` require >= 0.8.1).
 metadata:
   author: ModernRelay
-  version: "0.7.0"
+  version: "0.8.1"
   repository: https://github.com/ModernRelay/omnigraph
 ---
 
@@ -96,7 +96,8 @@ The non-obvious facts that bite, then the full grammar:
 - **Scalar param types**: `String Bool I32 I64 U32 U64 F32 F64 DateTime Date Blob`. Modifiers: `T?` (optional), `[T]` (list), `Vector(N)`. There is **no `Int`** — use `I64`.
 - **A read query needs `match` *and* `return`** (`order`/`limit` optional); a mutation has neither — only `insert`/`update`/`delete`.
 - **`limit` takes an integer literal, not a param** — `limit 50`, never `limit $n`.
-- **Variable-hop traversal**: `$p knows{1,3} $f` (`{1,}` = unbounded).
+- **Variable-hop traversal**: `$p knows{1,3} $f` — bounds are **required to be finite** (`{1,}` is rejected: "unbounded traversal is disabled").
+- **Undirected traversal** (omnigraph >= 0.8.1): `$p <knows> $f` matches the edge in either direction, deduplicated (a pair connected both ways appears once). Same-endpoint-type edges only (e.g. `Related: Issue -> Issue`) — asymmetric edges are rejected (T22). Composes with bounds (`$p <knows>{1,3} $f`) and `not { }`. Replaces the query-both-directions-and-merge workaround for symmetric relations.
 - **Literals & calls**: `now()`, `date("2026-04-29")`, `datetime("…T00:00:00Z")`, list `[…]`.
 - **Filters** `= != > < >= <= contains`; **aggregates** `count/sum/avg/min/max` (`count($f) as n`).
 - **Stored-query metadata**: `@description("…")` / `@instruction("…")` may follow the param list.
@@ -159,8 +160,9 @@ prop_match_list = { prop_match ~ ("," ~ prop_match)* ~ ","? }
 prop_match = { ident ~ ":" ~ match_value }
 match_value = { literal | variable | now_call }
 
-// Traversal: $p knows $f
-traversal = { variable ~ edge_ident ~ traversal_bounds? ~ variable }
+// Traversal: $p knows $f (directional) or $p <knows> $f (undirected, >= 0.8.1)
+traversal = { variable ~ (undirected_edge | edge_ident) ~ traversal_bounds? ~ variable }
+undirected_edge = { "<" ~ edge_ident ~ ">" }
 traversal_bounds = { "{" ~ integer ~ "," ~ integer? ~ "}" }
 
 // Filter: $f.age > 25

--- a/skills/omnigraph/SKILL.md
+++ b/skills/omnigraph/SKILL.md
@@ -377,7 +377,7 @@ These are the traps most likely to bite. Scan this table before debugging any pa
 | `load --mode merge` after `@embed` source change | stale embeddings | `omnigraph embed --reembed_all` or `load --mode overwrite` |
 | `schema apply` with feature branches open | rejected | Merge or delete branches first |
 | `nearest(...)` / `bm25(...)` / `rrf(...)` without `limit` | compile error | Add `limit N` |
-| Adding non-nullable property without backfill | unsupported migration | Make optional → backfill → tighten in follow-up apply |
+| Adding non-nullable property without backfill | unsupported migration | Make optional → backfill; keep it optional (tightening `T?` → `T` is refused, OG-MF-106) |
 | `omnigraph init --json` | `unexpected argument --json` | `init` doesn't support `--json`; drop the flag |
 | `omnigraph init` on an already-initialized URI | `AlreadyInitialized` error (v0.6.0+) | `--force` to re-init (skips the schema preflight; does **not** purge data) |
 | `schema apply` dropping a property/type | soft-dropped or rejected (no data loss) | add `--allow-data-loss` to actually drop the column |

--- a/skills/omnigraph/references/queries.md
+++ b/skills/omnigraph/references/queries.md
@@ -115,6 +115,26 @@ query employees_of($company: String) {
 }
 ```
 
+### Undirected traversal (omnigraph >= 0.8.1)
+
+For symmetric relations (same-endpoint-type edges like `Related: Issue -> Issue`),
+angle brackets match the edge in **either direction**, deduplicated — one
+pattern replaces querying both directions and merging:
+
+```gq
+query related_to($slug: String) {
+    match {
+        $i: Issue { slug: $slug }
+        $i <issueRelated> $r
+    }
+    return { $r.slug }
+}
+```
+
+Composes with hop bounds (`$a <knows>{1,3} $b`) and `not { }` ("no edge in
+either direction"). Asymmetric edges (e.g. `Comment -> Issue`) are rejected at
+typecheck (T22) — use the directional form there.
+
 ### Negation
 
 ```gq

--- a/skills/omnigraph/references/queries.md
+++ b/skills/omnigraph/references/queries.md
@@ -117,7 +117,7 @@ query employees_of($company: String) {
 
 ### Undirected traversal (omnigraph >= 0.8.1)
 
-For symmetric relations (same-endpoint-type edges like `Related: Issue -> Issue`),
+For symmetric relations (same-endpoint-type edges like `IssueRelated: Issue -> Issue`),
 angle brackets match the edge in **either direction**, deduplicated — one
 pattern replaces querying both directions and merging:
 
@@ -291,7 +291,7 @@ query add_and_link($slug: String, $pattern: String, $createdAt: DateTime, $updat
 
 There's no `upsert` keyword at the query level — use `load --mode merge` for bulk upsert.
 
-> **Insert/update-only OR delete-only (the D₂ rule).** A single mutation query may contain inserts and updates, **or** deletes — never both. Mixing a `delete` with an `insert`/`update` in the same query is rejected at parse time. (Inserts/updates go through a staged two-phase publish; deletes inline-commit — omnigraph doesn't yet use Lance's two-phase delete API (it shipped in Lance 7.0.0 but isn't wired in) — so they can't share one atomic statement.) Split a delete-then-insert into two separate mutations.
+> **Insert/update-only OR delete-only (the D₂ rule).** A single mutation query may contain inserts and updates, **or** deletes — never both. Mixing a `delete` with an `insert`/`update` in the same query is rejected at parse time. (Deletes stage through the same two-phase publish as inserts/updates since 0.8.0; the D₂ split is a deliberate semantic boundary — one mutation query is constructive XOR destructive, keeping read-your-writes unambiguous — not an implementation gap.) Split a delete-then-insert into two separate mutations.
 
 ### Date and DateTime values
 

--- a/skills/omnigraph/references/schema.md
+++ b/skills/omnigraph/references/schema.md
@@ -106,7 +106,17 @@ Adding a non-nullable property to an existing node is rejected as unsupported. P
 1. Add as optional: `new_prop: String?`
 2. Apply
 3. Backfill via a `mutate` or `load --mode merge`
-4. Tighten to required in a follow-up apply: `new_prop: String`
+4. Keep it optional: tightening `T?` -> `T` is currently refused by the planner
+   (a property-type change, OG-MF-106). Enforce presence at write time by
+   convention until required-tightening ships as a migration step.
+
+### Enum widening is a supported apply (omnigraph >= 0.8.1)
+
+Adding variants to an `enum(...)` property is a metadata-only migration step:
+`schema plan` shows `extend enum ...`, `apply` touches no table data, and new
+variants are accepted immediately on every write surface. Narrowing, renaming
+a variant, or converting enum <-> `String` still refuse (OG-MF-106) — those
+remain rebuild territory. Value *order* never matters (values are normalized).
 
 ### Keep `@key` stable
 


### PR DESCRIPTION
Post-release alignment sweep for v0.8.1, skill portion.

- **Undirected traversal** (`$a <edge> $b`) added to the quick rules, the embedded grammar excerpt, and `references/queries.md` (worked example; T22 rule; composition with bounds/`not{}`) — marked `>= 0.8.1`.
- **Enum widening** added to `references/schema.md` as a supported metadata-only apply; narrowing/rename/enum↔String noted as still refused.
- **Two pre-existing inaccuracies found by verification during the sweep**: the skill claimed `{1,}` = unbounded traversal (the typechecker rejects unbounded, T15), and the required-property recipe ended with "tighten to required in a follow-up apply" (refused by the planner as a property-type change, OG-MF-106). Both corrected to match engine behavior.
- Skill `version` → 0.8.1; compatibility line marks version-gated features.

Rest of the sweep (verified aligned, no changes needed): README (no version-bearing claims), docs/ (no stale 0.8.0 refs outside history), Homebrew tap (auto-updated to v0.8.1 by release.yml), omnigraph-ts (0.8.0 sync merged; 0.8.1 sync to follow via its pipeline), omnigraph-web (doc re-sync remains deferred pending the flat-only import script fix).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/modernrelay/omnigraph/pull/339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns the omnigraph skill with the v0.8.1 release by adding new features and correcting two pre-existing inaccuracies discovered during the sweep.

- **New: Undirected traversal** (`$a <edge> $b`, >= 0.8.1) added to quick rules, the embedded PEG grammar excerpt, and `references/queries.md` with a worked example, T22 rule (asymmetric-edge rejection), and bounds/`not{}` composition notes.
- **New: Enum widening** added to `references/schema.md` as a supported metadata-only `schema apply` (narrowing/rename/enum↔String remain refused per OG-MF-106).
- **Corrected: Bounded-traversal** — the previous claim that `{1,}` equals unbounded traversal has been fixed to state the typechecker rejects unbounded bounds outright ("unbounded traversal is disabled"); **Corrected: required-property recipe** — step 4 formerly advised tightening `T?` → `T` in a follow-up apply, which the planner actively refuses (OG-MF-106); both the `references/schema.md` recipe and the Common Gotchas table in `SKILL.md` now reflect the correct behavior.

<h3>Confidence Score: 5/5</h3>

Documentation-only change correcting two previously inaccurate gotchas and adding two new 0.8.1 features; all edits are internally consistent across the three skill files and cross-check cleanly against AGENTS.md.

Every factual claim in the diff was cross-verified: undirected traversal semantics (T22, deduplication, bounds composition) align with AGENTS.md's GraphIndex/CSR description; the bounded-only traversal correction matches the stated typecheck behaviour; enum widening as metadata-only apply is consistent with the schema.md supported-types section; the D₂ explanation update matches the staged-delete path described in AGENTS.md. The prior P1 finding (stale gotcha advising a refused schema apply) is addressed in both SKILL.md and references/schema.md. No logic, runtime, or contract changes are introduced.

No files require special attention; all three changed files are consistent with each other and with AGENTS.md.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| skills/omnigraph/SKILL.md | Version bumped to 0.8.1; compatibility line extended; two pre-existing inaccuracies corrected (bounded-only traversal, required-property tighten refused); undirected traversal added to quick rules, grammar excerpt, and Common Gotchas; all changes are internally consistent |
| skills/omnigraph/references/queries.md | Undirected traversal section added with a worked example (T22 rule, bounds composition, negation); D₂ rule explanation updated to reflect that deletes now use the same staged publish path as inserts/updates (since 0.8.0), making it a deliberate semantic boundary rather than an implementation gap; both changes align with AGENTS.md |
| skills/omnigraph/references/schema.md | Required-property backfill recipe step 4 corrected (tightening T?→T is refused, OG-MF-106); enum widening section added describing it as a metadata-only apply with dedup of value order; both additions are consistent with AGENTS.md and schema.md supported-types table |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Traversal in .gq match block"] --> B{Edge brackets?}
    B -- "directional\n$p edge $q" --> C["Directional traversal\n(all engine versions)"]
    B -- "undirected\n$p <edge> $q\n>= 0.8.1" --> D{Same endpoint type?}
    D -- "yes\ne.g. Issue -> Issue" --> E["Undirected match\n(either direction, deduplicated)"]
    D -- "no\ne.g. Comment -> Issue" --> F["Rejected: T22\nasymmetric edge"]
    C --> G{Hop bounds?}
    E --> G
    G -- "{n,m} finite" --> H["Variable-hop traversal"]
    G -- "{n,} unbounded" --> I["Rejected: T15\nunbounded disabled"]
    G -- "none" --> J["Single-hop traversal"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Traversal in .gq match block"] --> B{Edge brackets?}
    B -- "directional\n$p edge $q" --> C["Directional traversal\n(all engine versions)"]
    B -- "undirected\n$p <edge> $q\n>= 0.8.1" --> D{Same endpoint type?}
    D -- "yes\ne.g. Issue -> Issue" --> E["Undirected match\n(either direction, deduplicated)"]
    D -- "no\ne.g. Comment -> Issue" --> F["Rejected: T22\nasymmetric edge"]
    C --> G{Hop bounds?}
    E --> G
    G -- "{n,m} finite" --> H["Variable-hop traversal"]
    G -- "{n,} unbounded" --> I["Rejected: T15\nunbounded disabled"]
    G -- "none" --> J["Single-hop traversal"]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `skills/omnigraph/SKILL.md`, line 380 ([link](https://github.com/modernrelay/omnigraph/blob/9488b2716cb01fbace4d82dfc7e2ef3fc3a6e431/skills/omnigraph/SKILL.md#L380)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Stale gotcha: still advises "tighten in follow-up apply"**

   The PR corrects the inaccurate step-4 text in `references/schema.md` (tightening `T?` → `T` is refused, OG-MF-106), but the matching "Common Gotchas" row in SKILL.md still ends with "Make optional → backfill → **tighten in follow-up apply**". An agent following only the main SKILL.md (the default load path) will be advised to attempt a `schema apply` that the planner actively refuses, which is the exact footgun this PR was targeting.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20skills%2Fomnigraph%2FSKILL.md%0ALine%3A%20380%0A%0AComment%3A%0A**Stale%20gotcha%3A%20still%20advises%20%22tighten%20in%20follow-up%20apply%22**%0A%0AThe%20PR%20corrects%20the%20inaccurate%20step-4%20text%20in%20%60references%2Fschema.md%60%20%28tightening%20%60T%3F%60%20%E2%86%92%20%60T%60%20is%20refused%2C%20OG-MF-106%29%2C%20but%20the%20matching%20%22Common%20Gotchas%22%20row%20in%20SKILL.md%20still%20ends%20with%20%22Make%20optional%20%E2%86%92%20backfill%20%E2%86%92%20**tighten%20in%20follow-up%20apply**%22.%20An%20agent%20following%20only%20the%20main%20SKILL.md%20%28the%20default%20load%20path%29%20will%20be%20advised%20to%20attempt%20a%20%60schema%20apply%60%20that%20the%20planner%20actively%20refuses%2C%20which%20is%20the%20exact%20footgun%20this%20PR%20was%20targeting.%0A%0A%60%60%60suggestion%0A%7C%20Adding%20non-nullable%20property%20without%20backfill%20%7C%20unsupported%20migration%20%7C%20Make%20optional%20%E2%86%92%20backfill%20%E2%86%92%20keep%20optional%20%28tightening%20%60T%3F%60%20%E2%86%92%20%60T%60%20is%20refused%20by%20the%20planner%2C%20OG-MF-106%20%E2%80%94%20enforce%20presence%20at%20write%20time%20by%20convention%29%20%7C%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modernrelay%2Fomnigraph&pr=339&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["docs(skill): review follow-ups — gotcha-..."](https://github.com/modernrelay/omnigraph/commit/5ea0e6ba2eeae33f86f909aa92a914df6c5f0556) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42205243)</sub>

<!-- /greptile_comment -->