### PR TITLE
bench: compare RFC-023 update and insert merges on diverged targets

### DIFF
--- a/crates/omnigraph/benches/scenarios.rs
+++ b/crates/omnigraph/benches/scenarios.rs
@@ -80,6 +80,11 @@ struct Args {
     selectivity: f64,
     /// ANN k (the query's `limit`) for nearest-prefilter.
     k: usize,
+    /// How many already-committed rows the source branch MODIFIES, for
+    /// `general-merge-updates`. This is the branch delta; `--rows` is the
+    /// target size. Holding this small while `--rows` grows is the whole
+    /// point of that scenario: it separates delta cost from target cost.
+    delta_rows: usize,
     memory_cap_mb: Option<u64>,
     /// Results-log override; see `results_path`.
     out: Option<String>,
@@ -110,6 +115,7 @@ impl Args {
             runs: 1,
             selectivity: 0.05,
             k: 10,
+            delta_rows: 50,
             memory_cap_mb: None,
             out: None,
             baseline: false,
@@ -133,6 +139,9 @@ impl Args {
                     args.selectivity = take("--selectivity").parse().expect("--selectivity")
                 }
                 "--k" => args.k = take("--k").parse().expect("--k"),
+                "--delta-rows" => {
+                    args.delta_rows = take("--delta-rows").parse().expect("--delta-rows")
+                }
                 "--out" => args.out = Some(take("--out")),
                 "--memory-cap-mb" => {
                     args.memory_cap_mb = Some(take("--memory-cap-mb").parse().expect("cap"))
@@ -163,6 +172,8 @@ impl Args {
             self.selectivity.to_string(),
             "--k".into(),
             self.k.to_string(),
+            "--delta-rows".into(),
+            self.delta_rows.to_string(),
             "--child".into(),
         ];
         if self.baseline {
@@ -199,8 +210,9 @@ fn main() {
     if args.scenario.is_empty() {
         eprintln!(
             "usage: --scenario <merge-all-changed|nearest-prefilter|fenced-small-upsert|\
-             fenced-adopt-all-new> [--rows N] [--dims D] \
-             [--seed S] [--runs K] [--selectivity F] [--k K] [--memory-cap-mb M]"
+             fenced-adopt-all-new|general-merge-updates> [--rows N] [--dims D] \
+             [--seed S] [--runs K] [--selectivity F] [--k K] [--delta-rows N] \
+             [--memory-cap-mb M]"
         );
         // `cargo bench` with no args must exit 0 so the target stays inert in
         // any blanket `cargo bench` invocation.
@@ -216,7 +228,10 @@ fn main() {
     }
     let mut aggregate_exit_status = 0_i64;
     for run in 0..args.runs {
-        let record = if args.scenario == "fenced-adopt-all-new" {
+        let record = if matches!(
+            args.scenario.as_str(),
+            "fenced-adopt-all-new" | "general-merge-updates"
+        ) {
             run_phased_adopt_once(&args, run)
         } else {
             run_once(&args, run)
@@ -579,6 +594,7 @@ fn run_phased_adopt_once(args: &Args, run: usize) -> serde_json::Value {
             "seed": args.seed,
             "selectivity": args.selectivity,
             "k": args.k,
+            "delta_rows": args.delta_rows,
             "memory_cap_mb": args.memory_cap_mb,
             "baseline": args.baseline,
         },
@@ -701,6 +717,15 @@ fn run_child(args: &Args) {
             }
             ("fenced-adopt-all-new", Some("verify")) => {
                 rfc023_scenarios::fenced_adopt_verify(args).await
+            }
+            ("general-merge-updates", Some("setup")) => {
+                rfc023_scenarios::general_merge_setup(args).await
+            }
+            ("general-merge-updates", Some("operation")) => {
+                rfc023_scenarios::general_merge_operation(args).await
+            }
+            ("general-merge-updates", Some("verify")) => {
+                rfc023_scenarios::general_merge_verify(args).await
             }
             ("merge-all-changed", None) => merge_all_changed(args).await,
             ("nearest-prefilter", None) => nearest_prefilter(args).await,

--- a/crates/omnigraph/benches/scenarios.rs
+++ b/crates/omnigraph/benches/scenarios.rs
@@ -85,6 +85,11 @@ struct Args {
     /// target size. Holding this small while `--rows` grows is the whole
     /// point of that scenario: it separates delta cost from target cost.
     delta_rows: usize,
+    /// `general-merge-updates` source shape: "update" rewrites committed rows,
+    /// "insert" adds brand-new rows. Both run against a target that advanced
+    /// after the fork, which is what distinguishes this from the adopt
+    /// scenario's untouched target.
+    source_mode: String,
     memory_cap_mb: Option<u64>,
     /// Results-log override; see `results_path`.
     out: Option<String>,
@@ -116,6 +121,7 @@ impl Args {
             selectivity: 0.05,
             k: 10,
             delta_rows: 50,
+            source_mode: "update".to_string(),
             memory_cap_mb: None,
             out: None,
             baseline: false,
@@ -142,6 +148,7 @@ impl Args {
                 "--delta-rows" => {
                     args.delta_rows = take("--delta-rows").parse().expect("--delta-rows")
                 }
+                "--source-mode" => args.source_mode = take("--source-mode"),
                 "--out" => args.out = Some(take("--out")),
                 "--memory-cap-mb" => {
                     args.memory_cap_mb = Some(take("--memory-cap-mb").parse().expect("cap"))
@@ -174,6 +181,8 @@ impl Args {
             self.k.to_string(),
             "--delta-rows".into(),
             self.delta_rows.to_string(),
+            "--source-mode".into(),
+            self.source_mode.clone(),
             "--child".into(),
         ];
         if self.baseline {
@@ -212,7 +221,7 @@ fn main() {
             "usage: --scenario <merge-all-changed|nearest-prefilter|fenced-small-upsert|\
              fenced-adopt-all-new|general-merge-updates> [--rows N] [--dims D] \
              [--seed S] [--runs K] [--selectivity F] [--k K] [--delta-rows N] \
-             [--memory-cap-mb M]"
+             [--source-mode update|insert] [--memory-cap-mb M]"
         );
         // `cargo bench` with no args must exit 0 so the target stays inert in
         // any blanket `cargo bench` invocation.
@@ -595,6 +604,7 @@ fn run_phased_adopt_once(args: &Args, run: usize) -> serde_json::Value {
             "selectivity": args.selectivity,
             "k": args.k,
             "delta_rows": args.delta_rows,
+            "source_mode": args.source_mode,
             "memory_cap_mb": args.memory_cap_mb,
             "baseline": args.baseline,
         },

--- a/crates/omnigraph/benches/scenarios/rfc023.rs
+++ b/crates/omnigraph/benches/scenarios/rfc023.rs
@@ -71,6 +71,12 @@ pub(super) fn validate_args(args: &Args) -> Result<(), String> {
             if args.delta_rows == 0 {
                 return Err("--delta-rows must be greater than zero".to_string());
             }
+            if !matches!(args.source_mode.as_str(), "update" | "insert") {
+                return Err(format!(
+                    "--source-mode must be 'update' or 'insert', got '{}'",
+                    args.source_mode
+                ));
+            }
             // The branch's updates and main's divergence must address disjoint
             // key ranges, or the merge reports a row conflict instead of
             // measuring the general reconciliation route.
@@ -86,6 +92,19 @@ pub(super) fn validate_args(args: &Args) -> Result<(), String> {
                 ));
             }
             rfc023_limits::derive_chunk_plan(args.dims, "base", args.delta_rows)?;
+            let source_batch_rows = general_merge_batch_rows(args.dims);
+            let source_transaction_count = args.delta_rows.div_ceil(source_batch_rows);
+            if args.source_mode == "insert"
+                && source_transaction_count
+                    > rfc023_limits::PURE_INSERT_HISTORY_MAX_VERSIONS
+            {
+                return Err(format!(
+                    "--source-mode insert needs {source_transaction_count} source transactions at \
+                     {source_batch_rows} rows/chunk, exceeding the pure-insert history proof limit \
+                     of {}; reduce --delta-rows or --dims",
+                    rfc023_limits::PURE_INSERT_HISTORY_MAX_VERSIONS
+                ));
+            }
             if args.child {
                 let phase = args
                     .phase
@@ -1399,15 +1418,16 @@ pub(super) async fn fenced_adopt_verify(args: &Args) -> serde_json::Value {
 }
 
 // ---------------------------------------------------------------------------
-// general-merge-updates: the route the proven adopt path does NOT cover
+// general-merge-updates: compare diverged-target update and insert routes
 // ---------------------------------------------------------------------------
 //
 // `fenced-adopt-all-new` measures the proven insert-only shortcut, where the
-// merge never compares against the target at all. This scenario measures the
-// other road: a source branch that MODIFIES already-committed rows carries no
-// insert-absence certificate, so reconciliation falls back to the general
-// ordered diff, which streams the base, source, AND target cursors and stages
-// the delta through Lance's target merge join.
+// merge never compares against an unchanged target. This scenario always
+// advances the target after the fork, then compares two source shapes:
+// `--source-mode update` modifies committed rows and must take the general
+// ordered diff; `--source-mode insert` carries the same durable insert-absence
+// certificate as the adopt workload and records whether the shortcut survives
+// target movement.
 //
 // The fixture deliberately holds the branch delta small (`--delta-rows`, 50 by
 // default) while `--rows` grows. If merge cost were proportional to the change
@@ -1514,25 +1534,38 @@ pub(super) async fn general_merge_setup(args: &Args) -> serde_json::Value {
         .expect("create general-merge source branch");
     let branch_create_ms = branch_start.elapsed().as_millis() as u64;
 
-    // The branch delta: SAME keys, DIFFERENT embeddings. Upsert, so the row
-    // count never moves — every changed row must be reconciled against the
-    // target rather than adopted.
+    // The branch delta. In `update` mode: SAME keys, DIFFERENT embeddings, so
+    // the row count never moves and every changed row must be reconciled
+    // against the target. In `insert` mode: brand-new keys, which is the shape
+    // the proven adopt shortcut is built for — the question that mode answers
+    // is whether that shortcut survives the target having moved.
+    let inserting = args.source_mode == "insert";
+    let source_prefix = if inserting { "adopt-new" } else { "base" };
     let source_vectors = vector_json_patterns(args.dims, args.seed ^ 0x0230_0384);
     let source_start = Instant::now();
     let mut cursor = 0;
     let mut max_source_json_chunk_bytes = 0_u64;
     while cursor < args.delta_rows {
-        let end = cursor
-            .saturating_add(batch_rows)
-            .min(args.delta_rows);
-        let jsonl = graph_jsonl_chunk("base", cursor, end, &source_vectors);
+        let end = cursor.saturating_add(batch_rows).min(args.delta_rows);
+        let jsonl = graph_jsonl_chunk(source_prefix, cursor, end, &source_vectors);
         max_source_json_chunk_bytes = max_source_json_chunk_bytes.max(jsonl.len() as u64);
-        db.load(GENERAL_MERGE_SOURCE_BRANCH, &jsonl, LoadMode::Merge)
+        let mode = if inserting {
+            LoadMode::Append
+        } else {
+            LoadMode::Merge
+        };
+        db.load(GENERAL_MERGE_SOURCE_BRANCH, &jsonl, mode)
             .await
-            .unwrap_or_else(|error| panic!("update source rows {cursor}..{end}: {error}"));
+            .unwrap_or_else(|error| panic!("write source rows {cursor}..{end}: {error}"));
         cursor = end;
     }
     let source_load_ms = source_start.elapsed().as_millis() as u64;
+    let source_transaction_count = args.delta_rows.div_ceil(batch_rows);
+    let expected_source_rows = if inserting {
+        args.rows + args.delta_rows
+    } else {
+        args.rows
+    };
 
     // Advance main on a disjoint key range so the merge is genuinely diverged.
     let target_divergence_start = args.rows - GENERAL_MERGE_TARGET_DELTA_ROWS;
@@ -1581,15 +1614,16 @@ pub(super) async fn general_merge_setup(args: &Args) -> serde_json::Value {
         .await
         .expect("count prepared source rows");
     assert_eq!(
-        setup_source_rows, args.rows,
-        "upsert-only branch delta must not change the source row count"
+        setup_source_rows, expected_source_rows,
+        "prepared source branch row count drift"
     );
     let setup_source_table_version = source_table.version();
     let setup_verify_ms = verify_start.elapsed().as_millis() as u64;
 
     let setup_fingerprint = format!(
-        "general-merge-updates-v1:rows={}:delta={}:target_delta={}:dims={}:seed={}:\
+        "general-merge-updates-v2:mode={}:rows={}:delta={}:target_delta={}:dims={}:seed={}:\
          main-v{}-rows{}:source-v{}-rows{}",
+        args.source_mode,
         args.rows,
         args.delta_rows,
         GENERAL_MERGE_TARGET_DELTA_ROWS,
@@ -1606,6 +1640,9 @@ pub(super) async fn general_merge_setup(args: &Args) -> serde_json::Value {
         "dims": args.dims,
         "delta_rows": args.delta_rows,
         "target_delta_rows": GENERAL_MERGE_TARGET_DELTA_ROWS,
+        "source_mode": args.source_mode,
+        "source_transaction_count": source_transaction_count,
+        "pure_insert_history_limit": rfc023_limits::PURE_INSERT_HISTORY_MAX_VERSIONS,
         "setup_fingerprint": setup_fingerprint,
         "setup_main_rows": setup_main_rows,
         "setup_source_rows": setup_source_rows,
@@ -1653,25 +1690,37 @@ pub(super) async fn general_merge_operation(args: &Args) -> serde_json::Value {
         .filter(|increase| *increase > 0);
 
     // Structural assertions: keep the run honest about which road it took.
+    // The target always advanced after the fork, so this can never be a
+    // fast-forward regardless of source shape.
     assert_eq!(
         outcome,
         MergeOutcome::Merged,
         "a diverged target must produce a three-way merge, not a fast-forward"
     );
     let ordered_cursor_scan_calls = probes.ordered_cursor_scan_calls();
-    assert!(
-        ordered_cursor_scan_calls > 0,
-        "general-merge scenario did not enter the ordered diff — it took a shortcut path \
-         and is not measuring the route issue #384 reports"
-    );
-    assert_eq!(
-        probes.strict_insert_preflight_calls(),
-        0,
-        "an update-only delta must not preflight strict inserts"
-    );
+    let fenced_insert_calls = probes.stage_fenced_insert_calls();
+    // `update` mode must be on the general route — that is the whole point.
+    // `insert` mode deliberately asserts nothing about the route: it exists to
+    // DISCOVER whether the proven adopt shortcut survives a moved target, so
+    // the route is recorded as a result rather than pinned as a precondition.
+    if args.source_mode == "update" {
+        assert!(
+            ordered_cursor_scan_calls > 0,
+            "update-mode run did not enter the ordered diff — it took a shortcut path \
+             and is not measuring the route issue #384 reports"
+        );
+        assert_eq!(
+            probes.strict_insert_preflight_calls(),
+            0,
+            "an update-only delta must not preflight strict inserts"
+        );
+    }
+    let took_proven_shortcut = fenced_insert_calls > 0 && ordered_cursor_scan_calls == 0;
 
     serde_json::json!({
-        "routing": "production-omnigraph-branch-merge-general-ordered-diff",
+        "routing": "production-omnigraph-branch-merge-diverged-target",
+        "source_mode": args.source_mode,
+        "took_proven_shortcut": took_proven_shortcut,
         "measurement_boundary": "operation_wall_ms starts after the common fresh Omnigraph::open and covers Omnigraph::branch_merge; no post-op scan",
         "production_path": true,
         "baseline": false,
@@ -1701,8 +1750,96 @@ pub(super) async fn general_merge_operation(args: &Args) -> serde_json::Value {
     })
 }
 
-/// Phase 3: unmeasured correctness check. The merged main must still hold
-/// exactly `--rows` rows, and both deltas must be visible.
+/// Verify one exact deterministic fixture row through the public snapshot
+/// scanner. The limit of two makes duplicate IDs fail visibly without an
+/// unbounded verification read.
+async fn verify_fixture_row(
+    table: &SnapshotTable,
+    prefix: &str,
+    ordinal: usize,
+    dims: usize,
+    domain_seed: u64,
+) -> serde_json::Value {
+    let id = format!("{prefix}-{ordinal:010}");
+    let mut scanner = table.scan();
+    scanner
+        .project(&["id", "slug", "embedding"])
+        .expect("project representative merge-verification row");
+    scanner
+        .filter(&format!("id = '{id}'"))
+        .expect("filter representative merge-verification row");
+    scanner
+        .limit(Some(2), None)
+        .expect("limit representative merge-verification row");
+    scanner.batch_size(2);
+    scanner.batch_size_bytes(rfc023_limits::KEYED_WRITE_MAX_BYTES);
+    scanner.strict_batch_size(true);
+    let mut stream = scanner
+        .try_into_stream()
+        .await
+        .expect("scan representative merge-verification row");
+    let mut observed_rows = 0_usize;
+    while let Some(batch) = stream
+        .try_next()
+        .await
+        .expect("read representative merge-verification row")
+    {
+        let batch = rfc023_limits::compact_oversized_verification_slice(batch)
+            .unwrap_or_else(|error| panic!("bound representative verification batch: {error}"));
+        let ids = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("representative verification ID must be Utf8");
+        let slugs = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("representative verification slug must be Utf8");
+        let embeddings = batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<FixedSizeListArray>()
+            .expect("representative verification embedding must be FixedSizeList");
+        let embedding_values = embeddings
+            .values()
+            .as_any()
+            .downcast_ref::<Float32Array>()
+            .expect("representative verification embedding values must be Float32");
+        assert_eq!(embeddings.value_length() as usize, dims);
+        for row_index in 0..batch.num_rows() {
+            assert!(!ids.is_null(row_index));
+            assert!(!slugs.is_null(row_index));
+            assert!(!embeddings.is_null(row_index));
+            assert_eq!(ids.value(row_index), id);
+            assert_eq!(slugs.value(row_index), id);
+            verify_fixture_vector(
+                embedding_values,
+                usize::try_from(embeddings.value_offset(row_index))
+                    .expect("representative embedding offset must be non-negative"),
+                dims,
+                domain_seed,
+                ordinal,
+                &id,
+            );
+            observed_rows += 1;
+        }
+    }
+    assert_eq!(
+        observed_rows, 1,
+        "merged target must contain exactly one representative row {id}"
+    );
+    serde_json::json!({
+        "id": id,
+        "ordinal": ordinal,
+        "domain_seed": domain_seed,
+        "payload_values_verified": true,
+    })
+}
+
+/// Phase 3: unmeasured correctness check. The merged main must have the exact
+/// expected row count, and representative rows from both disjoint deltas must
+/// retain their deterministic payloads.
 pub(super) async fn general_merge_verify(args: &Args) -> serde_json::Value {
     let root = general_merge_fixture_root(args);
     let uri = root.to_str().expect("UTF-8 benchmark fixture root");
@@ -1722,15 +1859,43 @@ pub(super) async fn general_merge_verify(args: &Args) -> serde_json::Value {
         .count_rows(None)
         .await
         .expect("count merged main rows");
+    let expected_final_rows = if args.source_mode == "insert" {
+        args.rows + args.delta_rows
+    } else {
+        args.rows
+    };
     assert_eq!(
-        final_rows, args.rows,
-        "an upsert-only merge must not change the target row count"
+        final_rows, expected_final_rows,
+        "merged target row count drift"
     );
+    let source_prefix = if args.source_mode == "insert" {
+        "adopt-new"
+    } else {
+        "base"
+    };
+    let source_delta_row = verify_fixture_row(
+        &table,
+        source_prefix,
+        0,
+        args.dims,
+        args.seed ^ 0x0230_0384,
+    )
+    .await;
+    let target_delta_row = verify_fixture_row(
+        &table,
+        "base",
+        args.rows - GENERAL_MERGE_TARGET_DELTA_ROWS,
+        args.dims,
+        args.seed ^ 0x0230_0385,
+    )
+    .await;
     let verify_wall_ms = verify_start.elapsed().as_millis() as u64;
 
     serde_json::json!({
         "verify_wall_ms": verify_wall_ms,
         "final_rows": final_rows,
         "verify_main_table_version": table.version(),
+        "source_delta_row": source_delta_row,
+        "target_delta_row": target_delta_row,
     })
 }

--- a/crates/omnigraph/benches/scenarios/rfc023.rs
+++ b/crates/omnigraph/benches/scenarios/rfc023.rs
@@ -66,9 +66,50 @@ pub(super) fn validate_args(args: &Args) -> Result<(), String> {
                 );
             }
         }
+        "general-merge-updates" => {
+            rfc023_limits::derive_chunk_plan(args.dims, "base", args.rows)?;
+            if args.delta_rows == 0 {
+                return Err("--delta-rows must be greater than zero".to_string());
+            }
+            // The branch's updates and main's divergence must address disjoint
+            // key ranges, or the merge reports a row conflict instead of
+            // measuring the general reconciliation route.
+            if args
+                .delta_rows
+                .saturating_add(GENERAL_MERGE_TARGET_DELTA_ROWS)
+                > args.rows
+            {
+                return Err(format!(
+                    "--delta-rows {} plus the {GENERAL_MERGE_TARGET_DELTA_ROWS}-row target \
+                     divergence must fit inside --rows {}",
+                    args.delta_rows, args.rows
+                ));
+            }
+            rfc023_limits::derive_chunk_plan(args.dims, "base", args.delta_rows)?;
+            if args.child {
+                let phase = args
+                    .phase
+                    .as_deref()
+                    .ok_or_else(|| "phased merge child is missing --phase".to_string())?;
+                if !matches!(phase, "setup" | "operation" | "verify") {
+                    return Err(format!("unknown phased merge child phase '{phase}'"));
+                }
+                if args.fixture_root.as_deref().is_none_or(str::is_empty) {
+                    return Err("phased merge child is missing --fixture-root".to_string());
+                }
+            } else if args.phase.is_some() || args.fixture_root.is_some() {
+                return Err(
+                    "--phase/--fixture-root are internal to phased merge children".to_string(),
+                );
+            }
+        }
         _ => {
             if args.phase.is_some() || args.fixture_root.is_some() {
-                return Err("--phase/--fixture-root require fenced-adopt-all-new".to_string());
+                return Err(
+                    "--phase/--fixture-root require fenced-adopt-all-new or \
+                     general-merge-updates"
+                        .to_string(),
+                );
             }
         }
     }
@@ -1354,5 +1395,342 @@ pub(super) async fn fenced_adopt_verify(args: &Args) -> serde_json::Value {
         "physical_source_content": physical_source_content,
         "manifest_main_content": manifest_main_content,
         "manifest_source_content": manifest_source_content,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// general-merge-updates: the route the proven adopt path does NOT cover
+// ---------------------------------------------------------------------------
+//
+// `fenced-adopt-all-new` measures the proven insert-only shortcut, where the
+// merge never compares against the target at all. This scenario measures the
+// other road: a source branch that MODIFIES already-committed rows carries no
+// insert-absence certificate, so reconciliation falls back to the general
+// ordered diff, which streams the base, source, AND target cursors and stages
+// the delta through Lance's target merge join.
+//
+// The fixture deliberately holds the branch delta small (`--delta-rows`, 50 by
+// default) while `--rows` grows. If merge cost were proportional to the change
+// set, every column here would be flat in `--rows`. Issue #384 reports that it
+// is not — a ~50-row branch exhausts the memory pool against a large target —
+// so this scenario exists to turn that report into a curve.
+//
+// Main is also advanced after the branch forks, on a disjoint key range, so the
+// merge is genuinely diverged and takes the three-way route rather than the
+// two-way fast-forward diff. That matches the reported production shape, where
+// other writers land on main while a branch is open.
+
+/// Rows rewritten on `main` after the branch forks, to force divergence.
+/// Small and fixed: this is the "someone else wrote to main" trigger, not a
+/// variable under study.
+const GENERAL_MERGE_TARGET_DELTA_ROWS: usize = 8;
+
+const GENERAL_MERGE_SOURCE_BRANCH: &str = "update-source";
+
+/// Rows per fixture `load()` call, sized against the loader's ACTUAL keyed
+/// byte accounting rather than the shared benchmark estimator.
+///
+/// `derive_chunk_plan` models a vector row as `dims * 4` — the Arrow value
+/// buffer. The loader's `account_keyed_json_row` instead charges a JSON array
+/// as `(dims + 1) * 4` offset bytes PLUS `dims * 4` value bytes, so the real
+/// per-row charge is ~`dims * 8`. At dims=256 the 8,192-row cap binds first and
+/// the difference is invisible, which is why `fenced-adopt-all-new` never saw
+/// it. At dims=1024 the derived batch lands ~2x over the 32 MiB ceiling, and
+/// because the budget accumulates across a whole `load()` call it always
+/// crosses at the same row index regardless of the requested chunk width.
+///
+/// This scenario sweeps vector width deliberately, so it models the real
+/// charge locally instead of widening the shared estimator — that estimator's
+/// exact plan is load-bearing for `fenced-adopt-all-new`'s recorded evidence,
+/// and re-planning it would invalidate those runs. Chunk count is a fixture
+/// detail here; only the merge is measured.
+fn general_merge_batch_rows(dims: usize) -> usize {
+    // (dims + 1) * 4 offsets + dims * 4 values, plus generous room for the
+    // slug string, its offset, and per-row bookkeeping.
+    let per_row = (dims as u64)
+        .saturating_mul(8)
+        .saturating_add(128)
+        .max(1);
+    // Spend only 90% of the ceiling so a future accounting tweak does not put
+    // the fixture back on the cliff.
+    let by_bytes = rfc023_limits::KEYED_WRITE_MAX_BYTES
+        .saturating_mul(9)
+        .saturating_div(10)
+        .saturating_div(per_row);
+    usize::try_from(by_bytes)
+        .unwrap_or(rfc023_limits::KEYED_WRITE_MAX_ROWS)
+        .min(rfc023_limits::KEYED_WRITE_MAX_ROWS)
+        .max(1)
+}
+
+fn general_merge_fixture_root(args: &Args) -> &std::path::Path {
+    std::path::Path::new(
+        args.fixture_root
+            .as_deref()
+            .expect("validated general-merge fixture root"),
+    )
+}
+
+/// Phase 1: build the persisted fixture. Exits before the measured child runs,
+/// so none of this allocation can raise the operation high-water mark.
+pub(super) async fn general_merge_setup(args: &Args) -> serde_json::Value {
+    // Shape validation only — the fixture's chunk width comes from
+    // `general_merge_batch_rows`, which models the loader's real byte charge.
+    rfc023_limits::derive_chunk_plan(args.dims, "base", args.rows)
+        .expect("validated general-merge target chunk plan");
+    let batch_rows = general_merge_batch_rows(args.dims);
+    let root = general_merge_fixture_root(args);
+    assert!(
+        std::fs::read_dir(root)
+            .expect("read empty general-merge fixture root")
+            .next()
+            .is_none(),
+        "general-merge setup root must start empty"
+    );
+    let uri = root.to_str().expect("UTF-8 benchmark fixture root");
+
+    let init_start = Instant::now();
+    let db = Omnigraph::init(uri, &graph_schema(args.dims))
+        .await
+        .expect("initialize general-merge benchmark graph");
+    let init_ms = init_start.elapsed().as_millis() as u64;
+
+    // The committed target image.
+    let target_vectors = vector_json_patterns(args.dims, args.seed);
+    let (target_load_ms, max_target_json_chunk_bytes) = load_graph_rows(
+        &db,
+        "main",
+        "base",
+        args.rows,
+        batch_rows,
+        &target_vectors,
+        LoadMode::Overwrite,
+    )
+    .await;
+
+    let branch_start = Instant::now();
+    db.branch_create(GENERAL_MERGE_SOURCE_BRANCH)
+        .await
+        .expect("create general-merge source branch");
+    let branch_create_ms = branch_start.elapsed().as_millis() as u64;
+
+    // The branch delta: SAME keys, DIFFERENT embeddings. Upsert, so the row
+    // count never moves — every changed row must be reconciled against the
+    // target rather than adopted.
+    let source_vectors = vector_json_patterns(args.dims, args.seed ^ 0x0230_0384);
+    let source_start = Instant::now();
+    let mut cursor = 0;
+    let mut max_source_json_chunk_bytes = 0_u64;
+    while cursor < args.delta_rows {
+        let end = cursor
+            .saturating_add(batch_rows)
+            .min(args.delta_rows);
+        let jsonl = graph_jsonl_chunk("base", cursor, end, &source_vectors);
+        max_source_json_chunk_bytes = max_source_json_chunk_bytes.max(jsonl.len() as u64);
+        db.load(GENERAL_MERGE_SOURCE_BRANCH, &jsonl, LoadMode::Merge)
+            .await
+            .unwrap_or_else(|error| panic!("update source rows {cursor}..{end}: {error}"));
+        cursor = end;
+    }
+    let source_load_ms = source_start.elapsed().as_millis() as u64;
+
+    // Advance main on a disjoint key range so the merge is genuinely diverged.
+    let target_divergence_start = args.rows - GENERAL_MERGE_TARGET_DELTA_ROWS;
+    let diverge_vectors = vector_json_patterns(args.dims, args.seed ^ 0x0230_0385);
+    let diverge_start = Instant::now();
+    let diverge_jsonl = graph_jsonl_chunk(
+        "base",
+        target_divergence_start,
+        args.rows,
+        &diverge_vectors,
+    );
+    db.load("main", &diverge_jsonl, LoadMode::Merge)
+        .await
+        .expect("advance main after the branch forked");
+    let target_diverge_ms = diverge_start.elapsed().as_millis() as u64;
+
+    let verify_start = Instant::now();
+    let main_snapshot = db
+        .snapshot_of(ReadTarget::branch("main"))
+        .await
+        .expect("capture prepared main snapshot");
+    let main_table = main_snapshot
+        .open("node:Chunk")
+        .await
+        .expect("open prepared main table");
+    let setup_main_rows = main_table
+        .count_rows(None)
+        .await
+        .expect("count prepared main rows");
+    assert_eq!(
+        setup_main_rows, args.rows,
+        "upsert-only divergence must not change the main row count"
+    );
+    let setup_main_table_version = main_table.version();
+
+    let source_snapshot = db
+        .snapshot_of(ReadTarget::branch(GENERAL_MERGE_SOURCE_BRANCH))
+        .await
+        .expect("capture prepared source snapshot");
+    let source_table = source_snapshot
+        .open("node:Chunk")
+        .await
+        .expect("open prepared source table");
+    let setup_source_rows = source_table
+        .count_rows(None)
+        .await
+        .expect("count prepared source rows");
+    assert_eq!(
+        setup_source_rows, args.rows,
+        "upsert-only branch delta must not change the source row count"
+    );
+    let setup_source_table_version = source_table.version();
+    let setup_verify_ms = verify_start.elapsed().as_millis() as u64;
+
+    let setup_fingerprint = format!(
+        "general-merge-updates-v1:rows={}:delta={}:target_delta={}:dims={}:seed={}:\
+         main-v{}-rows{}:source-v{}-rows{}",
+        args.rows,
+        args.delta_rows,
+        GENERAL_MERGE_TARGET_DELTA_ROWS,
+        args.dims,
+        args.seed,
+        setup_main_table_version,
+        setup_main_rows,
+        setup_source_table_version,
+        setup_source_rows,
+    );
+
+    serde_json::json!({
+        "rows": args.rows,
+        "dims": args.dims,
+        "delta_rows": args.delta_rows,
+        "target_delta_rows": GENERAL_MERGE_TARGET_DELTA_ROWS,
+        "setup_fingerprint": setup_fingerprint,
+        "setup_main_rows": setup_main_rows,
+        "setup_source_rows": setup_source_rows,
+        "setup_main_table_version": setup_main_table_version,
+        "setup_source_table_version": setup_source_table_version,
+        "fixture_batch_rows": batch_rows,
+        "max_target_json_chunk_bytes": max_target_json_chunk_bytes,
+        "max_source_json_chunk_bytes": max_source_json_chunk_bytes,
+        "init_ms": init_ms,
+        "target_load_ms": target_load_ms,
+        "branch_create_ms": branch_create_ms,
+        "source_load_ms": source_load_ms,
+        "target_diverge_ms": target_diverge_ms,
+        "setup_verify_ms": setup_verify_ms,
+    })
+}
+
+/// Phase 2: the measured child. Opens the fixture and runs exactly one
+/// production `branch_merge`, then records wall time plus this process's peak
+/// RSS. The parent's `wait4` peak for this child is the memory number.
+pub(super) async fn general_merge_operation(args: &Args) -> serde_json::Value {
+    let root = general_merge_fixture_root(args);
+    let uri = root.to_str().expect("UTF-8 benchmark fixture root");
+    let open_start = Instant::now();
+    let db = Omnigraph::open(uri)
+        .await
+        .expect("fresh-open general-merge fixture");
+    let operation_open_ms = open_start.elapsed().as_millis() as u64;
+    let operation_pre_peak_rss_bytes = super::current_process_peak_rss_bytes();
+
+    let probes = MergeWriteProbes::default();
+    let operation_start = Instant::now();
+    let outcome = with_merge_write_probes(
+        probes.clone(),
+        db.branch_merge(GENERAL_MERGE_SOURCE_BRANCH, "main"),
+    )
+    .await
+    .expect("run production branch merge");
+    let operation_elapsed = operation_start.elapsed();
+    let operation_wall_ms = operation_elapsed.as_millis() as u64;
+    let operation_wall_us = u64::try_from(operation_elapsed.as_micros()).unwrap_or(u64::MAX);
+    let operation_post_peak_rss_bytes = super::current_process_peak_rss_bytes();
+    let operation_hwm_increase_bytes = operation_post_peak_rss_bytes
+        .checked_sub(operation_pre_peak_rss_bytes)
+        .filter(|increase| *increase > 0);
+
+    // Structural assertions: keep the run honest about which road it took.
+    assert_eq!(
+        outcome,
+        MergeOutcome::Merged,
+        "a diverged target must produce a three-way merge, not a fast-forward"
+    );
+    let ordered_cursor_scan_calls = probes.ordered_cursor_scan_calls();
+    assert!(
+        ordered_cursor_scan_calls > 0,
+        "general-merge scenario did not enter the ordered diff — it took a shortcut path \
+         and is not measuring the route issue #384 reports"
+    );
+    assert_eq!(
+        probes.strict_insert_preflight_calls(),
+        0,
+        "an update-only delta must not preflight strict inserts"
+    );
+
+    serde_json::json!({
+        "routing": "production-omnigraph-branch-merge-general-ordered-diff",
+        "measurement_boundary": "operation_wall_ms starts after the common fresh Omnigraph::open and covers Omnigraph::branch_merge; no post-op scan",
+        "production_path": true,
+        "baseline": false,
+        "operation_open_ms": operation_open_ms,
+        "operation_wall_ms": operation_wall_ms,
+        "operation_wall_us": operation_wall_us,
+        "operation_pre_peak_rss_bytes": operation_pre_peak_rss_bytes,
+        "operation_post_peak_rss_bytes": operation_post_peak_rss_bytes,
+        "operation_hwm_censored": operation_hwm_increase_bytes.is_none(),
+        "operation_hwm_increase_bytes": operation_hwm_increase_bytes,
+        "merge_outcome": "merged",
+        "probe_ordered_cursor_scan_calls": ordered_cursor_scan_calls,
+        "probe_ordered_cursor_batch_rows": probes.ordered_cursor_batch_rows(),
+        "probe_ordered_cursor_batch_bytes": probes.ordered_cursor_batch_bytes(),
+        "probe_stage_merge_insert_calls": probes.stage_merge_insert_calls(),
+        "probe_stage_merge_insert_rows": probes.stage_merge_insert_rows(),
+        "probe_stage_fenced_insert_calls": probes.stage_fenced_insert_calls(),
+        "probe_stage_fenced_insert_rows": probes.stage_fenced_insert_rows(),
+        "probe_stage_append_calls": probes.stage_append_calls(),
+        "probe_stage_append_rows": probes.stage_append_rows(),
+        "probe_scan_staged_combined_calls": probes.scan_staged_combined_calls(),
+        "probe_strict_insert_preflight_calls": probes.strict_insert_preflight_calls(),
+        "probe_validation_scan_batches": probes.validation_scan_batches(),
+        "probe_validation_scan_projected_bytes": probes.validation_scan_projected_bytes(),
+        "probe_stage_vector_index_calls": probes.stage_vector_index_calls(),
+        "probe_phase_us": merge_phase_metrics(&probes),
+    })
+}
+
+/// Phase 3: unmeasured correctness check. The merged main must still hold
+/// exactly `--rows` rows, and both deltas must be visible.
+pub(super) async fn general_merge_verify(args: &Args) -> serde_json::Value {
+    let root = general_merge_fixture_root(args);
+    let uri = root.to_str().expect("UTF-8 benchmark fixture root");
+    let verify_start = Instant::now();
+    let db = Omnigraph::open(uri)
+        .await
+        .expect("reopen merged general-merge fixture");
+    let snapshot = db
+        .snapshot_of(ReadTarget::branch("main"))
+        .await
+        .expect("capture merged main snapshot");
+    let table = snapshot
+        .open("node:Chunk")
+        .await
+        .expect("open merged main table");
+    let final_rows = table
+        .count_rows(None)
+        .await
+        .expect("count merged main rows");
+    assert_eq!(
+        final_rows, args.rows,
+        "an upsert-only merge must not change the target row count"
+    );
+    let verify_wall_ms = verify_start.elapsed().as_millis() as u64;
+
+    serde_json::json!({
+        "verify_wall_ms": verify_wall_ms,
+        "final_rows": final_rows,
+        "verify_main_table_version": table.version(),
     })
 }

--- a/crates/omnigraph/benches/scenarios/rfc023_limits.rs
+++ b/crates/omnigraph/benches/scenarios/rfc023_limits.rs
@@ -6,6 +6,8 @@ use arrow_array::{RecordBatch, UInt32Array};
 pub(crate) const KEYED_WRITE_MAX_ROWS: usize = 8192;
 pub(crate) const KEYED_WRITE_MAX_BYTES: u64 = 32 * 1024 * 1024;
 pub(crate) const RECOVERY_MAX_TRANSACTIONS: usize = 1024;
+/// Maximum source-version interval eligible for the pure-insert proof walk.
+pub(crate) const PURE_INSERT_HISTORY_MAX_VERSIONS: usize = 1024;
 
 // Arrow's value buffers dominate these vector batches. Reserve a deliberately
 // conservative fixed allowance for ArrayData/offset buffers and per-row slack

--- a/crates/omnigraph/tests/benchmark_scenario_contract.rs
+++ b/crates/omnigraph/tests/benchmark_scenario_contract.rs
@@ -54,6 +54,12 @@ fn benchmark_caps_match_production() {
         product_const(recovery, "MAX_BRANCH_MERGE_DATA_TRANSACTIONS"),
         rfc023_limits::RECOVERY_MAX_TRANSACTIONS as u64
     );
+
+    let merge = include_str!("../src/exec/merge.rs");
+    assert_eq!(
+        product_const(merge, "PURE_INSERT_HISTORY_MAX_VERSIONS"),
+        rfc023_limits::PURE_INSERT_HISTORY_MAX_VERSIONS as u64
+    );
 }
 
 /// Pin the phased measurement boundary in the ordinary test suite. Setup,
@@ -99,8 +105,15 @@ fn adopt_comparator_is_phased_and_streams_only_the_operation_substitution() {
     );
 
     let source = include_str!("../benches/scenarios/rfc023.rs");
+    let setup = source
+        .split_once("pub(super) async fn fenced_adopt_setup")
+        .expect("setup phase")
+        .1
+        .split_once("/// Phase 2 baseline")
+        .expect("setup phase boundary")
+        .0;
     assert_eq!(
-        source.matches("Omnigraph::init(").count(),
+        setup.matches("Omnigraph::init(").count(),
         1,
         "the persisted fixture must have one common OmniGraph initializer"
     );
@@ -152,13 +165,6 @@ fn adopt_comparator_is_phased_and_streams_only_the_operation_substitution() {
     assert!(!baseline.contains("count_rows("));
     assert!(!baseline.contains("snapshot_of("));
 
-    let setup = source
-        .split_once("pub(super) async fn fenced_adopt_setup")
-        .expect("setup phase")
-        .1
-        .split_once("/// Phase 2 baseline")
-        .expect("setup phase boundary")
-        .0;
     assert!(setup.contains("setup_fingerprint"));
     assert!(setup.contains("setup_main_rows"));
     assert!(setup.contains("setup_source_rows"));
@@ -168,7 +174,10 @@ fn adopt_comparator_is_phased_and_streams_only_the_operation_substitution() {
     let verify = source
         .split_once("pub(super) async fn fenced_adopt_verify")
         .expect("verify phase")
-        .1;
+        .1
+        .split_once("// general-merge-updates:")
+        .expect("verify phase boundary")
+        .0;
     assert!(verify.contains("Omnigraph::open(uri)"));
     assert!(verify.contains("manifest_visible_final_rows"));
     assert!(verify.contains("physical_main_rows"));

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -1383,22 +1383,27 @@ The CLI system tests (`system_local.rs`) spawn the workspace-built `omnigraph` a
 - `crates/omnigraph/benches/scenarios.rs` with
   `benches/scenarios/rfc023.rs` — the `general-merge-updates` scenario, the
   counterpart to `fenced-adopt-all-new`. That scenario measures the proven
-  insert-only shortcut, where the merge never compares against the target;
-  this one measures the route the shortcut does **not** cover. Its source
-  branch upserts already-committed rows, so it carries no insert-absence
-  certificate and reconciliation falls back to the general ordered diff;
-  `main` is separately advanced on a disjoint key range so the merge is
-  genuinely diverged and takes the three-way route. Structural assertions
-  keep the run honest: `MergeOutcome::Merged`, `ordered_cursor_scan_calls > 0`
-  (base + source + target), and zero strict-insert preflights. `--delta-rows`
-  sets the branch delta independently of `--rows`, which is the whole point —
-  the scenario exists to separate delta cost from target cost for
-  [#384](https://github.com/ModernRelay/omnigraph/issues/384). Its fixture
-  sizes `load()` chunks from the loader's real keyed accounting (a JSON array
-  is charged `(dims + 1) * 4` offset bytes **plus** `dims * 4` value bytes,
-  roughly `dims * 8`), not from `derive_chunk_plan`'s `dims * 4` value-buffer
-  model; the two agree at dims=256 only because the 8,192-row cap binds first.
-  A decision instrument, not a CI gate: it asserts route, never a threshold.
+  insert-only shortcut against an untouched target; this one always advances
+  `main` on a disjoint key range so the merge is genuinely diverged. The update
+  arm (`--source-mode update`) rewrites committed rows, carries no
+  insert-absence certificate, and pins the general ordered-diff route. The
+  insert arm (`--source-mode insert`) writes all-new rows within the pure-insert
+  history-proof limit and records whether the shortcut survives target
+  movement. Both arms assert `MergeOutcome::Merged`; the update arm
+  additionally asserts ordered cursor scans and zero strict-insert preflights.
+  Fresh verification checks the exact
+  row count plus deterministic payloads from both the source delta and target
+  divergence. `--delta-rows` sets the branch delta independently of `--rows`,
+  which is the whole point — the scenario separates delta cost from target
+  cost for [#384](https://github.com/ModernRelay/omnigraph/issues/384). Its
+  fixture sizes `load()` chunks from the loader's real keyed accounting (a
+  JSON array is charged `(dims + 1) * 4` offset bytes **plus** `dims * 4`
+  value bytes, roughly `dims * 8`), not from `derive_chunk_plan`'s `dims * 4`
+  value-buffer model; the two agree at dims=256 only because the 8,192-row cap
+  binds first.
+  A decision instrument, not a CI gate: it asserts route where the shape fixes
+  it, records the insert-arm discovery, and never asserts a performance
+  threshold.
 - Add `benches/` per crate when you ship a perf-driven change, and include the motivating workload with the optimization.
 
 ## Coverage tooling — what's missing

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -1380,6 +1380,25 @@ The CLI system tests (`system_local.rs`) spawn the workspace-built `omnigraph` a
   Those macOS measurements predate fail-closed cap handling: the RFC records
   observed `ru_maxrss` and does not claim the requested 256 MiB cap was
   enforced. The current harness refuses a requested capped scenario on macOS.
+- `crates/omnigraph/benches/scenarios.rs` with
+  `benches/scenarios/rfc023.rs` — the `general-merge-updates` scenario, the
+  counterpart to `fenced-adopt-all-new`. That scenario measures the proven
+  insert-only shortcut, where the merge never compares against the target;
+  this one measures the route the shortcut does **not** cover. Its source
+  branch upserts already-committed rows, so it carries no insert-absence
+  certificate and reconciliation falls back to the general ordered diff;
+  `main` is separately advanced on a disjoint key range so the merge is
+  genuinely diverged and takes the three-way route. Structural assertions
+  keep the run honest: `MergeOutcome::Merged`, `ordered_cursor_scan_calls > 0`
+  (base + source + target), and zero strict-insert preflights. `--delta-rows`
+  sets the branch delta independently of `--rows`, which is the whole point —
+  the scenario exists to separate delta cost from target cost for
+  [#384](https://github.com/ModernRelay/omnigraph/issues/384). Its fixture
+  sizes `load()` chunks from the loader's real keyed accounting (a JSON array
+  is charged `(dims + 1) * 4` offset bytes **plus** `dims * 4` value bytes,
+  roughly `dims * 8`), not from `derive_chunk_plan`'s `dims * 4` value-buffer
+  model; the two agree at dims=256 only because the 8,192-row cap binds first.
+  A decision instrument, not a CI gate: it asserts route, never a threshold.
 - Add `benches/` per crate when you ship a perf-driven change, and include the motivating workload with the optimization.
 
 ## Coverage tooling — what's missing


### PR DESCRIPTION
## Summary

- add a phased `general-merge-updates` decision instrument for the production branch-merge path
- compare an update delta with an all-new insert delta after `main` has independently advanced
- record whether the proven insert shortcut is selected, while pinning the update arm to the general ordered-diff route
- validate pure-insert history eligibility and verify exact representative payloads from both source and target deltas
- document the new `--source-mode update|insert` control and repair the existing benchmark contract assertions

## Why

The existing `fenced-adopt-all-new` benchmark covers an untouched target. It cannot explain issue #384's diverged-target shape. This benchmark separates target-size cost from delta-size cost and tests whether durable insert-absence provenance still enables the shortcut once the target has moved.

A 64-row smoke run with an 8-row delta observed three ordered cursor scans, one MergeInsert, and zero fenced inserts in both modes. The insert fixture used one certified source transaction—well inside the pinned 1,024-version proof limit—so its general-route result is not caused by an ineligible history interval.

No production behavior changes.

Related to #384.

## Validation

- `cargo check -p omnigraph-engine --bench scenarios --locked`
- `cargo test -p omnigraph-engine --locked --test benchmark_scenario_contract` (7 passed)
- end-to-end update-mode smoke run with exact payload verification
- end-to-end insert-mode smoke run with exact payload verification
- `scripts/check-agents-md.sh`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a phased benchmark comparing update and insert source deltas when the merge target has independently advanced. It also adds route instrumentation, fixture validation, representative payload checks, benchmark contract assertions, and developer documentation.

- Adds `general-merge-updates` setup, measured operation, and verification phases.
- Introduces `--delta-rows` and `--source-mode update|insert`.
- Pins the benchmark's pure-insert proof limit to the production constant.
- Documents the diverged-target workload and measurement boundary.

<h3>Confidence Score: 4/5</h3>

The unsupported `--baseline` combination should be rejected or implemented before merging because it currently produces a production measurement despite the caller explicitly requesting a baseline.

The new scenario participates in the shared benchmark CLI and receives the baseline flag in its child process, but unconditionally runs `branch_merge` and reports that the operation was not a baseline.

**Files Needing Attention:** crates/omnigraph/benches/scenarios/rfc023.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/omnigraph/benches/scenarios.rs | Adds shared CLI controls and routes the new scenario through the existing three-phase benchmark controller. |
| crates/omnigraph/benches/scenarios/rfc023.rs | Implements the diverged-target fixture and measurements, but silently ignores the shared `--baseline` control. |
| crates/omnigraph/benches/scenarios/rfc023_limits.rs | Adds a benchmark-side pure-insert history constant whose value is pinned to production by a contract test. |
| crates/omnigraph/tests/benchmark_scenario_contract.rs | Updates source-walk boundaries and verifies benchmark limits remain aligned with production constants. |
| docs/dev/testing.md | Documents the new workload, route assertions, chunking model, and representative verification behavior. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Parent as Benchmark parent
    participant Setup as Setup child
    participant Operation as Measured child
    participant Verify as Verify child
    Parent->>Setup: Create target and source branch
    Setup->>Setup: Advance main after fork
    Setup-->>Parent: Persisted diverged fixture
    Parent->>Operation: Open fixture and branch_merge
    Operation-->>Parent: Timing, RSS, and route probes
    Parent->>Verify: Reopen merged fixture
    Verify-->>Parent: Row count and representative payloads
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Acrates%2Fomnigraph%2Fbenches%2Fscenarios%2Frfc023.rs%3A1725-1726%0A**Baseline%20mode%20is%20silently%20ignored**%0A%0AWhen%20%60general-merge-updates%60%20is%20run%20with%20%60--baseline%60%2C%20the%20flag%20reaches%20this%20operation%20but%20the%20code%20unconditionally%20executes%20%60Omnigraph%3A%3Abranch_merge%60%20and%20reports%20%60%22baseline%22%3A%20false%60%2C%20causing%20a%20requested%20baseline%20run%20to%20produce%20misleading%20production-path%20benchmark%20results%20instead%20of%20rejecting%20or%20honoring%20the%20option.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=modernrelay%2Fomnigraph&pr=427&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["bench: compare diverged update and inser..."](https://github.com/modernrelay/omnigraph/commit/ff56d77697cac6e73d2ca9dc67b6f47b1fd35bb0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49528794)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Branching and merge](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/branching-and-merge.md)
- Knowledge Base — [Dev conventions and invariants](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/dev-conventions-and-invariants.md)

<!-- /greptile_comment -->