### PR TITLE
Move root documentation into docs tree

### DIFF
--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -29,6 +29,7 @@ roadmap). The per-area docs below remain the mechanical authority.
 | On-disk layout, manifest schema, URI behavior | [storage.md](../user/concepts/storage.md) |
 | Direct-publish writes, D2, staged writes, recovery sidecars | [writes.md](writes.md) |
 | Write-path state of affairs — shipped RFCs, current boundaries, blockers, upstream alignment, and next gates | [writing-path-state-of-affairs.md](writing-path-state-of-affairs.md) |
+| RFC-026 supporting analysis — WAL mental model, retention options, and the deferred managed-reclamation proposal | [wal-thinking.md](wal-thinking.md), [wal-options.md](wal-options.md), [lance-memwal-pr.md](lance-memwal-pr.md) |
 | Query execution, mutation execution, loader flow | [execution.md](execution.md) |
 | Index lifecycle and graph topology indexes | [indexes.md](../user/search/indexes.md) |
 | Branch and commit internals | [branches-commits.md](../user/branching/index.md) |

--- a/docs/dev/lance-memwal-pr.md
+++ b/docs/dev/lance-memwal-pr.md
@@ -6,9 +6,9 @@ retain-all activation dependency
 **Surveyed substrate:** Lance 9.0.0-rc.1 at
 `cec0b7dffe2d85c7e66dbe9d1f3891c297903a1d`
 
-**Related:** [RFC-026](docs/rfcs/0026-memwal-streaming-ingest.md),
-[write-path state of affairs](docs/dev/writing-path-state-of-affairs.md), and
-[WAL thinking](WAL-thinking.md)
+**Related:** [RFC-026](../rfcs/0026-memwal-streaming-ingest.md),
+[write-path state of affairs](writing-path-state-of-affairs.md), and
+[WAL thinking](wal-thinking.md)
 
 ## Decision in one paragraph
 

--- a/docs/dev/wal-options.md
+++ b/docs/dev/wal-options.md
@@ -7,10 +7,10 @@
 **Surveyed substrate:** OmniGraph's pinned Lance 9.0.0-rc.1 plus the public
 LanceDB MemWAL integration on Lance 9.1.0-beta.4
 
-**Related:** [RFC-026](docs/rfcs/0026-memwal-streaming-ingest.md),
-[WAL thinking](WAL-thinking.md),
+**Related:** [RFC-026](../rfcs/0026-memwal-streaming-ingest.md),
+[WAL thinking](wal-thinking.md),
 [Lance MemWAL PR](lance-memwal-pr.md), and
-[architectural invariants](docs/dev/invariants.md)
+[architectural invariants](invariants.md)
 
 ## Executive summary
 
@@ -582,10 +582,10 @@ future improvements, not blockers for this profile.
 
 ## References
 
-- [RFC-026: MemWAL streaming ingest](docs/rfcs/0026-memwal-streaming-ingest.md)
-- [WAL thinking](WAL-thinking.md)
+- [RFC-026: MemWAL streaming ingest](../rfcs/0026-memwal-streaming-ingest.md)
+- [WAL thinking](wal-thinking.md)
 - [Lance MemWAL PR proposal](lance-memwal-pr.md)
-- [OmniGraph write-path state of affairs](docs/dev/writing-path-state-of-affairs.md)
+- [OmniGraph write-path state of affairs](writing-path-state-of-affairs.md)
 - [Lance MemWAL format](https://lance.org/format/table/mem_wal/)
 - [LanceDB MemWAL write integration](https://github.com/lancedb/lancedb/blob/8450683b2aba033b12d8fe4c6e1601cc4b733b91/rust/lancedb/src/table/merge/lsm.rs)
 - [LanceDB proposed LSM read path, PR #3489](https://github.com/lancedb/lancedb/pull/3489)

--- a/docs/dev/wal-thinking.md
+++ b/docs/dev/wal-thinking.md
@@ -1,8 +1,8 @@
 # WAL Thinking
 
 Working notes, updated 2026-07-21. Plain-language grounding for the WAL/streaming
-discussion ([RFC-018](docs/rfcs/0018-ingest-wal.md) →
-[RFC-026](docs/rfcs/0026-memwal-streaming-ingest.md)). Three parts: the
+discussion ([RFC-018](../rfcs/0018-ingest-wal.md) →
+[RFC-026](../rfcs/0026-memwal-streaming-ingest.md)). Three parts: the
 contract difference between an interactive graph commit and durable stream
 admission, the expected performance shape and evidence still required, and the
 build inventory.
@@ -327,8 +327,8 @@ complete end-to-end call count:
 - those counters overlap and do not identify sequential critical-path hops, so
   they cannot be added into a truthful “12 calls per write” result.
 
-See [`write_cost.rs`](crates/omnigraph/tests/write_cost.rs) and
-[`memwal_stream_cost.rs`](crates/omnigraph/tests/memwal_stream_cost.rs). B1 has
+See [`write_cost.rs`](../../crates/omnigraph/tests/write_cost.rs) and
+[`memwal_stream_cost.rs`](../../crates/omnigraph/tests/memwal_stream_cost.rs). B1 has
 accepted component evidence for its measured fixture set: the current
 post-containment warm already-claimed acknowledgement result is local, while
 the configured-RustFS figures are a 2026-07-19 pre-containment baseline that

--- a/docs/releases/v0.8.1-community.md
+++ b/docs/releases/v0.8.1-community.md
@@ -1,0 +1,27 @@
+:tada: *OmniGraph v0.8.1 is out* — and since we never announced v0.8.0, this covers both.
+
+:warning: *Upgrading from v0.7.x or earlier: one-time graph rebuild.*
+v0.8.0 changed the on-disk format (commit lineage now lives inside the graph's manifest, written atomically with every commit). A binary reads exactly one format version, so pre-0.8.0 graphs need a one-time *export → init → load* rebuild. The new binary won't guess — it refuses politely and (as of 0.8.1) tells you exactly which release wrote your graph and the commands to run.
+:book: Rebuild guide: [Upgrading across a storage-format change](https://omnigraph-web.vercel.app/docs/operations/upgrade)
+_Already on v0.8.0? No rebuild — just swap the binary._
+
+*New in v0.8.1*
+• *Reliability on embedding-heavy graphs* — moved to Lance 9.0.0-beta.15, picking up two upstream fixes the Lance team landed for issues under heavy update-then-maintain write patterns (failing filtered reads; failing keyed lookups after `optimize`). If you ever hit those: your data was always intact — upgrading the binary is the whole fix.
+• *Filtered vector search is now correct* — `match` filters apply _before_ `nearest()`/`bm25()`, so `limit k` means top-k of the rows matching your filter.
+• *Undirected traversal* — `$a <edgeName> $b` matches an edge in either direction; one pattern for symmetric relations.
+• *Enum widening without a rebuild* — adding variants to an `enum(...)` property is now a metadata-only schema migration.
+• *Stricter embedding validation* — non-finite/zero vectors and non-numeric elements are rejected at write time instead of stored silently.
+
+*From v0.8.0 (previously unannounced)*
+• Commit lineage in the manifest (format v4), atomic with every commit
+• One unified, stricter validator across load / mutate / merge
+• Format visibility: `omnigraph version`, `omnigraph snapshot`, server health
+• Linux arm64 prebuilt binaries
+
+*Install / upgrade*
+```curl -fsSL https://raw.githubusercontent.com/ModernRelay/omnigraph/main/scripts/install.sh | bash```
+or `brew install ModernRelay/tap/omnigraph`
+
+_Note for `cargo install` users: v0.8.1 is binaries-only — the Lance 9 pre-release isn't on crates.io yet; registry publication resumes at v0.9.0. Until then:_ `cargo install --git https://github.com/ModernRelay/omnigraph --tag v0.8.1 omnigraph-cli`
+
+Full notes: [v0.8.1 release](https://github.com/ModernRelay/omnigraph/releases/tag/v0.8.1)


### PR DESCRIPTION
## Summary

- move the tracked RFC-026 supporting notes from the repository root into docs/dev
- normalize WAL-thinking.md to lowercase kebab-case and repair all relative links
- index the supporting analysis from the developer docs entry point
- place the v0.8.1 community announcement alongside release notes
- keep conventional repository discovery and governance documents at the root

## Why

The repository root should contain project entry points and control files. Design analysis belongs in the developer documentation taxonomy, while release-specific communication belongs with release history.

## Validation

- scripts/check-agents-md.sh
- git diff --check
- verified all moved-document relative targets exist

## Dependency

Stacked on #379 because two of the moved WAL documents are introduced there. Retarget this PR to main after #379 merges.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR organizes design and release documentation under the existing docs tree. The main changes are:

- Moves RFC-026 supporting notes into `docs/dev`.
- Renames the WAL notes to lowercase kebab-case.
- Repairs relative links in the moved documents.
- Adds the supporting analysis to the developer docs index.
- Places the v0.8.1 community announcement under `docs/releases`.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The previously broken Slack-style links now use standard Markdown syntax.
- No incomplete or unsafe fix remains in the changed documentation.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/dev/index.md | Adds an index entry for the relocated RFC-026 supporting analysis. |
| docs/dev/lance-memwal-pr.md | Moves the Lance MemWAL proposal into developer docs and updates its relative links. |
| docs/dev/wal-options.md | Moves the WAL options analysis into developer docs and repairs internal links. |
| docs/dev/wal-thinking.md | Moves and renames the WAL notes while updating links to RFCs and test files. |
| docs/releases/v0.8.1-community.md | Adds the v0.8.1 community announcement with standard Markdown links. |

<sub>Reviews (2): Last reviewed commit: ["Move root documentation into docs tree"](https://github.com/modernrelay/omnigraph/commit/e389e1c33aa882be2695afc61b8f1e3cb4f3d194) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45827573)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=59169be6-01cf-4bae-80fc-604b6a708098))
- Context used - CLAUDE.md ([source](https://app.greptile.com/modernrelay/github/ModernRelay/omnigraph/-/custom-context?memory=fba7c581-edb6-48b3-90ce-1db695f47e8b))

<!-- /greptile_comment -->