### PR TITLE
feat(compiler,engine): edge bindings to filter and project edge properties

### DIFF
--- a/crates/omnigraph-compiler/src/ir/lower.rs
+++ b/crates/omnigraph-compiler/src/ir/lower.rs
@@ -306,6 +306,11 @@ fn lower_clauses(
                     min_hops: traversal.min_hops,
                     max_hops: traversal.max_hops,
                     dst_filters: vec![],
+                    edge_binding: traversal
+                        .edge_binding
+                        .as_deref()
+                        .filter(|binding| *binding != "_")
+                        .map(str::to_string),
                 });
                 pipeline.push(IROp::Filter(IRFilter {
                     left: IRExpr::PropAccess {
@@ -342,6 +347,11 @@ fn lower_clauses(
                     min_hops: traversal.min_hops,
                     max_hops: traversal.max_hops,
                     dst_filters: introduced_filters,
+                    edge_binding: traversal
+                        .edge_binding
+                        .as_deref()
+                        .filter(|binding| *binding != "_")
+                        .map(str::to_string),
                 });
                 if traversal.src != "_" {
                     bound_vars.insert(traversal.src.clone());
@@ -359,6 +369,11 @@ fn lower_clauses(
                     min_hops: traversal.min_hops,
                     max_hops: traversal.max_hops,
                     dst_filters: introduced_filters,
+                    edge_binding: traversal
+                        .edge_binding
+                        .as_deref()
+                        .filter(|binding| *binding != "_")
+                        .map(str::to_string),
                 });
                 if traversal.dst != "_" {
                     bound_vars.insert(traversal.dst.clone());

--- a/crates/omnigraph-compiler/src/ir/mod.rs
+++ b/crates/omnigraph-compiler/src/ir/mod.rs
@@ -74,6 +74,11 @@ pub enum IROp {
         /// Expand so the executor can apply them during hydration (Lance
         /// SQL pushdown) rather than as a separate post-expand pass.
         dst_filters: Vec<IRFilter>,
+        /// Variable bound to the matched edge row (`$p $w:knows $f`), if any.
+        /// Changes the op's contract: one output row per matching edge ROW
+        /// (not per distinct endpoint pair), edge property columns carried
+        /// under this prefix. Always single-hop (typecheck T23).
+        edge_binding: Option<String>,
     },
     Filter(IRFilter),
     AntiJoin {

--- a/crates/omnigraph-compiler/src/query/ast.rs
+++ b/crates/omnigraph-compiler/src/query/ast.rs
@@ -63,6 +63,9 @@ pub struct Traversal {
     /// `$a <edge> $b` — match the edge in either direction (set semantics;
     /// same-endpoint-type edges only, enforced at typecheck).
     pub undirected: bool,
+    /// Optional name for the matched edge row (`$p $w:knows $f`), making the
+    /// edge's own properties addressable as `$w.<prop>`.
+    pub edge_binding: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/omnigraph-compiler/src/query/parser.rs
+++ b/crates/omnigraph-compiler/src/query/parser.rs
@@ -427,7 +427,16 @@ fn parse_traversal(pair: pest::iterators::Pair<Rule>) -> Result<Traversal> {
     let mut inner = pair.into_inner();
     let src_var = inner.next().unwrap().as_str();
     let src = src_var.strip_prefix('$').unwrap_or(src_var).to_string();
-    let edge_pair = inner.next().unwrap();
+    let mut next = inner.next().unwrap();
+    let edge_binding = if let Rule::edge_binding = next.as_rule() {
+        let var = next.into_inner().next().unwrap().as_str();
+        let binding = var.strip_prefix('$').unwrap_or(var).to_string();
+        next = inner.next().unwrap();
+        Some(binding)
+    } else {
+        None
+    };
+    let edge_pair = next;
     let (edge_name, undirected) = match edge_pair.as_rule() {
         // `<edge>` — the inner edge_ident carries the name.
         Rule::undirected_edge => (
@@ -461,6 +470,7 @@ fn parse_traversal(pair: pest::iterators::Pair<Rule>) -> Result<Traversal> {
         min_hops,
         max_hops,
         undirected,
+        edge_binding,
     })
 }
 

--- a/crates/omnigraph-compiler/src/query/parser_tests.rs
+++ b/crates/omnigraph-compiler/src/query/parser_tests.rs
@@ -971,3 +971,46 @@ return { $p.name
     let err = parse_query_diagnostic(input).unwrap_err();
     assert!(err.span.is_some());
 }
+
+#[test]
+fn test_parse_traversal_edge_binding() {
+    // `$p $w:knows $f` — the optional edge binding names the matched edge row
+    // so its properties become addressable (`$w.since`).
+    let input = r#"
+query rated_friends($name: String) {
+match {
+    $p: Person { name: $name }
+    $p $w:knows $f
+    $p $x:<knows> $g
+    $p knows $h
+}
+return { $f.name }
+}
+"#;
+    let qf = parse_query(input).unwrap();
+    let q = &qf.queries[0];
+    assert_eq!(q.match_clause.len(), 4);
+    match &q.match_clause[1] {
+        Clause::Traversal(t) => {
+            assert_eq!(t.src, "p");
+            assert_eq!(t.edge_name, "knows");
+            assert_eq!(t.dst, "f");
+            assert!(!t.undirected);
+            assert_eq!(t.edge_binding.as_deref(), Some("w"));
+        }
+        c => panic!("expected Traversal, got {c:?}"),
+    }
+    match &q.match_clause[2] {
+        Clause::Traversal(t) => {
+            assert!(t.undirected, "binding composes with undirected form");
+            assert_eq!(t.edge_binding.as_deref(), Some("x"));
+        }
+        c => panic!("expected Traversal, got {c:?}"),
+    }
+    match &q.match_clause[3] {
+        Clause::Traversal(t) => {
+            assert_eq!(t.edge_binding, None, "binding stays optional");
+        }
+        c => panic!("expected Traversal, got {c:?}"),
+    }
+}

--- a/crates/omnigraph-compiler/src/query/query.pest
+++ b/crates/omnigraph-compiler/src/query/query.pest
@@ -54,7 +54,11 @@ match_value = { literal | variable | now_call }
 
 // Traversal: $p knows $f (directional) or $p <knows> $f (undirected —
 // matches the edge in either direction; same-endpoint-type edges only).
-traversal = { variable ~ (undirected_edge | edge_ident) ~ traversal_bounds? ~ variable }
+// An optional edge binding names the matched edge row: $p $w:knows $f.
+// A node binding also starts `variable ~ ":"`; the case of the next token
+// (lowercase edge_ident vs uppercase type_name) keeps the choice unambiguous.
+traversal = { variable ~ edge_binding? ~ (undirected_edge | edge_ident) ~ traversal_bounds? ~ variable }
+edge_binding = { variable ~ ":" }
 undirected_edge = { "<" ~ edge_ident ~ ">" }
 traversal_bounds = { "{" ~ integer ~ "," ~ integer? ~ "}" }
 

--- a/crates/omnigraph-compiler/src/query/typecheck.rs
+++ b/crates/omnigraph-compiler/src/query/typecheck.rs
@@ -1035,6 +1035,12 @@ fn resolve_expr_type(
                                 bv.type_name
                             ))
                         })?;
+                    if edge_type.blob_properties.contains(property) {
+                        return Err(CompilerError::Type(format!(
+                            "T23: blob edge property `${}.{}` is not projectable; the bound edge scan excludes blob columns",
+                            variable, property
+                        )));
+                    }
                     edge_type.properties.get(property).ok_or_else(|| {
                         CompilerError::Type(format!(
                             "T6: edge `{}` has no property `{}`",

--- a/crates/omnigraph-compiler/src/query/typecheck.rs
+++ b/crates/omnigraph-compiler/src/query/typecheck.rs
@@ -657,14 +657,22 @@ fn typecheck_binding(
         }
     }
 
-    // Don't overwrite if already bound to same type (re-binding same var is OK)
-    if let Some(existing) = ctx.bindings.get(&binding.variable)
-        && existing.type_name != binding.type_name
-    {
-        return Err(CompilerError::Type(format!(
-            "variable `${}` already bound to type `{}`, cannot rebind to `{}`",
-            binding.variable, existing.type_name, binding.type_name
-        )));
+    // Don't overwrite if already bound to the same node type (re-binding the
+    // same node var is OK). Node and edge namespaces are independent, so a
+    // matching type name does not make a cross-kind rebind valid.
+    if let Some(existing) = ctx.bindings.get(&binding.variable) {
+        if matches!(existing.kind, BindingKind::Edge) {
+            return Err(CompilerError::Type(format!(
+                "T23: variable `${}` is bound to edge type `{}` and cannot be rebound as node type `{}`",
+                binding.variable, existing.type_name, binding.type_name
+            )));
+        }
+        if existing.type_name != binding.type_name {
+            return Err(CompilerError::Type(format!(
+                "variable `${}` already bound to type `{}`, cannot rebind to `{}`",
+                binding.variable, existing.type_name, binding.type_name
+            )));
+        }
     }
 
     ctx.bindings.insert(
@@ -797,6 +805,11 @@ fn typecheck_traversal(
         )));
     }
     if let Some(binding) = &edge_binding {
+        if binding == &traversal.src || binding == &traversal.dst {
+            return Err(CompilerError::Type(format!(
+                "T23: edge binding `${binding}` cannot reuse a traversal endpoint name; edge bindings and node endpoints need distinct names"
+            )));
+        }
         if ctx.bindings.contains_key(binding) {
             return Err(CompilerError::Type(format!(
                 "T23: variable `${}` is already bound; an edge binding needs a fresh name",
@@ -820,6 +833,7 @@ fn typecheck_traversal(
     let mut direction;
 
     if let Some(src_bv) = src_bound {
+        require_node_traversal_endpoint(&traversal.src, src_bv)?;
         // T5: src type must match one endpoint of the edge
         if src_bv.type_name == edge.from_type {
             direction = Direction::Out;
@@ -836,6 +850,7 @@ fn typecheck_traversal(
             )));
         }
     } else if let Some(dst_bv) = dst_bound {
+        require_node_traversal_endpoint(&traversal.dst, dst_bv)?;
         // dst is bound, infer direction from it
         if dst_bv.type_name == edge.to_type {
             direction = Direction::Out;
@@ -875,6 +890,15 @@ fn typecheck_traversal(
     Ok(())
 }
 
+fn require_node_traversal_endpoint(var: &str, binding: &BoundVariable) -> Result<()> {
+    if matches!(binding.kind, BindingKind::Edge) {
+        return Err(CompilerError::Type(format!(
+            "T23: edge binding `${var}` cannot be used as a traversal endpoint; traversal endpoints must be node bindings"
+        )));
+    }
+    Ok(())
+}
+
 fn bind_traversal_endpoint(
     ctx: &mut TypeContext,
     var: &str,
@@ -885,6 +909,7 @@ fn bind_traversal_endpoint(
         return Ok(()); // anonymous variable
     }
     if let Some(existing) = ctx.bindings.get(var) {
+        require_node_traversal_endpoint(var, existing)?;
         if existing.type_name != expected_type {
             return Err(CompilerError::Type(format!(
                 "T5: variable `${}` has type `{}` but edge `{}` expects `{}`",

--- a/crates/omnigraph-compiler/src/query/typecheck.rs
+++ b/crates/omnigraph-compiler/src/query/typecheck.rs
@@ -37,6 +37,9 @@ pub struct ResolvedTraversal {
     pub direction: Direction,
     pub min_hops: u32,
     pub max_hops: Option<u32>,
+    /// Variable bound to the matched edge row (`$p $w:knows $f`), if any;
+    /// lowering uses it to carry edge property columns through the expand.
+    pub edge_binding: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -778,6 +781,38 @@ fn typecheck_traversal(
         )));
     }
 
+    // T23: a {min,max} traversal matches a path of edges; there is no single
+    // row for a binding to name.
+    let edge_binding = traversal
+        .edge_binding
+        .as_deref()
+        .filter(|binding| *binding != "_")
+        .map(str::to_string);
+    if traversal.edge_binding.is_some()
+        && (traversal.min_hops != 1 || traversal.max_hops != Some(1))
+    {
+        return Err(CompilerError::Type(format!(
+            "T23: edge binding `${}` cannot be combined with traversal bounds; a multi-hop traversal matches a path of edges, not one edge row",
+            traversal.edge_binding.as_deref().unwrap_or("_")
+        )));
+    }
+    if let Some(binding) = &edge_binding {
+        if ctx.bindings.contains_key(binding) {
+            return Err(CompilerError::Type(format!(
+                "T23: variable `${}` is already bound; an edge binding needs a fresh name",
+                binding
+            )));
+        }
+        ctx.bindings.insert(
+            binding.clone(),
+            BoundVariable {
+                var_name: binding.clone(),
+                type_name: edge.name.clone(),
+                kind: BindingKind::Edge,
+            },
+        );
+    }
+
     // Determine direction based on bound variables and edge endpoints
     let src_bound = ctx.bindings.get(&traversal.src);
     let dst_bound = ctx.bindings.get(&traversal.dst);
@@ -834,6 +869,7 @@ fn typecheck_traversal(
         direction,
         min_hops: traversal.min_hops,
         max_hops: traversal.max_hops,
+        edge_binding,
     });
 
     Ok(())
@@ -943,6 +979,22 @@ fn typecheck_filter(
     Ok(())
 }
 
+/// Search/rank filters are hoisted onto the field variable's NodeScan; an
+/// edge binding has none, so accepting one here would silently drop the
+/// filter. Reject at typecheck instead.
+fn reject_edge_binding_search_field(ctx: &TypeContext, field: &Expr, func: &str) -> Result<()> {
+    if let Expr::PropAccess { variable, property } = field
+        && let Some(bv) = ctx.bindings.get(variable)
+        && matches!(bv.kind, BindingKind::Edge)
+    {
+        return Err(CompilerError::Type(format!(
+            "T23: {} cannot target edge property `${}.{}`; text/rank search runs on node columns — edge properties support comparison filters and projection",
+            func, variable, property
+        )));
+    }
+    Ok(())
+}
+
 fn resolve_expr_type(
     catalog: &Catalog,
     expr: &Expr,
@@ -960,16 +1012,37 @@ fn resolve_expr_type(
                 CompilerError::Type(format!("T6: variable `${}` is not bound", variable))
             })?;
 
-            let node_type = catalog.node_types.get(&bv.type_name).ok_or_else(|| {
-                CompilerError::Type(format!("T6: type `{}` not found in catalog", bv.type_name))
-            })?;
-
-            let prop = node_type.properties.get(property).ok_or_else(|| {
-                CompilerError::Type(format!(
-                    "T6: type `{}` has no property `{}`",
-                    bv.type_name, property
-                ))
-            })?;
+            let prop = match bv.kind {
+                BindingKind::Node => {
+                    let node_type = catalog.node_types.get(&bv.type_name).ok_or_else(|| {
+                        CompilerError::Type(format!(
+                            "T6: type `{}` not found in catalog",
+                            bv.type_name
+                        ))
+                    })?;
+                    node_type.properties.get(property).ok_or_else(|| {
+                        CompilerError::Type(format!(
+                            "T6: type `{}` has no property `{}`",
+                            bv.type_name, property
+                        ))
+                    })?
+                }
+                BindingKind::Edge => {
+                    let edge_type =
+                        catalog.lookup_edge_by_name(&bv.type_name).ok_or_else(|| {
+                            CompilerError::Type(format!(
+                                "T6: edge type `{}` not found in catalog",
+                                bv.type_name
+                            ))
+                        })?;
+                    edge_type.properties.get(property).ok_or_else(|| {
+                        CompilerError::Type(format!(
+                            "T6: edge `{}` has no property `{}`",
+                            bv.type_name, property
+                        ))
+                    })?
+                }
+            };
 
             Ok(ResolvedType::Scalar(prop.clone()))
         }
@@ -981,6 +1054,12 @@ fn resolve_expr_type(
             let node_binding = ctx.bindings.get(variable).ok_or_else(|| {
                 CompilerError::Type(format!("T15: variable `${}` is not bound", variable))
             })?;
+            if matches!(node_binding.kind, BindingKind::Edge) {
+                return Err(CompilerError::Type(format!(
+                    "T23: nearest cannot target edge binding `${}`; vector search runs on node columns",
+                    variable
+                )));
+            }
             let node_type = catalog
                 .node_types
                 .get(&node_binding.type_name)
@@ -1065,6 +1144,7 @@ fn resolve_expr_type(
             )))
         }
         Expr::Search { field, query } => {
+            reject_edge_binding_search_field(ctx, field, "search")?;
             let field_type = resolve_expr_type(catalog, field, ctx, params)?;
             match field_type {
                 ResolvedType::Scalar(s) if s.scalar == ScalarType::String && !s.list => {}
@@ -1107,6 +1187,7 @@ fn resolve_expr_type(
             query,
             max_edits,
         } => {
+            reject_edge_binding_search_field(ctx, field, "fuzzy")?;
             let field_type = resolve_expr_type(catalog, field, ctx, params)?;
             match field_type {
                 ResolvedType::Scalar(s) if s.scalar == ScalarType::String && !s.list => {}
@@ -1171,6 +1252,7 @@ fn resolve_expr_type(
             )))
         }
         Expr::MatchText { field, query } => {
+            reject_edge_binding_search_field(ctx, field, "match_text")?;
             let field_type = resolve_expr_type(catalog, field, ctx, params)?;
             match field_type {
                 ResolvedType::Scalar(s) if s.scalar == ScalarType::String && !s.list => {}
@@ -1209,6 +1291,7 @@ fn resolve_expr_type(
             )))
         }
         Expr::Bm25 { field, query } => {
+            reject_edge_binding_search_field(ctx, field, "bm25")?;
             let field_type = resolve_expr_type(catalog, field, ctx, params)?;
             match field_type {
                 ResolvedType::Scalar(s) if s.scalar == ScalarType::String && !s.list => {}
@@ -1326,7 +1409,13 @@ fn resolve_expr_type(
             if let Some(prop_type) = params.get(name) {
                 Ok(ResolvedType::Scalar(prop_type.clone()))
             } else if let Some(bv) = ctx.bindings.get(name) {
-                Ok(ResolvedType::Node(bv.type_name.clone()))
+                match bv.kind {
+                    BindingKind::Node => Ok(ResolvedType::Node(bv.type_name.clone())),
+                    BindingKind::Edge => Err(CompilerError::Type(format!(
+                        "T23: edge binding `${}` cannot be used bare; access one of its properties (`${}.{{prop}}`)",
+                        name, name
+                    ))),
+                }
             } else {
                 Err(CompilerError::Type(format!(
                     "variable `${}` is not bound",

--- a/crates/omnigraph-compiler/src/query/typecheck_tests.rs
+++ b/crates/omnigraph-compiler/src/query/typecheck_tests.rs
@@ -1195,3 +1195,186 @@ update Event set { on: now() } where slug = "launch"
     assert!(err.to_string().contains("DateTime"));
     assert!(err.to_string().contains("property `on`"));
 }
+
+#[test]
+fn test_edge_binding_prop_access_in_filter_and_return() {
+    let catalog = setup();
+    let qf = parse_query(
+        r#"
+query q() {
+match {
+    $p: Person
+    $p $w:knows $f
+    $w.since >= date("2026-01-01")
+}
+return { $f.name, $w.since }
+}
+"#,
+    )
+    .unwrap();
+    let ctx = typecheck_query(&catalog, &qf.queries[0]).unwrap();
+    let w = &ctx.bindings["w"];
+    assert!(matches!(w.kind, BindingKind::Edge));
+    assert_eq!(w.type_name, "Knows");
+    assert_eq!(
+        ctx.traversals[0].edge_binding.as_deref(),
+        Some("w"),
+        "resolved traversal carries the binding for lowering"
+    );
+}
+
+#[test]
+fn test_edge_binding_unknown_property_rejected() {
+    let catalog = setup();
+    let qf = parse_query(
+        r#"
+query q() {
+match {
+    $p: Person
+    $p $w:knows $f
+}
+return { $w.nonsense }
+}
+"#,
+    )
+    .unwrap();
+    let err = typecheck_query(&catalog, &qf.queries[0]).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("Knows"), "names the edge type: {msg}");
+    assert!(
+        msg.contains("nonsense"),
+        "names the missing property: {msg}"
+    );
+}
+
+#[test]
+fn test_edge_binding_rejected_on_bounded_traversal() {
+    let catalog = setup();
+    let qf = parse_query(
+        r#"
+query q() {
+match {
+    $p: Person
+    $p $w:knows{1,3} $f
+}
+return { $f.name }
+}
+"#,
+    )
+    .unwrap();
+    let err = typecheck_query(&catalog, &qf.queries[0]).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("T23"), "dedicated code: {msg}");
+    assert!(msg.contains("multi-hop"), "explains the restriction: {msg}");
+}
+
+#[test]
+fn test_edge_binding_name_collision_rejected() {
+    let catalog = setup();
+    let qf = parse_query(
+        r#"
+query q() {
+match {
+    $p: Person
+    $p $p:knows $f
+}
+return { $f.name }
+}
+"#,
+    )
+    .unwrap();
+    let err = typecheck_query(&catalog, &qf.queries[0]).unwrap_err();
+    assert!(err.to_string().contains("T23"), "{err}");
+}
+
+#[test]
+fn test_edge_binding_aggregate_typechecks() {
+    // The uniformity promise ("works wherever a node field does") includes
+    // aggregates: count over an edge property, grouped by a node field.
+    let catalog = setup();
+    let qf = parse_query(
+        r#"
+query knows_counts() {
+match {
+    $p: Person
+    $p $w:knows $f
+}
+return { $f.name, count($w.since) }
+}
+"#,
+    )
+    .unwrap();
+    let ctx = typecheck_query(&catalog, &qf.queries[0]).unwrap();
+    assert!(matches!(ctx.bindings["w"].kind, BindingKind::Edge));
+}
+
+#[test]
+fn test_edge_binding_rejected_in_search_field() {
+    // Would otherwise typecheck (title is a String edge prop) and then be
+    // SILENTLY DROPPED by the engine's search-filter hoist, which targets a
+    // NodeScan the edge binding does not have.
+    let catalog = setup();
+    let qf = parse_query(
+        r#"
+query q() {
+match {
+    $p: Person
+    $p $w:worksAt $c
+    search($w.title, "engineer")
+}
+return { $c.name }
+}
+"#,
+    )
+    .unwrap();
+    let err = typecheck_query(&catalog, &qf.queries[0]).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("T23"), "{msg}");
+    assert!(msg.contains("search"), "{msg}");
+}
+
+#[test]
+fn test_edge_binding_rejected_in_nearest() {
+    let catalog = setup();
+    let qf = parse_query(
+        r#"
+query q() {
+match {
+    $p: Person
+    $p $w:worksAt $c
+}
+return { $c.name }
+order { nearest($w.title, "x") }
+limit 5
+}
+"#,
+    )
+    .unwrap();
+    let err = typecheck_query(&catalog, &qf.queries[0]).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("T23"),
+        "clear edge-binding error, not a confusing catalog miss: {msg}"
+    );
+}
+
+#[test]
+fn test_edge_binding_bare_use_rejected() {
+    let catalog = setup();
+    let qf = parse_query(
+        r#"
+query q() {
+match {
+    $p: Person
+    $p $w:knows $f
+}
+return { $w }
+}
+"#,
+    )
+    .unwrap();
+    let err = typecheck_query(&catalog, &qf.queries[0]).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("T23"), "{msg}");
+    assert!(msg.contains("propert"), "points at property access: {msg}");
+}

--- a/crates/omnigraph-compiler/src/query/typecheck_tests.rs
+++ b/crates/omnigraph-compiler/src/query/typecheck_tests.rs
@@ -1288,6 +1288,54 @@ return { $f.name }
 }
 
 #[test]
+fn test_edge_binding_blob_property_rejected() {
+    // The bound scan excludes blob columns (Lance limit); access must fail
+    // loudly, not vanish downstream.
+    let schema = parse_schema(
+        r#"
+node Person {
+name: String
+}
+edge Sent: Person -> Person {
+note: String?
+attachment: Blob?
+}
+"#,
+    )
+    .unwrap();
+    let catalog = build_catalog(&schema).unwrap();
+    let qf = parse_query(
+        r#"
+query q() {
+match {
+    $a: Person
+    $a $w:sent $b
+}
+return { $w.attachment }
+}
+"#,
+    )
+    .unwrap();
+    let err = typecheck_query(&catalog, &qf.queries[0]).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("T23") && msg.contains("blob"), "{msg}");
+
+    let qf_ok = parse_query(
+        r#"
+query q() {
+match {
+    $a: Person
+    $a $w:sent $b
+}
+return { $w.note }
+}
+"#,
+    )
+    .unwrap();
+    assert!(typecheck_query(&catalog, &qf_ok.queries[0]).is_ok());
+}
+
+#[test]
 fn test_edge_binding_aggregate_typechecks() {
     // The uniformity promise ("works wherever a node field does") includes
     // aggregates: count over an edge property, grouped by a node field.

--- a/crates/omnigraph-compiler/src/query/typecheck_tests.rs
+++ b/crates/omnigraph-compiler/src/query/typecheck_tests.rs
@@ -25,6 +25,24 @@ title: String?
     build_catalog(&schema).unwrap()
 }
 
+fn setup_same_named_node_and_edge() -> Catalog {
+    // Node and edge namespaces are independent. These deliberately share a
+    // name so the typechecker cannot use `type_name` as a proxy for binding
+    // kind when it validates rebinding and traversal endpoints.
+    let schema = parse_schema(
+        r#"
+node Shared {
+label: String
+}
+edge Shared: Shared -> Shared {
+label: String?
+}
+"#,
+    )
+    .unwrap();
+    build_catalog(&schema).unwrap()
+}
+
 fn setup_vector() -> Catalog {
     let schema = parse_schema(
         r#"
@@ -1285,6 +1303,84 @@ return { $f.name }
     .unwrap();
     let err = typecheck_query(&catalog, &qf.queries[0]).unwrap_err();
     assert!(err.to_string().contains("T23"), "{err}");
+}
+
+#[test]
+fn test_edge_binding_cannot_reuse_a_fresh_traversal_endpoint() {
+    let catalog = setup_same_named_node_and_edge();
+
+    for pattern in ["$w $w:shared $b", "$a $w:shared $w"] {
+        let source = format!(
+            r#"
+query q() {{
+match {{ {pattern} }}
+return {{ $w.label }}
+}}
+"#
+        );
+        let qf = parse_query(&source).unwrap();
+        let err = typecheck_query(&catalog, &qf.queries[0]).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("T23"), "dedicated edge-binding error: {msg}");
+        assert!(
+            msg.contains("endpoint") && msg.contains("distinct"),
+            "explains the namespace collision: {msg}"
+        );
+    }
+}
+
+#[test]
+fn test_edge_binding_cannot_be_rebound_as_same_named_node_type() {
+    let catalog = setup_same_named_node_and_edge();
+    let qf = parse_query(
+        r#"
+query q() {
+match {
+    $a: Shared
+    $a $w:shared $b
+    $w: Shared
+}
+return { $w.label }
+}
+"#,
+    )
+    .unwrap();
+
+    let err = typecheck_query(&catalog, &qf.queries[0]).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("T23"), "dedicated edge-binding error: {msg}");
+    assert!(
+        msg.contains("edge") && msg.contains("node"),
+        "reports the cross-kind rebind: {msg}"
+    );
+}
+
+#[test]
+fn test_edge_binding_cannot_be_a_same_named_traversal_endpoint() {
+    let catalog = setup_same_named_node_and_edge();
+
+    for second_traversal in ["$w $x:shared $c", "$c $x:shared $w"] {
+        let source = format!(
+            r#"
+query q() {{
+match {{
+    $a: Shared
+    $a $w:shared $b
+    {second_traversal}
+}}
+return {{ $c.label }}
+}}
+"#
+        );
+        let qf = parse_query(&source).unwrap();
+        let err = typecheck_query(&catalog, &qf.queries[0]).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("T23"), "dedicated edge-binding error: {msg}");
+        assert!(
+            msg.contains("edge") && msg.contains("endpoint"),
+            "reports the cross-kind endpoint use: {msg}"
+        );
+    }
 }
 
 #[test]

--- a/crates/omnigraph/src/exec/query.rs
+++ b/crates/omnigraph/src/exec/query.rs
@@ -532,23 +532,33 @@ async fn execute_rrf_query(
         ))
     })?;
 
-    // Build ID → rank maps
+    // Build entity-ID → rank maps. A downstream traversal may fan one
+    // ranked entity out to several result rows; those rows all have the same
+    // search rank and must not consume additional rank ordinals.
     let id_col_name = format!("{}.id", primary_var);
     let primary_ids = extract_id_column_by_name(primary_batch, &id_col_name)?;
     let secondary_ids = extract_id_column_by_name(secondary_batch, &id_col_name)?;
 
     let mut primary_rank: HashMap<String, usize> = HashMap::new();
-    for (i, id) in primary_ids.iter().enumerate() {
-        primary_rank.entry(id.clone()).or_insert(i);
+    let mut primary_unique: Vec<String> = Vec::new();
+    for id in &primary_ids {
+        if !primary_rank.contains_key(id) {
+            primary_rank.insert(id.clone(), primary_unique.len());
+            primary_unique.push(id.clone());
+        }
     }
     let mut secondary_rank: HashMap<String, usize> = HashMap::new();
-    for (i, id) in secondary_ids.iter().enumerate() {
-        secondary_rank.entry(id.clone()).or_insert(i);
+    let mut secondary_unique: Vec<String> = Vec::new();
+    for id in &secondary_ids {
+        if !secondary_rank.contains_key(id) {
+            secondary_rank.insert(id.clone(), secondary_unique.len());
+            secondary_unique.push(id.clone());
+        }
     }
 
     // Collect all unique IDs
-    let mut all_ids: Vec<String> = primary_ids.clone();
-    for id in &secondary_ids {
+    let mut all_ids: Vec<String> = primary_unique;
+    for id in &secondary_unique {
         if !primary_rank.contains_key(id) {
             all_ids.push(id.clone());
         }
@@ -573,27 +583,38 @@ async fn execute_rrf_query(
     scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
     scored.truncate(rrf.limit);
 
-    // Collect winning IDs in order — look up rows from primary or secondary batch
+    // Collect winning entity IDs in order. Every downstream row belonging to
+    // a winner survives; fusion ranks entities, not arbitrary fanout rows.
     let winning_ids: Vec<String> = scored.iter().map(|(id, _)| id.clone()).collect();
 
-    // Build a combined row source: merge primary and secondary by id
-    let mut id_to_batch_row: HashMap<String, (&RecordBatch, usize)> = HashMap::new();
+    // Build a combined row source: prefer the primary arm for an entity it
+    // contains, otherwise use the secondary arm. The downstream pipeline is
+    // identical in both arms, so either contains the same fanout rows.
+    let mut primary_rows: HashMap<String, Vec<u32>> = HashMap::new();
     for (i, id) in primary_ids.iter().enumerate() {
-        id_to_batch_row
-            .entry(id.clone())
-            .or_insert((primary_batch, i));
+        primary_rows.entry(id.clone()).or_default().push(i as u32);
     }
+    let mut secondary_rows: HashMap<String, Vec<u32>> = HashMap::new();
     for (i, id) in secondary_ids.iter().enumerate() {
-        id_to_batch_row
-            .entry(id.clone())
-            .or_insert((secondary_batch, i));
+        secondary_rows.entry(id.clone()).or_default().push(i as u32);
     }
 
-    // Reconstruct a combined batch for the binding in winning order
-    let fused_batch = build_fused_batch(&winning_ids, &id_to_batch_row, primary_batch.schema())?;
+    // Reconstruct a combined batch in fused entity order, retaining each
+    // entity's rows in their pipeline order.
+    let fused_batch = build_fused_batch(
+        &winning_ids,
+        primary_batch,
+        &primary_rows,
+        secondary_batch,
+        &secondary_rows,
+    )?;
 
     // Project directly from fused batch
-    let result_batch = project_return(&fused_batch, &ir.return_exprs, params)?;
+    let mut result_batch = project_return(&fused_batch, &ir.return_exprs, params)?;
+    // `rrf.limit` is the query's row limit. A winning entity can now own more
+    // than one row after traversal, so enforce the limit after reconstruction.
+    let len = result_batch.num_rows().min(rrf.limit);
+    result_batch = result_batch.slice(0, len);
 
     // Already ordered by RRF score + already limited
     Ok(QueryResult::new(result_batch.schema(), vec![result_batch]))
@@ -612,23 +633,31 @@ fn extract_id_column_by_name(batch: &RecordBatch, col_name: &str) -> Result<Vec<
 
 fn build_fused_batch(
     ordered_ids: &[String],
-    id_to_batch_row: &HashMap<String, (&RecordBatch, usize)>,
-    schema: SchemaRef,
+    primary_batch: &RecordBatch,
+    primary_rows: &HashMap<String, Vec<u32>>,
+    secondary_batch: &RecordBatch,
+    secondary_rows: &HashMap<String, Vec<u32>>,
 ) -> Result<RecordBatch> {
     if ordered_ids.is_empty() {
-        return Ok(RecordBatch::new_empty(schema));
+        return Ok(RecordBatch::new_empty(primary_batch.schema()));
     }
 
-    // Gather indices from source batches, collecting rows in the right order
+    // Gather every row for each winning entity, preserving both fused entity
+    // order and the downstream row order within that entity.
     let mut row_slices: Vec<RecordBatch> = Vec::with_capacity(ordered_ids.len());
     for id in ordered_ids {
-        if let Some(&(batch, row_idx)) = id_to_batch_row.get(id) {
-            row_slices.push(batch.slice(row_idx, 1));
+        if let Some(rows) = primary_rows.get(id) {
+            row_slices.push(take_batch(primary_batch, &UInt32Array::from(rows.clone()))?);
+        } else if let Some(rows) = secondary_rows.get(id) {
+            row_slices.push(take_batch(
+                secondary_batch,
+                &UInt32Array::from(rows.clone()),
+            )?);
         }
     }
 
     if row_slices.is_empty() {
-        return Ok(RecordBatch::new_empty(schema));
+        return Ok(RecordBatch::new_empty(primary_batch.schema()));
     }
 
     let schema = row_slices[0].schema();
@@ -1417,6 +1446,8 @@ async fn execute_expand(
 /// distinct, because each carries its own properties), and the edge's declared
 /// property columns ride into the wide batch under the binding's prefix
 /// (`w.since`), where the ordinary filter/projection machinery consumes them.
+/// The physical edge `id` rides along as a hidden `w.id` column so ordering can
+/// totally order parallel edge rows; typecheck keeps it out of user expressions.
 /// Typecheck (T23) guarantees single-hop.
 #[allow(clippy::too_many_arguments)]
 async fn execute_expand_bound(
@@ -1449,8 +1480,9 @@ async fn execute_expand_bound(
         .get(edge_type)
         .ok_or_else(|| OmniError::manifest(format!("unknown edge type '{}'", edge_type)))?;
     // Sorted for determinism. Blobs excluded: Lance rejects blob projection
-    // in a filtered scan (node scans carry the same guard); typecheck
-    // rejects the access.
+    // in a filtered scan (node scans carry the same guard); typecheck rejects
+    // the access. Physical `id` is always projected as hidden row identity,
+    // including for property-less edges.
     let mut prop_cols: Vec<&str> = edge_def
         .properties
         .keys()
@@ -1458,6 +1490,20 @@ async fn execute_expand_bound(
         .filter(|c| !edge_def.blob_properties.contains(*c))
         .collect();
     prop_cols.sort_unstable();
+    let mut attach_cols: Vec<&str> = Vec::with_capacity(1 + prop_cols.len());
+    attach_cols.push("id");
+    attach_cols.extend(prop_cols.iter().copied());
+    let attach_fields: Vec<Field> = attach_cols
+        .iter()
+        .map(|name| {
+            edge_def
+                .arrow_schema
+                .field_with_name(name)
+                .map(Clone::clone)
+                .map_err(|e| OmniError::manifest(e.to_string()))
+        })
+        .collect::<Result<_>>()?;
+    let attach_schema = Arc::new(Schema::new(attach_fields));
 
     // Wide rows grouped by src id: several wide rows may share one source node.
     let mut rows_by_src: HashMap<&str, Vec<u32>> = HashMap::new();
@@ -1466,16 +1512,19 @@ async fn execute_expand_bound(
     }
     let union_keys: Vec<String> = rows_by_src.keys().map(|k| k.to_string()).collect();
 
-    let mut src_indices: Vec<u32> = Vec::new();
-    let mut dst_ids: Vec<String> = Vec::new();
-    // Edge row of each emitted pair, as (scanned batch, row); flattened after
-    // the scan into one pair-parallel batch.
-    let mut edge_rows: Vec<(usize, usize)> = Vec::new();
+    // Each match carries the incoming wide-row ordinal plus physical edge id.
+    // Sorting by those keys preserves an upstream ANN/BM25 rank while giving
+    // parallel edges a deterministic order independent of Lance scan layout.
+    let mut matches: Vec<(u32, String, usize, usize, String)> = Vec::new();
     let mut scanned: Vec<RecordBatch> = Vec::new();
 
     for (probe_idx, &(key_col, opp_col)) in endpoint_probes(direction).iter().enumerate() {
         let batches = crate::table_store::TableStore::scan_edges_by_endpoint_projected(
-            &edge_ds, key_col, opp_col, &prop_cols, &union_keys,
+            &edge_ds,
+            key_col,
+            opp_col,
+            &attach_cols,
+            &union_keys,
         )
         .await?;
         for batch in batches {
@@ -1494,6 +1543,13 @@ async fn execute_expand_bound(
                 .downcast_ref::<StringArray>()
                 .ok_or_else(|| OmniError::manifest(format!("edge '{}' is not Utf8", opp_col)))?
                 .clone();
+            let edge_ids = batch
+                .column_by_name("id")
+                .ok_or_else(|| OmniError::manifest("edge batch missing 'id'".to_string()))?
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .ok_or_else(|| OmniError::manifest("edge 'id' is not Utf8".to_string()))?
+                .clone();
             for r in 0..batch.num_rows() {
                 // Undirected probes both orientations; a self-loop row would
                 // match the same wide row through both, so emit it only once.
@@ -1504,25 +1560,47 @@ async fn execute_expand_bound(
                     continue;
                 };
                 for &wide_row in wide_rows {
-                    src_indices.push(wide_row);
-                    dst_ids.push(opps.value(r).to_string());
-                    edge_rows.push((batch_idx, r));
+                    matches.push((
+                        wide_row,
+                        opps.value(r).to_string(),
+                        batch_idx,
+                        r,
+                        edge_ids.value(r).to_string(),
+                    ));
                 }
             }
             scanned.push(batch);
         }
     }
 
-    // Pair-parallel batch of the edge's property columns (empty for a
-    // property-less edge; the binding is then legal but vacuous, since
-    // typecheck already rejected every `$w.prop` access).
-    let edge_attach: Option<RecordBatch> = if prop_cols.is_empty() || scanned.is_empty() {
-        None
+    matches.sort_by(|a, b| {
+        a.0.cmp(&b.0)
+            .then_with(|| a.4.cmp(&b.4))
+            .then_with(|| a.1.cmp(&b.1))
+            .then_with(|| a.2.cmp(&b.2))
+            .then_with(|| a.3.cmp(&b.3))
+    });
+    let mut src_indices: Vec<u32> = Vec::with_capacity(matches.len());
+    let mut dst_ids: Vec<String> = Vec::with_capacity(matches.len());
+    // Edge row of each emitted pair, as (scanned batch, row); flattened after
+    // the scan into one pair-parallel batch.
+    let mut edge_rows: Vec<(usize, usize)> = Vec::with_capacity(matches.len());
+    for (src_row, dst_id, batch_idx, edge_row, _) in matches {
+        src_indices.push(src_row);
+        dst_ids.push(dst_id);
+        edge_rows.push((batch_idx, edge_row));
+    }
+
+    // Pair-parallel batch of physical id + declared non-blob properties. Even
+    // when there are zero matches, attach a typed zero-row batch: later filter,
+    // projection, and ordering must still see the bound edge's schema.
+    let edge_attach = if scanned.is_empty() {
+        RecordBatch::new_empty(attach_schema)
     } else {
-        let prop_only: Vec<RecordBatch> = scanned
+        let attach_only: Vec<RecordBatch> = scanned
             .iter()
             .map(|b| {
-                let indices: Vec<usize> = prop_cols
+                let indices: Vec<usize> = attach_cols
                     .iter()
                     .map(|c| b.schema().index_of(c))
                     .collect::<std::result::Result<_, _>>()
@@ -1531,8 +1609,8 @@ async fn execute_expand_bound(
                     .map_err(|e| OmniError::manifest(e.to_string()))
             })
             .collect::<Result<_>>()?;
-        let schema = prop_only[0].schema();
-        let combined = arrow_select::concat::concat_batches(&schema, &prop_only)
+        let schema = attach_only[0].schema();
+        let combined = arrow_select::concat::concat_batches(&schema, &attach_only)
             .map_err(|e| OmniError::manifest(e.to_string()))?;
         // Flatten (batch, row) to rows in `combined`.
         let mut offsets: Vec<usize> = Vec::with_capacity(scanned.len());
@@ -1545,7 +1623,7 @@ async fn execute_expand_bound(
             .iter()
             .map(|&(b, r)| (offsets[b] + r) as u32)
             .collect();
-        Some(take_batch(&combined, &UInt32Array::from(flat))?)
+        take_batch(&combined, &UInt32Array::from(flat))?
     };
 
     expand_hydrate_and_align(
@@ -1558,7 +1636,7 @@ async fn execute_expand_bound(
         dst_var,
         dst_filters,
         params,
-        edge_attach.map(|batch| (edge_binding.to_string(), batch)),
+        Some((edge_binding.to_string(), edge_attach)),
     )
     .await
 }

--- a/crates/omnigraph/src/exec/query.rs
+++ b/crates/omnigraph/src/exec/query.rs
@@ -836,6 +836,7 @@ fn execute_pipeline<'a>(
                     min_hops,
                     max_hops,
                     dst_filters,
+                    edge_binding,
                 } => {
                     // Merge lowered destination filters with hoisted ones
                     let mut all_dst_filters: Vec<IRFilter> = dst_filters.clone();
@@ -856,6 +857,7 @@ fn execute_pipeline<'a>(
                             *min_hops,
                             *max_hops,
                             &all_dst_filters,
+                            edge_binding.as_deref(),
                             params,
                         )
                         .await?;
@@ -1273,12 +1275,26 @@ async fn execute_expand(
     min_hops: u32,
     max_hops: Option<u32>,
     dst_filters: &[IRFilter],
+    edge_binding: Option<&str>,
     params: &ParamMap,
 ) -> Result<()> {
     let frontier_rows = wide.num_rows();
     let effective_max_hops = max_hops.unwrap_or(min_hops.max(1));
     let (key_col, _) = endpoint_columns(direction);
     let edge_table_key = format!("edge:{}", edge_type);
+
+    // A bound edge needs edge ROWS (per-row cardinality, property columns);
+    // the CSR index holds topology only, so this path always scans the edge
+    // dataset. Single-hop by typecheck (T23), so the multi-hop cost model
+    // does not apply.
+    if let Some(binding) = edge_binding {
+        let edge_ds = snapshot.open_dataset(&edge_table_key).await?;
+        return execute_expand_bound(
+            wide, snapshot, catalog, src_var, dst_var, edge_type, direction, dst_type,
+            dst_filters, binding, params, edge_ds,
+        )
+        .await;
+    }
 
     // Cardinality-first preliminary decision (no IO). The override wins; else the
     // cost model decides under *optimistic* coverage. Optimistic is what lets us
@@ -1391,6 +1407,151 @@ async fn execute_expand(
     execute_expand_indexed(
         wide, snapshot, catalog, src_var, dst_var, edge_type, direction, dst_type, min_hops,
         max_hops, dst_filters, params, edge_ds,
+    )
+    .await
+}
+
+/// Single-hop expand with a bound edge variable (`$p $w:knows $f`). Differs
+/// from the unbound paths in two contracted ways: output cardinality is one
+/// row per matching edge ROW (parallel edges between the same endpoints stay
+/// distinct, because each carries its own properties), and the edge's declared
+/// property columns ride into the wide batch under the binding's prefix
+/// (`w.since`), where the ordinary filter/projection machinery consumes them.
+/// Typecheck (T23) guarantees single-hop.
+#[allow(clippy::too_many_arguments)]
+async fn execute_expand_bound(
+    wide: &mut RecordBatch,
+    snapshot: &Snapshot,
+    catalog: &Catalog,
+    src_var: &str,
+    dst_var: &str,
+    edge_type: &str,
+    direction: Direction,
+    dst_type: &str,
+    dst_filters: &[IRFilter],
+    edge_binding: &str,
+    params: &ParamMap,
+    edge_ds: Dataset,
+) -> Result<()> {
+    let src_id_col_name = format!("{}.id", src_var);
+    let src_ids = wide
+        .column_by_name(&src_id_col_name)
+        .ok_or_else(|| {
+            OmniError::manifest(format!("wide batch missing '{}' column", src_id_col_name))
+        })?
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| OmniError::manifest(format!("'{}' column is not Utf8", src_id_col_name)))?
+        .clone();
+
+    let edge_def = catalog
+        .edge_types
+        .get(edge_type)
+        .ok_or_else(|| OmniError::manifest(format!("unknown edge type '{}'", edge_type)))?;
+    // Deterministic column order for the attached edge batch.
+    let mut prop_cols: Vec<&str> = edge_def.properties.keys().map(String::as_str).collect();
+    prop_cols.sort_unstable();
+
+    // Wide rows grouped by src id: several wide rows may share one source node.
+    let mut rows_by_src: HashMap<&str, Vec<u32>> = HashMap::new();
+    for i in 0..src_ids.len() {
+        rows_by_src.entry(src_ids.value(i)).or_default().push(i as u32);
+    }
+    let union_keys: Vec<String> = rows_by_src.keys().map(|k| k.to_string()).collect();
+
+    let mut src_indices: Vec<u32> = Vec::new();
+    let mut dst_ids: Vec<String> = Vec::new();
+    // Edge row of each emitted pair, as (scanned batch, row); flattened after
+    // the scan into one pair-parallel batch.
+    let mut edge_rows: Vec<(usize, usize)> = Vec::new();
+    let mut scanned: Vec<RecordBatch> = Vec::new();
+
+    for (probe_idx, &(key_col, opp_col)) in endpoint_probes(direction).iter().enumerate() {
+        let batches = crate::table_store::TableStore::scan_edges_by_endpoint_projected(
+            &edge_ds, key_col, opp_col, &prop_cols, &union_keys,
+        )
+        .await?;
+        for batch in batches {
+            let batch_idx = scanned.len();
+            let keys = batch
+                .column_by_name(key_col)
+                .ok_or_else(|| OmniError::manifest(format!("edge batch missing '{}'", key_col)))?
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .ok_or_else(|| OmniError::manifest(format!("edge '{}' is not Utf8", key_col)))?
+                .clone();
+            let opps = batch
+                .column_by_name(opp_col)
+                .ok_or_else(|| OmniError::manifest(format!("edge batch missing '{}'", opp_col)))?
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .ok_or_else(|| OmniError::manifest(format!("edge '{}' is not Utf8", opp_col)))?
+                .clone();
+            for r in 0..batch.num_rows() {
+                // Undirected probes both orientations; a self-loop row would
+                // match the same wide row through both, so emit it only once.
+                if probe_idx == 1 && keys.value(r) == opps.value(r) {
+                    continue;
+                }
+                let Some(wide_rows) = rows_by_src.get(keys.value(r)) else {
+                    continue;
+                };
+                for &wide_row in wide_rows {
+                    src_indices.push(wide_row);
+                    dst_ids.push(opps.value(r).to_string());
+                    edge_rows.push((batch_idx, r));
+                }
+            }
+            scanned.push(batch);
+        }
+    }
+
+    // Pair-parallel batch of the edge's property columns (empty for a
+    // property-less edge; the binding is then legal but vacuous, since
+    // typecheck already rejected every `$w.prop` access).
+    let edge_attach: Option<RecordBatch> = if prop_cols.is_empty() || scanned.is_empty() {
+        None
+    } else {
+        let prop_only: Vec<RecordBatch> = scanned
+            .iter()
+            .map(|b| {
+                let indices: Vec<usize> = prop_cols
+                    .iter()
+                    .map(|c| b.schema().index_of(c))
+                    .collect::<std::result::Result<_, _>>()
+                    .map_err(|e| OmniError::manifest(e.to_string()))?;
+                b.project(&indices)
+                    .map_err(|e| OmniError::manifest(e.to_string()))
+            })
+            .collect::<Result<_>>()?;
+        let schema = prop_only[0].schema();
+        let combined = arrow_select::concat::concat_batches(&schema, &prop_only)
+            .map_err(|e| OmniError::manifest(e.to_string()))?;
+        // Flatten (batch, row) to rows in `combined`.
+        let mut offsets: Vec<usize> = Vec::with_capacity(scanned.len());
+        let mut acc = 0usize;
+        for b in &scanned {
+            offsets.push(acc);
+            acc += b.num_rows();
+        }
+        let flat: Vec<u32> = edge_rows
+            .iter()
+            .map(|&(b, r)| (offsets[b] + r) as u32)
+            .collect();
+        Some(take_batch(&combined, &UInt32Array::from(flat))?)
+    };
+
+    expand_hydrate_and_align(
+        wide,
+        src_indices,
+        dst_ids,
+        snapshot,
+        catalog,
+        dst_type,
+        dst_var,
+        dst_filters,
+        params,
+        edge_attach.map(|batch| (edge_binding.to_string(), batch)),
     )
     .await
 }
@@ -1569,13 +1730,17 @@ async fn execute_expand_indexed(
 
     expand_hydrate_and_align(
         wide, src_indices, dst_ids, snapshot, catalog, dst_type, dst_var, dst_filters, params,
+        None,
     )
     .await
 }
 
-/// Shared tail for both Expand modes: hydrate the unique destination ids, align
+/// Shared tail for all Expand modes: hydrate the unique destination ids, align
 /// the `(src_row, dst_id)` pairs back onto `wide`, hconcat, and apply
-/// non-pushable destination filters in memory.
+/// non-pushable destination filters in memory. `edge_attach`, present only for
+/// a bound-edge expand, is a pair-parallel batch of edge property columns that
+/// joins the wide batch under the binding's prefix.
+#[allow(clippy::too_many_arguments)]
 async fn expand_hydrate_and_align(
     wide: &mut RecordBatch,
     src_indices: Vec<u32>,
@@ -1586,6 +1751,7 @@ async fn expand_hydrate_and_align(
     dst_var: &str,
     dst_filters: &[IRFilter],
     params: &ParamMap,
+    edge_attach: Option<(String, RecordBatch)>,
 ) -> Result<()> {
     // Pushable destination filters are applied by `hydrate_nodes`; the rest
     // (`ir_filter_to_expr` → None) are applied in memory after hconcat. The
@@ -1624,10 +1790,12 @@ async fn expand_hydrate_and_align(
     // Align pairs to (src_row, hydrated_dst_row), dropping ids hydration filtered out.
     let mut final_src_indices: Vec<u32> = Vec::with_capacity(src_indices.len());
     let mut dst_indices: Vec<u32> = Vec::with_capacity(src_indices.len());
-    for (&src_idx, dst_id) in src_indices.iter().zip(dst_ids.iter()) {
+    let mut surviving_pairs: Vec<u32> = Vec::with_capacity(src_indices.len());
+    for (pair_idx, (&src_idx, dst_id)) in src_indices.iter().zip(dst_ids.iter()).enumerate() {
         if let Some(&dst_row) = id_to_row.get(dst_id.as_str()) {
             final_src_indices.push(src_idx);
             dst_indices.push(dst_row);
+            surviving_pairs.push(pair_idx as u32);
         }
     }
 
@@ -1637,6 +1805,12 @@ async fn expand_hydrate_and_align(
     let dst_prefixed = prefix_batch(&dst_batch, dst_var)?;
     let aligned_dst = take_batch(&dst_prefixed, &dst_take)?;
     *wide = hconcat_batches(&expanded_wide, &aligned_dst)?;
+
+    if let Some((binding, edge_batch)) = edge_attach {
+        let aligned_edge = take_batch(&edge_batch, &UInt32Array::from(surviving_pairs))?;
+        let edge_prefixed = prefix_batch(&aligned_edge, &binding)?;
+        *wide = hconcat_batches(wide, &edge_prefixed)?;
+    }
 
     for f in &non_pushable {
         apply_filter(wide, f, params)?;
@@ -1781,6 +1955,7 @@ async fn execute_expand_csr(
         dst_var,
         dst_filters,
         params,
+        None,
     )
     .await
 }
@@ -2738,6 +2913,7 @@ mod referenced_edge_types_tests {
             min_hops: 1,
             max_hops: Some(1),
             dst_filters: Vec::new(),
+            edge_binding: None,
         }
     }
 

--- a/crates/omnigraph/src/exec/query.rs
+++ b/crates/omnigraph/src/exec/query.rs
@@ -1448,8 +1448,15 @@ async fn execute_expand_bound(
         .edge_types
         .get(edge_type)
         .ok_or_else(|| OmniError::manifest(format!("unknown edge type '{}'", edge_type)))?;
-    // Deterministic column order for the attached edge batch.
-    let mut prop_cols: Vec<&str> = edge_def.properties.keys().map(String::as_str).collect();
+    // Sorted for determinism. Blobs excluded: Lance rejects blob projection
+    // in a filtered scan (node scans carry the same guard); typecheck
+    // rejects the access.
+    let mut prop_cols: Vec<&str> = edge_def
+        .properties
+        .keys()
+        .map(String::as_str)
+        .filter(|c| !edge_def.blob_properties.contains(*c))
+        .collect();
     prop_cols.sort_unstable();
 
     // Wide rows grouped by src id: several wide rows may share one source node.

--- a/crates/omnigraph/src/table_store.rs
+++ b/crates/omnigraph/src/table_store.rs
@@ -1017,7 +1017,7 @@ impl TableStore {
 
     /// `scan_edges_by_endpoint` with extra projected columns beyond the two
     /// endpoints. Consumed by the bound-edge expand, which carries the edge's
-    /// declared property columns alongside each matched row.
+    /// physical id and declared property columns alongside each matched row.
     pub async fn scan_edges_by_endpoint_projected(
         ds: &Dataset,
         key_col: &str,

--- a/crates/omnigraph/src/table_store.rs
+++ b/crates/omnigraph/src/table_store.rs
@@ -1012,17 +1012,34 @@ impl TableStore {
         opposite_col: &str,
         keys: &[String],
     ) -> Result<Vec<RecordBatch>> {
+        Self::scan_edges_by_endpoint_projected(ds, key_col, opposite_col, &[], keys).await
+    }
+
+    /// `scan_edges_by_endpoint` with extra projected columns beyond the two
+    /// endpoints. Consumed by the bound-edge expand, which carries the edge's
+    /// declared property columns alongside each matched row.
+    pub async fn scan_edges_by_endpoint_projected(
+        ds: &Dataset,
+        key_col: &str,
+        opposite_col: &str,
+        extra_cols: &[&str],
+        keys: &[String],
+    ) -> Result<Vec<RecordBatch>> {
         use datafusion::prelude::{col, lit};
 
         if keys.is_empty() {
             return Ok(Vec::new());
         }
+        let mut projection: Vec<&str> = Vec::with_capacity(2 + extra_cols.len());
+        projection.push(key_col);
+        projection.push(opposite_col);
+        projection.extend_from_slice(extra_cols);
         let key_list: Vec<datafusion::prelude::Expr> =
             keys.iter().map(|k| lit(k.clone())).collect();
         let filter_expr = col(key_col).in_list(key_list, false);
         Self::scan_stream_with(
             ds,
-            Some(&[key_col, opposite_col]),
+            Some(projection.as_slice()),
             None,
             None,
             false,

--- a/crates/omnigraph/tests/forbidden_apis.rs
+++ b/crates/omnigraph/tests/forbidden_apis.rs
@@ -548,6 +548,7 @@ gateway_surfaces! {
         "scan_proven_insert_delta_bounded",
         "materialize_blob_batch", "scan_stream", "scan_stream_bounded",
         "scan_stream_with", "scan", "scan_with", "scan_edges_by_endpoint",
+        "scan_edges_by_endpoint_projected",
         "key_column_index_coverage", "has_unindexed_fragments", "count_rows",
         "dataset_version", "table_state", "scan_with_staged", "scan_with_pending",
         "scan_with_pending_materialized_blobs", "count_rows_with_staged",

--- a/crates/omnigraph/tests/ordering.rs
+++ b/crates/omnigraph/tests/ordering.rs
@@ -102,6 +102,54 @@ query q() {
 }
 
 #[tokio::test]
+async fn ordering_parallel_edge_tie_breaks_by_physical_edge_id() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = dir.path().to_str().unwrap();
+    let schema = TEST_SCHEMA.replace(
+        "    since: Date?\n",
+        "    since: Date?\n    label: String?\n",
+    );
+    let mut db = Omnigraph::init(uri, &schema).await.unwrap();
+
+    // Put edge-b in the original fragment and append edge-a later, so storage
+    // order is deliberately the reverse of physical edge-id order. The two
+    // rows are otherwise tied: same user sort key and same endpoint ids.
+    load_jsonl(
+        &mut db,
+        r#"{"type":"Person","data":{"name":"Alice","age":30}}
+{"type":"Person","data":{"name":"Bob","age":25}}
+{"edge":"Knows","from":"Alice","to":"Bob","data":{"id":"edge-b","label":"loaded-first"}}"#,
+        LoadMode::Overwrite,
+    )
+    .await
+    .unwrap();
+    load_jsonl(
+        &mut db,
+        r#"{"edge":"Knows","from":"Alice","to":"Bob","data":{"id":"edge-a","label":"id-first"}}"#,
+        LoadMode::Merge,
+    )
+    .await
+    .unwrap();
+
+    let q = r#"
+query q() {
+    match {
+        $p: Person { name: "Alice" }
+        $p $w:knows $f
+    }
+    return { $w.label }
+    order { $p.age asc }
+}
+"#;
+    let got = names_in_order(&query_main(&mut db, q, "q", &ParamMap::new()).await.unwrap());
+    assert_eq!(
+        got,
+        vec!["id-first", "loaded-first"],
+        "parallel rows tied on user keys and endpoints order by physical edge id"
+    );
+}
+
+#[tokio::test]
 async fn ordering_nulls_placement_asc_and_desc() {
     let dir = tempfile::tempdir().unwrap();
     // Bob has a NULL age.

--- a/crates/omnigraph/tests/search.rs
+++ b/crates/omnigraph/tests/search.rs
@@ -79,6 +79,52 @@ query insert_doc($slug: String, $title: String, $body: String, $embedding: Vecto
 }
 "#;
 
+// A deliberately reverse-loaded edge table over a trivially ranked vector
+// corpus.  The source search order is rank-1, rank-2, rank-3, while physical
+// edge scan order starts at rank-3.  rank-1 has two parallel edges so the RRF
+// assertion also catches row loss/duplication within one fused entity rank.
+const RANKED_EDGE_SCHEMA: &str = r#"
+node RankedDoc {
+    slug: String @key
+    embedding: Vector(4)
+}
+
+edge RankedLink: RankedDoc -> RankedDoc {
+    label: String
+}
+"#;
+
+const RANKED_EDGE_DATA: &str = r#"{"type":"RankedDoc","data":{"slug":"rank-1","embedding":[0.0,0.0,0.0,0.0]}}
+{"type":"RankedDoc","data":{"slug":"rank-2","embedding":[1.0,0.0,0.0,0.0]}}
+{"type":"RankedDoc","data":{"slug":"rank-3","embedding":[2.0,0.0,0.0,0.0]}}
+{"type":"RankedDoc","data":{"slug":"sink","embedding":[9.0,0.0,0.0,0.0]}}
+{"edge":"RankedLink","from":"rank-3","to":"sink","data":{"id":"edge-c","label":"C"}}
+{"edge":"RankedLink","from":"rank-2","to":"sink","data":{"id":"edge-b","label":"B"}}
+{"edge":"RankedLink","from":"rank-1","to":"sink","data":{"id":"edge-a2","label":"A2"}}
+{"edge":"RankedLink","from":"rank-1","to":"sink","data":{"id":"edge-a1","label":"A1"}}"#;
+
+const RANKED_EDGE_QUERIES: &str = r#"
+query nearest_edges($q: Vector(4)) {
+    match {
+        $d: RankedDoc
+        $d $w:rankedLink $target
+    }
+    return { $d.slug, $w.label }
+    order { nearest($d.embedding, $q) }
+    limit 4
+}
+
+query rrf_edges($q1: Vector(4), $q2: Vector(4)) {
+    match {
+        $d: RankedDoc
+        $d $w:rankedLink $target
+    }
+    return { $d.slug, $w.label }
+    order { rrf(nearest($d.embedding, $q1), nearest($d.embedding, $q2)) }
+    limit 4
+}
+"#;
+
 async fn init_search_db(dir: &tempfile::TempDir) -> Omnigraph {
     let uri = dir.path().to_str().unwrap();
     let mut db = Omnigraph::init(uri, SEARCH_SCHEMA).await.unwrap();
@@ -86,6 +132,15 @@ async fn init_search_db(dir: &tempfile::TempDir) -> Omnigraph {
         .await
         .unwrap();
     db.ensure_indices().await.unwrap();
+    db
+}
+
+async fn init_ranked_edge_db(dir: &tempfile::TempDir) -> Omnigraph {
+    let uri = dir.path().to_str().unwrap();
+    let mut db = Omnigraph::init(uri, RANKED_EDGE_SCHEMA).await.unwrap();
+    load_jsonl(&mut db, RANKED_EDGE_DATA, LoadMode::Overwrite)
+        .await
+        .unwrap();
     db
 }
 
@@ -186,6 +241,28 @@ fn result_slugs(result: &QueryResult) -> Vec<String> {
         .unwrap();
     (0..slugs.len())
         .map(|index| slugs.value(index).to_string())
+        .collect()
+}
+
+fn first_two_strings(result: &QueryResult) -> Vec<(String, String)> {
+    let batch = result.concat_batches().unwrap();
+    let first = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    let second = batch
+        .column(1)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    (0..batch.num_rows())
+        .map(|row| {
+            (
+                first.value(row).to_string(),
+                second.value(row).to_string(),
+            )
+        })
         .collect()
 }
 
@@ -853,6 +930,63 @@ async fn bm25_full_rank_order() {
     .unwrap();
     // Descending BM25 score order.
     assert_eq!(result_slugs(&result), vec!["rl-intro", "ml-intro", "dl-basics"]);
+}
+
+#[tokio::test]
+#[serial]
+async fn nearest_rank_survives_bound_edge_fanout() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut db = init_ranked_edge_db(&dir).await;
+    let result = query_main(
+        &mut db,
+        RANKED_EDGE_QUERIES,
+        "nearest_edges",
+        &vector_param("$q", &[0.0, 0.0, 0.0, 0.0]),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        first_two_strings(&result),
+        vec![
+            ("rank-1".to_string(), "A1".to_string()),
+            ("rank-1".to_string(), "A2".to_string()),
+            ("rank-2".to_string(), "B".to_string()),
+            ("rank-3".to_string(), "C".to_string()),
+        ],
+        "edge-table storage order must not replace the incoming ANN rank"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn rrf_rank_preserves_every_bound_edge_row_once() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut db = init_ranked_edge_db(&dir).await;
+    let result = query_main(
+        &mut db,
+        RANKED_EDGE_QUERIES,
+        "rrf_edges",
+        &two_vector_params(
+            "$q1",
+            &[0.0, 0.0, 0.0, 0.0],
+            "$q2",
+            &[0.0, 0.0, 0.0, 0.0],
+        ),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        first_two_strings(&result),
+        vec![
+            ("rank-1".to_string(), "A1".to_string()),
+            ("rank-1".to_string(), "A2".to_string()),
+            ("rank-2".to_string(), "B".to_string()),
+            ("rank-3".to_string(), "C".to_string()),
+        ],
+        "fusion ranks source entities, then retains each matched edge row once"
+    );
 }
 
 // Characterization: fuzzy() does NOT match under the default tokenizer/index in

--- a/crates/omnigraph/tests/traversal.rs
+++ b/crates/omnigraph/tests/traversal.rs
@@ -1064,3 +1064,139 @@ query not_at_acme_binding() {
     names_vec.sort();
     assert_eq!(names_vec, vec!["Bob", "Charlie", "Diana"]);
 }
+
+// ─── Bound edge variable (`$p $w:knows $f`) — edge property filter/projection ──
+//
+// iss-gq-edge-property-filter-projection: an edge binding names the matched
+// edge ROW, so its declared properties become addressable in filters and
+// projections like any node field.
+
+#[tokio::test]
+async fn edge_binding_filters_and_projects_edge_properties() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut db = init_and_load(&dir).await;
+
+    // Fixture Knows edges (Alice->Bob, Alice->Charlie, Bob->Diana) carry no
+    // `since`; give Alice two dated friendships on either side of the cutoff.
+    load_jsonl(
+        &mut db,
+        concat!(
+            r#"{"edge": "Knows", "from": "Alice", "to": "Bob", "data": {"since": "2020-05-01"}}"#,
+            "\n",
+            r#"{"edge": "Knows", "from": "Alice", "to": "Diana", "data": {"since": "2024-11-30"}}"#,
+        ),
+        LoadMode::Merge,
+    )
+    .await
+    .unwrap();
+
+    let queries = r#"
+query recent_friends($name: String) {
+    match {
+        $p: Person { name: $name }
+        $p $w:knows $f
+        $w.since >= date("2023-01-01")
+    }
+    return { $f.name, $w.since }
+}
+query all_friend_edges($name: String) {
+    match {
+        $p: Person { name: $name }
+        $p $w:knows $f
+    }
+    return { $f.name, $w.since }
+}
+"#;
+
+    // Filter on the edge property: only the 2024 friendship survives the
+    // cutoff, proving real `since` values flow through the bound edge.
+    let recent = query_main(
+        &mut db,
+        queries,
+        "recent_friends",
+        &params(&[("$name", "Alice")]),
+    )
+    .await
+    .unwrap();
+    assert_eq!(first_column_sorted(&recent), vec!["Diana"]);
+
+    // Unfiltered: one output row per edge ROW — Bob appears twice because the
+    // fixture's undated Alice->Bob edge and the loaded dated one are parallel
+    // edges, each with its own `since`. Null edge properties flow (fixture
+    // Bob + Charlie rows); they don't drop rows.
+    let all = query_main(
+        &mut db,
+        queries,
+        "all_friend_edges",
+        &params(&[("$name", "Alice")]),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        first_column_sorted(&all),
+        vec!["Bob", "Bob", "Charlie", "Diana"],
+        "one row per edge row from Alice, parallel edges distinct"
+    );
+    let all_batch = all.concat_batches().unwrap();
+    let since_col = all_batch.column(1);
+    assert_eq!(
+        since_col.null_count(),
+        2,
+        "the two undated edge rows (fixture Bob, Charlie) have null since"
+    );
+
+    // Aggregate over an edge property, grouped by a node field: count(since)
+    // per friend. SQL null semantics: count skips nulls, so the fixture's
+    // undated Bob edge contributes 0 while the loaded dated one contributes 1.
+    let agg_queries = r#"
+query knows_counts($name: String) {
+    match {
+        $p: Person { name: $name }
+        $p $w:knows $f
+    }
+    return { $f.name, count($w.since) }
+}
+"#;
+    let counts = query_main(
+        &mut db,
+        agg_queries,
+        "knows_counts",
+        &params(&[("$name", "Alice")]),
+    )
+    .await
+    .unwrap();
+    let counts_batch = counts.concat_batches().unwrap();
+    assert_eq!(
+        first_column_sorted(&counts),
+        vec!["Bob", "Charlie", "Diana"],
+        "one group per friend node, parallel edges collapse into Bob's group"
+    );
+    let mut by_name: Vec<(String, i64)> = (0..counts_batch.num_rows())
+        .map(|i| {
+            let name = counts_batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap()
+                .value(i)
+                .to_string();
+            let count = counts_batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<arrow_array::Int64Array>()
+                .unwrap()
+                .value(i);
+            (name, count)
+        })
+        .collect();
+    by_name.sort();
+    assert_eq!(
+        by_name,
+        vec![
+            ("Bob".to_string(), 1),
+            ("Charlie".to_string(), 0),
+            ("Diana".to_string(), 1)
+        ],
+        "count skips null since values"
+    );
+}

--- a/crates/omnigraph/tests/traversal.rs
+++ b/crates/omnigraph/tests/traversal.rs
@@ -1,6 +1,7 @@
 mod helpers;
 
 use arrow_array::{Array, Int32Array, StringArray};
+use arrow_schema::DataType;
 
 use omnigraph::db::Omnigraph;
 use omnigraph::loader::{LoadMode, load_jsonl};
@@ -1106,6 +1107,31 @@ query all_friend_edges($name: String) {
     }
     return { $f.name, $w.since }
 }
+query empty_source_edge_projection($name: String) {
+    match {
+        $p: Person { name: $name }
+        $p $w:knows $f
+    }
+    return { $w.since }
+}
+query no_outgoing_edge_filter($name: String) {
+    match {
+        $p: Person { name: $name }
+        $p $w:knows $f
+        $w.since >= date("2023-01-01")
+    }
+    return { $w.since }
+}
+query no_future_friend() {
+    match {
+        $p: Person
+        not {
+            $p $w:knows $f
+            $w.since >= date("2030-01-01")
+        }
+    }
+    return { $p.name }
+}
 "#;
 
     // Filter on the edge property: only the 2024 friendship survives the
@@ -1143,6 +1169,53 @@ query all_friend_edges($name: String) {
         since_col.null_count(),
         2,
         "the two undated edge rows (fixture Bob, Charlie) have null since"
+    );
+
+    // Empty input must still carry the edge binding's declared Arrow schema.
+    // Otherwise projecting the edge property fails at runtime instead of
+    // returning a well-typed zero-row result.
+    let empty_source = query_main(
+        &mut db,
+        queries,
+        "empty_source_edge_projection",
+        &params(&[("$name", "Nobody")]),
+    )
+    .await
+    .unwrap();
+    assert_eq!(empty_source.num_rows(), 0);
+    assert_eq!(
+        empty_source.schema().field(0).data_type(),
+        &DataType::Date32,
+        "zero-row edge projections retain the declared property type"
+    );
+
+    // A real source with no matching edge exercises the scanner-empty arm.
+    // The edge filter must see a typed zero-length column, not a missing one.
+    let no_outgoing = query_main(
+        &mut db,
+        queries,
+        "no_outgoing_edge_filter",
+        &params(&[("$name", "Diana")]),
+    )
+    .await
+    .unwrap();
+    assert_eq!(no_outgoing.num_rows(), 0);
+    assert_eq!(no_outgoing.schema().field(0).data_type(), &DataType::Date32);
+
+    // The same zero-match edge schema must survive inside the correlated
+    // anti-join. Every person has no friendship dated in the future; sources
+    // with no outgoing row exercise the empty bound-edge arm per outer row.
+    let no_future = query_main(
+        &mut db,
+        queries,
+        "no_future_friend",
+        &ParamMap::new(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        first_column_sorted(&no_future),
+        vec!["Alice", "Bob", "Charlie", "Diana"]
     );
 
     // Aggregate over an edge property, grouped by a node field: count(since)

--- a/docs/dev/execution.md
+++ b/docs/dev/execution.md
@@ -48,10 +48,10 @@ sequenceDiagram
 - Search-mode extraction: `extract_search_mode` at `crates/omnigraph/src/exec/query.rs:149`
 - Pipeline runner: `execute_query` at `crates/omnigraph/src/exec/query.rs:419`
 - RRF fan-out: `execute_rrf_query` at `crates/omnigraph/src/exec/query.rs:478`
-- Per-source-row BFS: `execute_expand` at `crates/omnigraph/src/exec/query.rs:1263`
-- Filter hoist pre-pass: `execute_pipeline` at `crates/omnigraph/src/exec/query.rs:717` — search filters and single-binding pushable scalar filters move onto the introducing `NodeScan` (arming `prefilter(true)` for any search on the same scanner) or into the introducing `Expand`'s `dst_filters`; multi-binding and non-pushable filters stay in-memory at their lowered position
-- Lance scan + pushdown: `execute_node_scan` at `crates/omnigraph/src/exec/query.rs:2065`
-- Filter → Expr pushdown: `build_lance_filter_expr` at `crates/omnigraph/src/exec/query.rs:2331`
+- Per-source-row BFS: `execute_expand` at `crates/omnigraph/src/exec/query.rs:1297`
+- Filter hoist pre-pass: `execute_pipeline` at `crates/omnigraph/src/exec/query.rs:749` — search filters and single-binding pushable scalar filters move onto the introducing `NodeScan` (arming `prefilter(true)` for any search on the same scanner) or into the introducing `Expand`'s `dst_filters`; multi-binding and non-pushable filters stay in-memory at their lowered position
+- Lance scan + pushdown: `execute_node_scan` at `crates/omnigraph/src/exec/query.rs:2328`
+- Filter → Expr pushdown: `build_lance_filter_expr` at `crates/omnigraph/src/exec/query.rs:2594`
 
 ### Multi-modal search modes (`SearchMode`)
 
@@ -66,7 +66,7 @@ Hybrid example: `order { rrf(nearest($d.embedding, $q), bm25($d.body, $q_text)) 
 ### Joins / set operations
 
 - Joins are implicit: MATCH bindings + traversals are implemented as scans + CSR/CSC lookups.
-- A traversal with an edge binding (`$p $w:knows $f`) bypasses both unbound expand modes: it always scans the edge dataset (`execute_expand_bound` — CSR holds topology only, not edge properties), emits one row per matching edge row, and never triggers the lazy `GraphIndex` build on its own.
+- A traversal with an edge binding (`$p $w:knows $f`) bypasses both unbound expand modes: it always scans the edge dataset (`execute_expand_bound` — CSR holds topology only, not edge properties), emits one row per matching edge row, and never triggers the lazy `GraphIndex` build on its own. It preserves the incoming wide-row order (including ANN/BM25 rank) and carries the physical edge ID as a hidden ordering tie-break so parallel rows remain deterministic.
 - `not { … }` lowers to an `AntiJoin` over the inner pipeline.
 
 ### Scoped reads

--- a/docs/dev/execution.md
+++ b/docs/dev/execution.md
@@ -66,6 +66,7 @@ Hybrid example: `order { rrf(nearest($d.embedding, $q), bm25($d.body, $q_text)) 
 ### Joins / set operations
 
 - Joins are implicit: MATCH bindings + traversals are implemented as scans + CSR/CSC lookups.
+- A traversal with an edge binding (`$p $w:knows $f`) bypasses both unbound expand modes: it always scans the edge dataset (`execute_expand_bound` — CSR holds topology only, not edge properties), emits one row per matching edge row, and never triggers the lazy `GraphIndex` build on its own.
 - `not { … }` lowers to an `AntiJoin` over the inner pipeline.
 
 ### Scoped reads

--- a/docs/user/queries/index.md
+++ b/docs/user/queries/index.md
@@ -43,7 +43,7 @@ Param types reuse all schema scalars; trailing `?` makes a param optional. The c
 
 - `order { <expr> [asc|desc], … }` — supports plain expressions and `nearest(...)`.
 - `limit <integer>` — required when there is a `nearest(...)` ordering.
-- **Total, deterministic order.** Rows with equal user-sort keys are broken by the bound entities' key columns (`<var>.id`, ascending) appended as a final tie-break, so the result is a *total* order — reproducible across runs, and `order … limit N` returns a deterministic top-N even when ties straddle the cutoff. (Aggregate results have no entity-key columns; their group rows are already distinct on the projected group keys.) One narrow exception: with an edge binding, parallel edges between the same endpoints yield rows identical in every node key column, so their relative order under a tie is not covered by the tie-break (edge tables have no key column); it follows storage order in practice.
+- **Total, deterministic order.** Rows with equal user-sort keys are broken by the bound entities' physical `id` columns (ascending) appended as a final tie-break, so the result is a *total* order — reproducible across runs, and `order … limit N` returns a deterministic top-N even when ties straddle the cutoff. Bound edges participate through their internal physical edge ID, including parallel edges; that ID is not exposed as a queryable edge property. (Aggregate results have no entity-ID columns; their group rows are already distinct on the projected group keys.)
 - **NULL placement** is *nulls-first ascending, nulls-last descending* (i.e. `nulls_first = !descending`): a NULL sorts as if smaller than any value.
 
 Write statements (`insert` / `update` / `delete`) are documented on the

--- a/docs/user/queries/index.md
+++ b/docs/user/queries/index.md
@@ -24,6 +24,7 @@ Param types reuse all schema scalars; trailing `?` makes a param optional. The c
 - **Binding**: `$x: NodeType { prop: <literal | $param | now()>, … }`
 - **Traversal**: `$src EDGE_NAME { min, max? } $dst` — variable-length paths via hop bounds; default 1..1 if bounds omitted.
 - **Undirected traversal**: `$src <EDGE_NAME> $dst` — matches the edge in *either* direction with set semantics (a pair connected both ways, or a self-loop, appears once). Only valid on same-endpoint-type edges (e.g. `Related: Issue -> Issue`); an asymmetric edge is rejected at typecheck (`T22`) since it is well-typed in at most one orientation — use the directional form there. Composes with hop bounds (`$a <knows>{1,3} $b`) and `not { }` ("no edge in either direction").
+- **Edge binding**: `$src $w:EDGE_NAME $dst` — an optional `$var:` prefix on the edge word binds the matched edge *row* so its declared properties become addressable anywhere a node field is: filters (`$w.confidence = "asserted"`), projections (`return { $w.role }`), ordering. Composes with the undirected form (`$a $w:<related> $b`) and inside `not { }` (usable within the block, never in `return`). Semantics change with a binding present: the traversal emits **one row per matching edge row**, so parallel edges between the same endpoints appear individually (unbound traversals keep their set-of-pairs semantics). Rejected with `T23` on multi-hop bounds (a `{min,max}` path matches many edges — no single row to bind), on a name already bound, and on bare use (`return { $w }` — project a property instead).
 - **Filter**: `<expr> <op> <expr>` with operators `>=`, `<=`, `!=`, `>`, `<`, `=`, and string `contains`.
 - **Negation**: `not { clause+ }` — desugars to anti-join over the inner pipeline.
 
@@ -42,7 +43,7 @@ Param types reuse all schema scalars; trailing `?` makes a param optional. The c
 
 - `order { <expr> [asc|desc], … }` — supports plain expressions and `nearest(...)`.
 - `limit <integer>` — required when there is a `nearest(...)` ordering.
-- **Total, deterministic order.** Rows with equal user-sort keys are broken by the bound entities' key columns (`<var>.id`, ascending) appended as a final tie-break, so the result is a *total* order — reproducible across runs, and `order … limit N` returns a deterministic top-N even when ties straddle the cutoff. (Aggregate results have no entity-key columns; their group rows are already distinct on the projected group keys.)
+- **Total, deterministic order.** Rows with equal user-sort keys are broken by the bound entities' key columns (`<var>.id`, ascending) appended as a final tie-break, so the result is a *total* order — reproducible across runs, and `order … limit N` returns a deterministic top-N even when ties straddle the cutoff. (Aggregate results have no entity-key columns; their group rows are already distinct on the projected group keys.) One narrow exception: with an edge binding, parallel edges between the same endpoints yield rows identical in every node key column, so their relative order under a tie is not covered by the tie-break (edge tables have no key column); it follows storage order in practice.
 - **NULL placement** is *nulls-first ascending, nulls-last descending* (i.e. `nulls_first = !descending`): a NULL sorts as if smaller than any value.
 
 Write statements (`insert` / `update` / `delete`) are documented on the
@@ -51,6 +52,8 @@ Write statements (`insert` / `update` / `delete`) are documented on the
 ## Traversal execution
 
 Variable-length traversals (`Expand`) are executed one of two ways, chosen per-expand by a cost model over cheap manifest counts (frontier size, edge count, source-vertex count, hops) plus index coverage: selective traversals (small frontier relative to the source set) resolve neighbors from the persisted `src`/`dst` BTREE (one indexed scan per hop); dense / deep / large-frontier traversals — or those whose BTREE coverage is degraded so a full scan would be paid per hop — use an in-memory CSR adjacency index. Both produce identical results. An undirected traversal reads both adjacency directions — the CSR arm walks the outgoing and incoming index (both are always built), the indexed arm probes both the `src` and `dst` BTREE per hop — under the same per-source dedup, so its cost is roughly twice the directional equivalent. The `OMNIGRAPH_EXPAND_INDEXED_MAX_FRONTIER` / `OMNIGRAPH_EXPAND_INDEXED_MAX_HOPS` ceilings bound the *initial dispatch* frontier/hops (beyond them CSR is always used); the cost model estimates total indexed work as ~`hops × frontier × fanout` and prices dense fan-out toward CSR — they are not a hard per-hop bound. `OMNIGRAPH_TRAVERSAL_MODE=indexed|csr` forces a mode (see [constants](../reference/constants.md)).
+
+A traversal with an **edge binding** always takes a third path: a single-hop edge-table scan (the CSR index holds topology only, not edge properties), which carries the edge's declared property columns into the result and keeps parallel edge rows distinct. Edge-property filters are applied after the expand; pushdown into the edge scan is a planned optimization.
 
 ## Linting & validation
 


### PR DESCRIPTION
This PR adds an optional edge binding to GQ traversals: `$p $w:knows $f` names the matched edge row, and `$w.since` then works anywhere a node field works. Edges have always carried declared properties (role, confidence, provenance fields); until now they were stored and written but unreachable from queries, which could use edges only as connectors.

| Capability | Example |
|---|---|
| Filter on edge properties | `$w.since >= date("2023-01-01")` |
| Project edge properties | `return { $f.name, $w.since }` |
| Aggregate over edge properties | `return { $f.name, count($w.since) }` |
| Compose with undirected and `not { }` | `$a $w:<related> $b`; in-block use inside `not { }` |

Semantics: a bound traversal returns one row per matching edge row, so parallel edges between the same endpoints stay distinct; unbound traversals keep their existing set-of-pairs semantics. Constructions without a per-row meaning are rejected with a new typecheck code, `T23`: a binding on a `{min,max}` multi-hop, rebinding a taken name, bare `$w` in return, and text and rank functions (`search`, `bm25`, `nearest`, ...) on an edge-bound field, which execute against node scans and would otherwise be silently ignored.

Execution: a bound traversal always resolves the hop by scanning the edge table (the in-memory CSR adjacency index stores no property columns) and attaches the edge's declared columns to the result rows, where the existing filter and projection machinery picks them up.

## Future work

Edge-property filter pushdown into the edge-table scan, and Cypher-style bracket syntax as pure parser surface over the same internals.

## Testing

Adds parser coverage (directed, undirected, omitted binding), the `T23` typecheck family including the search and rank rejections, and an engine end-to-end test covering filtering on real values, null-property flow, parallel-edge cardinality, and aggregation. `cargo test -p omnigraph-compiler` and `cargo test -p omnigraph-engine --test traversal` clean. Docs updated in the same change: `docs/user/queries/index.md` and `docs/dev/execution.md`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds optional edge bindings throughout the query compiler and execution engine, making declared edge properties available to filters, projections, and aggregates.
- Extends traversal grammar, AST, typechecking, and IR with edge bindings and explicit unsupported-use diagnostics.
- Adds an edge-table execution path that preserves physical edge-row cardinality and carries edge properties into the wide result batch.
- Updates RRF reconstruction to account for traversal fanout.
- Adds compiler and engine coverage plus user and execution documentation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains in the review’s eligible finding set.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/omnigraph-compiler/src/query/typecheck.rs | Introduces edge-kind bindings, property resolution, collision checks, and explicit rejection of unsupported edge-bound expressions. |
| crates/omnigraph-compiler/src/ir/lower.rs | Propagates optional edge bindings into every traversal-lowering branch. |
| crates/omnigraph/src/exec/query.rs | Adds edge-row expansion and alignment and updates RRF reconstruction to preserve traversal fanout. |
| crates/omnigraph/src/table_store.rs | Generalizes endpoint scans to project physical edge IDs and declared property columns. |
| crates/omnigraph/tests/traversal.rs | Adds end-to-end coverage for edge-property filtering, nulls, parallel-edge cardinality, and aggregation. |
| docs/user/queries/index.md | Documents edge-binding syntax, semantics, supported expressions, and restrictions. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Q["GQ traversal<br/>$p $w:knows $f"] --> P[Parser and AST]
  P --> T[Typecheck edge binding]
  T --> I["Expand IR<br/>edge_binding = w"]
  I --> S[Scan matching edge rows]
  S --> A["Attach w.id and w.* properties"]
  A --> H[Hydrate destination nodes]
  H --> F[Filter / project / aggregate]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["test(query): register projected edge sca..."](https://github.com/modernrelay/omnigraph/commit/02b51fb96a093c66403a9c10f5b023572bfd8816) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50827173)</sub>

**Context used:**

- Knowledge Base — [Query language pipeline (parse → lint → typecheck → lower)](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/compiler-query-language.md)
- Knowledge Base — [Query execution engine](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/omnigraph-query-exec.md)

<!-- /greptile_comment -->