### PR TITLE
Fix main workspace test baseline

### DIFF
--- a/crates/omnigraph-cli/tests/cli_data.rs
+++ b/crates/omnigraph-cli/tests/cli_data.rs
@@ -173,15 +173,15 @@ fn optimize_with_server_flag_errors_wrong_plane() {
 
 #[test]
 fn optimize_with_as_flag_errors() {
-    // `--as` attributes an actor on a direct-engine or cluster write; the
-    // Direct maintenance verbs record no actor, so the flag is rejected
-    // loudly (was: silently ignored).
+    // `--as` attributes an actor on a direct-engine or actor-bound cluster
+    // operation; the Direct maintenance verbs record no actor, so the flag is
+    // rejected loudly (was: silently ignored).
     let output = output_failure(cli().arg("optimize").arg("--as").arg("act-op"));
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("`optimize` is a direct (storage-native) command")
             && stderr.contains(
-                "--as sets the actor for a direct-engine or cluster write and does not apply"
+                "--as sets the actor for a direct-engine or actor-bound cluster operation and does not apply"
             ),
         "expected the addressing-guard --as rejection; got: {stderr}"
     );

--- a/crates/omnigraph-cli/tests/cli_schema_config.rs
+++ b/crates/omnigraph-cli/tests/cli_schema_config.rs
@@ -740,13 +740,14 @@ fn graphs_list_rejects_cluster_bound_profile() {
 #[test]
 fn graphs_list_rejects_as_actor() {
     // The registry read carries no actor; `--as` is for direct-engine and
-    // cluster writes. Rejected loudly instead of silently ignored.
+    // actor-bound cluster operations. Rejected loudly instead of silently
+    // ignored.
     let output = output_failure(cli().arg("graphs").arg("list").arg("--as").arg("act-op"));
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
     assert!(
         stderr.contains("`graphs list` is a served command")
             && stderr.contains(
-                "--as sets the actor for a direct-engine or cluster write and does not apply"
+                "--as sets the actor for a direct-engine or actor-bound cluster operation and does not apply"
             ),
         "expected the addressing-guard --as rejection in stderr; got:\n{stderr}"
     );

--- a/crates/omnigraph-cluster/src/tests.rs
+++ b/crates/omnigraph-cluster/src/tests.rs
@@ -4335,6 +4335,7 @@ graphs:
 
     #[cfg(feature = "failpoints")]
     #[test]
+    #[serial_test::serial]
     fn blocked_disable_persists_exact_disabling_correction_authority() {
         on_big_stack(blocked_disable_persists_exact_disabling_correction_authority_body);
     }
@@ -4437,7 +4438,9 @@ query seed($name: String, $age: I32) {
     async fn blocked_disable_persists_exact_disabling_correction_authority_body() {
         let _scenario = fail::FailScenario::setup();
         let dir = fixture();
-        let graph_root = prepare_blocked_disable_data_block(dir.path()).await;
+        // Heap-bound the setup future: inlining its state into this already-large
+        // test future exceeds rustc's default layout-query recursion limit on Linux.
+        let graph_root = Box::pin(prepare_blocked_disable_data_block(dir.path())).await;
         let _dead_letter_object_overflow = omnigraph::failpoints::ScopedFailPoint::new(
             omnigraph::failpoints::names::STREAM_DEAD_LETTER_FORCE_OBJECT_LIMIT,
             "1*return",
@@ -5156,6 +5159,7 @@ policies: {}
 
     #[cfg(feature = "failpoints")]
     #[test]
+    #[serial_test::serial]
     fn authority_retirement_confirm_converges_applied_state_to_retired() {
         on_big_stack(|| async {
         let _scenario = fail::FailScenario::setup();
@@ -5567,6 +5571,7 @@ policies: {}
 
     #[cfg(feature = "failpoints")]
     #[tokio::test]
+    #[serial_test::serial]
     async fn stream_block_authority_and_shape_refusals_precede_recovery() {
         let _scenario = fail::FailScenario::setup();
 

--- a/crates/omnigraph/src/db/manifest/recovery.rs
+++ b/crates/omnigraph/src/db/manifest/recovery.rs
@@ -27339,7 +27339,7 @@ mod tests {
         assert!(
             error
                 .to_string()
-                .contains("more than one row per planned key"),
+                .contains("more than one row per queried key"),
             "{error:?}"
         );
     }

--- a/crates/omnigraph/src/db/manifest/recovery/stream_correction_v20.rs
+++ b/crates/omnigraph/src/db/manifest/recovery/stream_correction_v20.rs
@@ -1908,7 +1908,6 @@ mod tests {
     #[test]
     fn recovery_v20_is_a_distinct_closed_discriminator() {
         assert_eq!(STREAM_CORRECTION_SIDECAR_SCHEMA_VERSION, 20);
-        assert_eq!(SIDECAR_SCHEMA_VERSION, 20);
         let json = serde_json::json!({
             "kind": "StreamCorrection",
             "payload": {

--- a/crates/omnigraph/src/db/manifest/tests.rs
+++ b/crates/omnigraph/src/db/manifest/tests.rs
@@ -2456,7 +2456,6 @@ async fn test_init_stamps_internal_schema_version() {
     ManifestCoordinator::init(uri, &catalog).await.unwrap();
 
     let ds = open_manifest_dataset(uri, None).await.unwrap();
-    assert_eq!(super::migrations::INTERNAL_MANIFEST_SCHEMA_VERSION, 16);
     assert_eq!(
         super::migrations::read_stamp(&ds),
         super::migrations::INTERNAL_MANIFEST_SCHEMA_VERSION,

--- a/crates/omnigraph/src/db/omnigraph/stream_retirement.rs
+++ b/crates/omnigraph/src/db/omnigraph/stream_retirement.rs
@@ -255,6 +255,69 @@ impl StreamAuthorityRetirementExportReceipt {
             Self::V1(receipt) => &receipt.export_cut_digest,
         }
     }
+
+    fn retirement_id(&self) -> &str {
+        match self {
+            Self::V2(receipt) => &receipt.retirement_id,
+            Self::V1(receipt) => &receipt.retirement_id,
+        }
+    }
+
+    fn record_id(&self) -> &str {
+        match self {
+            Self::V2(receipt) => &receipt.record_id,
+            Self::V1(receipt) => &receipt.record_id,
+        }
+    }
+
+    fn graph_identity_digest(&self) -> &str {
+        match self {
+            Self::V2(receipt) => &receipt.graph_identity_digest,
+            Self::V1(receipt) => &receipt.graph_identity_digest,
+        }
+    }
+
+    fn source_internal_schema_version(&self) -> u32 {
+        match self {
+            Self::V2(receipt) => receipt.source_internal_schema_version,
+            Self::V1(receipt) => receipt.source_internal_schema_version,
+        }
+    }
+
+    fn source_manifest_version(&self) -> u64 {
+        match self {
+            Self::V2(receipt) => receipt.source_manifest_version,
+            Self::V1(receipt) => receipt.source_manifest_version,
+        }
+    }
+
+    fn source_profile_revision(&self) -> u64 {
+        match self {
+            Self::V2(receipt) => receipt.source_profile_revision,
+            Self::V1(receipt) => receipt.source_profile_revision,
+        }
+    }
+
+    fn live_branch_heads_digest(&self) -> &str {
+        match self {
+            Self::V2(receipt) => &receipt.live_branch_heads_digest,
+            Self::V1(receipt) => &receipt.live_branch_heads_digest,
+        }
+    }
+
+    fn pre_retirement_token_head(&self) -> &crate::db::manifest::CurrentHeadWitness {
+        match self {
+            Self::V2(receipt) => &receipt.pre_retirement_token_head,
+            Self::V1(receipt) => &receipt.pre_retirement_token_head,
+        }
+    }
+
+    fn next_chain_ref(&self) -> Result<crate::db::manifest::stream_profile::ReceiptChainRef> {
+        match self {
+            Self::V2(receipt) => Ok(receipt.next_chain_ref()?),
+            Self::V1(receipt) => receipt.next_chain_ref(),
+        }
+    }
 }
 
 impl From<AuthorityRetirementReceiptV2> for StreamAuthorityRetirementExportReceipt {
@@ -802,8 +865,11 @@ impl Omnigraph {
                     retirement_id: retirement_id.to_string(),
                 });
             }
-            self.validate_visible_retirement_receipt(&current, &receipt)
-                .await?;
+            self.validate_visible_retirement_receipt(
+                &current,
+                &StreamAuthorityRetirementExportReceipt::V2(receipt.clone()),
+            )
+            .await?;
             return Ok(StreamAuthorityRetirementResult::from_receipt(
                 false,
                 &receipt,
@@ -1172,25 +1238,49 @@ impl Omnigraph {
     pub(super) async fn export_stream_authority_preflight_at(
         &self,
         snapshot: &crate::db::Snapshot,
-    ) -> Result<Option<AuthorityRetirementReceiptV2>> {
+    ) -> Result<Option<StreamAuthorityRetirementExportReceipt>> {
         if let crate::db::manifest::StreamProfileState::Retired {
             authority_retirement_receipt_id,
             ..
         } = &snapshot.stream_profile().state
         {
             let tokens = snapshot.open_stream_token_authority().await?;
-            let selected = lookup_lifecycle_ledger_record_by_id(
+            let selected_v2 = lookup_lifecycle_ledger_record_by_id(
                 &tokens,
                 snapshot.stream_token_authority(),
                 AUTHORITY_RETIREMENT_RECEIPT_V2_TAG,
                 authority_retirement_receipt_id,
             )
             .await?;
-            let Some(LifecycleLedgerRecord::AuthorityRetirementReceiptV2(receipt)) = selected
-            else {
-                return Err(OmniError::manifest_internal(
-                    "RETIRED profile does not select its immutable authority-retirement receipt",
-                ));
+            let selected_v1 = lookup_lifecycle_ledger_record_by_id(
+                &tokens,
+                snapshot.stream_token_authority(),
+                crate::db::manifest::stream_profile::AUTHORITY_RETIREMENT_RECEIPT_TAG,
+                authority_retirement_receipt_id,
+            )
+            .await?;
+            let receipt = match (selected_v2, selected_v1) {
+                (Some(LifecycleLedgerRecord::AuthorityRetirementReceiptV2(receipt)), None) => {
+                    StreamAuthorityRetirementExportReceipt::V2(receipt)
+                }
+                (None, Some(LifecycleLedgerRecord::AuthorityRetirementReceipt(receipt))) => {
+                    StreamAuthorityRetirementExportReceipt::V1(receipt)
+                }
+                (None, None) => {
+                    return Err(OmniError::manifest_internal(
+                        "RETIRED profile does not select its immutable authority-retirement receipt",
+                    ));
+                }
+                (Some(_), Some(_)) => {
+                    return Err(OmniError::manifest_internal(
+                        "RETIRED profile ambiguously selects both v1 and v2 authority-retirement receipts",
+                    ));
+                }
+                _ => {
+                    return Err(OmniError::manifest_internal(
+                        "RETIRED profile selects an invalid authority-retirement ledger family",
+                    ));
+                }
             };
             self.validate_visible_retirement_receipt(snapshot, &receipt)
                 .await?;
@@ -1230,7 +1320,7 @@ impl Omnigraph {
     pub(super) async fn validate_visible_retirement_receipt(
         &self,
         snapshot: &crate::db::Snapshot,
-        receipt: &AuthorityRetirementReceiptV2,
+        receipt: &StreamAuthorityRetirementExportReceipt,
     ) -> Result<()> {
         receipt.validate()?;
         let schema_state =
@@ -1238,15 +1328,15 @@ impl Omnigraph {
         let graph_identity_digest =
             stream_graph_identity_digest(&schema_state.schema_identity_domain)?;
         let expected_profile_revision = receipt
-            .source_profile_revision
+            .source_profile_revision()
             .checked_add(1)
             .ok_or_else(|| OmniError::manifest_internal("retirement profile revision overflow"))?;
         let expected_manifest_version = receipt
-            .source_manifest_version
+            .source_manifest_version()
             .checked_add(1)
             .ok_or_else(|| OmniError::manifest_internal("retirement manifest version overflow"))?;
         let expected_token_version = receipt
-            .pre_retirement_token_head
+            .pre_retirement_token_head()
             .table_version
             .checked_add(1)
             .ok_or_else(|| OmniError::manifest_internal("retirement token version overflow"))?;
@@ -1258,13 +1348,13 @@ impl Omnigraph {
                 authority_retirement_id,
                 authority_retirement_receipt_id,
                 authority_retirement_cut_digest,
-            } if authority_retirement_id == &receipt.retirement_id
-                && authority_retirement_receipt_id == &receipt.record_id
-                && authority_retirement_cut_digest == &receipt.export_cut_digest
+            } if authority_retirement_id == receipt.retirement_id()
+                && authority_retirement_receipt_id == receipt.record_id()
+                && authority_retirement_cut_digest == receipt.export_cut_digest()
         );
         if !matches_profile
-            || receipt.graph_identity_digest != graph_identity_digest
-            || receipt.source_internal_schema_version != INTERNAL_MANIFEST_SCHEMA_VERSION
+            || receipt.graph_identity_digest() != graph_identity_digest
+            || receipt.source_internal_schema_version() != INTERNAL_MANIFEST_SCHEMA_VERSION
             || profile.profile_revision != expected_profile_revision
             || profile.profile_receipt_chain != expected_chain
             || snapshot.version() != expected_manifest_version
@@ -1277,7 +1367,7 @@ impl Omnigraph {
                 .stream_token_authority()
                 .current_head_witness
                 .transaction_uuid
-                == receipt.pre_retirement_token_head.transaction_uuid
+                == receipt.pre_retirement_token_head().transaction_uuid
             || snapshot
                 .stream_token_authority()
                 .current_head_witness
@@ -1294,9 +1384,11 @@ impl Omnigraph {
             ));
         }
         let (heads, cut) = self
-            .capture_retirement_logical_cut_with_main_version(Some(receipt.source_manifest_version))
+            .capture_retirement_logical_cut_with_main_version(Some(
+                receipt.source_manifest_version(),
+            ))
             .await?;
-        if heads != receipt.live_branch_heads_digest || cut != receipt.export_cut_digest {
+        if heads != receipt.live_branch_heads_digest() || cut != receipt.export_cut_digest() {
             return Err(OmniError::manifest_internal(
                 "retired graph logical cut differs from its selected authority-retirement receipt",
             ));
@@ -1509,7 +1601,7 @@ impl Omnigraph {
         &self,
         branch: &str,
         expected_snapshot: &crate::db::Snapshot,
-        receipt: AuthorityRetirementReceiptV2,
+        receipt: StreamAuthorityRetirementExportReceipt,
     ) -> Result<StreamAuthorityRetirementExportProvenance> {
         let normalized = Self::normalize_branch_name(branch)?;
         let canonical_branch = normalized.as_deref().unwrap_or("main").to_string();
@@ -1524,7 +1616,7 @@ impl Omnigraph {
         }
         let (source_schema_ir_hash, members) = self
             .capture_retirement_logical_cut_members_with_main_version(Some(
-                receipt.source_manifest_version,
+                receipt.source_manifest_version(),
             ))
             .await?;
         let live_branch_heads_digest = retirement_live_branch_heads_digest(&members)?;
@@ -1534,8 +1626,8 @@ impl Omnigraph {
             .collect::<Vec<_>>();
         let export_cut_digest =
             retirement_export_cut_digest(&source_schema_ir_hash, &ordered_branch_member_digests)?;
-        if live_branch_heads_digest != receipt.live_branch_heads_digest
-            || export_cut_digest != receipt.export_cut_digest
+        if live_branch_heads_digest != receipt.live_branch_heads_digest()
+            || export_cut_digest != receipt.export_cut_digest()
         {
             return Err(OmniError::manifest_internal(
                 "retired export proof differs from its selected authority-retirement receipt",
@@ -1555,7 +1647,7 @@ impl Omnigraph {
         })?;
         let provenance = StreamAuthorityRetirementExportProvenance {
             kind: EXPORT_PROVENANCE_KIND.to_string(),
-            receipt: receipt.into(),
+            receipt,
             source_schema_ir_hash,
             ordered_branch_member_digests,
             selected_member_index,


### PR DESCRIPTION
## What changed

- heap-bound the large cluster failpoint setup future so Linux rustc no longer overflows its layout-query depth, and serialize the three failpoint-owned cluster tests
- update CLI assertions to the current actor-bound cluster-operation wording
- remove stale duplicate pins for the current manifest/recovery ceilings and align the frozen v12 duplicate-row refusal text
- restore retired-export compatibility for frozen v1 receipts while retaining exact, fail-closed v1/v2 receipt selection

## Root cause

Recent streaming slices changed production wording and advanced format ceilings without updating a handful of tests. Separately, a large inlined async test future exceeded rustc's Linux layout-query depth. The newest retirement receipt introduced a second ledger family, but export preflight only searched the v2 tag even though the frozen export envelope supports both v1 and v2.

## Validation

- focused CLI, manifest, recovery, cluster failpoint, and retirement compatibility tests
- `cargo test -p omnigraph-engine --lib --locked --features failpoints` (505 passed)
- `CARGO_TARGET_DIR=/Users/andrew/code/omnigraph-wt-f6b2/target RUST_MIN_STACK=16777216 cargo test --workspace --locked --no-fail-fast --features omnigraph-engine/failpoints,omnigraph-cluster/failpoints`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores the workspace test baseline and legacy retired-export compatibility without changing the current storage format.
- Serializes process-global failpoint tests and heap-bounds one oversized async test future.
- Updates CLI and recovery assertions to current production wording.
- Removes stale duplicate format-version assertions while retaining authoritative checks.
- Extends retired export preflight and provenance validation to accept exact frozen v1 or v2 retirement receipts while rejecting missing, ambiguous, or invalid ledger families.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the compatibility path remains exact and fail-closed, and the remaining changes repair test compilation or stale assertions.

The v1 and v2 receipt families are selected through distinct ledger tags, validated with family-specific canonical commitments, and rejected on ambiguity, while the test-only changes preserve runtime behavior and authoritative format checks.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/omnigraph/src/db/omnigraph/stream_retirement.rs | Adds exact v1/v2 retired-export receipt selection and shared validation while preserving fail-closed handling of inconsistent ledger state. |
| crates/omnigraph-cluster/src/tests.rs | Serializes the three process-global failpoint tests and boxes one large setup future to avoid Linux rustc layout-depth overflow. |
| crates/omnigraph/src/db/manifest/recovery/stream_correction_v20.rs | Removes a stale assertion equating the v20 protocol discriminator with the newer global sidecar ceiling. |
| crates/omnigraph/src/db/manifest/tests.rs | Removes a stale duplicate manifest-version pin while focused migration tests retain strict current/minimum version coverage. |
| crates/omnigraph/src/db/manifest/recovery.rs | Aligns a frozen duplicate-row refusal assertion with the current production wording. |
| crates/omnigraph-cli/tests/cli_data.rs | Updates the expected actor-addressing diagnostic to current CLI wording. |
| crates/omnigraph-cli/tests/cli_schema_config.rs | Updates the served-command actor rejection assertion to current CLI wording. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix main workspace test baseline"](https://github.com/modernrelay/omnigraph/commit/ac11e0f65219cc58b13095f8326f470728de11ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49518611)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [OmniGraph core storage: manifest, table store, and Lance access](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/omnigraph-core-storage.md)
- Knowledge Base — [Cluster Orchestration (`omnigraph-cluster`)](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/cluster-orchestration.md)
- Knowledge Base — [Dev conventions and invariants](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/dev-conventions-and-invariants.md)
</details>

<!-- /greptile_comment -->