### PR TITLE
Add --delete-branch to branch merge

### DIFF
--- a/crates/omnigraph-api-types/src/lib.rs
+++ b/crates/omnigraph-api-types/src/lib.rs
@@ -83,6 +83,12 @@ pub struct BranchMergeRequest {
     pub source: String,
     /// Target branch that will receive the merge. Defaults to `main`.
     pub target: Option<String>,
+    /// Delete the source branch after a successful merge. The deletion runs
+    /// under its own `branch_delete` policy check; a refusal or failure is
+    /// reported via `branch_deleted` / `branch_delete_error` on the response
+    /// and never fails the already-landed merge.
+    #[serde(default)]
+    pub delete_branch: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
@@ -119,6 +125,16 @@ pub struct BranchMergeOutput {
     pub target: String,
     pub outcome: BranchMergeOutcome,
     pub actor_id: Option<String>,
+    /// Result of the requested post-merge source-branch deletion. Absent when
+    /// `delete_branch` was not requested; `true` when the source branch was
+    /// deleted; `false` when the deletion was refused or failed (the merge
+    /// itself still succeeded — see `branch_delete_error`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch_deleted: Option<bool>,
+    /// Why the requested source-branch deletion did not happen. Present iff
+    /// `branch_deleted` is `false`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch_delete_error: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]

--- a/crates/omnigraph-cli/src/cli.rs
+++ b/crates/omnigraph-cli/src/cli.rs
@@ -517,6 +517,11 @@ pub(crate) enum BranchCommand {
         source: String,
         #[arg(long)]
         into: Option<String>,
+        /// Delete the source branch after a successful merge. Runs under its
+        /// own branch_delete policy check; a refusal is reported as a warning
+        /// and never fails the already-landed merge.
+        #[arg(long)]
+        delete_branch: bool,
         #[arg(long)]
         json: bool,
     },

--- a/crates/omnigraph-cli/src/client.rs
+++ b/crates/omnigraph-cli/src/client.rs
@@ -669,6 +669,7 @@ impl GraphClient {
                     Some(serde_json::to_value(BranchMergeRequest {
                         source: source.to_string(),
                         target: Some(into.to_string()),
+                        delete_branch: false,
                     })?),
                     token.as_deref(),
                 )
@@ -683,6 +684,8 @@ impl GraphClient {
                     target: into.to_string(),
                     outcome: outcome.into(),
                     actor_id: actor.map(String::from),
+                    branch_deleted: None,
+                    branch_delete_error: None,
                 })
             }
         }

--- a/crates/omnigraph-cli/src/client.rs
+++ b/crates/omnigraph-cli/src/client.rs
@@ -655,7 +655,12 @@ impl GraphClient {
         }
     }
 
-    pub(crate) async fn branch_merge(&self, source: &str, into: &str) -> Result<BranchMergeOutput> {
+    pub(crate) async fn branch_merge(
+        &self,
+        source: &str,
+        into: &str,
+        delete_branch: bool,
+    ) -> Result<BranchMergeOutput> {
         match self {
             GraphClient::Remote {
                 http,
@@ -669,7 +674,7 @@ impl GraphClient {
                     Some(serde_json::to_value(BranchMergeRequest {
                         source: source.to_string(),
                         target: Some(into.to_string()),
-                        delete_branch: false,
+                        delete_branch,
                     })?),
                     token.as_deref(),
                 )
@@ -679,13 +684,25 @@ impl GraphClient {
                 let db = Self::open_embedded(uri).await?;
                 let actor = actor.as_deref();
                 let outcome = db.branch_merge_as(source, into, actor).await?;
+                // Composed exactly like the server handler: the merge is
+                // durable, so a deletion refusal/failure is reported in the
+                // payload, never as an error (parity_matrix pins the two
+                // composition sites against drift).
+                let (branch_deleted, branch_delete_error) = if delete_branch {
+                    match db.branch_delete_as(source, actor).await {
+                        Ok(()) => (Some(true), None),
+                        Err(err) => (Some(false), Some(err.to_string())),
+                    }
+                } else {
+                    (None, None)
+                };
                 Ok(BranchMergeOutput {
                     source: source.to_string(),
                     target: into.to_string(),
                     outcome: outcome.into(),
                     actor_id: actor.map(String::from),
-                    branch_deleted: None,
-                    branch_delete_error: None,
+                    branch_deleted,
+                    branch_delete_error,
                 })
             }
         }

--- a/crates/omnigraph-cli/src/main.rs
+++ b/crates/omnigraph-cli/src/main.rs
@@ -386,6 +386,7 @@ async fn main() -> Result<()> {
                 uri,
                 source,
                 into,
+                delete_branch,
                 json,
             } => {
                 let client = client::GraphClient::resolve_with_policy(
@@ -399,7 +400,29 @@ async fn main() -> Result<()> {
                 .await?;
                 let into = resolve_branch(into, None, "main");
                 echo_write_target(cli.quiet, "branch merge", client.uri(), client.is_remote());
-                let payload = client.branch_merge(&source, &into).await?;
+                let payload = client.branch_merge(&source, &into, delete_branch).await?;
+                // Warnings go to stderr so `--json` consumers reading stdout
+                // are unaffected. `branch_deleted: None` after requesting
+                // deletion means an older server ignored the unknown request
+                // field — surface that instead of silently leaving the branch.
+                if delete_branch {
+                    match payload.branch_deleted {
+                        Some(true) => {}
+                        Some(false) => eprintln!(
+                            "warning: merged, but could not delete branch '{}': {}",
+                            payload.source,
+                            payload
+                                .branch_delete_error
+                                .as_deref()
+                                .unwrap_or("unknown error")
+                        ),
+                        None => eprintln!(
+                            "warning: merged, but the server does not support --delete-branch; \
+                             branch '{}' was not deleted",
+                            payload.source
+                        ),
+                    }
+                }
                 if json {
                     print_json(&payload)?;
                 } else {
@@ -409,6 +432,9 @@ async fn main() -> Result<()> {
                         payload.target,
                         payload.outcome.as_str()
                     );
+                    if payload.branch_deleted == Some(true) {
+                        println!("deleted branch {}", payload.source);
+                    }
                 }
             }
         },

--- a/crates/omnigraph-cli/tests/cli_data.rs
+++ b/crates/omnigraph-cli/tests/cli_data.rs
@@ -1900,6 +1900,127 @@ fn branch_merge_supports_explicit_target() {
 }
 
 #[test]
+fn branch_merge_delete_branch_deletes_source() {
+    let temp = tempdir().unwrap();
+    let graph = graph_path(temp.path());
+    init_graph(&graph);
+    load_fixture(&graph);
+
+    output_success(
+        cli()
+            .arg("branch")
+            .arg("create")
+            .arg("--uri")
+            .arg(&graph)
+            .arg("--from")
+            .arg("main")
+            .arg("feature"),
+    );
+    let feature_data = temp.path().join("feature-delete.jsonl");
+    write_jsonl(
+        &feature_data,
+        r#"{"type":"Person","data":{"name":"Gwen","age":35}}"#,
+    );
+    output_success(
+        cli()
+            .arg("load")
+            .arg("--data")
+            .arg(&feature_data)
+            .arg("--branch")
+            .arg("feature")
+            .arg("--mode")
+            .arg("append")
+            .arg(&graph),
+    );
+
+    let merge_output = output_success(
+        cli()
+            .arg("branch")
+            .arg("merge")
+            .arg("--uri")
+            .arg(&graph)
+            .arg("feature")
+            .arg("--delete-branch")
+            .arg("--json"),
+    );
+    let merge_payload: Value = serde_json::from_slice(&merge_output.stdout).unwrap();
+    assert_eq!(merge_payload["outcome"], "fast_forward");
+    assert_eq!(merge_payload["branch_deleted"], true);
+    assert!(merge_payload["branch_delete_error"].is_null());
+
+    let list_output = output_success(
+        cli()
+            .arg("branch")
+            .arg("list")
+            .arg("--uri")
+            .arg(&graph)
+            .arg("--json"),
+    );
+    let list_payload: Value = serde_json::from_slice(&list_output.stdout).unwrap();
+    assert_eq!(list_payload["branches"], serde_json::json!(["main"]));
+}
+
+#[test]
+fn branch_merge_delete_branch_refusal_warns_and_exits_zero() {
+    let temp = tempdir().unwrap();
+    let graph = graph_path(temp.path());
+    init_graph(&graph);
+    load_fixture(&graph);
+
+    for (from, name) in [("main", "feature"), ("feature", "feature-child")] {
+        output_success(
+            cli()
+                .arg("branch")
+                .arg("create")
+                .arg("--uri")
+                .arg(&graph)
+                .arg("--from")
+                .arg(from)
+                .arg(name),
+        );
+    }
+
+    // `feature` has a dependent descendant, so the post-merge deletion is
+    // refused — the merge (already_up_to_date: deletion is still attempted)
+    // must succeed with exit code 0 and a stderr warning.
+    let merge_output = output_success(
+        cli()
+            .arg("branch")
+            .arg("merge")
+            .arg("--uri")
+            .arg(&graph)
+            .arg("feature")
+            .arg("--delete-branch")
+            .arg("--json"),
+    );
+    let merge_payload: Value = serde_json::from_slice(&merge_output.stdout).unwrap();
+    assert_eq!(merge_payload["outcome"], "already_up_to_date");
+    assert_eq!(merge_payload["branch_deleted"], false);
+    assert!(
+        merge_payload["branch_delete_error"]
+            .as_str()
+            .unwrap()
+            .contains("feature-child")
+    );
+    let stderr = String::from_utf8_lossy(&merge_output.stderr);
+    assert!(stderr.contains("could not delete branch 'feature'"));
+
+    let list_output = output_success(
+        cli()
+            .arg("branch")
+            .arg("list")
+            .arg("--uri")
+            .arg(&graph)
+            .arg("--json"),
+    );
+    let list_payload: Value = serde_json::from_slice(&list_output.stdout).unwrap();
+    assert_eq!(
+        list_payload["branches"],
+        serde_json::json!(["feature", "feature-child", "main"])
+    );
+}
+
+#[test]
 fn snapshot_json_returns_manifest_version_and_tables() {
     let temp = tempdir().unwrap();
     let graph = graph_path(temp.path());

--- a/crates/omnigraph-cli/tests/parity_matrix.rs
+++ b/crates/omnigraph-cli/tests/parity_matrix.rs
@@ -159,6 +159,24 @@ fn parity_branch_merge() {
     let (l, r) = p.run(&["branch", "merge", "feature", "--into", "main", "--json"],
     );
     assert_parity("branch merge", &l, &r);
+    // `--delete-branch` composes merge + delete at each arm's own boundary
+    // (embedded: two engine calls; remote: the server handler) — this row is
+    // the referee that keeps the two composition sites from drifting.
+    let (l, r) = p.run(&["branch", "create", "--from", "main", "feature2", "--json"],
+    );
+    assert_parity("branch create (delete-branch setup)", &l, &r);
+    let (l, r) = p.run(&[
+        "branch",
+        "merge",
+        "feature2",
+        "--into",
+        "main",
+        "--delete-branch",
+        "--json",
+    ]);
+    assert_parity("branch merge --delete-branch", &l, &r);
+    let (l, r) = p.run(&["branch", "list", "--json"]);
+    assert_parity("branch list (post delete-branch)", &l, &r);
 }
 
 #[test]

--- a/crates/omnigraph-server/src/handlers.rs
+++ b/crates/omnigraph-server/src/handlers.rs
@@ -1585,6 +1585,11 @@ pub(crate) async fn server_branch_delete(
 /// `already_up_to_date`, `fast_forward`, or `merged`. Returns 409 with the
 /// list of conflicts if the merge cannot be completed; the target is left
 /// unchanged in that case. **Destructive** to `target` on success.
+///
+/// With `delete_branch: true` the source branch is deleted after a successful
+/// merge, under its own `branch_delete` policy check. The merge is durable by
+/// then, so a deletion refusal or failure never fails the request; it is
+/// reported via `branch_deleted: false` + `branch_delete_error`.
 pub(crate) async fn server_branch_merge(
     State(state): State<AppState>,
     Extension(handle): Extension<Arc<GraphHandle>>,
@@ -1621,12 +1626,55 @@ pub(crate) async fn server_branch_merge(
             .await
             .map_err(ApiError::from_omni)?
     };
+    let (branch_deleted, branch_delete_error) = if request.delete_branch {
+        match delete_merged_source_branch(&handle, actor.as_ref().map(|Extension(a)| a), &request.source)
+            .await
+        {
+            Ok(()) => (Some(true), None),
+            Err(message) => (Some(false), Some(message)),
+        }
+    } else {
+        (None, None)
+    };
     Ok(Json(BranchMergeOutput {
         source: request.source,
         target,
         outcome: outcome.into(),
         actor_id: actor_id.map(str::to_string),
+        branch_deleted,
+        branch_delete_error,
     }))
+}
+
+/// Delete the source branch of a just-landed merge, mirroring
+/// `server_branch_delete`'s authorization (same action and target scope) but
+/// converting every failure — policy denial, dependent-branch refusal,
+/// operational error — into a message instead of an error status: the merge is
+/// already durable, so the request must not report failure for it.
+async fn delete_merged_source_branch(
+    handle: &GraphHandle,
+    actor: Option<&ResolvedActor>,
+    source: &str,
+) -> std::result::Result<(), String> {
+    match authorize(
+        actor,
+        handle.policy.as_deref(),
+        PolicyRequest {
+            action: PolicyAction::BranchDelete,
+            branch: None,
+            target_branch: Some(source.to_string()),
+        },
+    ) {
+        Ok(Authz::Allowed) => {}
+        Ok(Authz::Denied(message)) => return Err(message),
+        Err(err) => return Err(err.message),
+    }
+    let actor_id = actor.map(|actor| actor.actor_id.as_ref());
+    handle
+        .engine
+        .branch_delete_as(source, actor_id)
+        .await
+        .map_err(|err| err.to_string())
 }
 
 #[utoipa::path(

--- a/crates/omnigraph-server/tests/auth_policy.rs
+++ b/crates/omnigraph-server/tests/auth_policy.rs
@@ -533,6 +533,7 @@ async fn policy_blocks_non_admin_merge_to_main_and_allows_admin() {
     let merge = BranchMergeRequest {
         source: "feature".to_string(),
         target: Some("main".to_string()),
+        delete_branch: false,
     };
     let (deny_status, deny_body) = json_response(
         &app,
@@ -659,6 +660,7 @@ async fn authenticated_branch_merge_stamps_merge_actor_on_head_commit() {
     let merge = BranchMergeRequest {
         source: "feature".to_string(),
         target: Some("main".to_string()),
+        delete_branch: false,
     };
     let (merge_status, merge_body) = json_response(
         &app,
@@ -691,6 +693,58 @@ async fn authenticated_branch_merge_stamps_merge_actor_on_head_commit() {
         .last()
         .expect("head commit should exist");
     assert_eq!(head["actor_id"], "act-ragnor");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn branch_merge_delete_branch_policy_denial_is_non_fatal() {
+    // act-ragnor (admins) may merge into the protected target, but the
+    // composed source deletion targets the UNPROTECTED branch `feature`,
+    // which `admins-merge` (target_branch_scope: protected) does not allow.
+    // The deletion runs under its own `branch_delete` decision, so the merge
+    // must succeed while the denial is reported non-fatally — composition
+    // never smuggles a delete through a merge permission.
+    let (temp, app) = app_for_loaded_graph_with_auth_tokens_and_policy(
+        &[("act-ragnor", "token-admin")],
+        POLICY_YAML,
+    )
+    .await;
+    let graph = graph_path(temp.path());
+
+    let db = Omnigraph::open(graph.to_str().unwrap()).await.unwrap();
+    db.branch_create_from(ReadTarget::branch("main"), "feature")
+        .await
+        .unwrap();
+    drop(db);
+
+    let merge = BranchMergeRequest {
+        source: "feature".to_string(),
+        target: Some("main".to_string()),
+        delete_branch: true,
+    };
+    let (merge_status, merge_body) = json_response(
+        &app,
+        Request::builder()
+            .uri(g("/branches/merge"))
+            .method(Method::POST)
+            .header("authorization", "Bearer token-admin")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&merge).unwrap()))
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(merge_status, StatusCode::OK);
+    assert_eq!(merge_body["outcome"], "already_up_to_date");
+    assert_eq!(merge_body["branch_deleted"], false);
+    assert!(
+        merge_body["branch_delete_error"]
+            .as_str()
+            .unwrap()
+            .contains("policy denied action 'branch_delete'")
+    );
+
+    let db = Omnigraph::open(graph.to_str().unwrap()).await.unwrap();
+    let branches = db.branch_list().await.unwrap();
+    assert!(branches.iter().any(|branch| branch == "feature"));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/omnigraph-server/tests/data_routes.rs
+++ b/crates/omnigraph-server/tests/data_routes.rs
@@ -419,6 +419,7 @@ async fn branch_merge_conflict_response_includes_structured_conflicts() {
     let merge = BranchMergeRequest {
         source: "feature".to_string(),
         target: Some("main".to_string()),
+        delete_branch: false,
     };
     let (status, body) = json_response(
         &app,
@@ -912,6 +913,7 @@ async fn remote_branch_list_create_merge_flow_works() {
     let merge = BranchMergeRequest {
         source: "feature".to_string(),
         target: Some("main".to_string()),
+        delete_branch: false,
     };
     let (merge_status, merge_body) = json_response(
         &app,
@@ -993,6 +995,141 @@ async fn remote_branch_delete_flow_works() {
     .await;
     assert_eq!(list_status, StatusCode::OK);
     assert_eq!(list_body["branches"], json!(["main"]));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn branch_merge_delete_branch_deletes_source_after_merge() {
+    let (_temp, app) = app_for_loaded_graph().await;
+
+    let create = BranchCreateRequest {
+        from: Some("main".to_string()),
+        name: "feature".to_string(),
+    };
+    let (create_status, _) = json_response(
+        &app,
+        Request::builder()
+            .uri(g("/branches"))
+            .method(Method::POST)
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&create).unwrap()))
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(create_status, StatusCode::OK);
+
+    let change = ChangeRequest {
+        query: MUTATION_QUERIES.to_string(),
+        name: Some("insert_person".to_string()),
+        params: Some(json!({ "name": "Zoe", "age": 33 })),
+        branch: Some("feature".to_string()),
+    };
+    let (change_status, _) = json_response(
+        &app,
+        Request::builder()
+            .uri(g("/change"))
+            .method(Method::POST)
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&change).unwrap()))
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(change_status, StatusCode::OK);
+
+    let merge = BranchMergeRequest {
+        source: "feature".to_string(),
+        target: Some("main".to_string()),
+        delete_branch: true,
+    };
+    let (merge_status, merge_body) = json_response(
+        &app,
+        Request::builder()
+            .uri(g("/branches/merge"))
+            .method(Method::POST)
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&merge).unwrap()))
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(merge_status, StatusCode::OK);
+    assert_eq!(merge_body["outcome"], "fast_forward");
+    assert_eq!(merge_body["branch_deleted"], true);
+    assert!(merge_body["branch_delete_error"].is_null());
+
+    let (list_status, list_body) = json_response(
+        &app,
+        Request::builder()
+            .uri(g("/branches"))
+            .method(Method::GET)
+            .body(Body::empty())
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(list_status, StatusCode::OK);
+    assert_eq!(list_body["branches"], json!(["main"]));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn branch_merge_delete_branch_refusal_is_non_fatal() {
+    let (_temp, app) = app_for_loaded_graph().await;
+
+    for (from, name) in [("main", "feature"), ("feature", "feature-child")] {
+        let create = BranchCreateRequest {
+            from: Some(from.to_string()),
+            name: name.to_string(),
+        };
+        let (create_status, _) = json_response(
+            &app,
+            Request::builder()
+                .uri(g("/branches"))
+                .method(Method::POST)
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&create).unwrap()))
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(create_status, StatusCode::OK);
+    }
+
+    // No writes on `feature`, so the merge is `already_up_to_date` — the
+    // deletion must still be attempted (the "already merged, clean me up"
+    // case) and its refusal (a dependent descendant branch) must be reported
+    // without failing the request.
+    let merge = BranchMergeRequest {
+        source: "feature".to_string(),
+        target: Some("main".to_string()),
+        delete_branch: true,
+    };
+    let (merge_status, merge_body) = json_response(
+        &app,
+        Request::builder()
+            .uri(g("/branches/merge"))
+            .method(Method::POST)
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&merge).unwrap()))
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(merge_status, StatusCode::OK);
+    assert_eq!(merge_body["outcome"], "already_up_to_date");
+    assert_eq!(merge_body["branch_deleted"], false);
+    assert!(
+        merge_body["branch_delete_error"]
+            .as_str()
+            .unwrap()
+            .contains("feature-child")
+    );
+
+    let (list_status, list_body) = json_response(
+        &app,
+        Request::builder()
+            .uri(g("/branches"))
+            .method(Method::GET)
+            .body(Body::empty())
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(list_status, StatusCode::OK);
+    assert_eq!(list_body["branches"], json!(["feature", "feature-child", "main"]));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/omnigraph-server/tests/support/mod.rs
+++ b/crates/omnigraph-server/tests/support/mod.rs
@@ -868,6 +868,7 @@ pub mod matrix {
                 let body = serde_json::to_vec(&BranchMergeRequest {
                     source,
                     target: Some(target),
+                    delete_branch: false,
                 })
                 .unwrap();
                 let response = app
@@ -1136,6 +1137,7 @@ pub async fn http_merge_decision(
     let req = BranchMergeRequest {
         source: "feature".to_string(),
         target: Some("main".to_string()),
+        delete_branch: false,
     };
     let (status, _body) = json_response(
         &app,

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -100,7 +100,7 @@ The CLI system tests (`system_local.rs`) spawn the workspace-built `omnigraph` a
 
 ## OpenAPI drift
 
-`crates/omnigraph-server/tests/openapi.rs` regenerates `openapi.json` and diffs against the checked-in copy. CI auto-commits the regeneration on same-repository PRs and otherwise runs in strict-check mode (env: `OMNIGRAPH_UPDATE_OPENAPI`).
+`crates/omnigraph-server/tests/openapi.rs` regenerates `openapi.json` and diffs against the checked-in copy. The drift check runs strict on PRs (the auto-commit step lives in the heavy `test` job, which is post-merge-only) — for server/API changes, regenerate locally with `OMNIGRAPH_UPDATE_OPENAPI=1 cargo test -p omnigraph-server --test openapi` and commit the result, or the PR's `test_aws_feature` job fails on drift. See [ci.md](ci.md).
 
 ## Examples & benches
 

--- a/docs/user/branching/index.md
+++ b/docs/user/branching/index.md
@@ -18,6 +18,13 @@ created lazily on first write:
   supported (`review/2026-07`), but `review` and `review/2026-07` cannot both be
   live because Lance stores them in overlapping physical directories. Choose
   sibling names, or delete the existing ancestor/descendant first.
+- **Delete branches after merging.** Branches are designed as short-lived
+  transactions: create → write → merge → delete. A merged branch is not cleaned
+  up automatically — it stays in `branch list`, and every live branch caps how
+  far [`cleanup`](../operations/maintenance.md) can GC the main versions it
+  inherited, so stale merged branches quietly retain old data. Pass
+  `--delete-branch` to [`branch merge`](merge.md) (or `delete_branch: true` on
+  the merge endpoint) to do it in one step.
 
 Graph branch create/delete are coordinated across handles in one writer
 process. Until Lance exposes conditional native ref mutation, separate writer

--- a/docs/user/branching/merge.md
+++ b/docs/user/branching/merge.md
@@ -12,6 +12,33 @@ omnigraph branch merge review/2026-04-25 --into main s3://bucket/graph.omni
 `branch merge <source> [--into <target>]` merges `<source>` into `<target>`
 (default `main`).
 
+## Deleting the source branch
+
+A merge never touches the source branch — it stays in `branch list`, holds its
+per-table storage, and pins the main versions it inherited against
+[`cleanup`](../operations/maintenance.md) GC until someone deletes it. Since a
+successful merge guarantees the target no longer depends on the source's
+storage, the recommended lifecycle is to delete the source right after merging.
+
+`--delete-branch` does that in one step (over HTTP, set `delete_branch: true`
+on `POST /branches/merge`):
+
+```bash
+omnigraph branch merge review/2026-04-25 --into main --delete-branch s3://bucket/graph.omni
+```
+
+The deletion runs after the merge has landed, under its **own** `branch_delete`
+policy check — an actor allowed to merge but not to delete branches gets the
+merge without the deletion. Deletion runs on every successful outcome,
+including `already_up_to_date` (the "already merged, clean me up" case). A
+refusal or failure — policy denial, a dependent descendant branch, a branch
+another branch's tables still fork from — never fails the request: the merge is
+durable by then, so the CLI exits 0 with a stderr warning, and the response
+reports `branch_deleted: false` plus `branch_delete_error` (on success,
+`branch_deleted: true`). Deleting a branch is irreversible: its own commit
+history is not retained (only the merge commit on the target records the merged
+state).
+
 ## Outcomes
 
 A merge resolves to one of three outcomes:

--- a/docs/user/cli/reference.md
+++ b/docs/user/cli/reference.md
@@ -16,7 +16,7 @@ Top-level command families and subcommands. Graph-targeting commands accept a po
 | `alias <name> [args]` | invoke an operator alias — a read-only personal binding (under `aliases:` in `~/.omnigraph/config.yaml`) to a stored query on a named server (replaces the removed `--alias` flag; stored mutations are rejected before execution) |
 | `snapshot` | print current snapshot (per-table version + row count) |
 | `export` | dump to JSONL on stdout (`--type T`, `--table K` filters) |
-| `branch create \| list \| delete \| merge` | branching ops |
+| `branch create \| list \| delete \| merge` | branching ops. `merge --delete-branch` deletes the source branch after a successful merge (its own `branch_delete` policy check; a refusal is a stderr warning, not a failure — see [merge](../branching/merge.md)) |
 | `commit list \| show` | inspect commit graph |
 | `schema plan \| apply \| show (alias: get)` | migrations. `apply` refuses a cluster-managed graph (one whose storage is inside a cluster) and points at `cluster apply` — those graphs evolve through the cluster ledger, not a direct apply |
 | `lint` (alias: `check`) | offline / graph-backed query validation. Replaces `query lint` / `query check`, which are kept as deprecated argv-level shims that print a one-line warning and rewrite to `omnigraph lint` |

--- a/docs/user/operations/server.md
+++ b/docs/user/operations/server.md
@@ -66,7 +66,7 @@ graph id from the cluster's applied revision:
 | GET | `/graphs/{id}/branches` | bearer + `read` | list branches |
 | POST | `/graphs/{id}/branches` | bearer + `branch_create` | create |
 | DELETE | `/graphs/{id}/branches/{branch}` | bearer + `branch_delete` | delete |
-| POST | `/graphs/{id}/branches/merge` | bearer + `branch_merge` | merge `source → target` |
+| POST | `/graphs/{id}/branches/merge` | bearer + `branch_merge` (+ `branch_delete` only when `delete_branch` is set) | merge `source → target`; `delete_branch: true` also deletes the source after the merge lands — a delete refusal is reported via `branch_deleted`/`branch_delete_error` on the 200 response, never as an error |
 | GET | `/graphs/{id}/commits?branch=` | bearer + `read` | list |
 | GET | `/graphs/{id}/commits/{commit_id}` | bearer + `read` | show |
 

--- a/openapi.json
+++ b/openapi.json
@@ -237,7 +237,7 @@
           "branches"
         ],
         "summary": "Merge one branch into another.",
-        "description": "Merges `source` into `target` (defaults to `main`). Outcome is one of\n`already_up_to_date`, `fast_forward`, or `merged`. Returns 409 with the\nlist of conflicts if the merge cannot be completed; the target is left\nunchanged in that case. **Destructive** to `target` on success.",
+        "description": "Merges `source` into `target` (defaults to `main`). Outcome is one of\n`already_up_to_date`, `fast_forward`, or `merged`. Returns 409 with the\nlist of conflicts if the merge cannot be completed; the target is left\nunchanged in that case. **Destructive** to `target` on success.\n\nWith `delete_branch: true` the source branch is deleted after a successful\nmerge, under its own `branch_delete` policy check. The merge is durable by\nthen, so a deletion refusal or failure never fails the request; it is\nreported via `branch_deleted: false` + `branch_delete_error`.",
         "operationId": "cluster_mergeBranches",
         "parameters": [
           {
@@ -1799,6 +1799,20 @@
               "null"
             ]
           },
+          "branch_delete_error": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Why the requested source-branch deletion did not happen. Present iff\n`branch_deleted` is `false`."
+          },
+          "branch_deleted": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Result of the requested post-merge source-branch deletion. Absent when\n`delete_branch` was not requested; `true` when the source branch was\ndeleted; `false` when the deletion was refused or failed (the merge\nitself still succeeded — see `branch_delete_error`)."
+          },
           "outcome": {
             "$ref": "#/components/schemas/BranchMergeOutcome"
           },
@@ -1816,6 +1830,10 @@
           "source"
         ],
         "properties": {
+          "delete_branch": {
+            "type": "boolean",
+            "description": "Delete the source branch after a successful merge. The deletion runs\nunder its own `branch_delete` policy check; a refusal or failure is\nreported via `branch_deleted` / `branch_delete_error` on the response\nand never fails the already-landed merge."
+          },
           "source": {
             "type": "string",
             "description": "Source branch whose commits will be merged."


### PR DESCRIPTION
## What & why

Merged source branches are never cleaned up automatically: they linger in `branch list` and pin the main versions they inherited against `cleanup` GC. This adds opt-in merge-then-delete composition — `delete_branch` on `POST /branches/merge` and `--delete-branch` on `omnigraph branch merge` — so the blessed lifecycle (create → write → merge → delete) is one step for both HTTP consumers and the CLI.

## Backing issue / RFC

- [ ] Fixes an **accepted** issue: Closes #
- [ ] Implements / is an **accepted** RFC
- [ ] **Trivial fast-lane** — no issue/RFC required

Maintainer change (per the maintainer process noted above).

## Checklist

- [x] Change is focused (one logical change)
- [x] Tests added/updated for behavior changes
- [x] Public docs updated (merge, branching index, CLI reference, server endpoint table)
- [x] Reviewed against docs/dev/invariants.md — no engine changes; the deletion runs under its own `branch_delete` authorization at each boundary, so a merge permission never implies a delete permission

## Notes for reviewers

- The deletion is composed at the two boundaries (server handler, CLI embedded arm), never inside the engine's `branch_merge`; the parity matrix gains a `--delete-branch` row that pins the two composition sites against drift.
- Deletion runs on every successful merge outcome including `already_up_to_date` (the "already merged, clean me up" case), and every deletion failure — Cedar denial, dependent descendant branch, operational error — is non-fatal by design: the merge is durable by then, so it is reported via `branch_deleted: false` + `branch_delete_error` (CLI: exit 0 + stderr warning). The CLI also warns when an older server silently ignores the unknown request field.
- `openapi.json` regeneration is left to CI's auto-commit on this PR (local regen was still queued behind a cold build); the TypeScript SDK's vendored spec copy should be re-synced after merge.
- Deliberate non-goals, discussed separately: a merged-indicator in `branch list` and a `cleanup` retention-pinning report.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches branch merge API and destructive branch_delete composition with policy boundaries; behavior is well-tested and merge success is isolated from delete failures, but operators must understand merge can succeed while delete does not.
> 
> **Overview**
> Adds **opt-in merge-then-delete** so merged feature branches can be removed in one step instead of lingering in `branch list` and pinning cleanup GC.
> 
> **API & CLI:** `BranchMergeRequest` gains `delete_branch` (default false); `BranchMergeOutput` reports `branch_deleted` and `branch_delete_error`. The CLI exposes `omnigraph branch merge --delete-branch` and threads the flag through remote and embedded clients.
> 
> **Composition (not in the engine):** After a successful merge (including `already_up_to_date`), the server handler and the CLI embedded path optionally call `branch_delete` under a **separate** `branch_delete` policy check. Merge permission never implies delete permission. Any delete refusal or failure stays **non-fatal**—HTTP still returns 200 with the merge outcome; the CLI exits 0 and prints stderr warnings (including when an older server omits the new response fields).
> 
> **Tests & docs:** Coverage for successful delete, dependent-branch refusal, and policy denial on delete; parity matrix row for embedded vs remote. User docs and `openapi.json` updated for the new contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8c2ecbfd2859c44856cba1fc89c584c7f9d2a48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds opt-in source-branch deletion after a successful branch merge. The main changes are:

- `delete_branch` on the merge request and deletion status fields on the response.
- `--delete-branch` support in the CLI for remote and embedded graphs.
- Server-side merge-then-delete behavior with separate delete authorization.
- Tests and docs for success, refusal, policy denial, CLI parity, and OpenAPI output.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/omnigraph-api-types/src/lib.rs | Adds the merge request flag and optional deletion result fields. |
| openapi.json | Updates the merge request and response schemas for the new fields. |
| crates/omnigraph-server/src/handlers.rs | Runs optional source deletion after a successful merge and reports delete failures in the response. |
| crates/omnigraph-cli/src/client.rs | Sends the new merge flag remotely and mirrors the merge-then-delete flow for embedded graphs. |
| crates/omnigraph-cli/src/main.rs | Prints warnings for failed or unsupported post-merge deletion while keeping JSON output on stdout. |

<sub>Reviews (2): Last reviewed commit: ["Correct the OpenAPI drift check descript..."](https://github.com/modernrelay/omnigraph/commit/a8c2ecbfd2859c44856cba1fc89c584c7f9d2a48) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43893749)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=59169be6-01cf-4bae-80fc-604b6a708098))
- Context used - CLAUDE.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=fba7c581-edb6-48b3-90ce-1db695f47e8b))

<!-- /greptile_comment -->