### PR TITLE
Raise cluster failpoint test query depth

### DIFF
--- a/crates/omnigraph-cluster/src/lib.rs
+++ b/crates/omnigraph-cluster/src/lib.rs
@@ -1,3 +1,8 @@
+// The failpoint-only cluster state-machine tests compose several large async
+// futures. Linux rustc needs the wider layout-query budget while building the
+// lib-test harness; production and ordinary test builds keep the default.
+#![cfg_attr(all(test, feature = "failpoints"), recursion_limit = "256")]
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self};
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
## What changed

Raise rustc's recursion limit to 256 only for the `omnigraph-cluster` lib-test harness when the `failpoints` feature is enabled.

## Why

Post-merge Linux CI still overflows while computing the layout of the large async `blocked_disable_persists_exact_disabling_correction_authority_body` future. Heap-bounding its largest setup future was insufficient. This applies rustc's own recommended query budget to the exact build configuration that needs it; production and ordinary test builds retain the default.

## Validation

`CARGO_TARGET_DIR=/Users/andrew/code/omnigraph-wt-f6b2/target RUST_MIN_STACK=16777216 cargo test -p omnigraph-cluster --lib --locked --features failpoints`

Result: 138 passed, 0 failed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Raises rustc's recursion limit to 256 specifically for the `omnigraph-cluster` lib-test harness when failpoints are enabled, addressing compile-time layout-query overflow without changing production or ordinary test builds.
- Adds a crate-level conditional `recursion_limit` attribute.
- Documents why the larger compiler query budget is narrowly scoped.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the compiler setting is narrowly scoped to the affected failpoint test harness.

The conditional crate attribute is active for the validated failpoint-enabled test command, applies to the failing test module, and remains inactive for production and ordinary test builds.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/omnigraph-cluster/src/lib.rs | Correctly scopes the higher recursion limit to failpoint-enabled test builds, covering the affected test module without altering normal builds. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Raise cluster failpoint test query depth"](https://github.com/modernrelay/omnigraph/commit/c112f5df8327303d70990f53be91bc3475d3f495) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49520677)</sub>

<!-- /greptile_comment -->