### PR TITLE
style: apply rustfmt across the workspace

### DIFF
--- a/crates/omnigraph-api-types/src/lib.rs
+++ b/crates/omnigraph-api-types/src/lib.rs
@@ -297,7 +297,9 @@ pub struct QueryRequest {
     /// with `name` when more than one is declared. Mutations
     /// (`insert`/`update`/`delete`) get 400 — use `POST /mutate` (or its
     /// deprecated alias `POST /change`) instead.
-    #[schema(example = "query get_person($name: String) {\n    match {\n        $p: Person { name: $name }\n    }\n    return { $p.name, $p.age }\n}")]
+    #[schema(
+        example = "query get_person($name: String) {\n    match {\n        $p: Person { name: $name }\n    }\n    return { $p.name, $p.age }\n}"
+    )]
     pub query: String,
     /// Name of the query to run when `query` declares multiple. Optional when
     /// only one query is declared.
@@ -483,7 +485,6 @@ pub fn param_descriptor(param: &Param) -> ParamDescriptor {
         },
     }
 }
-
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
 pub struct SchemaApplyRequest {

--- a/crates/omnigraph-cli/src/client.rs
+++ b/crates/omnigraph-cli/src/client.rs
@@ -32,10 +32,10 @@ use omnigraph_api_types::{
     BranchCreateOutput, BranchCreateRequest, BranchDeleteOutput, BranchListOutput,
     BranchMergeOutput, BranchMergeRequest, ChangeOutput, CommitListOutput, CommitOutput,
     ErrorOutput, ExportRequest, GraphListResponse, IngestOutput, IngestRequest,
-    InvokeStoredQueryRequest, ReadOutput,
-    ReadRequest, SchemaApplyOutput, SchemaApplyRequest, SchemaOutput, SnapshotOutput,
-    StreamEnsureIndicesOutput, StreamOptimizeOutput, StreamResumeOutput, StreamStatusOutput,
-    commit_output, ingest_output, read_output, schema_apply_output, snapshot_payload,
+    InvokeStoredQueryRequest, ReadOutput, ReadRequest, SchemaApplyOutput, SchemaApplyRequest,
+    SchemaOutput, SnapshotOutput, StreamEnsureIndicesOutput, StreamOptimizeOutput,
+    StreamResumeOutput, StreamStatusOutput, commit_output, ingest_output, read_output,
+    schema_apply_output, snapshot_payload,
 };
 use omnigraph_compiler::catalog::Catalog;
 use reqwest::Method;
@@ -46,9 +46,8 @@ use tokio::io::{AsyncRead, AsyncReadExt};
 use crate::cli::CliLoadMode;
 use crate::helpers::{
     apply_bearer_token, apply_server_flag, build_http_client, is_remote_uri,
-    legacy_change_request_body, query_params_from_json,
-    remote_json, remote_url, resolve_cli_actor, resolve_cli_graph, resolve_remote_bearer_token,
-    resolve_server_flag, select_named_query,
+    legacy_change_request_body, query_params_from_json, remote_json, remote_url, resolve_cli_actor,
+    resolve_cli_graph, resolve_remote_bearer_token, resolve_server_flag, select_named_query,
 };
 use crate::output::{LoadOutput, load_output_from_result, load_output_from_tables};
 
@@ -125,10 +124,7 @@ pub(crate) enum GraphClient {
     /// writes (`resolve_with_policy()`) attribute the resolved actor.
     /// Direct-store access carries no Cedar policy (RFC-011: policy lives
     /// in the cluster/server, not in per-operator addressing).
-    Embedded {
-        uri: String,
-        actor: Option<String>,
-    },
+    Embedded { uri: String, actor: Option<String> },
     /// Remote HTTP server. The actor is resolved server-side from the
     /// token; the client never sets identity.
     Remote {
@@ -145,9 +141,7 @@ pub(crate) enum GraphClient {
 /// a policy-gated `/graphs`, or an unreachable server all proceed — the bare URL
 /// is then correct, or the real request surfaces the failure. Only fires on the
 /// no-graph path, so a `--graph`/`default_graph` happy path does no extra I/O.
-async fn require_graph_for_multi_graph_server(
-    scope: &crate::scope::ResolvedScope,
-) -> Result<()> {
+async fn require_graph_for_multi_graph_server(scope: &crate::scope::ResolvedScope) -> Result<()> {
     let (Some(server), None) = (scope.server.as_deref(), scope.graph.as_deref()) else {
         return Ok(());
     };
@@ -187,8 +181,7 @@ impl GraphClient {
     /// resolution, no I/O. Used by the RFC-011 D7 multi-graph probe and the
     /// `graphs list` registry factory.
     fn registry_client(server: &str) -> Result<Self> {
-        let base = resolve_server_flag(Some(server), None)?
-            .expect("server name is present");
+        let base = resolve_server_flag(Some(server), None)?.expect("server name is present");
         let token = resolve_remote_bearer_token(Some(&base))?;
         Ok(GraphClient::Remote {
             http: build_http_client()?,
@@ -207,10 +200,7 @@ impl GraphClient {
     /// default would make `graphs list` unusable in any profile that sets
     /// one, and the registry is server-scoped either way). An explicit
     /// `--graph` never reaches here — the addressing guard rejects it.
-    pub(crate) fn resolve_registry(
-        server: Option<&str>,
-        profile: Option<&str>,
-    ) -> Result<Self> {
+    pub(crate) fn resolve_registry(server: Option<&str>, profile: Option<&str>) -> Result<Self> {
         let scope = crate::scope::resolve_scope(
             &crate::operator::load_operator_config()?,
             crate::planes::Capability::Served,
@@ -263,14 +253,17 @@ impl GraphClient {
         let scope = crate::scope::resolve_scope(
             &crate::operator::load_operator_config()?,
             capability,
-            crate::scope::ScopeFlags { profile, store, server, cluster: None, graph, uri },
+            crate::scope::ScopeFlags {
+                profile,
+                store,
+                server,
+                cluster: None,
+                graph,
+                uri,
+            },
         )?;
         require_graph_for_multi_graph_server(&scope).await?;
-        let (server, graph, uri) = (
-            scope.server.as_deref(),
-            scope.graph.as_deref(),
-            scope.uri,
-        );
+        let (server, graph, uri) = (scope.server.as_deref(), scope.graph.as_deref(), scope.uri);
         let via_server = server.is_some();
         let uri = apply_server_flag(server, graph, uri)?;
         let token = resolve_remote_bearer_token(uri.as_deref())?;
@@ -308,7 +301,14 @@ impl GraphClient {
         let scope = crate::scope::resolve_scope(
             &crate::operator::load_operator_config()?,
             capability,
-            crate::scope::ScopeFlags { profile, store, server, cluster: None, graph, uri },
+            crate::scope::ScopeFlags {
+                profile,
+                store,
+                server,
+                cluster: None,
+                graph,
+                uri,
+            },
         )?;
         Self::resolve_with_policy_scope(scope, cli_as).await
     }
@@ -390,11 +390,7 @@ impl GraphClient {
         cli_as: Option<&str>,
     ) -> Result<Self> {
         require_graph_for_multi_graph_server(&scope).await?;
-        let (server, graph, uri) = (
-            scope.server.as_deref(),
-            scope.graph.as_deref(),
-            scope.uri,
-        );
+        let (server, graph, uri) = (scope.server.as_deref(), scope.graph.as_deref(), scope.uri);
         let via_server = server.is_some();
         let uri = apply_server_flag(server, graph, uri)?;
         let token = resolve_remote_bearer_token(uri.as_deref())?;
@@ -603,7 +599,12 @@ impl GraphClient {
                     token.as_deref(),
                 )
                 .await?;
-                Ok(load_output_from_tables(base_url, branch, mode.as_str(), &output))
+                Ok(load_output_from_tables(
+                    base_url,
+                    branch,
+                    mode.as_str(),
+                    &output,
+                ))
             }
             GraphClient::Embedded { uri, actor } => {
                 let db = Self::open_embedded(uri).await?;
@@ -1040,11 +1041,7 @@ impl GraphClient {
             .get(CONTENT_TYPE)
             .and_then(|value| value.to_str().ok())
             .and_then(|value| value.split(';').next())
-            .is_some_and(|media_type| {
-                media_type
-                    .trim()
-                    .eq_ignore_ascii_case(NDJSON_CONTENT_TYPE)
-            });
+            .is_some_and(|media_type| media_type.trim().eq_ignore_ascii_case(NDJSON_CONTENT_TYPE));
         if !response_is_ndjson {
             bail!(
                 "stream ingest requires an exact 200 application/x-ndjson response from the server"
@@ -1150,9 +1147,9 @@ impl GraphClient {
                 )
                 .await
             }
-            GraphClient::Embedded { .. } => bail!(
-                "internal error: `stream maintenance optimize` reached an embedded client"
-            ),
+            GraphClient::Embedded { .. } => {
+                bail!("internal error: `stream maintenance optimize` reached an embedded client")
+            }
         }
     }
 
@@ -1338,8 +1335,7 @@ mod tests {
         // the trailing slash trimmed and no `/graphs/<id>` segment. A literal
         // `://` --server value bypasses the operator server registry, so a
         // developer's real config cannot change the outcome.
-        let client =
-            GraphClient::resolve_registry(Some("http://server.invalid:9/"), None).unwrap();
+        let client = GraphClient::resolve_registry(Some("http://server.invalid:9/"), None).unwrap();
         assert_eq!(client.uri(), "http://server.invalid:9");
         assert!(client.is_remote());
     }
@@ -1466,13 +1462,7 @@ mod tests {
                 let (mut ingest, _) = listener.accept().await.unwrap();
                 let request = read_http_request(&mut ingest).await;
                 assert_eq!(request.body, b"{}\n");
-                write_response(
-                    &mut ingest,
-                    status,
-                    &[("Content-Type", content_type)],
-                    &[],
-                )
-                .await;
+                write_response(&mut ingest, status, &[("Content-Type", content_type)], &[]).await;
             });
             let client = GraphClient::Remote {
                 http: reqwest::Client::new(),
@@ -1487,7 +1477,10 @@ mod tests {
             if status == "200 OK" {
                 assert!(error.contains("exact 200 application/x-ndjson"), "{error}");
             } else {
-                assert!(error.contains(status.split_whitespace().next().unwrap()), "{error}");
+                assert!(
+                    error.contains(status.split_whitespace().next().unwrap()),
+                    "{error}"
+                );
             }
             server.await.unwrap();
         }
@@ -1623,9 +1616,7 @@ mod tests {
                 let (mut stream, _) = listener.accept().await.unwrap();
                 let request = read_http_request(&mut stream).await;
                 assert!(
-                    request
-                        .head
-                        .starts_with(&format!("POST {path} HTTP/1.1")),
+                    request.head.starts_with(&format!("POST {path} HTTP/1.1")),
                     "{}",
                     request.head
                 );

--- a/crates/omnigraph-cli/src/helpers.rs
+++ b/crates/omnigraph-cli/src/helpers.rs
@@ -90,11 +90,7 @@ pub(crate) fn confirm_destructive(label: &str, uri: &str, yes: bool, json: bool)
 /// misses the route and 404s. Because callers pass structured segments rather
 /// than a pre-joined string, neither a stray `//` nor an un-encoded dynamic
 /// component is representable here.
-pub(crate) fn remote_url(
-    base: &str,
-    segments: &[&str],
-    query: &[(&str, &str)],
-) -> Result<String> {
+pub(crate) fn remote_url(base: &str, segments: &[&str], query: &[(&str, &str)]) -> Result<String> {
     let mut url = reqwest::Url::parse(base.trim_end_matches('/'))?;
     url.path_segments_mut()
         .map_err(|_| color_eyre::eyre::eyre!("invalid remote base url"))?
@@ -155,9 +151,11 @@ pub(crate) fn require_cluster_scope(
         return Ok(resolve_name(cluster));
     }
     // A cluster profile (flag, else OMNIGRAPH_PROFILE) binds the cluster too.
-    let profile_name = profile
-        .map(str::to_string)
-        .or_else(|| std::env::var(scope::PROFILE_ENV).ok().filter(|s| !s.is_empty()));
+    let profile_name = profile.map(str::to_string).or_else(|| {
+        std::env::var(scope::PROFILE_ENV)
+            .ok()
+            .filter(|s| !s.is_empty())
+    });
     if let Some(name) = profile_name {
         let profile = op.profile(&name).ok_or_else(|| {
             color_eyre::eyre::eyre!("unknown profile '{name}' (not defined under `profiles:`)")
@@ -232,7 +230,10 @@ pub(crate) fn select_cluster_policy<'p>(
                 "graph `{graph_id}` in cluster `{cluster}` matches {} policy bundles ([{}]); \
                  the cluster model expects one bundle per graph scope",
                 many.len(),
-                many.iter().map(|p| p.name.as_str()).collect::<Vec<_>>().join(", ")
+                many.iter()
+                    .map(|p| p.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
             ),
         };
     }
@@ -242,7 +243,10 @@ pub(crate) fn select_cluster_policy<'p>(
         many => bail!(
             "cluster `{cluster}` has {} policy bundles ([{}]); pass --graph <id> to select one",
             many.len(),
-            many.iter().map(|p| p.name.as_str()).collect::<Vec<_>>().join(", ")
+            many.iter()
+                .map(|p| p.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
         ),
     }
 }
@@ -620,7 +624,10 @@ pub(crate) fn resolve_read_target(
     if cli_branch.is_some() && cli_snapshot.is_some() {
         bail!("read target may specify branch or snapshot, not both");
     }
-    Ok(read_target_from_cli(cli_branch.or(alias_branch), cli_snapshot))
+    Ok(read_target_from_cli(
+        cli_branch.or(alias_branch),
+        cli_snapshot,
+    ))
 }
 
 pub(crate) fn resolve_query_path(
@@ -679,8 +686,6 @@ pub(crate) fn resolve_read_format(
         })
         .unwrap_or_default()
 }
-
-
 
 pub(crate) fn read_target_from_cli(branch: Option<String>, snapshot: Option<String>) -> ReadTarget {
     if let Some(snapshot) = snapshot {
@@ -796,7 +801,6 @@ fn registry_from_serving_queries(
     })
 }
 
-
 /// `queries validate --cluster <dir>` (RFC-011): type-check every stored query
 /// in the cluster catalog against its graph's applied schema. Both the registry
 /// and the schemas come from the cluster serving snapshot — no omnigraph.yaml.
@@ -820,7 +824,8 @@ pub(crate) async fn execute_queries_validate(
             continue;
         }
         matched_any = true;
-        let registry = registry_from_serving_queries(&snapshot.queries, Some(&serving_graph.graph_id))?;
+        let registry =
+            registry_from_serving_queries(&snapshot.queries, Some(&serving_graph.graph_id))?;
         let db = Omnigraph::open(&serving_graph.root.to_string_lossy()).await?;
         let report = check(&registry, &db.catalog());
         total += registry.len();

--- a/crates/omnigraph-cli/src/main.rs
+++ b/crates/omnigraph-cli/src/main.rs
@@ -800,12 +800,7 @@ async fn main() -> Result<()> {
                         cli.store.as_deref(),
                     )
                     .await?;
-                    echo_write_target(
-                        cli.quiet,
-                        "stream maintenance optimize",
-                        client.uri(),
-                        true,
-                    );
+                    echo_write_target(cli.quiet, "stream maintenance optimize", client.uri(), true);
                     let output = client.stream_optimize().await?;
                     finish_stream_optimize(&output, json)?;
                 }

--- a/crates/omnigraph-cli/src/main_tests.rs
+++ b/crates/omnigraph-cli/src/main_tests.rs
@@ -1,155 +1,155 @@
 //! In-source test suite for the CLI binary (moved verbatim from
 //! main.rs; `use super::*` resolves through the #[path] declaration).
 
-    use super::{
-        DEFAULT_BEARER_TOKEN_ENV, apply_bearer_token, legacy_change_request_body,
-        normalize_bearer_token, read_stream_data_correction_plan_with_limit,
-        resolve_remote_bearer_token,
-    };
-    use omnigraph::error::OmniError;
-    use reqwest::header::AUTHORIZATION;
-    use serde_json::json;
-    use std::fs;
+use super::{
+    DEFAULT_BEARER_TOKEN_ENV, apply_bearer_token, legacy_change_request_body,
+    normalize_bearer_token, read_stream_data_correction_plan_with_limit,
+    resolve_remote_bearer_token,
+};
+use omnigraph::error::OmniError;
+use reqwest::header::AUTHORIZATION;
+use serde_json::json;
+use std::fs;
 
-    #[test]
-    fn legacy_change_request_body_uses_legacy_field_names() {
-        // `mutate`'s remote arm hits `POST /change`, which old
-        // `omnigraph-server` builds deserialize as `ChangeRequest` with
-        // **required** `query_source` and optional `query_name` keys.
-        // Newer servers accept both spellings via serde alias, but a
-        // newer CLI must still emit the legacy keys on the wire so it
-        // can talk to an old server during a rolling upgrade.
-        let body = legacy_change_request_body(
-            "query insert_person($n: String) { insert Person { name: $n } }",
-            Some("insert_person"),
-            "main",
-            Some(&json!({ "n": "Alice" })),
-        );
-        assert_eq!(
-            body["query_source"].as_str(),
-            Some("query insert_person($n: String) { insert Person { name: $n } }"),
-        );
-        assert_eq!(body["query_name"].as_str(), Some("insert_person"));
-        assert_eq!(body["branch"].as_str(), Some("main"));
-        assert_eq!(body["params"]["n"].as_str(), Some("Alice"));
-        // Crucially, the **new** field names must NOT appear -- old
-        // servers would silently treat them as unknown fields and then
-        // fail on missing required `query_source`.
-        assert!(
-            body.get("query").is_none(),
-            "legacy /change body must not carry the renamed `query` key; got {body}"
-        );
-        assert!(
-            body.get("name").is_none(),
-            "legacy /change body must not carry the renamed `name` key; got {body}"
-        );
+#[test]
+fn legacy_change_request_body_uses_legacy_field_names() {
+    // `mutate`'s remote arm hits `POST /change`, which old
+    // `omnigraph-server` builds deserialize as `ChangeRequest` with
+    // **required** `query_source` and optional `query_name` keys.
+    // Newer servers accept both spellings via serde alias, but a
+    // newer CLI must still emit the legacy keys on the wire so it
+    // can talk to an old server during a rolling upgrade.
+    let body = legacy_change_request_body(
+        "query insert_person($n: String) { insert Person { name: $n } }",
+        Some("insert_person"),
+        "main",
+        Some(&json!({ "n": "Alice" })),
+    );
+    assert_eq!(
+        body["query_source"].as_str(),
+        Some("query insert_person($n: String) { insert Person { name: $n } }"),
+    );
+    assert_eq!(body["query_name"].as_str(), Some("insert_person"));
+    assert_eq!(body["branch"].as_str(), Some("main"));
+    assert_eq!(body["params"]["n"].as_str(), Some("Alice"));
+    // Crucially, the **new** field names must NOT appear -- old
+    // servers would silently treat them as unknown fields and then
+    // fail on missing required `query_source`.
+    assert!(
+        body.get("query").is_none(),
+        "legacy /change body must not carry the renamed `query` key; got {body}"
+    );
+    assert!(
+        body.get("name").is_none(),
+        "legacy /change body must not carry the renamed `name` key; got {body}"
+    );
+}
+
+#[test]
+fn legacy_change_request_body_omits_optional_fields_when_unset() {
+    let body = legacy_change_request_body(
+        "query find() { match { $p: Person } return { $p.name } }",
+        None,
+        "main",
+        None,
+    );
+    assert_eq!(body["branch"].as_str(), Some("main"));
+    assert!(body.get("query_name").is_none());
+    assert!(body.get("params").is_none());
+}
+
+#[test]
+fn apply_bearer_token_adds_header_when_configured() {
+    let client = reqwest::Client::new();
+    let request = apply_bearer_token(client.get("http://example.com"), Some("demo-token"))
+        .build()
+        .unwrap();
+    assert_eq!(
+        request
+            .headers()
+            .get(AUTHORIZATION)
+            .and_then(|value| value.to_str().ok()),
+        Some("Bearer demo-token")
+    );
+}
+
+#[test]
+fn apply_bearer_token_leaves_request_unchanged_when_not_configured() {
+    let client = reqwest::Client::new();
+    let request = apply_bearer_token(client.get("http://example.com"), None)
+        .build()
+        .unwrap();
+    assert!(request.headers().get(AUTHORIZATION).is_none());
+}
+
+#[test]
+fn normalize_bearer_token_trims_and_filters_blank_values() {
+    assert_eq!(normalize_bearer_token(None), None);
+    assert_eq!(normalize_bearer_token(Some("   ".to_string())), None);
+    assert_eq!(
+        normalize_bearer_token(Some(" demo-token ".to_string())).as_deref(),
+        Some("demo-token")
+    );
+}
+
+#[test]
+fn resolve_remote_bearer_token_falls_back_to_default_env() {
+    // RFC-011: with no operator server matching the URL, the only chain
+    // left is the default `OMNIGRAPH_BEARER_TOKEN` env (no omnigraph.yaml
+    // scoped chain). Hermetic: no operator config is read for a literal URL
+    // that matches no `servers:` entry.
+    let previous = std::env::var_os(DEFAULT_BEARER_TOKEN_ENV);
+    let previous_home = std::env::var_os("OMNIGRAPH_HOME");
+    unsafe {
+        std::env::set_var(DEFAULT_BEARER_TOKEN_ENV, "global-token");
+        std::env::set_var("OMNIGRAPH_HOME", "/nonexistent/omnigraph-test-home");
     }
 
-    #[test]
-    fn legacy_change_request_body_omits_optional_fields_when_unset() {
-        let body = legacy_change_request_body(
-            "query find() { match { $p: Person } return { $p.name } }",
-            None,
-            "main",
-            None,
-        );
-        assert_eq!(body["branch"].as_str(), Some("main"));
-        assert!(body.get("query_name").is_none());
-        assert!(body.get("params").is_none());
-    }
+    assert_eq!(
+        resolve_remote_bearer_token(Some("https://override.example.com"))
+            .unwrap()
+            .as_deref(),
+        Some("global-token")
+    );
 
-    #[test]
-    fn apply_bearer_token_adds_header_when_configured() {
-        let client = reqwest::Client::new();
-        let request = apply_bearer_token(client.get("http://example.com"), Some("demo-token"))
-            .build()
-            .unwrap();
-        assert_eq!(
-            request
-                .headers()
-                .get(AUTHORIZATION)
-                .and_then(|value| value.to_str().ok()),
-            Some("Bearer demo-token")
-        );
-    }
-
-    #[test]
-    fn apply_bearer_token_leaves_request_unchanged_when_not_configured() {
-        let client = reqwest::Client::new();
-        let request = apply_bearer_token(client.get("http://example.com"), None)
-            .build()
-            .unwrap();
-        assert!(request.headers().get(AUTHORIZATION).is_none());
-    }
-
-    #[test]
-    fn normalize_bearer_token_trims_and_filters_blank_values() {
-        assert_eq!(normalize_bearer_token(None), None);
-        assert_eq!(normalize_bearer_token(Some("   ".to_string())), None);
-        assert_eq!(
-            normalize_bearer_token(Some(" demo-token ".to_string())).as_deref(),
-            Some("demo-token")
-        );
-    }
-
-    #[test]
-    fn resolve_remote_bearer_token_falls_back_to_default_env() {
-        // RFC-011: with no operator server matching the URL, the only chain
-        // left is the default `OMNIGRAPH_BEARER_TOKEN` env (no omnigraph.yaml
-        // scoped chain). Hermetic: no operator config is read for a literal URL
-        // that matches no `servers:` entry.
-        let previous = std::env::var_os(DEFAULT_BEARER_TOKEN_ENV);
-        let previous_home = std::env::var_os("OMNIGRAPH_HOME");
-        unsafe {
-            std::env::set_var(DEFAULT_BEARER_TOKEN_ENV, "global-token");
-            std::env::set_var("OMNIGRAPH_HOME", "/nonexistent/omnigraph-test-home");
+    unsafe {
+        if let Some(value) = previous {
+            std::env::set_var(DEFAULT_BEARER_TOKEN_ENV, value);
+        } else {
+            std::env::remove_var(DEFAULT_BEARER_TOKEN_ENV);
         }
-
-        assert_eq!(
-            resolve_remote_bearer_token(Some("https://override.example.com"))
-                .unwrap()
-                .as_deref(),
-            Some("global-token")
-        );
-
-        unsafe {
-            if let Some(value) = previous {
-                std::env::set_var(DEFAULT_BEARER_TOKEN_ENV, value);
-            } else {
-                std::env::remove_var(DEFAULT_BEARER_TOKEN_ENV);
-            }
-            if let Some(value) = previous_home {
-                std::env::set_var("OMNIGRAPH_HOME", value);
-            } else {
-                std::env::remove_var("OMNIGRAPH_HOME");
-            }
+        if let Some(value) = previous_home {
+            std::env::set_var("OMNIGRAPH_HOME", value);
+        } else {
+            std::env::remove_var("OMNIGRAPH_HOME");
         }
     }
+}
 
-    #[test]
-    fn stream_correction_plan_reader_enforces_an_inclusive_typed_byte_cap() {
-        let directory = tempfile::tempdir().unwrap();
-        let path = directory.path().join("correction-plan.json");
-        let contents = br#"{"version":1,"actions":[]}"#;
-        fs::write(&path, contents).unwrap();
+#[test]
+fn stream_correction_plan_reader_enforces_an_inclusive_typed_byte_cap() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("correction-plan.json");
+    let contents = br#"{"version":1,"actions":[]}"#;
+    fs::write(&path, contents).unwrap();
 
-        assert_eq!(
-            read_stream_data_correction_plan_with_limit(&path, contents.len() as u64).unwrap(),
-            contents
-        );
-        let error = read_stream_data_correction_plan_with_limit(
-            &path,
-            u64::try_from(contents.len() - 1).unwrap(),
-        )
-        .expect_err("an oversized plan must be refused before deserialization");
-        assert!(matches!(
-            error.downcast_ref::<OmniError>(),
-            Some(OmniError::ResourceLimitExceeded {
-                resource,
-                limit,
-                actual,
-            }) if resource == "stream_correction_plan_file_bytes"
-                && *limit == (contents.len() - 1) as u64
-                && *actual == contents.len() as u64
-        ));
-    }
+    assert_eq!(
+        read_stream_data_correction_plan_with_limit(&path, contents.len() as u64).unwrap(),
+        contents
+    );
+    let error = read_stream_data_correction_plan_with_limit(
+        &path,
+        u64::try_from(contents.len() - 1).unwrap(),
+    )
+    .expect_err("an oversized plan must be refused before deserialization");
+    assert!(matches!(
+        error.downcast_ref::<OmniError>(),
+        Some(OmniError::ResourceLimitExceeded {
+            resource,
+            limit,
+            actual,
+        }) if resource == "stream_correction_plan_file_bytes"
+            && *limit == (contents.len() - 1) as u64
+            && *actual == contents.len() as u64
+    ));
+}

--- a/crates/omnigraph-cli/src/operator.rs
+++ b/crates/omnigraph-cli/src/operator.rs
@@ -440,11 +440,7 @@ pub(crate) fn remove_credential(server: &str) -> Result<PathBuf> {
     Ok(path)
 }
 
-pub(crate) fn rewrite_credentials_at(
-    path: &Path,
-    server: &str,
-    token: Option<&str>,
-) -> Result<()> {
+pub(crate) fn rewrite_credentials_at(path: &Path, server: &str, token: Option<&str>) -> Result<()> {
     let existing = match std::fs::read_to_string(path) {
         Ok(text) => {
             refuse_over_permissive(path)?;
@@ -673,9 +669,16 @@ profiles:
         let config = load_operator_config_at(&path).unwrap();
         assert_eq!(config.default_server(), Some("prod"));
         assert_eq!(config.default_graph(), Some("knowledge"));
-        assert_eq!(config.cluster_root("brain"), Some("s3://acme/clusters/brain"));
         assert_eq!(
-            config.profile("staging").unwrap().binding("staging").unwrap(),
+            config.cluster_root("brain"),
+            Some("s3://acme/clusters/brain")
+        );
+        assert_eq!(
+            config
+                .profile("staging")
+                .unwrap()
+                .binding("staging")
+                .unwrap(),
             ScopeBinding::Server("staging".into())
         );
         assert_eq!(
@@ -687,7 +690,11 @@ profiles:
             ScopeBinding::Cluster("brain".into())
         );
         // No unknown-key warnings for the new blocks.
-        assert!(config.unknown_key_warnings().is_empty(), "{:?}", config.unknown_key_warnings());
+        assert!(
+            config.unknown_key_warnings().is_empty(),
+            "{:?}",
+            config.unknown_key_warnings()
+        );
     }
 
     #[test]

--- a/crates/omnigraph-cli/src/output.rs
+++ b/crates/omnigraph-cli/src/output.rs
@@ -400,9 +400,7 @@ pub(crate) fn render_stream_status_human(output: &StreamStatusOutput) -> String 
             {
                 "optionally run graph-wide `stream maintenance ensure-indices|optimize`, then `stream resume`"
             }
-            StreamProfileModeOutput::Enabled => {
-                "send graph rows with `omnigraph stream ingest`"
-            }
+            StreamProfileModeOutput::Enabled => "send graph rows with `omnigraph stream ingest`",
             StreamProfileModeOutput::Disabling => {
                 "stop serving and retry `omnigraph cluster apply` to finish disabling"
             }
@@ -412,8 +410,7 @@ pub(crate) fn render_stream_status_human(output: &StreamStatusOutput) -> String 
             StreamProfileModeOutput::Retired => "export and rebuild into a fresh graph",
         }
     };
-    writeln!(rendered, "  next: {next}")
-        .expect("writing stream status to a String cannot fail");
+    writeln!(rendered, "  next: {next}").expect("writing stream status to a String cannot fail");
     rendered
 }
 
@@ -453,7 +450,11 @@ pub(crate) fn finish_stream_ensure_indices(
     }
     println!(
         "stream index maintenance: {} ({} pending index(es))",
-        if output.changed { "published" } else { "no change" },
+        if output.changed {
+            "published"
+        } else {
+            "no change"
+        },
         output.pending_index_count
     );
     Ok(())
@@ -465,7 +466,11 @@ pub(crate) fn finish_stream_optimize(output: &StreamOptimizeOutput, json: bool) 
     }
     println!(
         "stream optimize: {} ({} pending index(es))",
-        if output.changed { "published" } else { "no change" },
+        if output.changed {
+            "published"
+        } else {
+            "no change"
+        },
         output.pending_index_count
     );
     if output.requires_repair {

--- a/crates/omnigraph-cli/src/planes.rs
+++ b/crates/omnigraph-cli/src/planes.rs
@@ -15,8 +15,7 @@ use color_eyre::eyre::bail;
 use crate::cli::{
     Cli, ClusterCommand, ClusterStreamCommand, Command, GraphsCommand, QueriesCommand,
     SchemaCommand, StreamBlockCommand, StreamCommand, StreamDeadLetterCommand,
-    StreamMaintenanceCommand,
-    StreamRetireForRebuildCommand,
+    StreamMaintenanceCommand, StreamRetireForRebuildCommand,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -760,14 +759,7 @@ mod tests {
         }
 
         assert!(
-            Cli::try_parse_from([
-                "omnigraph",
-                "stream",
-                "resume",
-                "--type",
-                "Person",
-            ])
-            .is_err(),
+            Cli::try_parse_from(["omnigraph", "stream", "resume", "--type", "Person",]).is_err(),
             "graph resume must not accept a declaration selector"
         );
     }

--- a/crates/omnigraph-cli/src/scope.rs
+++ b/crates/omnigraph-cli/src/scope.rs
@@ -429,7 +429,9 @@ mod tests {
 
     #[test]
     fn flat_default_server_drives_data_verbs() {
-        let op = cfg("defaults:\n  server: prod\n  default_graph: knowledge\nservers:\n  prod:\n    url: https://x\n");
+        let op = cfg(
+            "defaults:\n  server: prod\n  default_graph: knowledge\nservers:\n  prod:\n    url: https://x\n",
+        );
         let scope = resolve_scope(&op, Capability::Any, flags()).unwrap();
         assert_eq!(scope.server.as_deref(), Some("prod"));
         assert_eq!(scope.graph.as_deref(), Some("knowledge"));
@@ -496,7 +498,9 @@ mod tests {
     #[test]
     fn server_scope_on_maintenance_verb_errors() {
         let op = cfg("defaults:\n  server: prod\nservers:\n  prod:\n    url: https://x\n");
-        let err = resolve_scope(&op, Capability::Direct, flags()).unwrap_err().to_string();
+        let err = resolve_scope(&op, Capability::Direct, flags())
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("direct storage access"), "{err}");
     }
 

--- a/crates/omnigraph-cli/tests/cli_cluster_e2e.rs
+++ b/crates/omnigraph-cli/tests/cli_cluster_e2e.rs
@@ -10,7 +10,6 @@ mod support;
 
 use support::*;
 
-
 #[test]
 fn cluster_e2e_lifecycle_import_apply_status_refresh_converges() {
     let temp = tempdir().unwrap();
@@ -49,7 +48,10 @@ fn cluster_e2e_lifecycle_import_apply_status_refresh_converges() {
         status["resource_statuses"]["query.knowledge.find_person"]["status"],
         "applied"
     );
-    assert_eq!(status["resource_statuses"]["policy.base"]["status"], "applied");
+    assert_eq!(
+        status["resource_statuses"]["policy.base"]["status"],
+        "applied"
+    );
     assert_eq!(
         status["resource_statuses"]["streaming.knowledge"]["status"],
         "applied"
@@ -75,13 +77,11 @@ fn cluster_e2e_lifecycle_import_apply_status_refresh_converges() {
     // refreshed streaming digest equals the declared one.)
     let observed = cluster_json(temp.path(), "status");
     assert_eq!(
-        observed["observations"]["graph.knowledge"]["streaming_enabled"],
-        true,
+        observed["observations"]["graph.knowledge"]["streaming_enabled"], true,
         "{observed}"
     );
     assert_eq!(
-        observed["observations"]["graph.knowledge"]["streaming_matches_desired"],
-        true,
+        observed["observations"]["graph.knowledge"]["streaming_matches_desired"], true,
         "{observed}"
     );
 
@@ -147,7 +147,10 @@ node Person {
     let evolve = cluster_json(temp.path(), "apply");
     assert_eq!(evolve["ok"], true, "{evolve}");
     assert_eq!(evolve["converged"], true, "{evolve}");
-    assert_eq!(change_for(&evolve, "schema.knowledge")["disposition"], "applied");
+    assert_eq!(
+        change_for(&evolve, "schema.knowledge")["disposition"],
+        "applied"
+    );
 
     // The live graph carries the new schema; the plan is empty.
     let schema_show = output_success(
@@ -156,7 +159,10 @@ node Person {
             .arg("show")
             .arg(temp.path().join("graphs/knowledge.omni")),
     );
-    assert!(stdout_string(&schema_show).contains("bio"), "live schema updated");
+    assert!(
+        stdout_string(&schema_show).contains("bio"),
+        "live schema updated"
+    );
     let replan = cluster_json(temp.path(), "plan");
     assert!(
         replan["changes"].as_array().unwrap().is_empty(),
@@ -356,7 +362,11 @@ fn cluster_e2e_graph_root_destruction_drifts_then_apply_recreates_empty_graph() 
     );
     // Graph/schema/streaming digests removed; query/policy digests preserved.
     assert!(refresh["resource_digests"].get("graph.knowledge").is_none());
-    assert!(refresh["resource_digests"].get("schema.knowledge").is_none());
+    assert!(
+        refresh["resource_digests"]
+            .get("schema.knowledge")
+            .is_none()
+    );
     assert!(
         refresh["resource_digests"]
             .get("streaming.knowledge")
@@ -374,8 +384,14 @@ fn cluster_e2e_graph_root_destruction_drifts_then_apply_recreates_empty_graph() 
     // Stage 4A: the re-create is executable and the plan says so — nothing
     // hidden about converging a destroyed root back to an EMPTY graph (the
     // data was already lost; this is declarative convergence, RFC-004 §D1).
-    assert_eq!(change_for(&plan, "graph.knowledge")["disposition"], "applied");
-    assert_eq!(change_for(&plan, "schema.knowledge")["disposition"], "applied");
+    assert_eq!(
+        change_for(&plan, "graph.knowledge")["disposition"],
+        "applied"
+    );
+    assert_eq!(
+        change_for(&plan, "schema.knowledge")["disposition"],
+        "applied"
+    );
     assert_eq!(
         change_for(&plan, "streaming.knowledge")["disposition"],
         "applied"
@@ -418,7 +434,10 @@ fn cluster_e2e_multi_graph_mixed_dispositions_then_approve_and_converge() {
     let apply = cluster_json(temp.path(), "apply");
     assert_eq!(apply["ok"], true, "{apply}");
     assert_eq!(apply["converged"], true, "{apply}");
-    assert_eq!(change_for(&apply, "graph.knowledge")["disposition"], "applied");
+    assert_eq!(
+        change_for(&apply, "graph.knowledge")["disposition"],
+        "applied"
+    );
     assert_eq!(
         change_for(&apply, "graph.engineering")["disposition"],
         "applied"
@@ -428,7 +447,10 @@ fn cluster_e2e_multi_graph_mixed_dispositions_then_approve_and_converge() {
         "applied"
     );
     // The graph-spanning and cluster-scoped policies ride the same run.
-    assert_eq!(change_for(&apply, "policy.shared")["disposition"], "applied");
+    assert_eq!(
+        change_for(&apply, "policy.shared")["disposition"],
+        "applied"
+    );
     assert_eq!(
         change_for(&apply, "policy.cluster_wide")["disposition"],
         "applied"
@@ -503,7 +525,10 @@ policies:
     // 5A: policy.shared's applies_to narrowed with an unchanged file digest
     // — now a first-class binding change, applied in the same run.
     assert_eq!(change_for(&mixed, "policy.shared")["binding_change"], true);
-    assert_eq!(change_for(&mixed, "policy.shared")["disposition"], "applied");
+    assert_eq!(
+        change_for(&mixed, "policy.shared")["disposition"],
+        "applied"
+    );
     assert_eq!(
         change_for(&mixed, "graph.knowledge")["disposition"],
         "derived"
@@ -543,7 +568,10 @@ policies:
     assert!(!temp.path().join("graphs/engineering.omni").exists());
 
     let status = cluster_json(temp.path(), "status");
-    assert_eq!(status["observations"]["graph.engineering"]["kind"], "tombstone");
+    assert_eq!(
+        status["observations"]["graph.engineering"]["kind"],
+        "tombstone"
+    );
     let final_plan = cluster_json(temp.path(), "plan");
     assert!(
         final_plan["changes"].as_array().unwrap().is_empty(),
@@ -579,7 +607,10 @@ fn cluster_e2e_declared_graph_created_by_apply() {
     let apply = cluster_json(temp.path(), "apply");
     assert_eq!(apply["ok"], true, "{apply}");
     assert_eq!(apply["converged"], true, "{apply}");
-    assert_eq!(change_for(&apply, "graph.knowledge")["disposition"], "applied");
+    assert_eq!(
+        change_for(&apply, "graph.knowledge")["disposition"],
+        "applied"
+    );
     assert!(temp.path().join("graphs/knowledge.omni").exists());
 
     // The created graph is a real graph: the per-graph CLI can open it.

--- a/crates/omnigraph-cli/tests/cli_data.rs
+++ b/crates/omnigraph-cli/tests/cli_data.rs
@@ -11,7 +11,6 @@ mod support;
 
 use support::*;
 
-
 #[test]
 fn short_version_flag_prints_current_cli_version() {
     let output = output_success(cli().arg("-v"));
@@ -269,8 +268,9 @@ fn optimize_with_remote_target_errors_storage_plane() {
     let output = output_failure(cli().arg("optimize").arg("https://graph.example.invalid"));
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("`optimize` is a direct (storage-native) command and needs direct storage access")
-            && stderr.contains("remote server"),
+        stderr.contains(
+            "`optimize` is a direct (storage-native) command and needs direct storage access"
+        ) && stderr.contains("remote server"),
         "direct remote-target message not found; got: {stderr}"
     );
 }
@@ -290,9 +290,11 @@ fn repair_json_reports_noop_on_clean_graph() {
     assert_eq!(payload["manifest_version"], Value::Null);
     let tables = payload["tables"].as_array().unwrap();
     assert_eq!(tables.len(), 4);
-    assert!(tables.iter().all(|table| {
-        table["classification"] == "no_drift" && table["action"] == "no_op"
-    }));
+    assert!(
+        tables
+            .iter()
+            .all(|table| { table["classification"] == "no_drift" && table["action"] == "no_op" })
+    );
 }
 
 #[test]
@@ -678,8 +680,9 @@ query list_people() {
     // RFC-010/011: the direct (storage-native) verbs share one declared message
     // (was: "query lint is only supported against local graph URIs …").
     assert!(
-        stderr.contains("`lint` is a direct (storage-native) command and needs direct storage access")
-            && stderr.contains("remote server"),
+        stderr.contains(
+            "`lint` is a direct (storage-native) command and needs direct storage access"
+        ) && stderr.contains("remote server"),
         "direct remote-target message not found; got: {stderr}"
     );
 }
@@ -1503,7 +1506,14 @@ fn read_rejects_empty_query_string() {
     init_graph(&repo);
     load_fixture(&repo);
 
-    let output = output_failure(cli().arg("read").arg("--store").arg(&repo).arg("-e").arg(""));
+    let output = output_failure(
+        cli()
+            .arg("read")
+            .arg("--store")
+            .arg(&repo)
+            .arg("-e")
+            .arg(""),
+    );
     let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(
         stderr.contains("must not be empty"),
@@ -2251,7 +2261,10 @@ fn profile_list_names_each_profile_with_its_binding_and_marks_active() {
     assert!(stdout.contains("cluster: brain"), "{stdout}");
     assert!(stdout.contains("store: file:///data/dev.omni"), "{stdout}");
     // A malformed (two-scope) profile is reported, not a hard failure.
-    assert!(stdout.contains("broken") && stdout.contains("invalid:"), "{stdout}");
+    assert!(
+        stdout.contains("broken") && stdout.contains("invalid:"),
+        "{stdout}"
+    );
 }
 
 #[test]

--- a/crates/omnigraph-cli/tests/cli_queries.rs
+++ b/crates/omnigraph-cli/tests/cli_queries.rs
@@ -1,13 +1,11 @@
 //! Stored-query commands and alias resolution.
 //! Moved verbatim from tests/cli.rs in the modularization.
 
-
 use tempfile::tempdir;
 
 mod support;
 
 use support::*;
-
 
 #[test]
 fn query_check_alias_matches_lint_output() {
@@ -129,9 +127,8 @@ fn queries_list_with_store_flag_errors() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("`queries list` is a cluster control command")
-            && stderr.contains(
-                "--store addresses a single graph's storage directly and does not apply"
-            ),
+            && stderr
+                .contains("--store addresses a single graph's storage directly and does not apply"),
         "expected the addressing-guard store rejection; got: {stderr}"
     );
 }
@@ -186,7 +183,11 @@ fn queries_and_policy_wrong_server_scope_points_at_cluster_scope() {
 
 /// Build a converged single-graph cluster (id `knowledge`) with one stored
 /// query. `query_block` is the YAML under the graph's `queries:` key.
-fn converged_cluster_with_query(query_file: &str, query_src: &str, query_block: &str) -> tempfile::TempDir {
+fn converged_cluster_with_query(
+    query_file: &str,
+    query_src: &str,
+    query_block: &str,
+) -> tempfile::TempDir {
     let temp = tempdir().unwrap();
     let dir = temp.path();
     std::fs::copy(fixture("test.pg"), dir.join("graph.pg")).unwrap();
@@ -292,7 +293,11 @@ fn queries_list_surfaces_description_and_instruction() {
 
     // Human output.
     let output = output_success(
-        cli().arg("queries").arg("list").arg("--cluster").arg(cluster.path()),
+        cli()
+            .arg("queries")
+            .arg("list")
+            .arg("--cluster")
+            .arg(cluster.path()),
     );
     let stdout = stdout_string(&output);
     assert!(
@@ -340,7 +345,11 @@ fn queries_list_indents_multiline_annotation_continuation() {
         "      multi:\n        file: ./multi.gq\n",
     );
     let output = output_success(
-        cli().arg("queries").arg("list").arg("--cluster").arg(cluster.path()),
+        cli()
+            .arg("queries")
+            .arg("list")
+            .arg("--cluster")
+            .arg(cluster.path()),
     );
     let stdout = stdout_string(&output);
     // "    description: " is 17 chars wide; the continuation aligns under it.
@@ -363,7 +372,11 @@ fn queries_list_omits_annotations_when_absent() {
 
     // Human output: the query is listed, but no annotation lines.
     let output = output_success(
-        cli().arg("queries").arg("list").arg("--cluster").arg(cluster.path()),
+        cli()
+            .arg("queries")
+            .arg("list")
+            .arg("--cluster")
+            .arg(cluster.path()),
     );
     let stdout = stdout_string(&output);
     assert!(stdout.contains("bare()"), "stdout:\n{stdout}");

--- a/crates/omnigraph-cli/tests/cli_schema_config.rs
+++ b/crates/omnigraph-cli/tests/cli_schema_config.rs
@@ -11,7 +11,6 @@ mod support;
 
 use support::*;
 
-
 #[test]
 fn version_command_prints_current_cli_version() {
     let output = output_success(cli().arg("version"));
@@ -628,9 +627,8 @@ fn graphs_list_rejects_store_scope() {
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
     assert!(
         stderr.contains("`graphs list` is a served command")
-            && stderr.contains(
-                "--store addresses a single graph's storage directly and does not apply"
-            )
+            && stderr
+                .contains("--store addresses a single graph's storage directly and does not apply")
             && stderr.contains("Address the server with --server <name|url> or --profile <name>."),
         "expected the addressing-guard store rejection in stderr; got:\n{stderr}"
     );

--- a/crates/omnigraph-cli/tests/crossversion_upgrade.rs
+++ b/crates/omnigraph-cli/tests/crossversion_upgrade.rs
@@ -1094,11 +1094,7 @@ fn current_refuses_and_rebuilds_genuine_v8_and_v8_refuses_current() {
             .arg(&current_graph),
     );
     let reexport = output_success(cli().arg("export").arg(&current_graph));
-    assert_export_fidelity(
-        "v8/config-v2 → current",
-        &export.stdout,
-        &reexport.stdout,
-    );
+    assert_export_fidelity("v8/config-v2 → current", &export.stdout, &reexport.stdout);
     assert_export_omits_trusted_stream_metadata("rebuilt current", &reexport.stdout);
     let rebuilt_legacy = exported_row_with_data_value(
         &reexport.stdout,

--- a/crates/omnigraph-cli/tests/parity_matrix.rs
+++ b/crates/omnigraph-cli/tests/parity_matrix.rs
@@ -81,15 +81,14 @@ fn parity_query() {
     let p = parity();
     let query = fixture("test.gq");
     let (l, r) = p.run(&[
-            "query",
-            "--query",
-            query.to_str().unwrap(),
-            "get_person",
-            "--params",
-            r#"{"name":"Alice"}"#,
-            "--json",
-        ],
-    );
+        "query",
+        "--query",
+        query.to_str().unwrap(),
+        "get_person",
+        "--params",
+        r#"{"name":"Alice"}"#,
+        "--json",
+    ]);
     assert_parity("query", &l, &r);
 }
 
@@ -134,45 +133,46 @@ fn parity_commit_list_branch() {
 fn parity_mutate() {
     let p = parity();
     let (l, r) = p.run(&[
-            "mutate",
-            "-e",
-            "query add($name: String, $age: I32) { insert Person { name: $name, age: $age } }",
-            "--params",
-            r#"{"name":"Parity","age":7}"#,
-            "--json",
-        ],
-    );
+        "mutate",
+        "-e",
+        "query add($name: String, $age: I32) { insert Person { name: $name, age: $age } }",
+        "--params",
+        r#"{"name":"Parity","age":7}"#,
+        "--json",
+    ]);
     assert_parity("mutate", &l, &r);
 }
 
 #[test]
 fn parity_branch_create_delete() {
     let p = parity();
-    let (l, r) = p.run(&["branch", "create", "--from", "main", "parity-branch", "--json"],
-    );
+    let (l, r) = p.run(&[
+        "branch",
+        "create",
+        "--from",
+        "main",
+        "parity-branch",
+        "--json",
+    ]);
     assert_parity("branch create", &l, &r);
     // `branch delete` is destructive: the served (remote) arm is non-local and
     // requires consent (RFC-011 Decision 9), so the row passes `--yes` to test
     // the operation itself, not the safety gate. The local arm ignores `--yes`.
-    let (l, r) = p.run(&["branch", "delete", "parity-branch", "--yes", "--json"],
-    );
+    let (l, r) = p.run(&["branch", "delete", "parity-branch", "--yes", "--json"]);
     assert_parity("branch delete", &l, &r);
 }
 
 #[test]
 fn parity_branch_merge() {
     let p = parity();
-    let (l, r) = p.run(&["branch", "create", "--from", "main", "feature", "--json"],
-    );
+    let (l, r) = p.run(&["branch", "create", "--from", "main", "feature", "--json"]);
     assert_parity("branch create (merge setup)", &l, &r);
-    let (l, r) = p.run(&["branch", "merge", "feature", "--into", "main", "--json"],
-    );
+    let (l, r) = p.run(&["branch", "merge", "feature", "--into", "main", "--json"]);
     assert_parity("branch merge", &l, &r);
     // `--delete-branch` composes merge + delete at each arm's own boundary
     // (embedded: two engine calls; remote: the server handler) — this row is
     // the referee that keeps the two composition sites from drifting.
-    let (l, r) = p.run(&["branch", "create", "--from", "main", "feature2", "--json"],
-    );
+    let (l, r) = p.run(&["branch", "create", "--from", "main", "feature2", "--json"]);
     assert_parity("branch create (delete-branch setup)", &l, &r);
     let (l, r) = p.run(&[
         "branch",
@@ -198,14 +198,13 @@ fn parity_load() {
     )
     .unwrap();
     let (l, r) = p.run(&[
-            "load",
-            "--mode",
-            "merge",
-            "--data",
-            data.to_str().unwrap(),
-            "--json",
-        ],
-    );
+        "load",
+        "--mode",
+        "merge",
+        "--data",
+        data.to_str().unwrap(),
+        "--json",
+    ]);
     assert_parity("load", &l, &r);
 }
 
@@ -245,8 +244,14 @@ fn parity_errors_share_exit_codes() {
     let p = parity();
 
     // unknown branch on merge
-    let (l, r) = p.run(&["branch", "merge", "no-such-branch", "--into", "main", "--json"],
-    );
+    let (l, r) = p.run(&[
+        "branch",
+        "merge",
+        "no-such-branch",
+        "--into",
+        "main",
+        "--json",
+    ]);
     assert_eq!(
         (l.status.success(), r.status.success()),
         (false, false),
@@ -256,13 +261,12 @@ fn parity_errors_share_exit_codes() {
     // unknown query name in the source
     let query = fixture("test.gq");
     let (l, r) = p.run(&[
-            "query",
-            "--query",
-            query.to_str().unwrap(),
-            "no_such_query",
-            "--json",
-        ],
-    );
+        "query",
+        "--query",
+        query.to_str().unwrap(),
+        "no_such_query",
+        "--json",
+    ]);
     assert_eq!(
         (l.status.success(), r.status.success()),
         (false, false),
@@ -275,13 +279,12 @@ fn parity_errors_share_exit_codes() {
     // path hard-errors 'parameter not provided'. Pinned here as agreeing
     // behavior; the cross-path asymmetry is filed separately.
     let (l, r) = p.run(&[
-            "query",
-            "--query",
-            query.to_str().unwrap(),
-            "get_person",
-            "--json",
-        ],
-    );
+        "query",
+        "--query",
+        query.to_str().unwrap(),
+        "get_person",
+        "--json",
+    ]);
     assert_eq!(
         (l.status.success(), r.status.success()),
         (true, true),

--- a/crates/omnigraph-cli/tests/system_local.rs
+++ b/crates/omnigraph-cli/tests/system_local.rs
@@ -1154,8 +1154,7 @@ fn local_cli_change_enforces_engine_layer_policy() {
         cluster.path(),
         &[("OMNIGRAPH_SERVER_BEARER_TOKENS_JSON", POLICY_TOKENS_JSON)],
     );
-    let insert =
-        "query add($name: String, $age: I32) { insert Person { name: $name, age: $age } }";
+    let insert = "query add($name: String, $age: I32) { insert Person { name: $name, age: $age } }";
 
     // Case 1: no token → the server refuses before any policy check.
     let no_token = cli()
@@ -1441,7 +1440,10 @@ fn local_cli_branch_create_enforces_engine_layer_policy() {
         .arg("bruno-feature")
         .output()
         .unwrap();
-    assert!(!denied.status.success(), "bruno branch create must be denied");
+    assert!(
+        !denied.status.success(),
+        "bruno branch create must be denied"
+    );
     let stderr = String::from_utf8_lossy(&denied.stderr);
     assert!(
         stderr.contains("denied"),
@@ -1505,7 +1507,10 @@ fn local_cli_branch_delete_enforces_engine_layer_policy() {
         .arg("doomed")
         .output()
         .unwrap();
-    assert!(!denied.status.success(), "bruno branch delete must be denied");
+    assert!(
+        !denied.status.success(),
+        "bruno branch delete must be denied"
+    );
     let stderr = String::from_utf8_lossy(&denied.stderr);
     assert!(
         stderr.contains("denied"),
@@ -1568,7 +1573,10 @@ fn local_cli_branch_merge_enforces_engine_layer_policy() {
         .arg("main")
         .output()
         .unwrap();
-    assert!(!denied.status.success(), "bruno branch merge must be denied");
+    assert!(
+        !denied.status.success(),
+        "bruno branch merge must be denied"
+    );
     let stderr = String::from_utf8_lossy(&denied.stderr);
     assert!(
         stderr.contains("denied"),
@@ -2144,8 +2152,16 @@ fn local_cluster_full_lifecycle_declare_serve_evolve_delete() {
     // Phase 3-4: one apply creates both graphs and publishes the catalog.
     let converge = cluster_cli(dir, &["apply"]);
     assert_eq!(converge["converged"], true, "{converge}");
-    seed_graph(dir, "knowledge", "{\"type\":\"Person\",\"data\":{\"name\":\"Ada\"}}\n");
-    seed_graph(dir, "engineering", "{\"type\":\"Service\",\"data\":{\"name\":\"billing\"}}\n");
+    seed_graph(
+        dir,
+        "knowledge",
+        "{\"type\":\"Person\",\"data\":{\"name\":\"Ada\"}}\n",
+    );
+    seed_graph(
+        dir,
+        "engineering",
+        "{\"type\":\"Service\",\"data\":{\"name\":\"billing\"}}\n",
+    );
 
     // Phase 5: serve the applied revision.
     let client = Client::new();
@@ -2228,8 +2244,7 @@ fn local_cluster_full_lifecycle_declare_serve_evolve_delete() {
     });
     let refresh = cluster_cli(dir, &["refresh"]);
     assert_eq!(
-        refresh["resource_statuses"]["schema.knowledge"]["status"],
-        "drifted",
+        refresh["resource_statuses"]["schema.knowledge"]["status"], "drifted",
         "{refresh}"
     );
     let heal = cluster_cli(dir, &["apply"]);
@@ -2246,7 +2261,10 @@ fn local_cluster_full_lifecycle_declare_serve_evolve_delete() {
         String::from_utf8_lossy(&schema_show.stderr)
     );
     let shown = String::from_utf8_lossy(&schema_show.stdout);
-    assert!(shown.contains("Person"), "schema show produced no schema: {shown}");
+    assert!(
+        shown.contains("Person"),
+        "schema show produced no schema: {shown}"
+    );
     assert!(
         !shown.contains("rogue"),
         "drift must be soft-dropped back to the declared schema: {shown}"
@@ -2395,7 +2413,11 @@ policies:
     assert_eq!(cluster_cli(dir, &["import"])["ok"], true);
     let converge = cluster_cli(dir, &["apply"]);
     assert_eq!(converge["converged"], true, "{converge}");
-    seed_graph(dir, "knowledge", "{\"type\":\"Person\",\"data\":{\"name\":\"Ada\"}}\n");
+    seed_graph(
+        dir,
+        "knowledge",
+        "{\"type\":\"Person\",\"data\":{\"name\":\"Ada\"}}\n",
+    );
 
     let server = spawn_server_with_cluster_env(
         dir,
@@ -2532,7 +2554,10 @@ fn local_cli_keyed_credentials_authenticate_url_matched_server() {
         .unwrap();
     assert!(output.status.success(), "{output:?}");
     let output = remote_read(&[]);
-    assert!(!output.status.success(), "wrong token must not authenticate");
+    assert!(
+        !output.status.success(),
+        "wrong token must not authenticate"
+    );
 
     // Re-login rotates to the right token (via --token); 0600 on disk.
     let output = cli()
@@ -2558,8 +2583,7 @@ fn local_cli_keyed_credentials_authenticate_url_matched_server() {
         output.status.success(),
         "keyed credential must authenticate the URL-matched server: {output:?}"
     );
-    let payload: serde_json::Value =
-        serde_json::from_slice(&output.stdout).unwrap();
+    let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(payload["rows"][0]["p.name"], "Alice");
 
     // OMNIGRAPH_TOKEN_<NAME> env outranks the credentials file.
@@ -2622,8 +2646,20 @@ fn local_cli_operator_alias_and_server_flag_invoke_stored_query() {
         "version: 1\nmetadata:\n  name: alias-sys\nstate:\n  backend: cluster\n  lock: true\ngraphs:\n  local:\n    schema: ./local.pg\n    queries:\n      find_person:\n        file: ./find-person.gq\n      insert_person:\n        file: ./insert-person.gq\npolicies:\n  graph:\n    file: ./graph.policy.yaml\n    applies_to: [local]\n",
     )
     .unwrap();
-    output_success(cli().arg("cluster").arg("import").arg("--config").arg(cluster.path()));
-    output_success(cli().arg("cluster").arg("apply").arg("--config").arg(cluster.path()));
+    output_success(
+        cli()
+            .arg("cluster")
+            .arg("import")
+            .arg("--config")
+            .arg(cluster.path()),
+    );
+    output_success(
+        cli()
+            .arg("cluster")
+            .arg("apply")
+            .arg("--config")
+            .arg(cluster.path()),
+    );
     output_success(
         cli()
             .arg("load")
@@ -2754,7 +2790,10 @@ fn local_cli_operator_alias_and_server_flag_invoke_stored_query() {
         .arg("--json")
         .output()
         .unwrap();
-    assert!(output.status.success(), "by-name catalog invocation: {output:?}");
+    assert!(
+        output.status.success(),
+        "by-name catalog invocation: {output:?}"
+    );
     let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(payload["rows"][0]["p.name"], "Alice", "{payload}");
 
@@ -2790,7 +2829,10 @@ fn local_cli_operator_alias_and_server_flag_invoke_stored_query() {
         .unwrap();
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("unknown server 'nope'") && stderr.contains("dev"), "{stderr}");
+    assert!(
+        stderr.contains("unknown server 'nope'") && stderr.contains("dev"),
+        "{stderr}"
+    );
 
     // --server is exclusive with --store (two ways to address the graph).
     // (RFC-011 D3: there is no positional URI anymore — the positional is a

--- a/crates/omnigraph-cli/tests/system_remote.rs
+++ b/crates/omnigraph-cli/tests/system_remote.rs
@@ -64,7 +64,10 @@ fn remote_server_and_cli_end_to_end_flow() {
     let cluster = converged_loaded_cluster(GRAPH_ID, None);
     let server = spawn_server_with_cluster(cluster.path());
     // The served graph's storage root — used for embedded-side cross checks.
-    let served_root = cluster.path().join("graphs").join(format!("{GRAPH_ID}.omni"));
+    let served_root = cluster
+        .path()
+        .join("graphs")
+        .join(format!("{GRAPH_ID}.omni"));
     let temp = tempfile::tempdir().unwrap();
     let mutation_file = temp.path().join("system-remote-change.gq");
     fs::write(
@@ -244,7 +247,10 @@ query insert_person($name: String, $age: I32) {
         }))
         .send()
         .unwrap();
-    assert_eq!(http_query_mutation.status(), reqwest::StatusCode::BAD_REQUEST);
+    assert_eq!(
+        http_query_mutation.status(),
+        reqwest::StatusCode::BAD_REQUEST
+    );
 }
 
 #[test]
@@ -252,7 +258,10 @@ query insert_person($name: String, $age: I32) {
 fn remote_schema_apply_via_cli_updates_graph() {
     let cluster = converged_loaded_cluster(GRAPH_ID, None);
     let server = spawn_server_with_cluster(cluster.path());
-    let served_root = cluster.path().join("graphs").join(format!("{GRAPH_ID}.omni"));
+    let served_root = cluster
+        .path()
+        .join("graphs")
+        .join(format!("{GRAPH_ID}.omni"));
     let temp = tempfile::tempdir().unwrap();
     let next_schema = temp.path().join("next.pg");
     fs::write(
@@ -1136,7 +1145,11 @@ fn graphs_list_against_multi_graph_server() {
     let cfg_dir = tempfile::tempdir().unwrap();
     let dir = cfg_dir.path();
     fs::copy(fixture("test.pg"), dir.join("alpha.pg")).unwrap();
-    fs::write(dir.join("server.policy.yaml"), GRAPH_LIST_SERVER_POLICY_YAML).unwrap();
+    fs::write(
+        dir.join("server.policy.yaml"),
+        GRAPH_LIST_SERVER_POLICY_YAML,
+    )
+    .unwrap();
     fs::write(
         dir.join("cluster.yaml"),
         "version: 1\nmetadata:\n  name: sys\nstate:\n  backend: cluster\n  lock: true\ngraphs:\n  alpha:\n    schema: ./alpha.pg\npolicies:\n  server:\n    file: ./server.policy.yaml\n    applies_to: [cluster]\n",

--- a/crates/omnigraph-cluster/src/config.rs
+++ b/crates/omnigraph-cluster/src/config.rs
@@ -415,11 +415,10 @@ pub(crate) async fn observe_declared_graphs(
                                 .as_ref()
                                 .map(|resource| {
                                     let digest = resource.digest.clone();
-                                    let declaration_revision = Some(
-                                        resource.declaration_revision.clone().unwrap_or_else(|| {
-                                            streaming_declaration_revision(&graph.id, &digest)
-                                        }),
-                                    );
+                                    let declaration_revision =
+                                        Some(resource.declaration_revision.clone().unwrap_or_else(
+                                            || streaming_declaration_revision(&graph.id, &digest),
+                                        ));
                                     (digest, declaration_revision)
                                 })
                                 .unwrap_or_else(|| {
@@ -487,20 +486,14 @@ pub(crate) async fn observe_declared_graphs(
                         schema_matches_desired: Some(schema_matches),
                         streaming_enabled: Some(observation.streaming_enabled),
                         streaming_undrained: Some(observation.streaming_undrained),
-                        streaming_profile_mode: Some(
-                            observation.streaming_profile_mode.as_str(),
-                        ),
-                        streaming_profile_revision: Some(
-                            observation.streaming_profile_revision,
-                        ),
-                        streaming_matches_desired: graph
-                            .streaming
-                            .map(|desired| {
-                                streaming_mode_matches_desired(
-                                    &observation.streaming_profile_mode,
-                                    desired,
-                                )
-                            }),
+                        streaming_profile_mode: Some(observation.streaming_profile_mode.as_str()),
+                        streaming_profile_revision: Some(observation.streaming_profile_revision),
+                        streaming_matches_desired: graph.streaming.map(|desired| {
+                            streaming_mode_matches_desired(
+                                &observation.streaming_profile_mode,
+                                desired,
+                            )
+                        }),
                         error: None,
                     }),
                 );
@@ -1024,10 +1017,7 @@ pub(crate) fn load_desired(config_dir: &Path) -> LoadOutcome {
                 .cloned()
                 .unwrap_or_default(),
             embedding_provider: graph_embedding_providers.get(graph_id).cloned(),
-            streaming: raw
-                .graphs
-                .get(graph_id)
-                .and_then(|graph| graph.streaming),
+            streaming: raw.graphs.get(graph_id).and_then(|graph| graph.streaming),
         })
         .collect();
     let config_digest = desired_config_digest(&raw, &resource_digests);
@@ -1213,10 +1203,7 @@ pub(crate) fn streaming_digest(graph_id: &str, enabled: bool) -> String {
 /// an otherwise unchanged enabled graph without any supported renewal
 /// transition. This domain-separated revision changes only with this graph's
 /// declaration digest and can therefore be reconstructed by refresh.
-pub(crate) fn streaming_declaration_revision(
-    graph_id: &str,
-    declaration_digest: &str,
-) -> String {
+pub(crate) fn streaming_declaration_revision(graph_id: &str, declaration_digest: &str) -> String {
     sha256_hex(
         format!(
             "omnigraph.cluster.streaming-declaration-revision.v1\0{graph_id}\0{declaration_digest}"
@@ -1239,10 +1226,7 @@ pub(crate) fn observed_streaming_digest(graph_id: &str, profile_mode: &str) -> S
     }
 }
 
-pub(crate) fn streaming_mode_matches_desired(
-    profile_mode: &str,
-    desired_enabled: bool,
-) -> bool {
+pub(crate) fn streaming_mode_matches_desired(profile_mode: &str, desired_enabled: bool) -> bool {
     matches!(
         (profile_mode, desired_enabled),
         ("ENABLED", true) | ("DISABLED" | "RETIRED", false)

--- a/crates/omnigraph-cluster/src/diff.rs
+++ b/crates/omnigraph-cluster/src/diff.rs
@@ -225,7 +225,10 @@ pub(crate) fn approved_resources(
 pub(crate) enum ResourceKind {
     Graph(String),
     Schema(String),
-    Query { graph: String, name: String },
+    Query {
+        graph: String,
+        name: String,
+    },
     Policy(String),
     EmbeddingProvider(String),
     /// RFC-026 §4.7 P1: the per-graph streaming-enablement flag. First-class

--- a/crates/omnigraph-cluster/src/lib.rs
+++ b/crates/omnigraph-cluster/src/lib.rs
@@ -1280,22 +1280,23 @@ pub async fn apply_config_dir_with_options(
             })
             .map(|artifact| artifact.approval_id.clone());
         let graph_uri = backend.graph_root(graph_id);
-        let _export_exclusion =
-            match omnigraph::db::reserve_stream_export_root_exclusion(&graph_uri) {
-                Ok(guard) => guard,
-                Err(error) => {
-                    diagnostics.push(Diagnostic::error(
+        let _export_exclusion = match omnigraph::db::reserve_stream_export_root_exclusion(
+            &graph_uri,
+        ) {
+            Ok(guard) => guard,
+            Err(error) => {
+                diagnostics.push(Diagnostic::error(
                         "graph_delete_export_in_progress",
                         graph_addr.clone(),
                         format!(
                             "cannot remove graph root '{graph_uri}' while an immutable export owns it: {error}"
                         ),
                     ));
-                    failed_graphs.insert(graph_id.clone(), FailedGraphOrigin::GraphDelete);
-                    graph_moving_aborted = true;
-                    continue;
-                }
-            };
+                failed_graphs.insert(graph_id.clone(), FailedGraphOrigin::GraphDelete);
+                graph_moving_aborted = true;
+                continue;
+            }
+        };
         let observed_manifest_version = match Omnigraph::open_read_only(&graph_uri).await {
             Ok(db) => match db.snapshot_of(ReadTarget::branch("main")).await {
                 Ok(snapshot) => Some(snapshot.version()),

--- a/crates/omnigraph-cluster/src/store.rs
+++ b/crates/omnigraph-cluster/src/store.rs
@@ -53,12 +53,8 @@ impl ClusterStore {
     /// (`file://<abs config dir>`), byte-compatible with every pre-existing
     /// cluster on disk.
     pub(crate) fn for_config_dir(config_dir: &Path) -> Self {
-        let absolute =
-            std::path::absolute(config_dir).unwrap_or_else(|_| config_dir.to_path_buf());
-        let display_root = absolute
-            .to_string_lossy()
-            .trim_end_matches('/')
-            .to_string();
+        let absolute = std::path::absolute(config_dir).unwrap_or_else(|_| config_dir.to_path_buf());
+        let display_root = absolute.to_string_lossy().trim_end_matches('/').to_string();
         let root = format!("file://{display_root}");
         let storage = storage_handle_for_uri(&root)
             .expect("local storage adapter construction is infallible for file:// roots");
@@ -231,7 +227,10 @@ impl ClusterStore {
     /// on the deletion (e.g. the pre-movement sidecar cleanup fast-path) can
     /// report it as a diagnostic instead of silently leaving stale state.
     pub(crate) async fn try_delete_object(&self, uri: &str) -> Result<(), String> {
-        self.adapter.delete(uri).await.map_err(|err| err.to_string())
+        self.adapter
+            .delete(uri)
+            .await
+            .map_err(|err| err.to_string())
     }
 
     /// Recursive prefix delete for graph roots (approved deletes). Idempotent;
@@ -408,16 +407,12 @@ impl ClusterStore {
             Ok(true) => {}
             Err(err) => return Err(err.to_string()),
         }
-        self.adapter
-            .read_text(&uri)
-            .await
-            .map(Some)
-            .map_err(|err| {
-                format!(
-                    "could not read catalog payload '{}': {err}",
-                    self.display(&relative)
-                )
-            })
+        self.adapter.read_text(&uri).await.map(Some).map_err(|err| {
+            format!(
+                "could not read catalog payload '{}': {err}",
+                self.display(&relative)
+            )
+        })
     }
 
     /// Idempotent content-addressed write: a payload already present at its
@@ -726,11 +721,13 @@ impl ClusterStore {
                 observations.locked = true;
                 match StateLockFile::parse(&text) {
                     Ok(lock) => observations.observe_lock_metadata(&lock),
-                    Err(AuthorityError::LockVersion(version)) => diagnostics.push(Diagnostic::warning(
-                        "unsupported_state_lock_version",
-                        CLUSTER_LOCK_FILE,
-                        format!("unsupported cluster state lock version {version}"),
-                    )),
+                    Err(AuthorityError::LockVersion(version)) => {
+                        diagnostics.push(Diagnostic::warning(
+                            "unsupported_state_lock_version",
+                            CLUSTER_LOCK_FILE,
+                            format!("unsupported cluster state lock version {version}"),
+                        ))
+                    }
                     Err(AuthorityError::LockParse(err)) => diagnostics.push(Diagnostic::warning(
                         "invalid_state_lock",
                         CLUSTER_LOCK_FILE,
@@ -752,10 +749,7 @@ impl ClusterStore {
         }
     }
 
-    pub(crate) async fn observe_lock_metadata_lossy(
-        &self,
-        observations: &mut StateObservations,
-    ) {
+    pub(crate) async fn observe_lock_metadata_lossy(&self, observations: &mut StateObservations) {
         observations.locked = true;
         let lock_uri = self.uri(CLUSTER_LOCK_FILE);
         if let Ok(Some((text, _))) = self.read_versioned_opt(&lock_uri).await {

--- a/crates/omnigraph-cluster/src/stream_block.rs
+++ b/crates/omnigraph-cluster/src/stream_block.rs
@@ -948,11 +948,7 @@ mod projection_tests {
         assert!(json.contains("logical-1"));
         assert!(json.contains(r#""kind":"node""#));
         assert!(json.contains(r#""type":"SecretDeclaration""#));
-        for forbidden in [
-            "stable_table_id",
-            "table_incarnation_id",
-            "table_key",
-        ] {
+        for forbidden in ["stable_table_id", "table_incarnation_id", "table_key"] {
             assert!(
                 !json.contains(forbidden),
                 "projection leaked {forbidden}: {json}"

--- a/crates/omnigraph-cluster/src/stream_policy.rs
+++ b/crates/omnigraph-cluster/src/stream_policy.rs
@@ -12,9 +12,7 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::sync::Arc;
 
-use omnigraph_policy::{
-    PolicyAction, PolicyChecker, PolicyEngine, PolicyError, ResourceScope,
-};
+use omnigraph_policy::{PolicyAction, PolicyChecker, PolicyEngine, PolicyError, ResourceScope};
 
 use crate::diff::{ResourceKind, resource_kind};
 use crate::store::ClusterStore;
@@ -112,22 +110,19 @@ pub(crate) async fn stream_profile_policy_checker(
     }
 
     if let Some(address) = desired_bound.into_iter().next() {
-        let digest = desired.resource_digests.get(address).ok_or_else(|| {
-            format!("desired graph policy '{address}' has no resource digest")
-        })?;
+        let digest = desired
+            .resource_digests
+            .get(address)
+            .ok_or_else(|| format!("desired graph policy '{address}' has no resource digest"))?;
         if !seen.contains(&(address.to_string(), digest.clone())) {
             let path = desired
                 .resources
                 .iter()
                 .find(|resource| resource.address == address)
                 .and_then(|resource| resource.path.as_deref())
-                .ok_or_else(|| {
-                    format!("desired graph policy '{address}' has no source path")
-                })?;
+                .ok_or_else(|| format!("desired graph policy '{address}' has no source path"))?;
             let source = fs::read_to_string(path).map_err(|error| {
-                format!(
-                    "could not read desired graph policy '{address}' from '{path}': {error}"
-                )
+                format!("could not read desired graph policy '{address}' from '{path}': {error}")
             })?;
             let observed = super::sha256_hex(source.as_bytes());
             if &observed != digest {

--- a/crates/omnigraph-cluster/src/stream_retirement.rs
+++ b/crates/omnigraph-cluster/src/stream_retirement.rs
@@ -230,11 +230,7 @@ async fn converge_retired_streaming_resource(
     profile_revision: u64,
 ) -> Result<(), Diagnostic> {
     let streaming_address = format!("streaming.{graph_id}");
-    let Some(streaming) = state
-        .applied_revision
-        .resources
-        .get_mut(&streaming_address)
-    else {
+    let Some(streaming) = state.applied_revision.resources.get_mut(&streaming_address) else {
         return Ok(());
     };
     if streaming.streaming_enabled == Some(false)

--- a/crates/omnigraph-cluster/src/tests.rs
+++ b/crates/omnigraph-cluster/src/tests.rs
@@ -3,48 +3,46 @@
 //! (cluster.yaml/JSON bodies) are content, not formatting.
 #![allow(clippy::all)]
 
-    use std::fs;
-    #[cfg(feature = "failpoints")]
-    use std::future::Future;
-    use std::path::Path;
-    #[cfg(feature = "failpoints")]
-    use std::sync::Arc;
+use std::fs;
+#[cfg(feature = "failpoints")]
+use std::future::Future;
+use std::path::Path;
+#[cfg(feature = "failpoints")]
+use std::sync::Arc;
 
-    use omnigraph::db::Omnigraph;
-    #[cfg(feature = "failpoints")]
-    use omnigraph_compiler::ir::ParamMap;
-    #[cfg(feature = "failpoints")]
-    use omnigraph_compiler::query::ast::Literal;
-    use serde_json::json;
-    use tempfile::tempdir;
+use omnigraph::db::Omnigraph;
+#[cfg(feature = "failpoints")]
+use omnigraph_compiler::ir::ParamMap;
+#[cfg(feature = "failpoints")]
+use omnigraph_compiler::query::ast::Literal;
+use serde_json::json;
+use tempfile::tempdir;
 
-    use crate::config::{
-        observed_streaming_digest, streaming_digest, streaming_mode_matches_desired,
-    };
-    use super::*;
+use super::*;
+use crate::config::{observed_streaming_digest, streaming_digest, streaming_mode_matches_desired};
 
-    const SCHEMA: &str = r#"
+const SCHEMA: &str = r#"
 node Person {
   name: String @key
   age: I32?
 }
 "#;
 
-    const QUERY: &str = r#"
+const QUERY: &str = r#"
 query find_person($name: String) {
   match { $p: Person { name: $name } }
   return { $p.name, $p.age }
 }
 "#;
 
-    fn fixture() -> tempfile::TempDir {
-        let dir = tempdir().unwrap();
-        fs::write(dir.path().join("people.pg"), SCHEMA).unwrap();
-        fs::write(dir.path().join("people.gq"), QUERY).unwrap();
-        fs::write(dir.path().join("base.policy.yaml"), "rules: []\n").unwrap();
-        fs::write(
-            dir.path().join(CLUSTER_CONFIG_FILE),
-            r#"
+fn fixture() -> tempfile::TempDir {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join("people.pg"), SCHEMA).unwrap();
+    fs::write(dir.path().join("people.gq"), QUERY).unwrap();
+    fs::write(dir.path().join("base.policy.yaml"), "rules: []\n").unwrap();
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        r#"
 version: 1
 metadata:
   name: test
@@ -62,38 +60,38 @@ policies:
     file: ./base.policy.yaml
     applies_to: [knowledge]
 "#,
-        )
+    )
+    .unwrap();
+    dir
+}
+
+/// Run a composed streaming lifecycle scenario outside libtest's 2-MiB
+/// thread. Individual operations run on ordinary stacks elsewhere; this
+/// only bounds the large debug future assembled by an end-to-end test.
+#[cfg(feature = "failpoints")]
+fn on_big_stack<F>(body: impl FnOnce() -> F + Send + 'static)
+where
+    F: Future<Output = ()>,
+{
+    std::thread::Builder::new()
+        .stack_size(64 * 1024 * 1024)
+        .spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap()
+                .block_on(body());
+        })
+        .unwrap()
+        .join()
         .unwrap();
-        dir
-    }
+}
 
-    /// Run a composed streaming lifecycle scenario outside libtest's 2-MiB
-    /// thread. Individual operations run on ordinary stacks elsewhere; this
-    /// only bounds the large debug future assembled by an end-to-end test.
-    #[cfg(feature = "failpoints")]
-    fn on_big_stack<F>(body: impl FnOnce() -> F + Send + 'static)
-    where
-        F: Future<Output = ()>,
-    {
-        std::thread::Builder::new()
-            .stack_size(64 * 1024 * 1024)
-            .spawn(move || {
-                tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .unwrap()
-                    .block_on(body());
-            })
-            .unwrap()
-            .join()
-            .unwrap();
-    }
-
-    fn write_mock_embedding_cluster(config_dir: &Path, model: &str) {
-        fs::write(
-            config_dir.join(CLUSTER_CONFIG_FILE),
-            format!(
-                r#"
+fn write_mock_embedding_cluster(config_dir: &Path, model: &str) {
+    fs::write(
+        config_dir.join(CLUSTER_CONFIG_FILE),
+        format!(
+            r#"
 version: 1
 metadata:
   name: test
@@ -117,104 +115,103 @@ policies:
     file: ./base.policy.yaml
     applies_to: [knowledge]
 "#
-            ),
-        )
+        ),
+    )
+    .unwrap();
+}
+
+async fn init_derived_graph(root: &Path) {
+    let graph_dir = root.join(CLUSTER_GRAPHS_DIR);
+    fs::create_dir_all(&graph_dir).unwrap();
+    let graph = graph_dir.join("knowledge.omni");
+    Omnigraph::init(graph.to_string_lossy().as_ref(), SCHEMA)
+        .await
         .unwrap();
-    }
+}
 
-    async fn init_derived_graph(root: &Path) {
-        let graph_dir = root.join(CLUSTER_GRAPHS_DIR);
-        fs::create_dir_all(&graph_dir).unwrap();
-        let graph = graph_dir.join("knowledge.omni");
-        Omnigraph::init(graph.to_string_lossy().as_ref(), SCHEMA)
-            .await
-            .unwrap();
-    }
+fn write_lock_file(config_dir: &Path, lock_id: &str, operation: &str) {
+    let state_dir = config_dir.join(CLUSTER_STATE_DIR);
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(
+        state_dir.join("lock.json"),
+        json!({
+            "version": 1,
+            "lock_id": lock_id,
+            "operation": operation,
+            "created_at": "1970-01-01T00:00:00Z",
+            "pid": 123
+        })
+        .to_string(),
+    )
+    .unwrap();
+}
 
-    fn write_lock_file(config_dir: &Path, lock_id: &str, operation: &str) {
-        let state_dir = config_dir.join(CLUSTER_STATE_DIR);
-        fs::create_dir_all(&state_dir).unwrap();
-        fs::write(
-            state_dir.join("lock.json"),
-            json!({
-                "version": 1,
-                "lock_id": lock_id,
-                "operation": operation,
-                "created_at": "1970-01-01T00:00:00Z",
-                "pid": 123
-            })
-            .to_string(),
-        )
-        .unwrap();
-    }
+#[test]
+fn valid_minimal_config() {
+    let dir = fixture();
+    let out = validate_config_dir(dir.path());
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert!(out.resource_digests.contains_key("graph.knowledge"));
+    assert!(out.resource_digests.contains_key("schema.knowledge"));
+    assert!(
+        out.dependencies
+            .iter()
+            .any(|dep| dep.from == "policy.base" && dep.to == "graph.knowledge")
+    );
+}
 
-    #[test]
-    fn valid_minimal_config() {
-        let dir = fixture();
-        let out = validate_config_dir(dir.path());
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert!(out.resource_digests.contains_key("graph.knowledge"));
-        assert!(out.resource_digests.contains_key("schema.knowledge"));
-        assert!(
-            out.dependencies
-                .iter()
-                .any(|dep| dep.from == "policy.base" && dep.to == "graph.knowledge")
-        );
-    }
+#[test]
+fn unknown_field_rejection() {
+    let dir = fixture();
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        "version: 1\ngraphs: {}\nwat: true\n",
+    )
+    .unwrap();
+    let out = validate_config_dir(dir.path());
+    assert!(!out.ok);
+    assert!(out.diagnostics[0].message.contains("unknown field"));
+}
 
-    #[test]
-    fn unknown_field_rejection() {
-        let dir = fixture();
-        fs::write(
-            dir.path().join(CLUSTER_CONFIG_FILE),
-            "version: 1\ngraphs: {}\nwat: true\n",
-        )
-        .unwrap();
-        let out = validate_config_dir(dir.path());
-        assert!(!out.ok);
-        assert!(out.diagnostics[0].message.contains("unknown field"));
-    }
+#[test]
+fn future_phase_field_rejection() {
+    let dir = fixture();
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        "version: 1\ngraphs: {}\npipelines: {}\n",
+    )
+    .unwrap();
+    let out = validate_config_dir(dir.path());
+    assert!(!out.ok);
+    assert_eq!(out.diagnostics[0].code, "future_phase_field");
+}
 
-    #[test]
-    fn future_phase_field_rejection() {
-        let dir = fixture();
-        fs::write(
-            dir.path().join(CLUSTER_CONFIG_FILE),
-            "version: 1\ngraphs: {}\npipelines: {}\n",
-        )
-        .unwrap();
-        let out = validate_config_dir(dir.path());
-        assert!(!out.ok);
-        assert_eq!(out.diagnostics[0].code, "future_phase_field");
-    }
+#[test]
+fn duplicate_yaml_key_rejection() {
+    let dir = fixture();
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        "version: 1\ngraphs: {}\ngraphs: {}\n",
+    )
+    .unwrap();
+    let out = validate_config_dir(dir.path());
+    assert!(!out.ok);
+    assert_eq!(out.diagnostics[0].code, "duplicate_yaml_key");
+}
 
-    #[test]
-    fn duplicate_yaml_key_rejection() {
-        let dir = fixture();
-        fs::write(
-            dir.path().join(CLUSTER_CONFIG_FILE),
-            "version: 1\ngraphs: {}\ngraphs: {}\n",
-        )
-        .unwrap();
-        let out = validate_config_dir(dir.path());
-        assert!(!out.ok);
-        assert_eq!(out.diagnostics[0].code, "duplicate_yaml_key");
-    }
+#[test]
+fn duplicate_yaml_key_rejection_keeps_quoted_hashes() {
+    let diagnostics = duplicate_key_diagnostics("\"name#display\": one\n\"name#display\": two\n");
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].code, "duplicate_yaml_key");
+}
 
-    #[test]
-    fn duplicate_yaml_key_rejection_keeps_quoted_hashes() {
-        let diagnostics =
-            duplicate_key_diagnostics("\"name#display\": one\n\"name#display\": two\n");
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].code, "duplicate_yaml_key");
-    }
-
-    #[test]
-    fn missing_schema_query_and_policy_files() {
-        let dir = fixture();
-        fs::write(
-            dir.path().join(CLUSTER_CONFIG_FILE),
-            r#"
+#[test]
+fn missing_schema_query_and_policy_files() {
+    let dir = fixture();
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        r#"
 version: 1
 graphs:
   knowledge:
@@ -226,22 +223,22 @@ policies:
     file: ./missing.policy.yaml
     applies_to: [knowledge]
 "#,
-        )
-        .unwrap();
-        let out = validate_config_dir(dir.path());
-        assert!(!out.ok);
-        let codes: BTreeSet<_> = out.diagnostics.iter().map(|d| d.code.as_str()).collect();
-        assert!(codes.contains("schema_file_missing"));
-        assert!(codes.contains("query_file_missing"));
-        assert!(codes.contains("policy_file_missing"));
-    }
+    )
+    .unwrap();
+    let out = validate_config_dir(dir.path());
+    assert!(!out.ok);
+    let codes: BTreeSet<_> = out.diagnostics.iter().map(|d| d.code.as_str()).collect();
+    assert!(codes.contains("schema_file_missing"));
+    assert!(codes.contains("query_file_missing"));
+    assert!(codes.contains("policy_file_missing"));
+}
 
-    #[test]
-    fn wrong_kind_and_dangling_refs_fail() {
-        let dir = fixture();
-        fs::write(
-            dir.path().join(CLUSTER_CONFIG_FILE),
-            r#"
+#[test]
+fn wrong_kind_and_dangling_refs_fail() {
+    let dir = fixture();
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        r#"
 version: 1
 graphs:
   knowledge:
@@ -251,68 +248,68 @@ policies:
     file: ./base.policy.yaml
     applies_to: [query.knowledge.find_person, missing]
 "#,
-        )
+    )
+    .unwrap();
+    let out = validate_config_dir(dir.path());
+    assert!(!out.ok);
+    let codes: BTreeSet<_> = out.diagnostics.iter().map(|d| d.code.as_str()).collect();
+    assert!(codes.contains("wrong_kind_reference"));
+    assert!(codes.contains("dangling_graph_reference"));
+}
+
+#[test]
+fn embedding_provider_config_accepts_provider_resources_and_graph_refs() {
+    let dir = fixture();
+    write_mock_embedding_cluster(dir.path(), "recorded-x");
+
+    let out = validate_config_dir(dir.path());
+    assert!(out.ok, "{:?}", out.diagnostics);
+    let provider_digest = out
+        .resource_digests
+        .get("provider.embedding.default")
+        .expect("provider resource digest");
+    assert!(
+        out.resources
+            .iter()
+            .any(|resource| resource.address == "provider.embedding.default"
+                && resource.kind == "embedding_provider"
+                && resource.path.is_none())
+    );
+    assert!(
+        out.dependencies
+            .iter()
+            .any(|dep| dep.from == "graph.knowledge" && dep.to == "provider.embedding.default"),
+        "{:?}",
+        out.dependencies
+    );
+    let schema_digest = out.resource_digests.get("schema.knowledge").unwrap();
+    let query_digest = out
+        .resource_digests
+        .get("query.knowledge.find_person")
         .unwrap();
-        let out = validate_config_dir(dir.path());
-        assert!(!out.ok);
-        let codes: BTreeSet<_> = out.diagnostics.iter().map(|d| d.code.as_str()).collect();
-        assert!(codes.contains("wrong_kind_reference"));
-        assert!(codes.contains("dangling_graph_reference"));
-    }
+    let expected_graph_digest = graph_digest(
+        "knowledge",
+        Some(schema_digest),
+        Some(
+            &[("find_person".to_string(), query_digest.clone())]
+                .into_iter()
+                .collect(),
+        ),
+        Some("provider.embedding.default"),
+        Some(provider_digest),
+    );
+    assert_eq!(
+        out.resource_digests["graph.knowledge"],
+        expected_graph_digest
+    );
+}
 
-    #[test]
-    fn embedding_provider_config_accepts_provider_resources_and_graph_refs() {
-        let dir = fixture();
-        write_mock_embedding_cluster(dir.path(), "recorded-x");
-
-        let out = validate_config_dir(dir.path());
-        assert!(out.ok, "{:?}", out.diagnostics);
-        let provider_digest = out
-            .resource_digests
-            .get("provider.embedding.default")
-            .expect("provider resource digest");
-        assert!(
-            out.resources
-                .iter()
-                .any(|resource| resource.address == "provider.embedding.default"
-                    && resource.kind == "embedding_provider"
-                    && resource.path.is_none())
-        );
-        assert!(
-            out.dependencies
-                .iter()
-                .any(|dep| dep.from == "graph.knowledge" && dep.to == "provider.embedding.default"),
-            "{:?}",
-            out.dependencies
-        );
-        let schema_digest = out.resource_digests.get("schema.knowledge").unwrap();
-        let query_digest = out
-            .resource_digests
-            .get("query.knowledge.find_person")
-            .unwrap();
-        let expected_graph_digest = graph_digest(
-            "knowledge",
-            Some(schema_digest),
-            Some(
-                &[("find_person".to_string(), query_digest.clone())]
-                    .into_iter()
-                    .collect(),
-            ),
-            Some("provider.embedding.default"),
-            Some(provider_digest),
-        );
-        assert_eq!(
-            out.resource_digests["graph.knowledge"],
-            expected_graph_digest
-        );
-    }
-
-    #[test]
-    fn embedding_provider_config_rejects_bad_refs_and_inline_secrets() {
-        let dir = fixture();
-        fs::write(
-            dir.path().join(CLUSTER_CONFIG_FILE),
-            r#"
+#[test]
+fn embedding_provider_config_rejects_bad_refs_and_inline_secrets() {
+    let dir = fixture();
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        r#"
 version: 1
 providers:
   embedding:
@@ -327,34 +324,34 @@ graphs:
     schema: ./people.pg
     embedding_provider: absent
 "#,
-        )
-        .unwrap();
-        let out = validate_config_dir(dir.path());
-        assert!(!out.ok);
-        let codes: BTreeSet<_> = out.diagnostics.iter().map(|d| d.code.as_str()).collect();
-        assert!(
-            codes.contains("embedding_api_key_inline"),
-            "{:?}",
-            out.diagnostics
-        );
-        assert!(
-            codes.contains("wrong_kind_reference"),
-            "{:?}",
-            out.diagnostics
-        );
-        assert!(
-            codes.contains("dangling_embedding_provider_reference"),
-            "{:?}",
-            out.diagnostics
-        );
-    }
+    )
+    .unwrap();
+    let out = validate_config_dir(dir.path());
+    assert!(!out.ok);
+    let codes: BTreeSet<_> = out.diagnostics.iter().map(|d| d.code.as_str()).collect();
+    assert!(
+        codes.contains("embedding_api_key_inline"),
+        "{:?}",
+        out.diagnostics
+    );
+    assert!(
+        codes.contains("wrong_kind_reference"),
+        "{:?}",
+        out.diagnostics
+    );
+    assert!(
+        codes.contains("dangling_embedding_provider_reference"),
+        "{:?}",
+        out.diagnostics
+    );
+}
 
-    #[test]
-    fn query_key_mismatch_fails() {
-        let dir = fixture();
-        fs::write(
-            dir.path().join(CLUSTER_CONFIG_FILE),
-            r#"
+#[test]
+fn query_key_mismatch_fails() {
+    let dir = fixture();
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        r#"
 version: 1
 graphs:
   knowledge:
@@ -362,56 +359,56 @@ graphs:
     queries:
       different: { file: ./people.gq }
 "#,
-        )
-        .unwrap();
-        let out = validate_config_dir(dir.path());
-        assert!(!out.ok);
-        assert_eq!(out.diagnostics[0].code, "query_key_mismatch");
-    }
+    )
+    .unwrap();
+    let out = validate_config_dir(dir.path());
+    assert!(!out.ok);
+    assert_eq!(out.diagnostics[0].code, "query_key_mismatch");
+}
 
-    #[test]
-    fn query_typecheck_failure_fails() {
-        let dir = fixture();
-        fs::write(
-            dir.path().join("people.gq"),
-            "query find_person() { match { $d: DoesNotExist } return { $d.name } }\n",
-        )
-        .unwrap();
-        let out = validate_config_dir(dir.path());
-        assert!(!out.ok);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "query_typecheck_error")
-        );
-    }
+#[test]
+fn query_typecheck_failure_fails() {
+    let dir = fixture();
+    fs::write(
+        dir.path().join("people.gq"),
+        "query find_person() { match { $d: DoesNotExist } return { $d.name } }\n",
+    )
+    .unwrap();
+    let out = validate_config_dir(dir.path());
+    assert!(!out.ok);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "query_typecheck_error")
+    );
+}
 
-    #[tokio::test]
-    async fn missing_state_plans_creates() {
-        let dir = fixture();
-        let out = plan_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert!(!out.state_observations.state_found);
-        assert!(!out.state_observations.locked);
-        assert!(out.state_observations.lock_acquired);
-        assert!(
-            out.changes
-                .iter()
-                .all(|c| c.operation == PlanOperation::Create)
-        );
-        assert!(out.changes.iter().any(|c| c.resource == "graph.knowledge"));
-        assert!(!dir.path().join(CLUSTER_LOCK_FILE).exists());
-    }
+#[tokio::test]
+async fn missing_state_plans_creates() {
+    let dir = fixture();
+    let out = plan_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert!(!out.state_observations.state_found);
+    assert!(!out.state_observations.locked);
+    assert!(out.state_observations.lock_acquired);
+    assert!(
+        out.changes
+            .iter()
+            .all(|c| c.operation == PlanOperation::Create)
+    );
+    assert!(out.changes.iter().any(|c| c.resource == "graph.knowledge"));
+    assert!(!dir.path().join(CLUSTER_LOCK_FILE).exists());
+}
 
-    #[tokio::test]
-    async fn config_digest_ignores_yaml_comments_and_formatting() {
-        let dir = fixture();
-        let first = plan_config_dir(dir.path()).await;
-        assert!(first.ok, "{:?}", first.diagnostics);
+#[tokio::test]
+async fn config_digest_ignores_yaml_comments_and_formatting() {
+    let dir = fixture();
+    let first = plan_config_dir(dir.path()).await;
+    assert!(first.ok, "{:?}", first.diagnostics);
 
-        fs::write(
-            dir.path().join(CLUSTER_CONFIG_FILE),
-            r#"
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        r#"
 # Same semantic config as the fixture, intentionally rendered differently.
 version: 1
 metadata: { name: test }
@@ -426,66 +423,66 @@ policies:
     applies_to:
       - knowledge
 "#,
-        )
-        .unwrap();
+    )
+    .unwrap();
 
-        let second = plan_config_dir(dir.path()).await;
-        assert!(second.ok, "{:?}", second.diagnostics);
-        assert_eq!(
-            first.desired_revision.config_digest,
-            second.desired_revision.config_digest
-        );
-    }
+    let second = plan_config_dir(dir.path()).await;
+    assert!(second.ok, "{:?}", second.diagnostics);
+    assert_eq!(
+        first.desired_revision.config_digest,
+        second.desired_revision.config_digest
+    );
+}
 
-    #[tokio::test]
-    async fn existing_state_plans_update_and_delete_deterministically() {
-        let dir = fixture();
-        let first = plan_config_dir(dir.path()).await;
-        let state_dir = dir.path().join("__cluster");
-        fs::create_dir_all(&state_dir).unwrap();
-        fs::write(
-            state_dir.join("state.json"),
-            serde_json::to_string_pretty(&json!({
-                "version": 1,
-                "applied_revision": {
-                    "config_digest": "old",
-                    "resources": {
-                        "graph.knowledge": { "digest": first.resource_digests["graph.knowledge"] },
-                        "policy.old": { "digest": "abc" },
-                        "schema.knowledge": { "digest": "old-schema" }
-                    }
+#[tokio::test]
+async fn existing_state_plans_update_and_delete_deterministically() {
+    let dir = fixture();
+    let first = plan_config_dir(dir.path()).await;
+    let state_dir = dir.path().join("__cluster");
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(
+        state_dir.join("state.json"),
+        serde_json::to_string_pretty(&json!({
+            "version": 1,
+            "applied_revision": {
+                "config_digest": "old",
+                "resources": {
+                    "graph.knowledge": { "digest": first.resource_digests["graph.knowledge"] },
+                    "policy.old": { "digest": "abc" },
+                    "schema.knowledge": { "digest": "old-schema" }
                 }
-            }))
-            .unwrap(),
-        )
-        .unwrap();
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
 
-        let out = plan_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        let rendered: Vec<_> = out
-            .changes
-            .iter()
-            .map(|change| (change.resource.as_str(), &change.operation))
-            .collect();
-        assert_eq!(
-            rendered,
-            vec![
-                ("policy.base", &PlanOperation::Create),
-                ("policy.old", &PlanOperation::Delete),
-                ("query.knowledge.find_person", &PlanOperation::Create),
-                ("schema.knowledge", &PlanOperation::Update),
-            ]
-        );
-    }
+    let out = plan_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    let rendered: Vec<_> = out
+        .changes
+        .iter()
+        .map(|change| (change.resource.as_str(), &change.operation))
+        .collect();
+    assert_eq!(
+        rendered,
+        vec![
+            ("policy.base", &PlanOperation::Create),
+            ("policy.old", &PlanOperation::Delete),
+            ("query.knowledge.find_person", &PlanOperation::Create),
+            ("schema.knowledge", &PlanOperation::Update),
+        ]
+    );
+}
 
-    #[tokio::test]
-    async fn old_minimal_state_json_still_plans_with_default_revision() {
-        let dir = fixture();
-        let state_dir = dir.path().join(CLUSTER_STATE_DIR);
-        fs::create_dir_all(&state_dir).unwrap();
-        fs::write(
-            state_dir.join("state.json"),
-            r#"{
+#[tokio::test]
+async fn old_minimal_state_json_still_plans_with_default_revision() {
+    let dir = fixture();
+    let state_dir = dir.path().join(CLUSTER_STATE_DIR);
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(
+        state_dir.join("state.json"),
+        r#"{
   "version": 1,
   "applied_revision": {
     "config_digest": "old",
@@ -494,24 +491,24 @@ policies:
     }
   }
 }"#,
-        )
-        .unwrap();
+    )
+    .unwrap();
 
-        let out = plan_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert_eq!(out.state_observations.state_revision, 0);
-        assert!(out.state_observations.state_cas.is_some());
-        assert!(out.changes.iter().any(|change| {
-            change.resource == "graph.knowledge" && change.operation == PlanOperation::Update
-        }));
-    }
+    let out = plan_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert_eq!(out.state_observations.state_revision, 0);
+    assert!(out.state_observations.state_cas.is_some());
+    assert!(out.changes.iter().any(|change| {
+        change.resource == "graph.knowledge" && change.operation == PlanOperation::Update
+    }));
+}
 
-    #[tokio::test]
-    async fn extended_state_json_status_surfaces_statuses() {
-        let dir = fixture();
-        let state_dir = dir.path().join(CLUSTER_STATE_DIR);
-        fs::create_dir_all(&state_dir).unwrap();
-        let state = r#"{
+#[tokio::test]
+async fn extended_state_json_status_surfaces_statuses() {
+    let dir = fixture();
+    let state_dir = dir.path().join(CLUSTER_STATE_DIR);
+    fs::create_dir_all(&state_dir).unwrap();
+    let state = r#"{
   "version": 1,
   "state_revision": 42,
   "applied_revision": {
@@ -533,175 +530,175 @@ policies:
     "graph.knowledge": { "manifest_version": 12 }
   }
 }"#;
-        fs::write(state_dir.join("state.json"), state).unwrap();
+    fs::write(state_dir.join("state.json"), state).unwrap();
 
-        let out = status_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert!(out.state_observations.state_found);
-        assert_eq!(out.state_observations.state_revision, 42);
-        assert_eq!(
-            out.state_observations.state_cas.as_deref(),
-            Some(format!("sha256:{}", sha256_hex(state.as_bytes())).as_str())
-        );
-        assert_eq!(
-            out.resource_digests
-                .get("graph.knowledge")
-                .map(String::as_str),
-            Some("graph-digest")
-        );
-        assert_eq!(
-            out.resource_statuses["graph.knowledge"].status,
-            ResourceLifecycleStatus::Applied
-        );
-    }
+    let out = status_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert!(out.state_observations.state_found);
+    assert_eq!(out.state_observations.state_revision, 42);
+    assert_eq!(
+        out.state_observations.state_cas.as_deref(),
+        Some(format!("sha256:{}", sha256_hex(state.as_bytes())).as_str())
+    );
+    assert_eq!(
+        out.resource_digests
+            .get("graph.knowledge")
+            .map(String::as_str),
+        Some("graph-digest")
+    );
+    assert_eq!(
+        out.resource_statuses["graph.knowledge"].status,
+        ResourceLifecycleStatus::Applied
+    );
+}
 
-    #[tokio::test]
-    async fn missing_state_status_succeeds_with_warning() {
-        let dir = fixture();
-        let out = status_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert!(!out.state_observations.state_found);
-        assert_eq!(out.state_observations.state_revision, 0);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "state_missing")
-        );
-    }
+#[tokio::test]
+async fn missing_state_status_succeeds_with_warning() {
+    let dir = fixture();
+    let out = status_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert!(!out.state_observations.state_found);
+    assert_eq!(out.state_observations.state_revision, 0);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "state_missing")
+    );
+}
 
-    #[tokio::test]
-    async fn invalid_state_status_fails() {
-        let dir = fixture();
-        let state_dir = dir.path().join(CLUSTER_STATE_DIR);
-        fs::create_dir_all(&state_dir).unwrap();
-        fs::write(state_dir.join("state.json"), "{").unwrap();
+#[tokio::test]
+async fn invalid_state_status_fails() {
+    let dir = fixture();
+    let state_dir = dir.path().join(CLUSTER_STATE_DIR);
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(state_dir.join("state.json"), "{").unwrap();
 
-        let out = status_config_dir(dir.path()).await;
-        assert!(!out.ok);
-        assert!(out.state_observations.state_found);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "invalid_state_json")
-        );
-    }
+    let out = status_config_dir(dir.path()).await;
+    assert!(!out.ok);
+    assert!(out.state_observations.state_found);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "invalid_state_json")
+    );
+}
 
-    #[tokio::test]
-    async fn status_surfaces_full_lock_metadata() {
-        let dir = fixture();
-        write_lock_file(dir.path(), "held-lock", "refresh");
+#[tokio::test]
+async fn status_surfaces_full_lock_metadata() {
+    let dir = fixture();
+    write_lock_file(dir.path(), "held-lock", "refresh");
 
-        let out = status_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert!(out.state_observations.locked);
-        assert_eq!(out.state_observations.lock_id.as_deref(), Some("held-lock"));
-        assert_eq!(
-            out.state_observations.lock_operation.as_deref(),
-            Some("refresh")
-        );
-        assert_eq!(
-            out.state_observations.lock_created_at.as_deref(),
-            Some("1970-01-01T00:00:00Z")
-        );
-        assert_eq!(out.state_observations.lock_pid, Some(123));
-        assert!(out.state_observations.lock_age_seconds.is_some());
-    }
+    let out = status_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert!(out.state_observations.locked);
+    assert_eq!(out.state_observations.lock_id.as_deref(), Some("held-lock"));
+    assert_eq!(
+        out.state_observations.lock_operation.as_deref(),
+        Some("refresh")
+    );
+    assert_eq!(
+        out.state_observations.lock_created_at.as_deref(),
+        Some("1970-01-01T00:00:00Z")
+    );
+    assert_eq!(out.state_observations.lock_pid, Some(123));
+    assert!(out.state_observations.lock_age_seconds.is_some());
+}
 
-    #[tokio::test]
-    async fn force_unlock_matching_id_removes_lock() {
-        let dir = fixture();
-        write_lock_file(dir.path(), "held-lock", "plan");
+#[tokio::test]
+async fn force_unlock_matching_id_removes_lock() {
+    let dir = fixture();
+    write_lock_file(dir.path(), "held-lock", "plan");
 
-        let out = force_unlock_config_dir(dir.path(), "held-lock").await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert!(out.lock_removed);
-        assert_eq!(out.state_observations.lock_id.as_deref(), Some("held-lock"));
-        assert_eq!(
-            out.state_observations.lock_operation.as_deref(),
-            Some("plan")
-        );
-        assert!(!dir.path().join(CLUSTER_LOCK_FILE).exists());
-    }
+    let out = force_unlock_config_dir(dir.path(), "held-lock").await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert!(out.lock_removed);
+    assert_eq!(out.state_observations.lock_id.as_deref(), Some("held-lock"));
+    assert_eq!(
+        out.state_observations.lock_operation.as_deref(),
+        Some("plan")
+    );
+    assert!(!dir.path().join(CLUSTER_LOCK_FILE).exists());
+}
 
-    #[tokio::test]
-    async fn force_unlock_wrong_id_fails_and_preserves_lock() {
-        let dir = fixture();
-        write_lock_file(dir.path(), "held-lock", "plan");
+#[tokio::test]
+async fn force_unlock_wrong_id_fails_and_preserves_lock() {
+    let dir = fixture();
+    write_lock_file(dir.path(), "held-lock", "plan");
 
-        let out = force_unlock_config_dir(dir.path(), "other-lock").await;
-        assert!(!out.ok);
-        assert!(!out.lock_removed);
-        assert_eq!(out.state_observations.lock_id.as_deref(), Some("held-lock"));
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "state_lock_id_mismatch")
-        );
-        assert!(dir.path().join(CLUSTER_LOCK_FILE).exists());
-    }
+    let out = force_unlock_config_dir(dir.path(), "other-lock").await;
+    assert!(!out.ok);
+    assert!(!out.lock_removed);
+    assert_eq!(out.state_observations.lock_id.as_deref(), Some("held-lock"));
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "state_lock_id_mismatch")
+    );
+    assert!(dir.path().join(CLUSTER_LOCK_FILE).exists());
+}
 
-    #[tokio::test]
-    async fn force_unlock_missing_lock_fails() {
-        let dir = fixture();
+#[tokio::test]
+async fn force_unlock_missing_lock_fails() {
+    let dir = fixture();
 
-        let out = force_unlock_config_dir(dir.path(), "held-lock").await;
-        assert!(!out.ok);
-        assert!(!out.lock_removed);
-        assert!(!out.state_observations.locked);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "state_lock_missing")
-        );
-    }
+    let out = force_unlock_config_dir(dir.path(), "held-lock").await;
+    assert!(!out.ok);
+    assert!(!out.lock_removed);
+    assert!(!out.state_observations.locked);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "state_lock_missing")
+    );
+}
 
-    #[tokio::test]
-    async fn force_unlock_invalid_lock_json_fails_and_preserves_lock() {
-        let dir = fixture();
-        let state_dir = dir.path().join(CLUSTER_STATE_DIR);
-        fs::create_dir_all(&state_dir).unwrap();
-        fs::write(state_dir.join("lock.json"), "{").unwrap();
+#[tokio::test]
+async fn force_unlock_invalid_lock_json_fails_and_preserves_lock() {
+    let dir = fixture();
+    let state_dir = dir.path().join(CLUSTER_STATE_DIR);
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(state_dir.join("lock.json"), "{").unwrap();
 
-        let out = force_unlock_config_dir(dir.path(), "held-lock").await;
-        assert!(!out.ok);
-        assert!(!out.lock_removed);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "invalid_state_lock")
-        );
-        assert!(dir.path().join(CLUSTER_LOCK_FILE).exists());
-    }
+    let out = force_unlock_config_dir(dir.path(), "held-lock").await;
+    assert!(!out.ok);
+    assert!(!out.lock_removed);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "invalid_state_lock")
+    );
+    assert!(dir.path().join(CLUSTER_LOCK_FILE).exists());
+}
 
-    #[tokio::test]
-    async fn force_unlock_unsupported_lock_version_fails_and_preserves_lock() {
-        let dir = fixture();
-        let state_dir = dir.path().join(CLUSTER_STATE_DIR);
-        fs::create_dir_all(&state_dir).unwrap();
-        fs::write(
+#[tokio::test]
+async fn force_unlock_unsupported_lock_version_fails_and_preserves_lock() {
+    let dir = fixture();
+    let state_dir = dir.path().join(CLUSTER_STATE_DIR);
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(
             state_dir.join("lock.json"),
             r#"{"version":2,"lock_id":"held-lock","operation":"plan","created_at":"1970-01-01T00:00:00Z","pid":123}"#,
         )
         .unwrap();
 
-        let out = force_unlock_config_dir(dir.path(), "held-lock").await;
-        assert!(!out.ok);
-        assert!(!out.lock_removed);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "unsupported_state_lock_version")
-        );
-        assert!(dir.path().join(CLUSTER_LOCK_FILE).exists());
-    }
+    let out = force_unlock_config_dir(dir.path(), "held-lock").await;
+    assert!(!out.ok);
+    assert!(!out.lock_removed);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "unsupported_state_lock_version")
+    );
+    assert!(dir.path().join(CLUSTER_LOCK_FILE).exists());
+}
 
-    #[tokio::test]
-    async fn force_unlock_external_state_backend_rejected() {
-        let dir = fixture();
-        write_lock_file(dir.path(), "held-lock", "plan");
-        fs::write(
-            dir.path().join(CLUSTER_CONFIG_FILE),
-            r#"
+#[tokio::test]
+async fn force_unlock_external_state_backend_rejected() {
+    let dir = fixture();
+    write_lock_file(dir.path(), "held-lock", "plan");
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        r#"
 version: 1
 state:
   backend: s3://state-bucket/cluster
@@ -709,47 +706,47 @@ graphs:
   knowledge:
     schema: ./people.pg
 "#,
-        )
-        .unwrap();
+    )
+    .unwrap();
 
-        let out = force_unlock_config_dir(dir.path(), "held-lock").await;
-        assert!(!out.ok);
-        assert!(!out.lock_removed);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "unsupported_state_backend")
-        );
-        assert!(dir.path().join(CLUSTER_LOCK_FILE).exists());
-    }
+    let out = force_unlock_config_dir(dir.path(), "held-lock").await;
+    assert!(!out.ok);
+    assert!(!out.lock_removed);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "unsupported_state_backend")
+    );
+    assert!(dir.path().join(CLUSTER_LOCK_FILE).exists());
+}
 
-    #[tokio::test]
-    async fn plan_succeeds_after_force_unlock() {
-        let dir = fixture();
-        write_lock_file(dir.path(), "held-lock", "plan");
+#[tokio::test]
+async fn plan_succeeds_after_force_unlock() {
+    let dir = fixture();
+    write_lock_file(dir.path(), "held-lock", "plan");
 
-        let locked = plan_config_dir(dir.path()).await;
-        assert!(!locked.ok);
-        assert!(
-            locked
-                .diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "state_lock_held")
-        );
+    let locked = plan_config_dir(dir.path()).await;
+    assert!(!locked.ok);
+    assert!(
+        locked
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "state_lock_held")
+    );
 
-        let unlocked = force_unlock_config_dir(dir.path(), "held-lock").await;
-        assert!(unlocked.ok, "{:?}", unlocked.diagnostics);
+    let unlocked = force_unlock_config_dir(dir.path(), "held-lock").await;
+    assert!(unlocked.ok, "{:?}", unlocked.diagnostics);
 
-        let out = plan_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-    }
+    let out = plan_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+}
 
-    #[tokio::test]
-    async fn plan_reports_state_cas_revision_and_removes_lock() {
-        let dir = fixture();
-        let state_dir = dir.path().join(CLUSTER_STATE_DIR);
-        fs::create_dir_all(&state_dir).unwrap();
-        let state = r#"{
+#[tokio::test]
+async fn plan_reports_state_cas_revision_and_removes_lock() {
+    let dir = fixture();
+    let state_dir = dir.path().join(CLUSTER_STATE_DIR);
+    fs::create_dir_all(&state_dir).unwrap();
+    let state = r#"{
   "version": 1,
   "state_revision": 7,
   "applied_revision": {
@@ -759,69 +756,69 @@ graphs:
     }
   }
 }"#;
-        fs::write(state_dir.join("state.json"), state).unwrap();
+    fs::write(state_dir.join("state.json"), state).unwrap();
 
-        let out = plan_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert_eq!(out.state_observations.state_revision, 7);
-        assert_eq!(
-            out.state_observations.state_cas.as_deref(),
-            Some(format!("sha256:{}", sha256_hex(state.as_bytes())).as_str())
-        );
-        assert!(!out.state_observations.locked);
-        assert!(out.state_observations.lock_id.is_none());
-        assert!(out.state_observations.lock_acquired);
-        assert!(out.state_observations.acquired_lock_id.is_some());
-        assert!(
-            !dir.path().join(CLUSTER_LOCK_FILE).exists(),
-            "plan must release lock before returning"
-        );
-    }
+    let out = plan_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert_eq!(out.state_observations.state_revision, 7);
+    assert_eq!(
+        out.state_observations.state_cas.as_deref(),
+        Some(format!("sha256:{}", sha256_hex(state.as_bytes())).as_str())
+    );
+    assert!(!out.state_observations.locked);
+    assert!(out.state_observations.lock_id.is_none());
+    assert!(out.state_observations.lock_acquired);
+    assert!(out.state_observations.acquired_lock_id.is_some());
+    assert!(
+        !dir.path().join(CLUSTER_LOCK_FILE).exists(),
+        "plan must release lock before returning"
+    );
+}
 
-    #[tokio::test]
-    async fn existing_lock_makes_plan_fail() {
-        let dir = fixture();
-        let state_dir = dir.path().join(CLUSTER_STATE_DIR);
-        fs::create_dir_all(&state_dir).unwrap();
-        fs::write(
-            state_dir.join("lock.json"),
-            r#"{
+#[tokio::test]
+async fn existing_lock_makes_plan_fail() {
+    let dir = fixture();
+    let state_dir = dir.path().join(CLUSTER_STATE_DIR);
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(
+        state_dir.join("lock.json"),
+        r#"{
   "version": 1,
   "lock_id": "held-lock",
   "operation": "plan",
   "created_at": "2026-06-08T00:00:00Z",
   "pid": 123
 }"#,
-        )
-        .unwrap();
+    )
+    .unwrap();
 
-        let out = plan_config_dir(dir.path()).await;
-        assert!(!out.ok);
-        assert!(out.state_observations.locked);
-        assert_eq!(out.state_observations.lock_id.as_deref(), Some("held-lock"));
-        assert!(!out.state_observations.lock_acquired);
-        assert!(out.state_observations.acquired_lock_id.is_none());
-        assert_eq!(
-            out.state_observations.lock_operation.as_deref(),
-            Some("plan")
-        );
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "state_lock_held")
-        );
-        assert!(out.diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == "state_lock_held"
-                && diagnostic.message.contains("force-unlock held-lock")
-        }));
-    }
+    let out = plan_config_dir(dir.path()).await;
+    assert!(!out.ok);
+    assert!(out.state_observations.locked);
+    assert_eq!(out.state_observations.lock_id.as_deref(), Some("held-lock"));
+    assert!(!out.state_observations.lock_acquired);
+    assert!(out.state_observations.acquired_lock_id.is_none());
+    assert_eq!(
+        out.state_observations.lock_operation.as_deref(),
+        Some("plan")
+    );
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "state_lock_held")
+    );
+    assert!(out.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "state_lock_held"
+            && diagnostic.message.contains("force-unlock held-lock")
+    }));
+}
 
-    #[tokio::test]
-    async fn state_lock_false_bypasses_lock_with_warning() {
-        let dir = fixture();
-        fs::write(
-            dir.path().join(CLUSTER_CONFIG_FILE),
-            r#"
+#[tokio::test]
+async fn state_lock_false_bypasses_lock_with_warning() {
+    let dir = fixture();
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        r#"
 version: 1
 state:
   backend: cluster
@@ -830,294 +827,292 @@ graphs:
   knowledge:
     schema: ./people.pg
 "#,
-        )
-        .unwrap();
+    )
+    .unwrap();
 
-        let out = plan_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert!(!out.state_observations.locked);
-        assert!(!out.state_observations.lock_acquired);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "state_lock_disabled")
-        );
-        assert!(!dir.path().join(CLUSTER_LOCK_FILE).exists());
-    }
+    let out = plan_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert!(!out.state_observations.locked);
+    assert!(!out.state_observations.lock_acquired);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "state_lock_disabled")
+    );
+    assert!(!dir.path().join(CLUSTER_LOCK_FILE).exists());
+}
 
-    #[test]
-    fn external_state_backend_rejected() {
-        let dir = fixture();
-        fs::write(
-            dir.path().join(CLUSTER_CONFIG_FILE),
-            "version: 1\nstate:\n  backend: s3://bucket/state\ngraphs: {}\n",
-        )
-        .unwrap();
-        let out = validate_config_dir(dir.path());
-        assert!(!out.ok);
-        assert_eq!(out.diagnostics[0].code, "unsupported_state_backend");
-    }
+#[test]
+fn external_state_backend_rejected() {
+    let dir = fixture();
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        "version: 1\nstate:\n  backend: s3://bucket/state\ngraphs: {}\n",
+    )
+    .unwrap();
+    let out = validate_config_dir(dir.path());
+    assert!(!out.ok);
+    assert_eq!(out.diagnostics[0].code, "unsupported_state_backend");
+}
 
-    #[tokio::test]
-    async fn external_state_backend_plan_rejected() {
-        let dir = fixture();
-        fs::write(
-            dir.path().join(CLUSTER_CONFIG_FILE),
-            "version: 1\nstate:\n  backend: s3://bucket/state\ngraphs: {}\n",
-        )
-        .unwrap();
-        let out = plan_config_dir(dir.path()).await;
-        assert!(!out.ok);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "unsupported_state_backend")
-        );
-    }
+#[tokio::test]
+async fn external_state_backend_plan_rejected() {
+    let dir = fixture();
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        "version: 1\nstate:\n  backend: s3://bucket/state\ngraphs: {}\n",
+    )
+    .unwrap();
+    let out = plan_config_dir(dir.path()).await;
+    assert!(!out.ok);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "unsupported_state_backend")
+    );
+}
 
-    #[tokio::test]
-    async fn import_missing_state_creates_state_with_graph_observation() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await;
+#[tokio::test]
+async fn import_missing_state_creates_state_with_graph_observation() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
 
-        let out = import_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert_eq!(out.state_observations.state_revision, 1);
-        assert!(out.state_observations.state_cas.is_some());
-        assert!(!out.state_observations.locked);
-        assert!(out.state_observations.lock_acquired);
-        assert!(out.state_observations.acquired_lock_id.is_some());
-        assert!(!dir.path().join(CLUSTER_LOCK_FILE).exists());
-        assert_eq!(
-            out.resource_digests
-                .get("schema.knowledge")
-                .map(String::as_str),
-            Some(sha256_hex(SCHEMA.as_bytes()).as_str())
-        );
-        assert!(out.observations["graph.knowledge"]["manifest_version"].is_number());
-        assert_eq!(
-            out.observations["graph.knowledge"]["schema_matches_desired"],
-            true
-        );
+    let out = import_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert_eq!(out.state_observations.state_revision, 1);
+    assert!(out.state_observations.state_cas.is_some());
+    assert!(!out.state_observations.locked);
+    assert!(out.state_observations.lock_acquired);
+    assert!(out.state_observations.acquired_lock_id.is_some());
+    assert!(!dir.path().join(CLUSTER_LOCK_FILE).exists());
+    assert_eq!(
+        out.resource_digests
+            .get("schema.knowledge")
+            .map(String::as_str),
+        Some(sha256_hex(SCHEMA.as_bytes()).as_str())
+    );
+    assert!(out.observations["graph.knowledge"]["manifest_version"].is_number());
+    assert_eq!(
+        out.observations["graph.knowledge"]["schema_matches_desired"],
+        true
+    );
 
-        let state: serde_json::Value =
-            serde_json::from_str(&fs::read_to_string(dir.path().join(CLUSTER_STATE_FILE)).unwrap())
-                .unwrap();
-        assert_eq!(state["state_revision"], 1);
-        assert_eq!(
-            state["resource_statuses"]["graph.knowledge"]["status"],
-            "applied"
-        );
-    }
+    let state: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(dir.path().join(CLUSTER_STATE_FILE)).unwrap())
+            .unwrap();
+    assert_eq!(state["state_revision"], 1);
+    assert_eq!(
+        state["resource_statuses"]["graph.knowledge"]["status"],
+        "applied"
+    );
+}
 
-    #[tokio::test]
-    async fn import_existing_state_fails() {
-        let dir = fixture();
-        let state_dir = dir.path().join(CLUSTER_STATE_DIR);
-        fs::create_dir_all(&state_dir).unwrap();
-        fs::write(
-            state_dir.join("state.json"),
-            r#"{"version":1,"applied_revision":{"resources":{}}}"#,
-        )
-        .unwrap();
+#[tokio::test]
+async fn import_existing_state_fails() {
+    let dir = fixture();
+    let state_dir = dir.path().join(CLUSTER_STATE_DIR);
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(
+        state_dir.join("state.json"),
+        r#"{"version":1,"applied_revision":{"resources":{}}}"#,
+    )
+    .unwrap();
 
-        let out = import_config_dir(dir.path()).await;
-        assert!(!out.ok);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "state_already_exists")
-        );
-    }
+    let out = import_config_dir(dir.path()).await;
+    assert!(!out.ok);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "state_already_exists")
+    );
+}
 
-    #[tokio::test]
-    async fn refresh_missing_state_fails() {
-        let dir = fixture();
-        let out = refresh_config_dir(dir.path()).await;
-        assert!(!out.ok);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "state_missing")
-        );
-    }
+#[tokio::test]
+async fn refresh_missing_state_fails() {
+    let dir = fixture();
+    let out = refresh_config_dir(dir.path()).await;
+    assert!(!out.ok);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "state_missing")
+    );
+}
 
-    #[tokio::test]
-    async fn refresh_existing_minimal_state_increments_revision_and_updates_cas() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await;
-        let state_dir = dir.path().join(CLUSTER_STATE_DIR);
-        fs::create_dir_all(&state_dir).unwrap();
-        fs::write(
+#[tokio::test]
+async fn refresh_existing_minimal_state_increments_revision_and_updates_cas() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    let state_dir = dir.path().join(CLUSTER_STATE_DIR);
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(
             state_dir.join("state.json"),
             r#"{"version":1,"applied_revision":{"config_digest":"old","resources":{"graph.knowledge":{"digest":"old"}}}}"#,
         )
         .unwrap();
 
-        let out = refresh_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert_eq!(out.state_observations.state_revision, 1);
-        assert!(out.state_observations.state_cas.is_some());
-        assert!(!out.state_observations.locked);
-        assert!(out.state_observations.lock_acquired);
-        assert_eq!(
-            out.resource_statuses["graph.knowledge"].status,
-            ResourceLifecycleStatus::Applied
-        );
-        assert!(!dir.path().join(CLUSTER_LOCK_FILE).exists());
-    }
+    let out = refresh_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert_eq!(out.state_observations.state_revision, 1);
+    assert!(out.state_observations.state_cas.is_some());
+    assert!(!out.state_observations.locked);
+    assert!(out.state_observations.lock_acquired);
+    assert_eq!(
+        out.resource_statuses["graph.knowledge"].status,
+        ResourceLifecycleStatus::Applied
+    );
+    assert!(!dir.path().join(CLUSTER_LOCK_FILE).exists());
+}
 
-    #[tokio::test]
-    async fn refresh_records_live_schema_digest_and_manifest_version() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await;
-        let state_dir = dir.path().join(CLUSTER_STATE_DIR);
-        fs::create_dir_all(&state_dir).unwrap();
-        fs::write(
-            state_dir.join("state.json"),
-            r#"{"version":1,"state_revision":4,"applied_revision":{"resources":{}}}"#,
-        )
-        .unwrap();
+#[tokio::test]
+async fn refresh_records_live_schema_digest_and_manifest_version() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    let state_dir = dir.path().join(CLUSTER_STATE_DIR);
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(
+        state_dir.join("state.json"),
+        r#"{"version":1,"state_revision":4,"applied_revision":{"resources":{}}}"#,
+    )
+    .unwrap();
 
-        let out = refresh_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert_eq!(out.state_observations.state_revision, 5);
-        assert_eq!(
-            out.observations["graph.knowledge"]["schema_digest"],
-            sha256_hex(SCHEMA.as_bytes())
-        );
-        assert!(out.observations["graph.knowledge"]["manifest_version"].is_u64());
-    }
+    let out = refresh_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert_eq!(out.state_observations.state_revision, 5);
+    assert_eq!(
+        out.observations["graph.knowledge"]["schema_digest"],
+        sha256_hex(SCHEMA.as_bytes())
+    );
+    assert!(out.observations["graph.knowledge"]["manifest_version"].is_u64());
+}
 
-    #[tokio::test]
-    async fn missing_derived_graph_root_marks_drifted_and_plans_creates() {
-        let dir = fixture();
-        write_streaming_cluster(dir.path(), Some(true));
-        let streaming_digest = validate_config_dir(dir.path()).resource_digests
-            ["streaming.knowledge"]
-            .clone();
-        write_state_resources(
-            dir.path(),
-            &[
-                ("graph.knowledge", "old-graph"),
-                ("schema.knowledge", "old-schema"),
-                ("streaming.knowledge", streaming_digest.as_str()),
-            ],
-        );
+#[tokio::test]
+async fn missing_derived_graph_root_marks_drifted_and_plans_creates() {
+    let dir = fixture();
+    write_streaming_cluster(dir.path(), Some(true));
+    let streaming_digest =
+        validate_config_dir(dir.path()).resource_digests["streaming.knowledge"].clone();
+    write_state_resources(
+        dir.path(),
+        &[
+            ("graph.knowledge", "old-graph"),
+            ("schema.knowledge", "old-schema"),
+            ("streaming.knowledge", streaming_digest.as_str()),
+        ],
+    );
 
-        let out = refresh_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert_eq!(
-            out.resource_statuses["graph.knowledge"].status,
-            ResourceLifecycleStatus::Drifted
-        );
-        assert!(!out.resource_digests.contains_key("graph.knowledge"));
-        assert!(!out.resource_digests.contains_key("streaming.knowledge"));
-        assert_eq!(out.observations["graph.knowledge"]["exists"], false);
-        assert_eq!(
-            out.resource_statuses["streaming.knowledge"].status,
-            ResourceLifecycleStatus::Drifted
-        );
+    let out = refresh_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert_eq!(
+        out.resource_statuses["graph.knowledge"].status,
+        ResourceLifecycleStatus::Drifted
+    );
+    assert!(!out.resource_digests.contains_key("graph.knowledge"));
+    assert!(!out.resource_digests.contains_key("streaming.knowledge"));
+    assert_eq!(out.observations["graph.knowledge"]["exists"], false);
+    assert_eq!(
+        out.resource_statuses["streaming.knowledge"].status,
+        ResourceLifecycleStatus::Drifted
+    );
 
-        let plan = plan_config_dir(dir.path()).await;
-        assert!(plan.ok, "{:?}", plan.diagnostics);
-        assert!(plan.changes.iter().any(|change| {
-            change.resource == "graph.knowledge" && change.operation == PlanOperation::Create
-        }));
-        assert!(plan.changes.iter().any(|change| {
-            change.resource == "schema.knowledge" && change.operation == PlanOperation::Create
-        }));
-        assert!(plan.changes.iter().any(|change| {
-            change.resource == "streaming.knowledge"
-                && change.operation == PlanOperation::Create
-        }));
+    let plan = plan_config_dir(dir.path()).await;
+    assert!(plan.ok, "{:?}", plan.diagnostics);
+    assert!(plan.changes.iter().any(|change| {
+        change.resource == "graph.knowledge" && change.operation == PlanOperation::Create
+    }));
+    assert!(plan.changes.iter().any(|change| {
+        change.resource == "schema.knowledge" && change.operation == PlanOperation::Create
+    }));
+    assert!(plan.changes.iter().any(|change| {
+        change.resource == "streaming.knowledge" && change.operation == PlanOperation::Create
+    }));
 
-        let applied = confirmed_streaming_apply(dir.path()).await;
-        assert!(applied.ok && applied.converged, "{applied:?}");
-        assert!(
-            live_streaming_enabled(dir.path()).await,
-            "a recreated graph must receive the managed streaming authority"
-        );
-    }
+    let applied = confirmed_streaming_apply(dir.path()).await;
+    assert!(applied.ok && applied.converged, "{applied:?}");
+    assert!(
+        live_streaming_enabled(dir.path()).await,
+        "a recreated graph must receive the managed streaming authority"
+    );
+}
 
-    #[tokio::test]
-    async fn live_schema_mismatch_marks_drifted_and_causes_plan_update() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await;
-        fs::write(
-            dir.path().join("people.pg"),
-            SCHEMA.replace("age: I32?", "age: I32?\n  nickname: String?"),
-        )
-        .unwrap();
-        let state_dir = dir.path().join(CLUSTER_STATE_DIR);
-        fs::create_dir_all(&state_dir).unwrap();
-        fs::write(
+#[tokio::test]
+async fn live_schema_mismatch_marks_drifted_and_causes_plan_update() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    fs::write(
+        dir.path().join("people.pg"),
+        SCHEMA.replace("age: I32?", "age: I32?\n  nickname: String?"),
+    )
+    .unwrap();
+    let state_dir = dir.path().join(CLUSTER_STATE_DIR);
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(
             state_dir.join("state.json"),
             r#"{"version":1,"applied_revision":{"resources":{"graph.knowledge":{"digest":"old-graph"},"schema.knowledge":{"digest":"old-schema"}}}}"#,
         )
         .unwrap();
 
-        let out = refresh_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert_eq!(
-            out.resource_statuses["schema.knowledge"].status,
-            ResourceLifecycleStatus::Drifted
-        );
-        assert_eq!(
-            out.observations["graph.knowledge"]["schema_matches_desired"],
-            false
-        );
+    let out = refresh_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert_eq!(
+        out.resource_statuses["schema.knowledge"].status,
+        ResourceLifecycleStatus::Drifted
+    );
+    assert_eq!(
+        out.observations["graph.knowledge"]["schema_matches_desired"],
+        false
+    );
 
-        let plan = plan_config_dir(dir.path()).await;
-        assert!(plan.ok, "{:?}", plan.diagnostics);
-        assert!(plan.changes.iter().any(|change| {
-            change.resource == "schema.knowledge" && change.operation == PlanOperation::Update
-        }));
-    }
+    let plan = plan_config_dir(dir.path()).await;
+    assert!(plan.ok, "{:?}", plan.diagnostics);
+    assert!(plan.changes.iter().any(|change| {
+        change.resource == "schema.knowledge" && change.operation == PlanOperation::Update
+    }));
+}
 
-    #[tokio::test]
-    async fn existing_lock_makes_refresh_fail() {
-        let dir = fixture();
-        let state_dir = dir.path().join(CLUSTER_STATE_DIR);
-        fs::create_dir_all(&state_dir).unwrap();
-        fs::write(
-            state_dir.join("state.json"),
-            r#"{"version":1,"applied_revision":{"resources":{}}}"#,
-        )
-        .unwrap();
-        fs::write(
+#[tokio::test]
+async fn existing_lock_makes_refresh_fail() {
+    let dir = fixture();
+    let state_dir = dir.path().join(CLUSTER_STATE_DIR);
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(
+        state_dir.join("state.json"),
+        r#"{"version":1,"applied_revision":{"resources":{}}}"#,
+    )
+    .unwrap();
+    fs::write(
             state_dir.join("lock.json"),
             r#"{"version":1,"lock_id":"held-lock","operation":"refresh","created_at":"2026-06-08T00:00:00Z","pid":123}"#,
         )
         .unwrap();
 
-        let out = refresh_config_dir(dir.path()).await;
-        assert!(!out.ok);
-        assert!(out.state_observations.locked);
-        assert_eq!(out.state_observations.lock_id.as_deref(), Some("held-lock"));
-        assert!(!out.state_observations.lock_acquired);
-        assert_eq!(
-            out.state_observations.lock_operation.as_deref(),
-            Some("refresh")
-        );
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "state_lock_held")
-        );
-        assert!(out.diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == "state_lock_held"
-                && diagnostic.message.contains("force-unlock held-lock")
-        }));
-    }
+    let out = refresh_config_dir(dir.path()).await;
+    assert!(!out.ok);
+    assert!(out.state_observations.locked);
+    assert_eq!(out.state_observations.lock_id.as_deref(), Some("held-lock"));
+    assert!(!out.state_observations.lock_acquired);
+    assert_eq!(
+        out.state_observations.lock_operation.as_deref(),
+        Some("refresh")
+    );
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "state_lock_held")
+    );
+    assert!(out.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "state_lock_held"
+            && diagnostic.message.contains("force-unlock held-lock")
+    }));
+}
 
-    #[tokio::test]
-    async fn state_lock_false_bypasses_refresh_lock_with_warning() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await;
-        fs::write(
-            dir.path().join(CLUSTER_CONFIG_FILE),
-            r#"
+#[tokio::test]
+async fn state_lock_false_bypasses_refresh_lock_with_warning() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        r#"
 version: 1
 state:
   backend: cluster
@@ -1126,1683 +1121,1710 @@ graphs:
   knowledge:
     schema: ./people.pg
 "#,
-        )
-        .unwrap();
-        let state_dir = dir.path().join(CLUSTER_STATE_DIR);
-        fs::create_dir_all(&state_dir).unwrap();
-        fs::write(
-            state_dir.join("state.json"),
-            r#"{"version":1,"applied_revision":{"resources":{}}}"#,
-        )
-        .unwrap();
+    )
+    .unwrap();
+    let state_dir = dir.path().join(CLUSTER_STATE_DIR);
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(
+        state_dir.join("state.json"),
+        r#"{"version":1,"applied_revision":{"resources":{}}}"#,
+    )
+    .unwrap();
 
-        let out = refresh_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert!(!out.state_observations.locked);
-        assert!(!out.state_observations.lock_acquired);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "state_lock_disabled")
-        );
-    }
-
-    #[tokio::test]
-    async fn external_state_backend_refresh_rejected() {
-        let dir = fixture();
-        fs::write(
-            dir.path().join(CLUSTER_CONFIG_FILE),
-            "version: 1\nstate:\n  backend: s3://bucket/state\ngraphs: {}\n",
-        )
-        .unwrap();
-
-        let out = refresh_config_dir(dir.path()).await;
-        assert!(!out.ok);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "unsupported_state_backend")
-        );
-    }
-
-    #[tokio::test]
-    async fn import_graph_open_error_does_not_create_state() {
-        let dir = fixture();
-        fs::create_dir_all(dir.path().join(CLUSTER_GRAPHS_DIR).join("knowledge.omni")).unwrap();
-
-        let out = import_config_dir(dir.path()).await;
-        assert!(!out.ok);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "graph_observation_error")
-        );
-        assert!(!dir.path().join(CLUSTER_STATE_FILE).exists());
-    }
-
-    // ---- config-only apply (Stage 3A) ----
-
-    /// Seed a state.json that simulates "graph exists with the desired schema,
-    /// queries/policies not yet applied" by borrowing the desired digests.
-    fn write_applyable_state(config_dir: &Path) {
-        let out = validate_config_dir(config_dir);
-        assert!(out.ok, "{:?}", out.diagnostics);
-        let schema_digest = out.resource_digests.get("schema.knowledge").unwrap().clone();
-        let graph_composite = graph_digest(
-            "knowledge",
-            Some(&schema_digest),
-            Some(&BTreeMap::new()),
-            None,
-            None,
-        );
-        write_state_resources(
-            config_dir,
-            &[
-                ("graph.knowledge", graph_composite.as_str()),
-                ("schema.knowledge", schema_digest.as_str()),
-            ],
-        );
-    }
-
-    fn write_state_resources(config_dir: &Path, resources: &[(&str, &str)]) {
-        let resource_map: serde_json::Map<String, serde_json::Value> = resources
+    let out = refresh_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert!(!out.state_observations.locked);
+    assert!(!out.state_observations.lock_acquired);
+    assert!(
+        out.diagnostics
             .iter()
-            .map(|(address, digest)| ((*address).to_string(), json!({ "digest": digest })))
-            .collect();
-        let state_dir = config_dir.join(CLUSTER_STATE_DIR);
-        fs::create_dir_all(&state_dir).unwrap();
-        fs::write(
-            state_dir.join("state.json"),
-            serde_json::to_string_pretty(&json!({
-                "version": 1,
-                "state_revision": 1,
-                "applied_revision": { "resources": resource_map }
-            }))
-            .unwrap(),
-        )
-        .unwrap();
-    }
+            .any(|diagnostic| diagnostic.code == "state_lock_disabled")
+    );
+}
 
-    fn read_state_json(config_dir: &Path) -> serde_json::Value {
-        serde_json::from_str(&fs::read_to_string(config_dir.join(CLUSTER_STATE_FILE)).unwrap())
-            .unwrap()
-    }
+#[tokio::test]
+async fn external_state_backend_refresh_rejected() {
+    let dir = fixture();
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        "version: 1\nstate:\n  backend: s3://bucket/state\ngraphs: {}\n",
+    )
+    .unwrap();
 
-    fn recovery_sidecars(config_dir: &Path) -> Vec<std::path::PathBuf> {
-        let dir = config_dir.join(CLUSTER_RECOVERIES_DIR);
-        if !dir.exists() {
-            return Vec::new();
-        }
-        let mut sidecars: Vec<_> = fs::read_dir(dir)
-            .unwrap()
-            .map(|entry| entry.unwrap().path())
-            .collect();
-        sidecars.sort();
-        sidecars
-    }
-
-    fn query_payload_path(config_dir: &Path, digest: &str) -> std::path::PathBuf {
-        config_dir
-            .join(CLUSTER_RESOURCES_DIR)
-            .join("query/knowledge/find_person")
-            .join(format!("{digest}.gq"))
-    }
-
-    fn policy_payload_path(config_dir: &Path, digest: &str) -> std::path::PathBuf {
-        config_dir
-            .join(CLUSTER_RESOURCES_DIR)
-            .join("policy/base")
-            .join(format!("{digest}.yaml"))
-    }
-
-    #[tokio::test]
-    async fn apply_without_state_fails_with_state_missing() {
-        let dir = fixture();
-        let out = apply_config_dir(dir.path()).await;
-        assert!(!out.ok);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "state_missing"
-                    && diagnostic.message.contains("cluster import"))
-        );
-        assert!(!dir.path().join(CLUSTER_STATE_FILE).exists());
-        assert!(!dir.path().join(CLUSTER_RESOURCES_DIR).exists());
-        assert!(!dir.path().join(CLUSTER_LOCK_FILE).exists());
-    }
-
-    #[tokio::test]
-    async fn apply_writes_payloads_state_and_statuses() {
-        let dir = fixture();
-        write_applyable_state(dir.path());
-        let desired = validate_config_dir(dir.path());
-        let query_digest = desired
-            .resource_digests
-            .get("query.knowledge.find_person")
-            .unwrap()
-            .clone();
-        let policy_digest = desired.resource_digests.get("policy.base").unwrap().clone();
-        let schema_digest = desired
-            .resource_digests
-            .get("schema.knowledge")
-            .unwrap()
-            .clone();
-
-        let out = apply_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert_eq!(out.applied_count, 2);
-        assert_eq!(out.deferred_count, 0);
-        assert!(out.converged);
-        assert!(out.state_written);
-
-        let query_blob = query_payload_path(dir.path(), &query_digest);
-        assert_eq!(fs::read_to_string(&query_blob).unwrap(), QUERY);
-        let policy_blob = policy_payload_path(dir.path(), &policy_digest);
-        assert_eq!(fs::read_to_string(&policy_blob).unwrap(), "rules: []\n");
-
-        let state = read_state_json(dir.path());
-        assert_eq!(state["state_revision"], 2);
-        let resources = &state["applied_revision"]["resources"];
-        assert_eq!(
-            resources["query.knowledge.find_person"]["digest"],
-            query_digest
-        );
-        assert_eq!(resources["policy.base"]["digest"], policy_digest);
-        let expected_composite = graph_digest(
-            "knowledge",
-            Some(&schema_digest),
-            Some(
-                &[("find_person".to_string(), query_digest.clone())]
-                    .into_iter()
-                    .collect(),
-            ),
-            None,
-            None,
-        );
-        assert_eq!(resources["graph.knowledge"]["digest"], expected_composite);
-        assert_eq!(
-            state["applied_revision"]["config_digest"],
-            desired_revision_digest(&out)
-        );
-        assert_eq!(
-            state["resource_statuses"]["query.knowledge.find_person"]["status"],
-            "applied"
-        );
-        assert_eq!(state["resource_statuses"]["policy.base"]["status"], "applied");
-        assert!(!dir.path().join(CLUSTER_LOCK_FILE).exists());
-    }
-
-    #[tokio::test]
-    async fn apply_records_embedding_provider_profile_and_graph_binding() {
-        let dir = fixture();
-        write_mock_embedding_cluster(dir.path(), "recorded-x");
-        write_applyable_state(dir.path());
-        let desired = validate_config_dir(dir.path());
-        let query_digest = desired
-            .resource_digests
-            .get("query.knowledge.find_person")
-            .unwrap()
-            .clone();
-        let schema_digest = desired
-            .resource_digests
-            .get("schema.knowledge")
-            .unwrap()
-            .clone();
-        let provider_digest = desired
-            .resource_digests
-            .get("provider.embedding.default")
-            .unwrap()
-            .clone();
-
-        let out = apply_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert!(out.converged, "{out:?}");
-
-        let state = read_state_json(dir.path());
-        let resources = &state["applied_revision"]["resources"];
-        let provider = resources["provider.embedding.default"]
-            .as_object()
-            .expect("provider resource");
-        assert_eq!(provider["digest"], provider_digest);
-        assert_eq!(provider["embedding_profile"]["kind"], "mock");
-        assert_eq!(provider["embedding_profile"]["model"], "recorded-x");
-        assert!(provider["embedding_profile"].get("api_key").is_none());
-        assert_eq!(
-            resources["graph.knowledge"]["embedding_provider"],
-            "provider.embedding.default"
-        );
-        let expected_graph_digest = graph_digest(
-            "knowledge",
-            Some(&schema_digest),
-            Some(
-                &[("find_person".to_string(), query_digest)]
-                    .into_iter()
-                    .collect(),
-            ),
-            Some("provider.embedding.default"),
-            Some(&provider_digest),
-        );
-        assert_eq!(resources["graph.knowledge"]["digest"], expected_graph_digest);
-    }
-
-    #[tokio::test]
-    async fn embedding_provider_changes_update_provider_and_graph_plan() {
-        let dir = fixture();
-        write_mock_embedding_cluster(dir.path(), "recorded-x");
-        write_applyable_state(dir.path());
-        let first = apply_config_dir(dir.path()).await;
-        assert!(first.ok && first.converged, "{first:?}");
-
-        write_mock_embedding_cluster(dir.path(), "recorded-y");
-        let plan = plan_config_dir(dir.path()).await;
-        assert!(plan.ok, "{:?}", plan.diagnostics);
-        let by_resource: BTreeMap<&str, &PlanChange> = plan
-            .changes
+    let out = refresh_config_dir(dir.path()).await;
+    assert!(!out.ok);
+    assert!(
+        out.diagnostics
             .iter()
-            .map(|change| (change.resource.as_str(), change))
-            .collect();
-        assert_eq!(
-            by_resource["provider.embedding.default"].operation,
-            PlanOperation::Update
-        );
-        assert_eq!(
-            by_resource["provider.embedding.default"].disposition,
-            Some(ApplyDisposition::Applied)
-        );
-        assert_eq!(
-            by_resource["graph.knowledge"].operation,
-            PlanOperation::Update
-        );
-        assert_eq!(
-            by_resource["graph.knowledge"].disposition,
-            Some(ApplyDisposition::Derived)
-        );
+            .any(|diagnostic| diagnostic.code == "unsupported_state_backend")
+    );
+}
+
+#[tokio::test]
+async fn import_graph_open_error_does_not_create_state() {
+    let dir = fixture();
+    fs::create_dir_all(dir.path().join(CLUSTER_GRAPHS_DIR).join("knowledge.omni")).unwrap();
+
+    let out = import_config_dir(dir.path()).await;
+    assert!(!out.ok);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "graph_observation_error")
+    );
+    assert!(!dir.path().join(CLUSTER_STATE_FILE).exists());
+}
+
+// ---- config-only apply (Stage 3A) ----
+
+/// Seed a state.json that simulates "graph exists with the desired schema,
+/// queries/policies not yet applied" by borrowing the desired digests.
+fn write_applyable_state(config_dir: &Path) {
+    let out = validate_config_dir(config_dir);
+    assert!(out.ok, "{:?}", out.diagnostics);
+    let schema_digest = out
+        .resource_digests
+        .get("schema.knowledge")
+        .unwrap()
+        .clone();
+    let graph_composite = graph_digest(
+        "knowledge",
+        Some(&schema_digest),
+        Some(&BTreeMap::new()),
+        None,
+        None,
+    );
+    write_state_resources(
+        config_dir,
+        &[
+            ("graph.knowledge", graph_composite.as_str()),
+            ("schema.knowledge", schema_digest.as_str()),
+        ],
+    );
+}
+
+fn write_state_resources(config_dir: &Path, resources: &[(&str, &str)]) {
+    let resource_map: serde_json::Map<String, serde_json::Value> = resources
+        .iter()
+        .map(|(address, digest)| ((*address).to_string(), json!({ "digest": digest })))
+        .collect();
+    let state_dir = config_dir.join(CLUSTER_STATE_DIR);
+    fs::create_dir_all(&state_dir).unwrap();
+    fs::write(
+        state_dir.join("state.json"),
+        serde_json::to_string_pretty(&json!({
+            "version": 1,
+            "state_revision": 1,
+            "applied_revision": { "resources": resource_map }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+}
+
+fn read_state_json(config_dir: &Path) -> serde_json::Value {
+    serde_json::from_str(&fs::read_to_string(config_dir.join(CLUSTER_STATE_FILE)).unwrap()).unwrap()
+}
+
+fn recovery_sidecars(config_dir: &Path) -> Vec<std::path::PathBuf> {
+    let dir = config_dir.join(CLUSTER_RECOVERIES_DIR);
+    if !dir.exists() {
+        return Vec::new();
     }
+    let mut sidecars: Vec<_> = fs::read_dir(dir)
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .collect();
+    sidecars.sort();
+    sidecars
+}
 
-    #[tokio::test]
-    async fn embedding_binding_survives_refresh() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await;
-        write_mock_embedding_cluster(dir.path(), "recorded-x");
-        write_applyable_state(dir.path());
-        let apply = apply_config_dir(dir.path()).await;
-        assert!(apply.ok && apply.converged, "{apply:?}");
+fn query_payload_path(config_dir: &Path, digest: &str) -> std::path::PathBuf {
+    config_dir
+        .join(CLUSTER_RESOURCES_DIR)
+        .join("query/knowledge/find_person")
+        .join(format!("{digest}.gq"))
+}
 
-        let refresh = refresh_config_dir(dir.path()).await;
-        assert!(refresh.ok, "{:?}", refresh.diagnostics);
+fn policy_payload_path(config_dir: &Path, digest: &str) -> std::path::PathBuf {
+    config_dir
+        .join(CLUSTER_RESOURCES_DIR)
+        .join("policy/base")
+        .join(format!("{digest}.yaml"))
+}
 
-        let state = read_state_json(dir.path());
-        let resources = &state["applied_revision"]["resources"];
-        assert_eq!(
-            resources["graph.knowledge"]["embedding_provider"],
-            "provider.embedding.default"
-        );
-        assert_eq!(
-            resources["provider.embedding.default"]["embedding_profile"]["model"],
-            "recorded-x"
-        );
-    }
+#[tokio::test]
+async fn apply_without_state_fails_with_state_missing() {
+    let dir = fixture();
+    let out = apply_config_dir(dir.path()).await;
+    assert!(!out.ok);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "state_missing"
+                && diagnostic.message.contains("cluster import"))
+    );
+    assert!(!dir.path().join(CLUSTER_STATE_FILE).exists());
+    assert!(!dir.path().join(CLUSTER_RESOURCES_DIR).exists());
+    assert!(!dir.path().join(CLUSTER_LOCK_FILE).exists());
+}
 
-    fn desired_revision_digest(out: &ApplyOutput) -> String {
-        out.desired_revision.config_digest.clone().unwrap()
-    }
+#[tokio::test]
+async fn apply_writes_payloads_state_and_statuses() {
+    let dir = fixture();
+    write_applyable_state(dir.path());
+    let desired = validate_config_dir(dir.path());
+    let query_digest = desired
+        .resource_digests
+        .get("query.knowledge.find_person")
+        .unwrap()
+        .clone();
+    let policy_digest = desired.resource_digests.get("policy.base").unwrap().clone();
+    let schema_digest = desired
+        .resource_digests
+        .get("schema.knowledge")
+        .unwrap()
+        .clone();
 
-    #[tokio::test]
-    async fn apply_update_changes_query_digest_and_keeps_old_blob() {
-        let dir = fixture();
-        let desired = validate_config_dir(dir.path());
-        let schema_digest = desired
-            .resource_digests
-            .get("schema.knowledge")
-            .unwrap()
-            .clone();
-        let old_digest = "0".repeat(64);
-        let graph_composite = graph_digest(
-            "knowledge",
-            Some(&schema_digest),
-            Some(&BTreeMap::new()),
-            None,
-            None,
-        );
-        write_state_resources(
-            dir.path(),
-            &[
-                ("graph.knowledge", graph_composite.as_str()),
-                ("schema.knowledge", schema_digest.as_str()),
-                ("query.knowledge.find_person", old_digest.as_str()),
-            ],
-        );
-        let old_blob = query_payload_path(dir.path(), &old_digest);
-        fs::create_dir_all(old_blob.parent().unwrap()).unwrap();
-        fs::write(&old_blob, "old query source").unwrap();
+    let out = apply_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert_eq!(out.applied_count, 2);
+    assert_eq!(out.deferred_count, 0);
+    assert!(out.converged);
+    assert!(out.state_written);
 
-        let out = apply_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        let new_digest = desired
-            .resource_digests
-            .get("query.knowledge.find_person")
-            .unwrap();
-        let state = read_state_json(dir.path());
-        assert_eq!(
-            state["applied_revision"]["resources"]["query.knowledge.find_person"]["digest"],
-            *new_digest
-        );
-        assert_eq!(fs::read_to_string(&old_blob).unwrap(), "old query source");
-        assert!(query_payload_path(dir.path(), new_digest).exists());
-    }
+    let query_blob = query_payload_path(dir.path(), &query_digest);
+    assert_eq!(fs::read_to_string(&query_blob).unwrap(), QUERY);
+    let policy_blob = policy_payload_path(dir.path(), &policy_digest);
+    assert_eq!(fs::read_to_string(&policy_blob).unwrap(), "rules: []\n");
 
-    #[tokio::test]
-    async fn apply_deletes_removed_resources_but_keeps_blobs() {
-        let dir = fixture();
-        let desired = validate_config_dir(dir.path());
-        let schema_digest = desired
-            .resource_digests
-            .get("schema.knowledge")
-            .unwrap()
-            .clone();
-        let stale_query_digest = "1".repeat(64);
-        let stale_policy_digest = "2".repeat(64);
-        let graph_composite = graph_digest(
-            "knowledge",
-            Some(&schema_digest),
-            Some(&BTreeMap::new()),
-            None,
-            None,
-        );
-        write_state_resources(
-            dir.path(),
-            &[
-                ("graph.knowledge", graph_composite.as_str()),
-                ("schema.knowledge", schema_digest.as_str()),
-                ("query.knowledge.orphan", stale_query_digest.as_str()),
-                ("policy.old", stale_policy_digest.as_str()),
-            ],
-        );
-        let stale_blob = dir
-            .path()
-            .join(CLUSTER_RESOURCES_DIR)
-            .join("policy/old")
-            .join(format!("{stale_policy_digest}.yaml"));
-        fs::create_dir_all(stale_blob.parent().unwrap()).unwrap();
-        fs::write(&stale_blob, "old policy").unwrap();
+    let state = read_state_json(dir.path());
+    assert_eq!(state["state_revision"], 2);
+    let resources = &state["applied_revision"]["resources"];
+    assert_eq!(
+        resources["query.knowledge.find_person"]["digest"],
+        query_digest
+    );
+    assert_eq!(resources["policy.base"]["digest"], policy_digest);
+    let expected_composite = graph_digest(
+        "knowledge",
+        Some(&schema_digest),
+        Some(
+            &[("find_person".to_string(), query_digest.clone())]
+                .into_iter()
+                .collect(),
+        ),
+        None,
+        None,
+    );
+    assert_eq!(resources["graph.knowledge"]["digest"], expected_composite);
+    assert_eq!(
+        state["applied_revision"]["config_digest"],
+        desired_revision_digest(&out)
+    );
+    assert_eq!(
+        state["resource_statuses"]["query.knowledge.find_person"]["status"],
+        "applied"
+    );
+    assert_eq!(
+        state["resource_statuses"]["policy.base"]["status"],
+        "applied"
+    );
+    assert!(!dir.path().join(CLUSTER_LOCK_FILE).exists());
+}
 
-        let out = apply_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert!(out.converged);
-        let state = read_state_json(dir.path());
-        let resources = &state["applied_revision"]["resources"];
-        assert!(resources.get("query.knowledge.orphan").is_none());
-        assert!(resources.get("policy.old").is_none());
-        assert!(
-            state["resource_statuses"]
-                .get("query.knowledge.orphan")
-                .is_none()
-        );
-        // Deleted resources leave their content-addressed blobs in place; GC is
-        // a later stage.
-        assert_eq!(fs::read_to_string(&stale_blob).unwrap(), "old policy");
-        // The composite no longer includes the orphan query.
-        let query_digest = desired
-            .resource_digests
-            .get("query.knowledge.find_person")
-            .unwrap()
-            .clone();
-        let expected_composite = graph_digest(
-            "knowledge",
-            Some(&schema_digest),
-            Some(&[("find_person".to_string(), query_digest)].into_iter().collect()),
-            None,
-            None,
-        );
-        assert_eq!(resources["graph.knowledge"]["digest"], expected_composite);
-    }
+#[tokio::test]
+async fn apply_records_embedding_provider_profile_and_graph_binding() {
+    let dir = fixture();
+    write_mock_embedding_cluster(dir.path(), "recorded-x");
+    write_applyable_state(dir.path());
+    let desired = validate_config_dir(dir.path());
+    let query_digest = desired
+        .resource_digests
+        .get("query.knowledge.find_person")
+        .unwrap()
+        .clone();
+    let schema_digest = desired
+        .resource_digests
+        .get("schema.knowledge")
+        .unwrap()
+        .clone();
+    let provider_digest = desired
+        .resource_digests
+        .get("provider.embedding.default")
+        .unwrap()
+        .clone();
 
-    #[tokio::test]
-    async fn apply_schema_update_and_dependent_query_in_one_run() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await;
-        write_applyable_state(dir.path());
-        // Schema update + a query update that depends on the new field: one
-        // apply executes the schema migration first, then the catalog write.
-        fs::write(dir.path().join("people.pg"), SCHEMA_V2).unwrap();
-        fs::write(
+    let out = apply_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert!(out.converged, "{out:?}");
+
+    let state = read_state_json(dir.path());
+    let resources = &state["applied_revision"]["resources"];
+    let provider = resources["provider.embedding.default"]
+        .as_object()
+        .expect("provider resource");
+    assert_eq!(provider["digest"], provider_digest);
+    assert_eq!(provider["embedding_profile"]["kind"], "mock");
+    assert_eq!(provider["embedding_profile"]["model"], "recorded-x");
+    assert!(provider["embedding_profile"].get("api_key").is_none());
+    assert_eq!(
+        resources["graph.knowledge"]["embedding_provider"],
+        "provider.embedding.default"
+    );
+    let expected_graph_digest = graph_digest(
+        "knowledge",
+        Some(&schema_digest),
+        Some(
+            &[("find_person".to_string(), query_digest)]
+                .into_iter()
+                .collect(),
+        ),
+        Some("provider.embedding.default"),
+        Some(&provider_digest),
+    );
+    assert_eq!(
+        resources["graph.knowledge"]["digest"],
+        expected_graph_digest
+    );
+}
+
+#[tokio::test]
+async fn embedding_provider_changes_update_provider_and_graph_plan() {
+    let dir = fixture();
+    write_mock_embedding_cluster(dir.path(), "recorded-x");
+    write_applyable_state(dir.path());
+    let first = apply_config_dir(dir.path()).await;
+    assert!(first.ok && first.converged, "{first:?}");
+
+    write_mock_embedding_cluster(dir.path(), "recorded-y");
+    let plan = plan_config_dir(dir.path()).await;
+    assert!(plan.ok, "{:?}", plan.diagnostics);
+    let by_resource: BTreeMap<&str, &PlanChange> = plan
+        .changes
+        .iter()
+        .map(|change| (change.resource.as_str(), change))
+        .collect();
+    assert_eq!(
+        by_resource["provider.embedding.default"].operation,
+        PlanOperation::Update
+    );
+    assert_eq!(
+        by_resource["provider.embedding.default"].disposition,
+        Some(ApplyDisposition::Applied)
+    );
+    assert_eq!(
+        by_resource["graph.knowledge"].operation,
+        PlanOperation::Update
+    );
+    assert_eq!(
+        by_resource["graph.knowledge"].disposition,
+        Some(ApplyDisposition::Derived)
+    );
+}
+
+#[tokio::test]
+async fn embedding_binding_survives_refresh() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    write_mock_embedding_cluster(dir.path(), "recorded-x");
+    write_applyable_state(dir.path());
+    let apply = apply_config_dir(dir.path()).await;
+    assert!(apply.ok && apply.converged, "{apply:?}");
+
+    let refresh = refresh_config_dir(dir.path()).await;
+    assert!(refresh.ok, "{:?}", refresh.diagnostics);
+
+    let state = read_state_json(dir.path());
+    let resources = &state["applied_revision"]["resources"];
+    assert_eq!(
+        resources["graph.knowledge"]["embedding_provider"],
+        "provider.embedding.default"
+    );
+    assert_eq!(
+        resources["provider.embedding.default"]["embedding_profile"]["model"],
+        "recorded-x"
+    );
+}
+
+fn desired_revision_digest(out: &ApplyOutput) -> String {
+    out.desired_revision.config_digest.clone().unwrap()
+}
+
+#[tokio::test]
+async fn apply_update_changes_query_digest_and_keeps_old_blob() {
+    let dir = fixture();
+    let desired = validate_config_dir(dir.path());
+    let schema_digest = desired
+        .resource_digests
+        .get("schema.knowledge")
+        .unwrap()
+        .clone();
+    let old_digest = "0".repeat(64);
+    let graph_composite = graph_digest(
+        "knowledge",
+        Some(&schema_digest),
+        Some(&BTreeMap::new()),
+        None,
+        None,
+    );
+    write_state_resources(
+        dir.path(),
+        &[
+            ("graph.knowledge", graph_composite.as_str()),
+            ("schema.knowledge", schema_digest.as_str()),
+            ("query.knowledge.find_person", old_digest.as_str()),
+        ],
+    );
+    let old_blob = query_payload_path(dir.path(), &old_digest);
+    fs::create_dir_all(old_blob.parent().unwrap()).unwrap();
+    fs::write(&old_blob, "old query source").unwrap();
+
+    let out = apply_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    let new_digest = desired
+        .resource_digests
+        .get("query.knowledge.find_person")
+        .unwrap();
+    let state = read_state_json(dir.path());
+    assert_eq!(
+        state["applied_revision"]["resources"]["query.knowledge.find_person"]["digest"],
+        *new_digest
+    );
+    assert_eq!(fs::read_to_string(&old_blob).unwrap(), "old query source");
+    assert!(query_payload_path(dir.path(), new_digest).exists());
+}
+
+#[tokio::test]
+async fn apply_deletes_removed_resources_but_keeps_blobs() {
+    let dir = fixture();
+    let desired = validate_config_dir(dir.path());
+    let schema_digest = desired
+        .resource_digests
+        .get("schema.knowledge")
+        .unwrap()
+        .clone();
+    let stale_query_digest = "1".repeat(64);
+    let stale_policy_digest = "2".repeat(64);
+    let graph_composite = graph_digest(
+        "knowledge",
+        Some(&schema_digest),
+        Some(&BTreeMap::new()),
+        None,
+        None,
+    );
+    write_state_resources(
+        dir.path(),
+        &[
+            ("graph.knowledge", graph_composite.as_str()),
+            ("schema.knowledge", schema_digest.as_str()),
+            ("query.knowledge.orphan", stale_query_digest.as_str()),
+            ("policy.old", stale_policy_digest.as_str()),
+        ],
+    );
+    let stale_blob = dir
+        .path()
+        .join(CLUSTER_RESOURCES_DIR)
+        .join("policy/old")
+        .join(format!("{stale_policy_digest}.yaml"));
+    fs::create_dir_all(stale_blob.parent().unwrap()).unwrap();
+    fs::write(&stale_blob, "old policy").unwrap();
+
+    let out = apply_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert!(out.converged);
+    let state = read_state_json(dir.path());
+    let resources = &state["applied_revision"]["resources"];
+    assert!(resources.get("query.knowledge.orphan").is_none());
+    assert!(resources.get("policy.old").is_none());
+    assert!(
+        state["resource_statuses"]
+            .get("query.knowledge.orphan")
+            .is_none()
+    );
+    // Deleted resources leave their content-addressed blobs in place; GC is
+    // a later stage.
+    assert_eq!(fs::read_to_string(&stale_blob).unwrap(), "old policy");
+    // The composite no longer includes the orphan query.
+    let query_digest = desired
+        .resource_digests
+        .get("query.knowledge.find_person")
+        .unwrap()
+        .clone();
+    let expected_composite = graph_digest(
+        "knowledge",
+        Some(&schema_digest),
+        Some(
+            &[("find_person".to_string(), query_digest)]
+                .into_iter()
+                .collect(),
+        ),
+        None,
+        None,
+    );
+    assert_eq!(resources["graph.knowledge"]["digest"], expected_composite);
+}
+
+#[tokio::test]
+async fn apply_schema_update_and_dependent_query_in_one_run() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    write_applyable_state(dir.path());
+    // Schema update + a query update that depends on the new field: one
+    // apply executes the schema migration first, then the catalog write.
+    fs::write(dir.path().join("people.pg"), SCHEMA_V2).unwrap();
+    fs::write(
             dir.path().join("people.gq"),
             "\nquery find_person($name: String) {\n  match { $p: Person { name: $name } }\n  return { $p.name, $p.bio }\n}\n",
         )
         .unwrap();
 
-        let out = apply_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert!(out.converged, "{out:?}");
-        let by_resource: BTreeMap<&str, &PlanChange> = out
-            .changes
-            .iter()
-            .map(|change| (change.resource.as_str(), change))
-            .collect();
-        assert_eq!(
-            by_resource["schema.knowledge"].disposition,
-            Some(ApplyDisposition::Applied)
-        );
-        assert_eq!(
-            by_resource["query.knowledge.find_person"].disposition,
-            Some(ApplyDisposition::Applied)
-        );
-        assert_eq!(
-            by_resource["graph.knowledge"].disposition,
-            Some(ApplyDisposition::Derived)
-        );
-        // The live graph carries the new schema.
-        let db = Omnigraph::open_read_only(&derived_graph_uri(dir.path(), "knowledge"))
-            .await
-            .unwrap();
-        let desired = validate_config_dir(dir.path());
-        assert_eq!(
-            sha256_hex(db.schema_source().as_bytes()),
-            desired.resource_digests["schema.knowledge"]
-        );
-        let state = read_state_json(dir.path());
-        assert_eq!(
-            state["applied_revision"]["resources"]["schema.knowledge"]["digest"],
-            desired.resource_digests["schema.knowledge"]
-        );
-        // Sidecar retired after the CAS landed.
-        assert!(
-            !dir.path().join(CLUSTER_RECOVERIES_DIR).exists()
-                || fs::read_dir(dir.path().join(CLUSTER_RECOVERIES_DIR))
-                    .unwrap()
-                    .next()
-                    .is_none()
-        );
-    }
-
-    #[tokio::test]
-    async fn apply_unsupported_schema_change_fails_loudly() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await;
-        write_applyable_state(dir.path());
-        write_streaming_cluster(dir.path(), Some(true));
-        // Property type changes are unsupported by the engine planner.
-        fs::write(
-            dir.path().join("people.pg"),
-            "\nnode Person {\n  name: String @key\n  age: I64?\n}\n",
-        )
-        .unwrap();
-
-        let out = confirmed_streaming_apply(dir.path()).await;
-        assert!(!out.ok);
-        assert!(out.diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == "schema_apply_failed"
-                && diagnostic.message.contains("changing property type")
-        }));
-        let by_resource: BTreeMap<&str, &PlanChange> = out
-            .changes
-            .iter()
-            .map(|change| (change.resource.as_str(), change))
-            .collect();
-        assert_eq!(
-            by_resource["schema.knowledge"].disposition,
-            Some(ApplyDisposition::Blocked)
-        );
-        assert_eq!(
-            by_resource["schema.knowledge"].reason.as_deref(),
-            Some("schema_apply_failed")
-        );
-        assert_eq!(
-            by_resource["streaming.knowledge"].disposition,
-            Some(ApplyDisposition::Blocked)
-        );
-        assert_eq!(
-            by_resource["streaming.knowledge"].reason.as_deref(),
-            Some("dependency_not_applied")
-        );
-        // The live schema and the ledger are unchanged.
-        let state = read_state_json(dir.path());
-        let desired = validate_config_dir(dir.path());
-        assert_ne!(
-            state["applied_revision"]["resources"]["schema.knowledge"]["digest"],
-            desired.resource_digests["schema.knowledge"]
-        );
-        let db = Omnigraph::open_read_only(&derived_graph_uri(dir.path(), "knowledge"))
-            .await
-            .unwrap();
-        assert_eq!(db.schema_source().as_str(), SCHEMA);
-        assert!(!db.snapshot_of("main").await.unwrap().streaming_status().enabled);
-        assert!(
-            state["applied_revision"]["resources"]
-                .get("streaming.knowledge")
-                .is_none()
-        );
-        assert!(
-            recovery_sidecars(dir.path()).is_empty(),
-            "{:?}",
-            recovery_sidecars(dir.path())
-        );
-        // Second run fails just as loudly and still leaves no sidecar because
-        // the engine preview rejects before graph state can move.
-        let second = confirmed_streaming_apply(dir.path()).await;
-        assert!(!second.ok);
-        assert!(
-            second
-                .diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "schema_apply_failed")
-        );
-        assert!(
-            recovery_sidecars(dir.path()).is_empty(),
-            "{:?}",
-            recovery_sidecars(dir.path())
-        );
-
-        // Once the graph failure is corrected, the unapplied streaming
-        // resource remains in the diff and is retried.
-        fs::write(dir.path().join("people.pg"), SCHEMA).unwrap();
-        let recovered = confirmed_streaming_apply(dir.path()).await;
-        assert!(recovered.ok && recovered.converged, "{recovered:?}");
-        assert!(live_streaming_enabled(dir.path()).await);
-    }
-
-    #[tokio::test]
-    async fn apply_schema_update_blocked_by_non_main_branch_leaves_no_sidecar() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await;
-        write_applyable_state(dir.path());
-        let graph_uri = derived_graph_uri(dir.path(), "knowledge");
-        let db = Omnigraph::open(&graph_uri).await.unwrap();
-        db.branch_create("feature").await.unwrap();
-        drop(db);
-        let before_state = read_state_json(dir.path());
-        fs::write(dir.path().join("people.pg"), SCHEMA_V2).unwrap();
-
-        let out = apply_config_dir(dir.path()).await;
-        assert!(!out.ok);
-        assert!(out.diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == "schema_apply_failed"
-                && diagnostic
-                    .message
-                    .contains("schema apply requires a graph with only main")
-        }));
-        assert!(
-            recovery_sidecars(dir.path()).is_empty(),
-            "{:?}",
-            recovery_sidecars(dir.path())
-        );
-        let after_state = read_state_json(dir.path());
-        assert_eq!(
-            after_state["applied_revision"]["resources"],
-            before_state["applied_revision"]["resources"]
-        );
-        let reopened = Omnigraph::open_read_only(&graph_uri).await.unwrap();
-        assert_eq!(reopened.schema_source().as_str(), SCHEMA);
-    }
-
-    #[tokio::test]
-    async fn apply_blocks_schema_update_while_recovery_pending() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await;
-        write_state_resources(dir.path(), &[("schema.knowledge", "stale-digest")]);
-        fs::write(dir.path().join("people.pg"), SCHEMA_V2).unwrap();
-        // A pending sidecar whose intent matches neither live nor recorded.
-        write_schema_apply_sidecar(dir.path(), "knowledge", "intended-digest", "01PENDS");
-
-        let out = apply_config_dir(dir.path()).await;
-        let by_resource: BTreeMap<&str, &PlanChange> = out
-            .changes
-            .iter()
-            .map(|change| (change.resource.as_str(), change))
-            .collect();
-        assert_eq!(
-            by_resource["schema.knowledge"].disposition,
-            Some(ApplyDisposition::Blocked)
-        );
-        assert_eq!(
-            by_resource["schema.knowledge"].reason.as_deref(),
-            Some("cluster_recovery_pending")
-        );
-    }
-
-    #[tokio::test]
-    async fn apply_creates_graph_and_unblocks_dependents() {
-        let dir = fixture();
-        write_state_resources(dir.path(), &[]);
-
-        let out = apply_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert!(out.converged, "{out:?}");
-        let by_resource: BTreeMap<&str, &PlanChange> = out
-            .changes
-            .iter()
-            .map(|change| (change.resource.as_str(), change))
-            .collect();
-        // Stage 4A: the create executes, and its dependents apply in-run.
-        assert_eq!(
-            by_resource["graph.knowledge"].disposition,
-            Some(ApplyDisposition::Applied)
-        );
-        assert_eq!(
-            by_resource["schema.knowledge"].disposition,
-            Some(ApplyDisposition::Applied)
-        );
-        assert_eq!(
-            by_resource["query.knowledge.find_person"].disposition,
-            Some(ApplyDisposition::Applied)
-        );
-        assert_eq!(
-            by_resource["policy.base"].disposition,
-            Some(ApplyDisposition::Applied)
-        );
-        // The graph exists on disk and opens; state records everything.
-        let graph_uri = derived_graph_uri(dir.path(), "knowledge");
-        let db = Omnigraph::open_read_only(&graph_uri).await.unwrap();
-        let desired = validate_config_dir(dir.path());
-        assert_eq!(
-            sha256_hex(db.schema_source().as_bytes()),
-            desired.resource_digests["schema.knowledge"]
-        );
-        let state = read_state_json(dir.path());
-        assert_eq!(
-            state["applied_revision"]["resources"]["schema.knowledge"]["digest"],
-            desired.resource_digests["schema.knowledge"]
-        );
-        assert_eq!(
-            state["resource_statuses"]["graph.knowledge"]["status"],
-            "applied"
-        );
-        // The create's sidecar was retired after the state CAS landed.
-        assert!(
-            !dir.path().join(CLUSTER_RECOVERIES_DIR).exists()
-                || fs::read_dir(dir.path().join(CLUSTER_RECOVERIES_DIR))
-                    .unwrap()
-                    .next()
-                    .is_none()
-        );
-    }
-
-    #[tokio::test]
-    async fn apply_create_failure_blocks_dependents_and_keeps_sidecar() {
-        let dir = fixture();
-        write_streaming_cluster(dir.path(), Some(true));
-        write_state_resources(dir.path(), &[]);
-        // Make the init fail its strict preflight: a junk _schema.pg already
-        // sits at the derived root (the engine refuses to overwrite it).
-        let root = dir.path().join(CLUSTER_GRAPHS_DIR).join("knowledge.omni");
-        fs::create_dir_all(&root).unwrap();
-        fs::write(root.join("_schema.pg"), "junk").unwrap();
-
-        let out = confirmed_streaming_apply(dir.path()).await;
-        assert!(!out.ok);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "graph_create_failed")
-        );
-        let by_resource: BTreeMap<&str, &PlanChange> = out
-            .changes
-            .iter()
-            .map(|change| (change.resource.as_str(), change))
-            .collect();
-        // Dependents are demoted: the run tells the truth about what executed.
-        assert_eq!(
-            by_resource["graph.knowledge"].disposition,
-            Some(ApplyDisposition::Blocked)
-        );
-        assert_eq!(
-            by_resource["query.knowledge.find_person"].disposition,
-            Some(ApplyDisposition::Blocked)
-        );
-        assert_eq!(
-            by_resource["query.knowledge.find_person"].reason.as_deref(),
-            Some("dependency_not_applied")
-        );
-        assert_eq!(
-            by_resource["policy.base"].disposition,
-            Some(ApplyDisposition::Blocked)
-        );
-        assert_eq!(
-            by_resource["streaming.knowledge"].disposition,
-            Some(ApplyDisposition::Blocked)
-        );
-        assert_eq!(
-            by_resource["streaming.knowledge"].reason.as_deref(),
-            Some("dependency_not_applied")
-        );
-        assert!(!out.converged);
-        // The sidecar stays for the sweep to classify next run.
-        assert!(
-            fs::read_dir(dir.path().join(CLUSTER_RECOVERIES_DIR))
-                .unwrap()
-                .next()
-                .is_some()
-        );
-        // No graph digests moved.
-        let state = read_state_json(dir.path());
-        assert!(
-            state["applied_revision"]["resources"]
-                .as_object()
-                .unwrap()
-                .is_empty()
-        );
-    }
-
-    #[tokio::test]
-    async fn apply_blocks_graph_delete_without_approval() {
-        let dir = fixture();
-        let desired = validate_config_dir(dir.path());
-        let schema_digest = desired
-            .resource_digests
-            .get("schema.knowledge")
-            .unwrap()
-            .clone();
-        let graph_composite = graph_digest(
-            "knowledge",
-            Some(&schema_digest),
-            Some(&BTreeMap::new()),
-            None,
-            None,
-        );
-        write_state_resources(
-            dir.path(),
-            &[
-                ("graph.knowledge", graph_composite.as_str()),
-                ("schema.knowledge", schema_digest.as_str()),
-                ("graph.old", "3333"),
-                ("schema.old", "4444"),
-                ("query.old.q", "5555"),
-            ],
-        );
-
-        let out = apply_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert!(!out.converged);
-        let by_resource: BTreeMap<&str, &PlanChange> = out
-            .changes
-            .iter()
-            .map(|change| (change.resource.as_str(), change))
-            .collect();
-        // Stage 4C: deletes are gated, not deferred — every subtree change
-        // blocks on the single graph-level approval.
-        assert_eq!(
-            by_resource["graph.old"].disposition,
-            Some(ApplyDisposition::Blocked)
-        );
-        assert_eq!(
-            by_resource["graph.old"].reason.as_deref(),
-            Some("approval_required")
-        );
-        assert_eq!(
-            by_resource["schema.old"].reason.as_deref(),
-            Some("approval_required")
-        );
-        assert_eq!(
-            by_resource["query.old.q"].reason.as_deref(),
-            Some("approval_required")
-        );
-        // State intact; nothing destroyed without the artifact.
-        let state = read_state_json(dir.path());
-        let resources = &state["applied_revision"]["resources"];
-        assert_eq!(resources["graph.old"]["digest"], "3333");
-        assert_eq!(resources["schema.old"]["digest"], "4444");
-        assert_eq!(resources["query.old.q"]["digest"], "5555");
-    }
-
-    #[tokio::test]
-    async fn approve_writes_digest_bound_artifact() {
-        let dir = fixture();
-        write_applyable_state(dir.path());
-        // Seed a deletable subtree.
-        let state = read_state_json(dir.path());
-        let graph_digest_str = state["applied_revision"]["resources"]["graph.knowledge"]["digest"]
-            .as_str()
-            .unwrap()
-            .to_string();
-        let schema_digest_str = state["applied_revision"]["resources"]["schema.knowledge"]
-            ["digest"]
-            .as_str()
-            .unwrap()
-            .to_string();
-        write_state_resources(
-            dir.path(),
-            &[
-                ("graph.knowledge", graph_digest_str.as_str()),
-                ("schema.knowledge", schema_digest_str.as_str()),
-                ("graph.old", "3333"),
-                ("schema.old", "4444"),
-            ],
-        );
-
-        let out = approve_config_dir(dir.path(), "graph.old", "andrew").await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        let approval_id = out.approval_id.clone().unwrap();
-        let artifact: serde_json::Value = serde_json::from_str(
-            &fs::read_to_string(
-                dir.path()
-                    .join(CLUSTER_APPROVALS_DIR)
-                    .join(format!("{approval_id}.json")),
-            )
-            .unwrap(),
-        )
-        .unwrap();
-        assert_eq!(artifact["resource"], "graph.old");
-        assert_eq!(artifact["operation"], "delete");
-        assert_eq!(artifact["approved_by"], "andrew");
-        assert_eq!(artifact["bound_before_digest"], "3333");
-        assert!(artifact["bound_after_digest"].is_null());
-        assert!(artifact["bound_config_digest"].is_string());
-        assert!(artifact["consumed_at"].is_null());
-
-        // A non-gated address is refused.
-        let not_gated = approve_config_dir(dir.path(), "query.knowledge.find_person", "andrew").await;
-        assert!(!not_gated.ok);
-        assert!(
-            not_gated
-                .diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "approval_not_required")
-        );
-    }
-
-    #[tokio::test]
-    async fn stale_approval_is_ignored() {
-        let dir = fixture();
-        write_applyable_state(dir.path());
-        let state = read_state_json(dir.path());
-        let graph_digest_str = state["applied_revision"]["resources"]["graph.knowledge"]["digest"]
-            .as_str()
-            .unwrap()
-            .to_string();
-        let schema_digest_str = state["applied_revision"]["resources"]["schema.knowledge"]
-            ["digest"]
-            .as_str()
-            .unwrap()
-            .to_string();
-        write_state_resources(
-            dir.path(),
-            &[
-                ("graph.knowledge", graph_digest_str.as_str()),
-                ("schema.knowledge", schema_digest_str.as_str()),
-                ("graph.old", "3333"),
-            ],
-        );
-        let approved = approve_config_dir(dir.path(), "graph.old", "andrew").await;
-        assert!(approved.ok, "{:?}", approved.diagnostics);
-        // The config moves after approval: the bound config digest no longer
-        // matches and the artifact authorizes nothing.
-        fs::write(dir.path().join("base.policy.yaml"), "rules: [] # moved\n").unwrap();
-
-        let out = apply_config_dir(dir.path()).await;
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "approval_stale"),
-            "{:?}",
-            out.diagnostics
-        );
-        let by_resource: BTreeMap<&str, &PlanChange> = out
-            .changes
-            .iter()
-            .map(|change| (change.resource.as_str(), change))
-            .collect();
-        assert_eq!(
-            by_resource["graph.old"].reason.as_deref(),
-            Some("approval_required")
-        );
-        let state = read_state_json(dir.path());
-        assert_eq!(
-            state["applied_revision"]["resources"]["graph.old"]["digest"],
-            "3333"
-        );
-    }
-
-    #[tokio::test]
-    async fn compute_approvals_one_gate_per_subtree() {
-        let dir = fixture();
-        write_applyable_state(dir.path());
-        let state = read_state_json(dir.path());
-        let g = state["applied_revision"]["resources"]["graph.knowledge"]["digest"]
-            .as_str()
-            .unwrap()
-            .to_string();
-        let sc = state["applied_revision"]["resources"]["schema.knowledge"]["digest"]
-            .as_str()
-            .unwrap()
-            .to_string();
-        write_state_resources(
-            dir.path(),
-            &[
-                ("graph.knowledge", g.as_str()),
-                ("schema.knowledge", sc.as_str()),
-                ("graph.old", "3333"),
-                ("schema.old", "4444"),
-                ("query.old.q", "5555"),
-            ],
-        );
-        let plan = plan_config_dir(dir.path()).await;
-        let gated: Vec<&str> = plan
-            .approvals_required
-            .iter()
-            .map(|gate| gate.resource.as_str())
-            .collect();
-        assert_eq!(gated, vec!["graph.old"], "{plan:?}");
-        assert!(!plan.approvals_required[0].satisfied);
-    }
-
-    #[tokio::test]
-    async fn apply_is_idempotent() {
-        let dir = fixture();
-        write_applyable_state(dir.path());
-
-        let first = apply_config_dir(dir.path()).await;
-        assert!(first.ok, "{:?}", first.diagnostics);
-        assert!(first.state_written);
-        let state_after_first = fs::read_to_string(dir.path().join(CLUSTER_STATE_FILE)).unwrap();
-
-        let second = apply_config_dir(dir.path()).await;
-        assert!(second.ok, "{:?}", second.diagnostics);
-        assert!(second.changes.is_empty());
-        assert_eq!(second.applied_count, 0);
-        assert!(second.converged);
-        assert!(!second.state_written);
-        let state_after_second = fs::read_to_string(dir.path().join(CLUSTER_STATE_FILE)).unwrap();
-        assert_eq!(state_after_first, state_after_second);
-        assert_eq!(second.state_observations.state_revision, 2);
-    }
-
-    #[tokio::test]
-    async fn apply_respects_held_lock() {
-        let dir = fixture();
-        write_applyable_state(dir.path());
-        write_lock_file(dir.path(), "held-lock", "plan");
-
-        let out = apply_config_dir(dir.path()).await;
-        assert!(!out.ok);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "state_lock_held")
-        );
-        // The held lock survives a refused apply, and nothing was written.
-        assert!(dir.path().join(CLUSTER_LOCK_FILE).exists());
-        assert!(!dir.path().join(CLUSTER_RESOURCES_DIR).exists());
-        let state = read_state_json(dir.path());
-        assert_eq!(state["state_revision"], 1);
-    }
-
-    #[tokio::test]
-    async fn apply_state_lock_false_bypasses_with_warning() {
-        let dir = fixture();
-        fs::write(
-            dir.path().join(CLUSTER_CONFIG_FILE),
-            r#"
-version: 1
-state:
-  backend: cluster
-  lock: false
-graphs:
-  knowledge:
-    schema: ./people.pg
-    queries:
-      find_person:
-        file: ./people.gq
-"#,
-        )
-        .unwrap();
-        write_applyable_state(dir.path());
-
-        let out = apply_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert!(out.state_written);
-        assert!(!out.state_observations.lock_acquired);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "state_lock_disabled")
-        );
-        assert!(!dir.path().join(CLUSTER_LOCK_FILE).exists());
-    }
-
-    #[tokio::test]
-    async fn apply_skips_existing_payload_blob() {
-        let dir = fixture();
-        write_applyable_state(dir.path());
-        let desired = validate_config_dir(dir.path());
-        let query_digest = desired
-            .resource_digests
-            .get("query.knowledge.find_person")
-            .unwrap()
-            .clone();
-        // Content-addressed blobs are trusted by name: an existing file is
-        // never rewritten.
-        let blob = query_payload_path(dir.path(), &query_digest);
-        fs::create_dir_all(blob.parent().unwrap()).unwrap();
-        fs::write(&blob, "pre-existing").unwrap();
-
-        let out = apply_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert_eq!(fs::read_to_string(&blob).unwrap(), "pre-existing");
-    }
-
-    #[tokio::test]
-    async fn apply_invalid_config_fails_before_lock() {
-        let dir = fixture();
-        fs::write(
-            dir.path().join(CLUSTER_CONFIG_FILE),
-            "version: 1\nnot_a_field: true\n",
-        )
-        .unwrap();
-
-        let out = apply_config_dir(dir.path()).await;
-        assert!(!out.ok);
-        // Config errors bail before the lock or any state directory exists.
-        assert!(!dir.path().join(CLUSTER_STATE_DIR).exists());
-    }
-
-    /// When the state write fails after payloads landed, the output must
-    /// report the statuses actually on disk — not the unpersisted in-memory
-    /// mutations (phantom `applied` entries would mislead automation that
-    /// reads `resource_statuses` independently of `ok`).
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn apply_state_write_failure_reports_persisted_statuses() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let dir = fixture();
-        // lock: false so the only write into __cluster/ is state.json itself.
-        fs::write(
-            dir.path().join(CLUSTER_CONFIG_FILE),
-            r#"
-version: 1
-state:
-  backend: cluster
-  lock: false
-graphs:
-  knowledge:
-    schema: ./people.pg
-    queries:
-      find_person:
-        file: ./people.gq
-"#,
-        )
-        .unwrap();
-        write_applyable_state(dir.path());
-        // Pre-create the payload blob so the payload phase is a no-op and the
-        // failure lands exactly at the state write.
-        let desired = validate_config_dir(dir.path());
-        let query_digest = desired
-            .resource_digests
-            .get("query.knowledge.find_person")
-            .unwrap();
-        let blob = query_payload_path(dir.path(), query_digest);
-        fs::create_dir_all(blob.parent().unwrap()).unwrap();
-        fs::write(&blob, QUERY).unwrap();
-
-        let state_dir = dir.path().join(CLUSTER_STATE_DIR);
-        fs::set_permissions(&state_dir, fs::Permissions::from_mode(0o555)).unwrap();
-        // Running as root ignores permission bits; skip rather than flake.
-        if fs::write(state_dir.join("probe"), b"x").is_ok() {
-            let _ = fs::remove_file(state_dir.join("probe"));
-            fs::set_permissions(&state_dir, fs::Permissions::from_mode(0o755)).unwrap();
-            eprintln!("skipping: permissions are not enforced (running as root)");
-            return;
-        }
-
-        let out = apply_config_dir(dir.path()).await;
-        fs::set_permissions(&state_dir, fs::Permissions::from_mode(0o755)).unwrap();
-
-        assert!(!out.ok);
-        assert!(!out.state_written);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "state_write_error"),
-            "{:?}",
-            out.diagnostics
-        );
-        // The seeded state has no statuses; the failed apply must not invent
-        // the in-memory `applied` ones it failed to persist.
-        assert!(
-            out.resource_statuses.is_empty(),
-            "unpersisted statuses leaked into output: {:?}",
-            out.resource_statuses
-        );
-    }
-
-    // ---- catalog payload verification (Stage 3B) ----
-
-    /// Converge a fixture dir and return the query blob path.
-    async fn converge_fixture(config_dir: &Path) -> std::path::PathBuf {
-        write_applyable_state(config_dir);
-        let out = apply_config_dir(config_dir).await;
-        assert!(out.ok && out.converged, "{:?}", out.diagnostics);
-        let desired = validate_config_dir(config_dir);
-        query_payload_path(
-            config_dir,
-            desired
-                .resource_digests
-                .get("query.knowledge.find_person")
-                .unwrap(),
-        )
-    }
-
-    #[tokio::test]
-    async fn status_reports_missing_payload_read_only() {
-        let dir = fixture();
-        let blob = converge_fixture(dir.path()).await;
-        let state_before = fs::read_to_string(dir.path().join(CLUSTER_STATE_FILE)).unwrap();
-        fs::remove_file(&blob).unwrap();
-
-        let out = status_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert!(out.diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == "catalog_payload_missing"
-                && diagnostic.path == "query.knowledge.find_person"
-        }));
-        // Read-only: persisted statuses and state bytes untouched.
-        assert_eq!(
-            out.resource_statuses["query.knowledge.find_person"].status,
-            ResourceLifecycleStatus::Applied
-        );
-        assert_eq!(
-            fs::read_to_string(dir.path().join(CLUSTER_STATE_FILE)).unwrap(),
-            state_before
-        );
-    }
-
-    #[tokio::test]
-    async fn refresh_removes_digest_and_drifts_on_missing_payload() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await;
-        let blob = converge_fixture(dir.path()).await;
-        fs::remove_file(&blob).unwrap();
-
-        let out = refresh_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "catalog_payload_missing")
-        );
-        let status = &out.resource_statuses["query.knowledge.find_person"];
-        assert_eq!(status.status, ResourceLifecycleStatus::Drifted);
-        assert!(status.conditions.contains(&"payload_missing".to_string()));
-        let state = read_state_json(dir.path());
-        assert!(
-            state["applied_revision"]["resources"]
-                .get("query.knowledge.find_person")
-                .is_none(),
-            "{state}"
-        );
-    }
-
-    #[tokio::test]
-    async fn refresh_drifts_on_corrupted_payload() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await;
-        let blob = converge_fixture(dir.path()).await;
-        fs::write(&blob, "corrupted content").unwrap();
-
-        let out = refresh_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        let status = &out.resource_statuses["query.knowledge.find_person"];
-        assert_eq!(status.status, ResourceLifecycleStatus::Drifted);
-        assert!(status.conditions.contains(&"payload_mismatch".to_string()));
-        let state = read_state_json(dir.path());
-        assert!(
-            state["applied_revision"]["resources"]
-                .get("query.knowledge.find_person")
-                .is_none()
-        );
-    }
-
-    #[tokio::test]
-    #[cfg(unix)]
-    async fn refresh_flags_unreadable_payload_as_error() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await;
-        let blob = converge_fixture(dir.path()).await;
-        // Make the payload unreadable without removing it: permission
-        // denied is a genuine non-NotFound IO error. (A same-named
-        // directory no longer triggers this path: object-store semantics
-        // classify a directory at an object path as NotFound — "only
-        // objects exist" — which is the missing-payload case, not the
-        // unreadable one.)
-        let mut perms = fs::metadata(&blob).unwrap().permissions();
-        std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o000);
-        fs::set_permissions(&blob, perms).unwrap();
-        // Root reads straight through mode 000 (container dev runners
-        // commonly run as root): skip rather than fail — the contract
-        // under test needs a genuine permission error.
-        if fs::read(&blob).is_ok() {
-            eprintln!(
-                "skipping refresh_flags_unreadable_payload_as_error:                  running as root (mode 000 is still readable)"
-            );
-            return;
-        }
-
-        let out = refresh_config_dir(dir.path()).await;
-        assert!(!out.ok);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "catalog_payload_read_error")
-        );
-        let status = &out.resource_statuses["query.knowledge.find_person"];
-        assert_eq!(status.status, ResourceLifecycleStatus::Error);
-        assert!(status.conditions.contains(&"payload_read_error".to_string()));
-        // Transient IO keeps the digest: no spurious republish.
-        let state = read_state_json(dir.path());
-        assert!(
-            state["applied_revision"]["resources"]
-                .get("query.knowledge.find_person")
-                .is_some()
-        );
-    }
-
-    #[tokio::test]
-    async fn payload_drift_self_heals_through_refresh_plan_apply() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await;
-        let blob = converge_fixture(dir.path()).await;
-        let original = fs::read_to_string(&blob).unwrap();
-        fs::remove_file(&blob).unwrap();
-
-        let refresh = refresh_config_dir(dir.path()).await;
-        assert!(refresh.ok, "{:?}", refresh.diagnostics);
-
-        let plan = plan_config_dir(dir.path()).await;
-        let query_change = plan
-            .changes
-            .iter()
-            .find(|change| change.resource == "query.knowledge.find_person")
-            .expect("plan must propose recreating the query");
-        assert_eq!(query_change.operation, PlanOperation::Create);
-        assert_eq!(query_change.disposition, Some(ApplyDisposition::Applied));
-
-        let apply = apply_config_dir(dir.path()).await;
-        assert!(apply.ok && apply.converged, "{:?}", apply.diagnostics);
-        assert_eq!(fs::read_to_string(&blob).unwrap(), original);
-
-        let status = status_config_dir(dir.path()).await;
-        assert!(
-            !status
-                .diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code.starts_with("catalog_payload")),
-            "{:?}",
-            status.diagnostics
-        );
-    }
-
-    #[tokio::test]
-    async fn verification_skips_graph_and_schema_resources() {
-        let dir = fixture();
-        write_applyable_state(dir.path()); // graph + schema digests only, no blobs
-
-        let out = status_config_dir(dir.path()).await;
-        assert!(
-            !out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code.starts_with("catalog_payload")),
-            "{:?}",
-            out.diagnostics
-        );
-    }
-
-    // ---- recovery sidecars + sweep (Stage 4A) ----
-
-    fn derived_graph_uri(config_dir: &Path, graph_id: &str) -> String {
-        display_path(
-            &config_dir
-                .join(CLUSTER_GRAPHS_DIR)
-                .join(format!("{graph_id}.omni")),
-        )
-    }
-
-    fn write_create_sidecar(
-        config_dir: &Path,
-        graph_id: &str,
-        desired_schema_digest: &str,
-        operation_id: &str,
-    ) -> PathBuf {
-        let dir = config_dir.join(CLUSTER_RECOVERIES_DIR);
-        fs::create_dir_all(&dir).unwrap();
-        let path = dir.join(format!("{operation_id}.json"));
-        fs::write(
-            &path,
-            serde_json::to_string_pretty(&json!({
-                "schema_version": 1,
-                "operation_id": operation_id,
-                "started_at": "1970-01-01T00:00:00Z",
-                "kind": "graph_create",
-                "graph_id": graph_id,
-                "graph_uri": derived_graph_uri(config_dir, graph_id),
-                "desired_schema_digest": desired_schema_digest,
-            }))
-            .unwrap(),
-        )
-        .unwrap();
-        path
-    }
-
-    #[tokio::test]
-    async fn sweep_removes_sidecar_when_root_absent() {
-        let dir = fixture();
-        write_applyable_state(dir.path());
-        let sidecar = write_create_sidecar(dir.path(), "knowledge", "irrelevant", "01ROW1");
-
-        let out = apply_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        // Row 1: nothing moved; intent removed, run proceeds normally.
-        assert!(!sidecar.exists());
-        assert!(out.converged);
-    }
-
-    #[tokio::test]
-    async fn sweep_rolls_forward_completed_create() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await;
-        write_state_resources(dir.path(), &[]); // state predates the create
-        let desired = validate_config_dir(dir.path());
-        let schema_digest = desired.resource_digests["schema.knowledge"].clone();
-        let sidecar = write_create_sidecar(dir.path(), "knowledge", &schema_digest, "01ROW4");
-
-        let out = apply_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "cluster_recovery_rolled_forward")
-        );
-        // Row 4: ledger converged to observable reality, audit recorded,
-        // sidecar retired after the CAS landed.
-        let state = read_state_json(dir.path());
-        assert_eq!(
-            state["applied_revision"]["resources"]["schema.knowledge"]["digest"],
-            schema_digest
-        );
-        assert!(
-            state["recovery_records"]
-                .as_object()
-                .unwrap()
-                .values()
-                .any(|record| record["outcome"] == "rolled_forward"
-                    && record["graph_id"] == "knowledge")
-        );
-        assert!(!sidecar.exists());
-        // With the graph rolled forward, the same run converges the catalog.
-        assert!(out.converged, "{out:?}");
-    }
-
-    #[tokio::test]
-    async fn sweep_completes_already_recorded_create() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await;
-        write_applyable_state(dir.path()); // state already records graph+schema
-        let desired = validate_config_dir(dir.path());
-        let sidecar = write_create_sidecar(
-            dir.path(),
-            "knowledge",
-            &desired.resource_digests["schema.knowledge"],
-            "01ROW2",
-        );
-
-        let out = apply_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        // Row 2: outcome was already durable; no audit entry, sidecar retired.
-        assert!(!sidecar.exists());
-        let state = read_state_json(dir.path());
-        assert!(
-            state["recovery_records"]
-                .as_object()
-                .is_none_or(|records| records.is_empty()),
-            "{state}"
-        );
-    }
-
-    #[tokio::test]
-    async fn sweep_keeps_sidecar_for_incomplete_root() {
-        let dir = fixture();
-        write_applyable_state(dir.path());
-        // A root that exists but cannot be opened: the engine's partial-init gap.
-        let root = dir.path().join(CLUSTER_GRAPHS_DIR).join("knowledge.omni");
-        fs::create_dir_all(&root).unwrap();
-        fs::write(root.join("_schema.pg"), "junk").unwrap();
-        let sidecar = write_create_sidecar(dir.path(), "knowledge", "whatever", "01ROW5");
-
-        let out = apply_config_dir(dir.path()).await;
-        assert!(!out.ok);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "graph_create_incomplete")
-        );
-        // Row 5: never auto-delete; sidecar and root stay for the operator,
-        // and the Error status is persisted by the run's state write.
-        assert!(sidecar.exists());
-        assert!(root.exists());
-        let state = read_state_json(dir.path());
-        assert_eq!(state["resource_statuses"]["graph.knowledge"]["status"], "error");
-        assert!(
-            state["resource_statuses"]["graph.knowledge"]["conditions"]
-                .as_array()
-                .unwrap()
-                .iter()
-                .any(|condition| condition == "graph_create_incomplete")
-        );
-    }
-
-    #[tokio::test]
-    async fn sweep_flags_unexpected_schema_as_pending() {
-        let dir = fixture();
-        write_state_resources(dir.path(), &[]);
-        // Live graph exists with a schema the sidecar never intended.
-        let graph_dir = dir.path().join(CLUSTER_GRAPHS_DIR);
-        fs::create_dir_all(&graph_dir).unwrap();
-        Omnigraph::init(
-            &derived_graph_uri(dir.path(), "knowledge"),
-            "\nnode Other {\n  name: String @key\n}\n",
-        )
+    let out = apply_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert!(out.converged, "{out:?}");
+    let by_resource: BTreeMap<&str, &PlanChange> = out
+        .changes
+        .iter()
+        .map(|change| (change.resource.as_str(), change))
+        .collect();
+    assert_eq!(
+        by_resource["schema.knowledge"].disposition,
+        Some(ApplyDisposition::Applied)
+    );
+    assert_eq!(
+        by_resource["query.knowledge.find_person"].disposition,
+        Some(ApplyDisposition::Applied)
+    );
+    assert_eq!(
+        by_resource["graph.knowledge"].disposition,
+        Some(ApplyDisposition::Derived)
+    );
+    // The live graph carries the new schema.
+    let db = Omnigraph::open_read_only(&derived_graph_uri(dir.path(), "knowledge"))
         .await
         .unwrap();
-        let desired = validate_config_dir(dir.path());
-        let sidecar = write_create_sidecar(
-            dir.path(),
-            "knowledge",
-            &desired.resource_digests["schema.knowledge"],
-            "01ROW6",
-        );
-
-        let out = apply_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics); // warning, not error
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "cluster_recovery_pending")
-        );
-        // Row 6: refuse to guess; sidecar kept, Drifted persisted.
-        assert!(sidecar.exists());
-        let state = read_state_json(dir.path());
-        assert_eq!(
-            state["resource_statuses"]["graph.knowledge"]["status"],
-            "drifted"
-        );
-        assert!(
-            state["resource_statuses"]["graph.knowledge"]["conditions"]
-                .as_array()
+    let desired = validate_config_dir(dir.path());
+    assert_eq!(
+        sha256_hex(db.schema_source().as_bytes()),
+        desired.resource_digests["schema.knowledge"]
+    );
+    let state = read_state_json(dir.path());
+    assert_eq!(
+        state["applied_revision"]["resources"]["schema.knowledge"]["digest"],
+        desired.resource_digests["schema.knowledge"]
+    );
+    // Sidecar retired after the CAS landed.
+    assert!(
+        !dir.path().join(CLUSTER_RECOVERIES_DIR).exists()
+            || fs::read_dir(dir.path().join(CLUSTER_RECOVERIES_DIR))
                 .unwrap()
-                .iter()
-                .any(|condition| condition == "actual_applied_state_pending")
-        );
-    }
+                .next()
+                .is_none()
+    );
+}
 
-    #[tokio::test]
-    async fn apply_blocks_create_while_recovery_pending() {
-        let dir = fixture();
-        write_state_resources(dir.path(), &[]);
-        // A kept (row 5) sidecar: partial root that cannot be opened.
-        let root = dir.path().join(CLUSTER_GRAPHS_DIR).join("knowledge.omni");
-        fs::create_dir_all(&root).unwrap();
-        fs::write(root.join("_schema.pg"), "junk").unwrap();
-        let sidecar = write_create_sidecar(dir.path(), "knowledge", "whatever", "01PEND");
+#[tokio::test]
+async fn apply_unsupported_schema_change_fails_loudly() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    write_applyable_state(dir.path());
+    write_streaming_cluster(dir.path(), Some(true));
+    // Property type changes are unsupported by the engine planner.
+    fs::write(
+        dir.path().join("people.pg"),
+        "\nnode Person {\n  name: String @key\n  age: I64?\n}\n",
+    )
+    .unwrap();
 
-        let out = apply_config_dir(dir.path()).await;
-        assert!(!out.ok); // row 5 is an error condition
-        let by_resource: BTreeMap<&str, &PlanChange> = out
-            .changes
-            .iter()
-            .map(|change| (change.resource.as_str(), change))
-            .collect();
-        // The pending recovery blocks the create and its dependents; the
-        // executor never attempts the init.
-        assert_eq!(
-            by_resource["graph.knowledge"].disposition,
-            Some(ApplyDisposition::Blocked)
-        );
-        assert_eq!(
-            by_resource["graph.knowledge"].reason.as_deref(),
-            Some("cluster_recovery_pending")
-        );
-        assert_eq!(
-            by_resource["query.knowledge.find_person"].reason.as_deref(),
-            Some("cluster_recovery_pending")
-        );
-        assert_eq!(
-            by_resource["policy.base"].reason.as_deref(),
-            Some("cluster_recovery_pending")
-        );
-        assert!(sidecar.exists());
-        // The sweep's Error status is what persists — not a generic Blocked.
-        let state = read_state_json(dir.path());
-        assert_eq!(state["resource_statuses"]["graph.knowledge"]["status"], "error");
-    }
-
-    #[tokio::test]
-    async fn plan_embeds_migration_preview_for_schema_update() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await;
-        write_applyable_state(dir.path());
-        fs::write(
-            dir.path().join("people.pg"),
-            "\nnode Person {\n  name: String @key\n  age: I32?\n  bio: String?\n}\n",
-        )
+    let out = confirmed_streaming_apply(dir.path()).await;
+    assert!(!out.ok);
+    assert!(out.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "schema_apply_failed"
+            && diagnostic.message.contains("changing property type")
+    }));
+    let by_resource: BTreeMap<&str, &PlanChange> = out
+        .changes
+        .iter()
+        .map(|change| (change.resource.as_str(), change))
+        .collect();
+    assert_eq!(
+        by_resource["schema.knowledge"].disposition,
+        Some(ApplyDisposition::Blocked)
+    );
+    assert_eq!(
+        by_resource["schema.knowledge"].reason.as_deref(),
+        Some("schema_apply_failed")
+    );
+    assert_eq!(
+        by_resource["streaming.knowledge"].disposition,
+        Some(ApplyDisposition::Blocked)
+    );
+    assert_eq!(
+        by_resource["streaming.knowledge"].reason.as_deref(),
+        Some("dependency_not_applied")
+    );
+    // The live schema and the ledger are unchanged.
+    let state = read_state_json(dir.path());
+    let desired = validate_config_dir(dir.path());
+    assert_ne!(
+        state["applied_revision"]["resources"]["schema.knowledge"]["digest"],
+        desired.resource_digests["schema.knowledge"]
+    );
+    let db = Omnigraph::open_read_only(&derived_graph_uri(dir.path(), "knowledge"))
+        .await
         .unwrap();
-
-        let out = plan_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        let schema_change = out
-            .changes
+    assert_eq!(db.schema_source().as_str(), SCHEMA);
+    assert!(
+        !db.snapshot_of("main")
+            .await
+            .unwrap()
+            .streaming_status()
+            .enabled
+    );
+    assert!(
+        state["applied_revision"]["resources"]
+            .get("streaming.knowledge")
+            .is_none()
+    );
+    assert!(
+        recovery_sidecars(dir.path()).is_empty(),
+        "{:?}",
+        recovery_sidecars(dir.path())
+    );
+    // Second run fails just as loudly and still leaves no sidecar because
+    // the engine preview rejects before graph state can move.
+    let second = confirmed_streaming_apply(dir.path()).await;
+    assert!(!second.ok);
+    assert!(
+        second
+            .diagnostics
             .iter()
-            .find(|change| change.resource == "schema.knowledge")
-            .unwrap();
-        let migration = schema_change.migration.as_ref().expect("preview embedded");
-        assert!(migration.supported);
-        assert!(
-            serde_json::to_string(&migration.steps)
+            .any(|diagnostic| diagnostic.code == "schema_apply_failed")
+    );
+    assert!(
+        recovery_sidecars(dir.path()).is_empty(),
+        "{:?}",
+        recovery_sidecars(dir.path())
+    );
+
+    // Once the graph failure is corrected, the unapplied streaming
+    // resource remains in the diff and is retried.
+    fs::write(dir.path().join("people.pg"), SCHEMA).unwrap();
+    let recovered = confirmed_streaming_apply(dir.path()).await;
+    assert!(recovered.ok && recovered.converged, "{recovered:?}");
+    assert!(live_streaming_enabled(dir.path()).await);
+}
+
+#[tokio::test]
+async fn apply_schema_update_blocked_by_non_main_branch_leaves_no_sidecar() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    write_applyable_state(dir.path());
+    let graph_uri = derived_graph_uri(dir.path(), "knowledge");
+    let db = Omnigraph::open(&graph_uri).await.unwrap();
+    db.branch_create("feature").await.unwrap();
+    drop(db);
+    let before_state = read_state_json(dir.path());
+    fs::write(dir.path().join("people.pg"), SCHEMA_V2).unwrap();
+
+    let out = apply_config_dir(dir.path()).await;
+    assert!(!out.ok);
+    assert!(out.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "schema_apply_failed"
+            && diagnostic
+                .message
+                .contains("schema apply requires a graph with only main")
+    }));
+    assert!(
+        recovery_sidecars(dir.path()).is_empty(),
+        "{:?}",
+        recovery_sidecars(dir.path())
+    );
+    let after_state = read_state_json(dir.path());
+    assert_eq!(
+        after_state["applied_revision"]["resources"],
+        before_state["applied_revision"]["resources"]
+    );
+    let reopened = Omnigraph::open_read_only(&graph_uri).await.unwrap();
+    assert_eq!(reopened.schema_source().as_str(), SCHEMA);
+}
+
+#[tokio::test]
+async fn apply_blocks_schema_update_while_recovery_pending() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    write_state_resources(dir.path(), &[("schema.knowledge", "stale-digest")]);
+    fs::write(dir.path().join("people.pg"), SCHEMA_V2).unwrap();
+    // A pending sidecar whose intent matches neither live nor recorded.
+    write_schema_apply_sidecar(dir.path(), "knowledge", "intended-digest", "01PENDS");
+
+    let out = apply_config_dir(dir.path()).await;
+    let by_resource: BTreeMap<&str, &PlanChange> = out
+        .changes
+        .iter()
+        .map(|change| (change.resource.as_str(), change))
+        .collect();
+    assert_eq!(
+        by_resource["schema.knowledge"].disposition,
+        Some(ApplyDisposition::Blocked)
+    );
+    assert_eq!(
+        by_resource["schema.knowledge"].reason.as_deref(),
+        Some("cluster_recovery_pending")
+    );
+}
+
+#[tokio::test]
+async fn apply_creates_graph_and_unblocks_dependents() {
+    let dir = fixture();
+    write_state_resources(dir.path(), &[]);
+
+    let out = apply_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert!(out.converged, "{out:?}");
+    let by_resource: BTreeMap<&str, &PlanChange> = out
+        .changes
+        .iter()
+        .map(|change| (change.resource.as_str(), change))
+        .collect();
+    // Stage 4A: the create executes, and its dependents apply in-run.
+    assert_eq!(
+        by_resource["graph.knowledge"].disposition,
+        Some(ApplyDisposition::Applied)
+    );
+    assert_eq!(
+        by_resource["schema.knowledge"].disposition,
+        Some(ApplyDisposition::Applied)
+    );
+    assert_eq!(
+        by_resource["query.knowledge.find_person"].disposition,
+        Some(ApplyDisposition::Applied)
+    );
+    assert_eq!(
+        by_resource["policy.base"].disposition,
+        Some(ApplyDisposition::Applied)
+    );
+    // The graph exists on disk and opens; state records everything.
+    let graph_uri = derived_graph_uri(dir.path(), "knowledge");
+    let db = Omnigraph::open_read_only(&graph_uri).await.unwrap();
+    let desired = validate_config_dir(dir.path());
+    assert_eq!(
+        sha256_hex(db.schema_source().as_bytes()),
+        desired.resource_digests["schema.knowledge"]
+    );
+    let state = read_state_json(dir.path());
+    assert_eq!(
+        state["applied_revision"]["resources"]["schema.knowledge"]["digest"],
+        desired.resource_digests["schema.knowledge"]
+    );
+    assert_eq!(
+        state["resource_statuses"]["graph.knowledge"]["status"],
+        "applied"
+    );
+    // The create's sidecar was retired after the state CAS landed.
+    assert!(
+        !dir.path().join(CLUSTER_RECOVERIES_DIR).exists()
+            || fs::read_dir(dir.path().join(CLUSTER_RECOVERIES_DIR))
                 .unwrap()
-                .contains("add_property"),
-            "{migration:?}"
-        );
-    }
+                .next()
+                .is_none()
+    );
+}
 
-    #[tokio::test]
-    async fn plan_warns_when_preview_unavailable() {
-        let dir = fixture();
-        write_applyable_state(dir.path()); // digests recorded, but no live root
-        fs::write(
-            dir.path().join("people.pg"),
-            "\nnode Person {\n  name: String @key\n  age: I32?\n  bio: String?\n}\n",
-        )
-        .unwrap();
+#[tokio::test]
+async fn apply_create_failure_blocks_dependents_and_keeps_sidecar() {
+    let dir = fixture();
+    write_streaming_cluster(dir.path(), Some(true));
+    write_state_resources(dir.path(), &[]);
+    // Make the init fail its strict preflight: a junk _schema.pg already
+    // sits at the derived root (the engine refuses to overwrite it).
+    let root = dir.path().join(CLUSTER_GRAPHS_DIR).join("knowledge.omni");
+    fs::create_dir_all(&root).unwrap();
+    fs::write(root.join("_schema.pg"), "junk").unwrap();
 
-        let out = plan_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        let schema_change = out
-            .changes
+    let out = confirmed_streaming_apply(dir.path()).await;
+    assert!(!out.ok);
+    assert!(
+        out.diagnostics
             .iter()
-            .find(|change| change.resource == "schema.knowledge")
-            .unwrap();
-        assert!(schema_change.migration.is_none());
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "schema_preview_unavailable")
-        );
+            .any(|diagnostic| diagnostic.code == "graph_create_failed")
+    );
+    let by_resource: BTreeMap<&str, &PlanChange> = out
+        .changes
+        .iter()
+        .map(|change| (change.resource.as_str(), change))
+        .collect();
+    // Dependents are demoted: the run tells the truth about what executed.
+    assert_eq!(
+        by_resource["graph.knowledge"].disposition,
+        Some(ApplyDisposition::Blocked)
+    );
+    assert_eq!(
+        by_resource["query.knowledge.find_person"].disposition,
+        Some(ApplyDisposition::Blocked)
+    );
+    assert_eq!(
+        by_resource["query.knowledge.find_person"].reason.as_deref(),
+        Some("dependency_not_applied")
+    );
+    assert_eq!(
+        by_resource["policy.base"].disposition,
+        Some(ApplyDisposition::Blocked)
+    );
+    assert_eq!(
+        by_resource["streaming.knowledge"].disposition,
+        Some(ApplyDisposition::Blocked)
+    );
+    assert_eq!(
+        by_resource["streaming.knowledge"].reason.as_deref(),
+        Some("dependency_not_applied")
+    );
+    assert!(!out.converged);
+    // The sidecar stays for the sweep to classify next run.
+    assert!(
+        fs::read_dir(dir.path().join(CLUSTER_RECOVERIES_DIR))
+            .unwrap()
+            .next()
+            .is_some()
+    );
+    // No graph digests moved.
+    let state = read_state_json(dir.path());
+    assert!(
+        state["applied_revision"]["resources"]
+            .as_object()
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn apply_blocks_graph_delete_without_approval() {
+    let dir = fixture();
+    let desired = validate_config_dir(dir.path());
+    let schema_digest = desired
+        .resource_digests
+        .get("schema.knowledge")
+        .unwrap()
+        .clone();
+    let graph_composite = graph_digest(
+        "knowledge",
+        Some(&schema_digest),
+        Some(&BTreeMap::new()),
+        None,
+        None,
+    );
+    write_state_resources(
+        dir.path(),
+        &[
+            ("graph.knowledge", graph_composite.as_str()),
+            ("schema.knowledge", schema_digest.as_str()),
+            ("graph.old", "3333"),
+            ("schema.old", "4444"),
+            ("query.old.q", "5555"),
+        ],
+    );
+
+    let out = apply_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert!(!out.converged);
+    let by_resource: BTreeMap<&str, &PlanChange> = out
+        .changes
+        .iter()
+        .map(|change| (change.resource.as_str(), change))
+        .collect();
+    // Stage 4C: deletes are gated, not deferred — every subtree change
+    // blocks on the single graph-level approval.
+    assert_eq!(
+        by_resource["graph.old"].disposition,
+        Some(ApplyDisposition::Blocked)
+    );
+    assert_eq!(
+        by_resource["graph.old"].reason.as_deref(),
+        Some("approval_required")
+    );
+    assert_eq!(
+        by_resource["schema.old"].reason.as_deref(),
+        Some("approval_required")
+    );
+    assert_eq!(
+        by_resource["query.old.q"].reason.as_deref(),
+        Some("approval_required")
+    );
+    // State intact; nothing destroyed without the artifact.
+    let state = read_state_json(dir.path());
+    let resources = &state["applied_revision"]["resources"];
+    assert_eq!(resources["graph.old"]["digest"], "3333");
+    assert_eq!(resources["schema.old"]["digest"], "4444");
+    assert_eq!(resources["query.old.q"]["digest"], "5555");
+}
+
+#[tokio::test]
+async fn approve_writes_digest_bound_artifact() {
+    let dir = fixture();
+    write_applyable_state(dir.path());
+    // Seed a deletable subtree.
+    let state = read_state_json(dir.path());
+    let graph_digest_str = state["applied_revision"]["resources"]["graph.knowledge"]["digest"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let schema_digest_str = state["applied_revision"]["resources"]["schema.knowledge"]["digest"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    write_state_resources(
+        dir.path(),
+        &[
+            ("graph.knowledge", graph_digest_str.as_str()),
+            ("schema.knowledge", schema_digest_str.as_str()),
+            ("graph.old", "3333"),
+            ("schema.old", "4444"),
+        ],
+    );
+
+    let out = approve_config_dir(dir.path(), "graph.old", "andrew").await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    let approval_id = out.approval_id.clone().unwrap();
+    let artifact: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(
+            dir.path()
+                .join(CLUSTER_APPROVALS_DIR)
+                .join(format!("{approval_id}.json")),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(artifact["resource"], "graph.old");
+    assert_eq!(artifact["operation"], "delete");
+    assert_eq!(artifact["approved_by"], "andrew");
+    assert_eq!(artifact["bound_before_digest"], "3333");
+    assert!(artifact["bound_after_digest"].is_null());
+    assert!(artifact["bound_config_digest"].is_string());
+    assert!(artifact["consumed_at"].is_null());
+
+    // A non-gated address is refused.
+    let not_gated = approve_config_dir(dir.path(), "query.knowledge.find_person", "andrew").await;
+    assert!(!not_gated.ok);
+    assert!(
+        not_gated
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "approval_not_required")
+    );
+}
+
+#[tokio::test]
+async fn stale_approval_is_ignored() {
+    let dir = fixture();
+    write_applyable_state(dir.path());
+    let state = read_state_json(dir.path());
+    let graph_digest_str = state["applied_revision"]["resources"]["graph.knowledge"]["digest"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let schema_digest_str = state["applied_revision"]["resources"]["schema.knowledge"]["digest"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    write_state_resources(
+        dir.path(),
+        &[
+            ("graph.knowledge", graph_digest_str.as_str()),
+            ("schema.knowledge", schema_digest_str.as_str()),
+            ("graph.old", "3333"),
+        ],
+    );
+    let approved = approve_config_dir(dir.path(), "graph.old", "andrew").await;
+    assert!(approved.ok, "{:?}", approved.diagnostics);
+    // The config moves after approval: the bound config digest no longer
+    // matches and the artifact authorizes nothing.
+    fs::write(dir.path().join("base.policy.yaml"), "rules: [] # moved\n").unwrap();
+
+    let out = apply_config_dir(dir.path()).await;
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "approval_stale"),
+        "{:?}",
+        out.diagnostics
+    );
+    let by_resource: BTreeMap<&str, &PlanChange> = out
+        .changes
+        .iter()
+        .map(|change| (change.resource.as_str(), change))
+        .collect();
+    assert_eq!(
+        by_resource["graph.old"].reason.as_deref(),
+        Some("approval_required")
+    );
+    let state = read_state_json(dir.path());
+    assert_eq!(
+        state["applied_revision"]["resources"]["graph.old"]["digest"],
+        "3333"
+    );
+}
+
+#[tokio::test]
+async fn compute_approvals_one_gate_per_subtree() {
+    let dir = fixture();
+    write_applyable_state(dir.path());
+    let state = read_state_json(dir.path());
+    let g = state["applied_revision"]["resources"]["graph.knowledge"]["digest"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let sc = state["applied_revision"]["resources"]["schema.knowledge"]["digest"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    write_state_resources(
+        dir.path(),
+        &[
+            ("graph.knowledge", g.as_str()),
+            ("schema.knowledge", sc.as_str()),
+            ("graph.old", "3333"),
+            ("schema.old", "4444"),
+            ("query.old.q", "5555"),
+        ],
+    );
+    let plan = plan_config_dir(dir.path()).await;
+    let gated: Vec<&str> = plan
+        .approvals_required
+        .iter()
+        .map(|gate| gate.resource.as_str())
+        .collect();
+    assert_eq!(gated, vec!["graph.old"], "{plan:?}");
+    assert!(!plan.approvals_required[0].satisfied);
+}
+
+#[tokio::test]
+async fn apply_is_idempotent() {
+    let dir = fixture();
+    write_applyable_state(dir.path());
+
+    let first = apply_config_dir(dir.path()).await;
+    assert!(first.ok, "{:?}", first.diagnostics);
+    assert!(first.state_written);
+    let state_after_first = fs::read_to_string(dir.path().join(CLUSTER_STATE_FILE)).unwrap();
+
+    let second = apply_config_dir(dir.path()).await;
+    assert!(second.ok, "{:?}", second.diagnostics);
+    assert!(second.changes.is_empty());
+    assert_eq!(second.applied_count, 0);
+    assert!(second.converged);
+    assert!(!second.state_written);
+    let state_after_second = fs::read_to_string(dir.path().join(CLUSTER_STATE_FILE)).unwrap();
+    assert_eq!(state_after_first, state_after_second);
+    assert_eq!(second.state_observations.state_revision, 2);
+}
+
+#[tokio::test]
+async fn apply_respects_held_lock() {
+    let dir = fixture();
+    write_applyable_state(dir.path());
+    write_lock_file(dir.path(), "held-lock", "plan");
+
+    let out = apply_config_dir(dir.path()).await;
+    assert!(!out.ok);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "state_lock_held")
+    );
+    // The held lock survives a refused apply, and nothing was written.
+    assert!(dir.path().join(CLUSTER_LOCK_FILE).exists());
+    assert!(!dir.path().join(CLUSTER_RESOURCES_DIR).exists());
+    let state = read_state_json(dir.path());
+    assert_eq!(state["state_revision"], 1);
+}
+
+#[tokio::test]
+async fn apply_state_lock_false_bypasses_with_warning() {
+    let dir = fixture();
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        r#"
+version: 1
+state:
+  backend: cluster
+  lock: false
+graphs:
+  knowledge:
+    schema: ./people.pg
+    queries:
+      find_person:
+        file: ./people.gq
+"#,
+    )
+    .unwrap();
+    write_applyable_state(dir.path());
+
+    let out = apply_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert!(out.state_written);
+    assert!(!out.state_observations.lock_acquired);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "state_lock_disabled")
+    );
+    assert!(!dir.path().join(CLUSTER_LOCK_FILE).exists());
+}
+
+#[tokio::test]
+async fn apply_skips_existing_payload_blob() {
+    let dir = fixture();
+    write_applyable_state(dir.path());
+    let desired = validate_config_dir(dir.path());
+    let query_digest = desired
+        .resource_digests
+        .get("query.knowledge.find_person")
+        .unwrap()
+        .clone();
+    // Content-addressed blobs are trusted by name: an existing file is
+    // never rewritten.
+    let blob = query_payload_path(dir.path(), &query_digest);
+    fs::create_dir_all(blob.parent().unwrap()).unwrap();
+    fs::write(&blob, "pre-existing").unwrap();
+
+    let out = apply_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert_eq!(fs::read_to_string(&blob).unwrap(), "pre-existing");
+}
+
+#[tokio::test]
+async fn apply_invalid_config_fails_before_lock() {
+    let dir = fixture();
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        "version: 1\nnot_a_field: true\n",
+    )
+    .unwrap();
+
+    let out = apply_config_dir(dir.path()).await;
+    assert!(!out.ok);
+    // Config errors bail before the lock or any state directory exists.
+    assert!(!dir.path().join(CLUSTER_STATE_DIR).exists());
+}
+
+/// When the state write fails after payloads landed, the output must
+/// report the statuses actually on disk — not the unpersisted in-memory
+/// mutations (phantom `applied` entries would mislead automation that
+/// reads `resource_statuses` independently of `ok`).
+#[cfg(unix)]
+#[tokio::test]
+async fn apply_state_write_failure_reports_persisted_statuses() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = fixture();
+    // lock: false so the only write into __cluster/ is state.json itself.
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        r#"
+version: 1
+state:
+  backend: cluster
+  lock: false
+graphs:
+  knowledge:
+    schema: ./people.pg
+    queries:
+      find_person:
+        file: ./people.gq
+"#,
+    )
+    .unwrap();
+    write_applyable_state(dir.path());
+    // Pre-create the payload blob so the payload phase is a no-op and the
+    // failure lands exactly at the state write.
+    let desired = validate_config_dir(dir.path());
+    let query_digest = desired
+        .resource_digests
+        .get("query.knowledge.find_person")
+        .unwrap();
+    let blob = query_payload_path(dir.path(), query_digest);
+    fs::create_dir_all(blob.parent().unwrap()).unwrap();
+    fs::write(&blob, QUERY).unwrap();
+
+    let state_dir = dir.path().join(CLUSTER_STATE_DIR);
+    fs::set_permissions(&state_dir, fs::Permissions::from_mode(0o555)).unwrap();
+    // Running as root ignores permission bits; skip rather than flake.
+    if fs::write(state_dir.join("probe"), b"x").is_ok() {
+        let _ = fs::remove_file(state_dir.join("probe"));
+        fs::set_permissions(&state_dir, fs::Permissions::from_mode(0o755)).unwrap();
+        eprintln!("skipping: permissions are not enforced (running as root)");
+        return;
     }
 
-    fn write_schema_apply_sidecar(
-        config_dir: &Path,
-        graph_id: &str,
-        desired_schema_digest: &str,
-        operation_id: &str,
-    ) -> PathBuf {
-        let dir = config_dir.join(CLUSTER_RECOVERIES_DIR);
-        fs::create_dir_all(&dir).unwrap();
-        let path = dir.join(format!("{operation_id}.json"));
-        fs::write(
-            &path,
-            serde_json::to_string_pretty(&json!({
-                "schema_version": 1,
-                "operation_id": operation_id,
-                "started_at": "1970-01-01T00:00:00Z",
-                "kind": "schema_apply",
-                "graph_id": graph_id,
-                "graph_uri": derived_graph_uri(config_dir, graph_id),
-                "desired_schema_digest": desired_schema_digest,
-            }))
+    let out = apply_config_dir(dir.path()).await;
+    fs::set_permissions(&state_dir, fs::Permissions::from_mode(0o755)).unwrap();
+
+    assert!(!out.ok);
+    assert!(!out.state_written);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "state_write_error"),
+        "{:?}",
+        out.diagnostics
+    );
+    // The seeded state has no statuses; the failed apply must not invent
+    // the in-memory `applied` ones it failed to persist.
+    assert!(
+        out.resource_statuses.is_empty(),
+        "unpersisted statuses leaked into output: {:?}",
+        out.resource_statuses
+    );
+}
+
+// ---- catalog payload verification (Stage 3B) ----
+
+/// Converge a fixture dir and return the query blob path.
+async fn converge_fixture(config_dir: &Path) -> std::path::PathBuf {
+    write_applyable_state(config_dir);
+    let out = apply_config_dir(config_dir).await;
+    assert!(out.ok && out.converged, "{:?}", out.diagnostics);
+    let desired = validate_config_dir(config_dir);
+    query_payload_path(
+        config_dir,
+        desired
+            .resource_digests
+            .get("query.knowledge.find_person")
             .unwrap(),
-        )
+    )
+}
+
+#[tokio::test]
+async fn status_reports_missing_payload_read_only() {
+    let dir = fixture();
+    let blob = converge_fixture(dir.path()).await;
+    let state_before = fs::read_to_string(dir.path().join(CLUSTER_STATE_FILE)).unwrap();
+    fs::remove_file(&blob).unwrap();
+
+    let out = status_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert!(out.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "catalog_payload_missing"
+            && diagnostic.path == "query.knowledge.find_person"
+    }));
+    // Read-only: persisted statuses and state bytes untouched.
+    assert_eq!(
+        out.resource_statuses["query.knowledge.find_person"].status,
+        ResourceLifecycleStatus::Applied
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join(CLUSTER_STATE_FILE)).unwrap(),
+        state_before
+    );
+}
+
+#[tokio::test]
+async fn refresh_removes_digest_and_drifts_on_missing_payload() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    let blob = converge_fixture(dir.path()).await;
+    fs::remove_file(&blob).unwrap();
+
+    let out = refresh_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "catalog_payload_missing")
+    );
+    let status = &out.resource_statuses["query.knowledge.find_person"];
+    assert_eq!(status.status, ResourceLifecycleStatus::Drifted);
+    assert!(status.conditions.contains(&"payload_missing".to_string()));
+    let state = read_state_json(dir.path());
+    assert!(
+        state["applied_revision"]["resources"]
+            .get("query.knowledge.find_person")
+            .is_none(),
+        "{state}"
+    );
+}
+
+#[tokio::test]
+async fn refresh_drifts_on_corrupted_payload() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    let blob = converge_fixture(dir.path()).await;
+    fs::write(&blob, "corrupted content").unwrap();
+
+    let out = refresh_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    let status = &out.resource_statuses["query.knowledge.find_person"];
+    assert_eq!(status.status, ResourceLifecycleStatus::Drifted);
+    assert!(status.conditions.contains(&"payload_mismatch".to_string()));
+    let state = read_state_json(dir.path());
+    assert!(
+        state["applied_revision"]["resources"]
+            .get("query.knowledge.find_person")
+            .is_none()
+    );
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn refresh_flags_unreadable_payload_as_error() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    let blob = converge_fixture(dir.path()).await;
+    // Make the payload unreadable without removing it: permission
+    // denied is a genuine non-NotFound IO error. (A same-named
+    // directory no longer triggers this path: object-store semantics
+    // classify a directory at an object path as NotFound — "only
+    // objects exist" — which is the missing-payload case, not the
+    // unreadable one.)
+    let mut perms = fs::metadata(&blob).unwrap().permissions();
+    std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o000);
+    fs::set_permissions(&blob, perms).unwrap();
+    // Root reads straight through mode 000 (container dev runners
+    // commonly run as root): skip rather than fail — the contract
+    // under test needs a genuine permission error.
+    if fs::read(&blob).is_ok() {
+        eprintln!(
+            "skipping refresh_flags_unreadable_payload_as_error:                  running as root (mode 000 is still readable)"
+        );
+        return;
+    }
+
+    let out = refresh_config_dir(dir.path()).await;
+    assert!(!out.ok);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "catalog_payload_read_error")
+    );
+    let status = &out.resource_statuses["query.knowledge.find_person"];
+    assert_eq!(status.status, ResourceLifecycleStatus::Error);
+    assert!(
+        status
+            .conditions
+            .contains(&"payload_read_error".to_string())
+    );
+    // Transient IO keeps the digest: no spurious republish.
+    let state = read_state_json(dir.path());
+    assert!(
+        state["applied_revision"]["resources"]
+            .get("query.knowledge.find_person")
+            .is_some()
+    );
+}
+
+#[tokio::test]
+async fn payload_drift_self_heals_through_refresh_plan_apply() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    let blob = converge_fixture(dir.path()).await;
+    let original = fs::read_to_string(&blob).unwrap();
+    fs::remove_file(&blob).unwrap();
+
+    let refresh = refresh_config_dir(dir.path()).await;
+    assert!(refresh.ok, "{:?}", refresh.diagnostics);
+
+    let plan = plan_config_dir(dir.path()).await;
+    let query_change = plan
+        .changes
+        .iter()
+        .find(|change| change.resource == "query.knowledge.find_person")
+        .expect("plan must propose recreating the query");
+    assert_eq!(query_change.operation, PlanOperation::Create);
+    assert_eq!(query_change.disposition, Some(ApplyDisposition::Applied));
+
+    let apply = apply_config_dir(dir.path()).await;
+    assert!(apply.ok && apply.converged, "{:?}", apply.diagnostics);
+    assert_eq!(fs::read_to_string(&blob).unwrap(), original);
+
+    let status = status_config_dir(dir.path()).await;
+    assert!(
+        !status
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code.starts_with("catalog_payload")),
+        "{:?}",
+        status.diagnostics
+    );
+}
+
+#[tokio::test]
+async fn verification_skips_graph_and_schema_resources() {
+    let dir = fixture();
+    write_applyable_state(dir.path()); // graph + schema digests only, no blobs
+
+    let out = status_config_dir(dir.path()).await;
+    assert!(
+        !out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code.starts_with("catalog_payload")),
+        "{:?}",
+        out.diagnostics
+    );
+}
+
+// ---- recovery sidecars + sweep (Stage 4A) ----
+
+fn derived_graph_uri(config_dir: &Path, graph_id: &str) -> String {
+    display_path(
+        &config_dir
+            .join(CLUSTER_GRAPHS_DIR)
+            .join(format!("{graph_id}.omni")),
+    )
+}
+
+fn write_create_sidecar(
+    config_dir: &Path,
+    graph_id: &str,
+    desired_schema_digest: &str,
+    operation_id: &str,
+) -> PathBuf {
+    let dir = config_dir.join(CLUSTER_RECOVERIES_DIR);
+    fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("{operation_id}.json"));
+    fs::write(
+        &path,
+        serde_json::to_string_pretty(&json!({
+            "schema_version": 1,
+            "operation_id": operation_id,
+            "started_at": "1970-01-01T00:00:00Z",
+            "kind": "graph_create",
+            "graph_id": graph_id,
+            "graph_uri": derived_graph_uri(config_dir, graph_id),
+            "desired_schema_digest": desired_schema_digest,
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    path
+}
+
+#[tokio::test]
+async fn sweep_removes_sidecar_when_root_absent() {
+    let dir = fixture();
+    write_applyable_state(dir.path());
+    let sidecar = write_create_sidecar(dir.path(), "knowledge", "irrelevant", "01ROW1");
+
+    let out = apply_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    // Row 1: nothing moved; intent removed, run proceeds normally.
+    assert!(!sidecar.exists());
+    assert!(out.converged);
+}
+
+#[tokio::test]
+async fn sweep_rolls_forward_completed_create() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    write_state_resources(dir.path(), &[]); // state predates the create
+    let desired = validate_config_dir(dir.path());
+    let schema_digest = desired.resource_digests["schema.knowledge"].clone();
+    let sidecar = write_create_sidecar(dir.path(), "knowledge", &schema_digest, "01ROW4");
+
+    let out = apply_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "cluster_recovery_rolled_forward")
+    );
+    // Row 4: ledger converged to observable reality, audit recorded,
+    // sidecar retired after the CAS landed.
+    let state = read_state_json(dir.path());
+    assert_eq!(
+        state["applied_revision"]["resources"]["schema.knowledge"]["digest"],
+        schema_digest
+    );
+    assert!(
+        state["recovery_records"]
+            .as_object()
+            .unwrap()
+            .values()
+            .any(
+                |record| record["outcome"] == "rolled_forward" && record["graph_id"] == "knowledge"
+            )
+    );
+    assert!(!sidecar.exists());
+    // With the graph rolled forward, the same run converges the catalog.
+    assert!(out.converged, "{out:?}");
+}
+
+#[tokio::test]
+async fn sweep_completes_already_recorded_create() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    write_applyable_state(dir.path()); // state already records graph+schema
+    let desired = validate_config_dir(dir.path());
+    let sidecar = write_create_sidecar(
+        dir.path(),
+        "knowledge",
+        &desired.resource_digests["schema.knowledge"],
+        "01ROW2",
+    );
+
+    let out = apply_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    // Row 2: outcome was already durable; no audit entry, sidecar retired.
+    assert!(!sidecar.exists());
+    let state = read_state_json(dir.path());
+    assert!(
+        state["recovery_records"]
+            .as_object()
+            .is_none_or(|records| records.is_empty()),
+        "{state}"
+    );
+}
+
+#[tokio::test]
+async fn sweep_keeps_sidecar_for_incomplete_root() {
+    let dir = fixture();
+    write_applyable_state(dir.path());
+    // A root that exists but cannot be opened: the engine's partial-init gap.
+    let root = dir.path().join(CLUSTER_GRAPHS_DIR).join("knowledge.omni");
+    fs::create_dir_all(&root).unwrap();
+    fs::write(root.join("_schema.pg"), "junk").unwrap();
+    let sidecar = write_create_sidecar(dir.path(), "knowledge", "whatever", "01ROW5");
+
+    let out = apply_config_dir(dir.path()).await;
+    assert!(!out.ok);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "graph_create_incomplete")
+    );
+    // Row 5: never auto-delete; sidecar and root stay for the operator,
+    // and the Error status is persisted by the run's state write.
+    assert!(sidecar.exists());
+    assert!(root.exists());
+    let state = read_state_json(dir.path());
+    assert_eq!(
+        state["resource_statuses"]["graph.knowledge"]["status"],
+        "error"
+    );
+    assert!(
+        state["resource_statuses"]["graph.knowledge"]["conditions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|condition| condition == "graph_create_incomplete")
+    );
+}
+
+#[tokio::test]
+async fn sweep_flags_unexpected_schema_as_pending() {
+    let dir = fixture();
+    write_state_resources(dir.path(), &[]);
+    // Live graph exists with a schema the sidecar never intended.
+    let graph_dir = dir.path().join(CLUSTER_GRAPHS_DIR);
+    fs::create_dir_all(&graph_dir).unwrap();
+    Omnigraph::init(
+        &derived_graph_uri(dir.path(), "knowledge"),
+        "\nnode Other {\n  name: String @key\n}\n",
+    )
+    .await
+    .unwrap();
+    let desired = validate_config_dir(dir.path());
+    let sidecar = write_create_sidecar(
+        dir.path(),
+        "knowledge",
+        &desired.resource_digests["schema.knowledge"],
+        "01ROW6",
+    );
+
+    let out = apply_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics); // warning, not error
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "cluster_recovery_pending")
+    );
+    // Row 6: refuse to guess; sidecar kept, Drifted persisted.
+    assert!(sidecar.exists());
+    let state = read_state_json(dir.path());
+    assert_eq!(
+        state["resource_statuses"]["graph.knowledge"]["status"],
+        "drifted"
+    );
+    assert!(
+        state["resource_statuses"]["graph.knowledge"]["conditions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|condition| condition == "actual_applied_state_pending")
+    );
+}
+
+#[tokio::test]
+async fn apply_blocks_create_while_recovery_pending() {
+    let dir = fixture();
+    write_state_resources(dir.path(), &[]);
+    // A kept (row 5) sidecar: partial root that cannot be opened.
+    let root = dir.path().join(CLUSTER_GRAPHS_DIR).join("knowledge.omni");
+    fs::create_dir_all(&root).unwrap();
+    fs::write(root.join("_schema.pg"), "junk").unwrap();
+    let sidecar = write_create_sidecar(dir.path(), "knowledge", "whatever", "01PEND");
+
+    let out = apply_config_dir(dir.path()).await;
+    assert!(!out.ok); // row 5 is an error condition
+    let by_resource: BTreeMap<&str, &PlanChange> = out
+        .changes
+        .iter()
+        .map(|change| (change.resource.as_str(), change))
+        .collect();
+    // The pending recovery blocks the create and its dependents; the
+    // executor never attempts the init.
+    assert_eq!(
+        by_resource["graph.knowledge"].disposition,
+        Some(ApplyDisposition::Blocked)
+    );
+    assert_eq!(
+        by_resource["graph.knowledge"].reason.as_deref(),
+        Some("cluster_recovery_pending")
+    );
+    assert_eq!(
+        by_resource["query.knowledge.find_person"].reason.as_deref(),
+        Some("cluster_recovery_pending")
+    );
+    assert_eq!(
+        by_resource["policy.base"].reason.as_deref(),
+        Some("cluster_recovery_pending")
+    );
+    assert!(sidecar.exists());
+    // The sweep's Error status is what persists — not a generic Blocked.
+    let state = read_state_json(dir.path());
+    assert_eq!(
+        state["resource_statuses"]["graph.knowledge"]["status"],
+        "error"
+    );
+}
+
+#[tokio::test]
+async fn plan_embeds_migration_preview_for_schema_update() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    write_applyable_state(dir.path());
+    fs::write(
+        dir.path().join("people.pg"),
+        "\nnode Person {\n  name: String @key\n  age: I32?\n  bio: String?\n}\n",
+    )
+    .unwrap();
+
+    let out = plan_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    let schema_change = out
+        .changes
+        .iter()
+        .find(|change| change.resource == "schema.knowledge")
         .unwrap();
-        path
-    }
+    let migration = schema_change.migration.as_ref().expect("preview embedded");
+    assert!(migration.supported);
+    assert!(
+        serde_json::to_string(&migration.steps)
+            .unwrap()
+            .contains("add_property"),
+        "{migration:?}"
+    );
+}
 
-    const SCHEMA_V2: &str = "\nnode Person {\n  name: String @key\n  age: I32?\n  bio: String?\n}\n";
+#[tokio::test]
+async fn plan_warns_when_preview_unavailable() {
+    let dir = fixture();
+    write_applyable_state(dir.path()); // digests recorded, but no live root
+    fs::write(
+        dir.path().join("people.pg"),
+        "\nnode Person {\n  name: String @key\n  age: I32?\n  bio: String?\n}\n",
+    )
+    .unwrap();
 
-    #[tokio::test]
-    async fn sweep_retires_schema_sidecar_when_ledger_consistent() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await;
-        write_applyable_state(dir.path()); // state digest == live digest
-        let sidecar =
-            write_schema_apply_sidecar(dir.path(), "knowledge", "never-applied", "01SROW1");
+    let out = plan_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    let schema_change = out
+        .changes
+        .iter()
+        .find(|change| change.resource == "schema.knowledge")
+        .unwrap();
+    assert!(schema_change.migration.is_none());
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "schema_preview_unavailable")
+    );
+}
 
-        let out = apply_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert!(!sidecar.exists());
-        let state = read_state_json(dir.path());
-        assert!(
-            state["recovery_records"]
-                .as_object()
-                .is_none_or(|records| records.is_empty())
-        );
-    }
+fn write_schema_apply_sidecar(
+    config_dir: &Path,
+    graph_id: &str,
+    desired_schema_digest: &str,
+    operation_id: &str,
+) -> PathBuf {
+    let dir = config_dir.join(CLUSTER_RECOVERIES_DIR);
+    fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("{operation_id}.json"));
+    fs::write(
+        &path,
+        serde_json::to_string_pretty(&json!({
+            "schema_version": 1,
+            "operation_id": operation_id,
+            "started_at": "1970-01-01T00:00:00Z",
+            "kind": "schema_apply",
+            "graph_id": graph_id,
+            "graph_uri": derived_graph_uri(config_dir, graph_id),
+            "desired_schema_digest": desired_schema_digest,
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    path
+}
 
-    #[tokio::test]
-    async fn sweep_rolls_forward_completed_schema_apply() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await;
-        write_applyable_state(dir.path());
-        // The schema apply completed on the graph out-of-process...
-        let graph_uri = derived_graph_uri(dir.path(), "knowledge");
-        let db = Omnigraph::open(&graph_uri).await.unwrap();
-        db.apply_schema(SCHEMA_V2).await.unwrap();
-        // ...the desired config matches it, and the sidecar records the intent.
-        fs::write(dir.path().join("people.pg"), SCHEMA_V2).unwrap();
-        let desired = validate_config_dir(dir.path());
-        let v2_digest = desired.resource_digests["schema.knowledge"].clone();
-        let sidecar = write_schema_apply_sidecar(dir.path(), "knowledge", &v2_digest, "01SROW3");
+const SCHEMA_V2: &str = "\nnode Person {\n  name: String @key\n  age: I32?\n  bio: String?\n}\n";
 
-        let out = apply_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "cluster_recovery_rolled_forward")
-        );
-        assert!(!sidecar.exists());
-        let state = read_state_json(dir.path());
-        assert_eq!(
-            state["applied_revision"]["resources"]["schema.knowledge"]["digest"],
-            v2_digest
-        );
-        assert!(
+#[tokio::test]
+async fn sweep_retires_schema_sidecar_when_ledger_consistent() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    write_applyable_state(dir.path()); // state digest == live digest
+    let sidecar = write_schema_apply_sidecar(dir.path(), "knowledge", "never-applied", "01SROW1");
+
+    let out = apply_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert!(!sidecar.exists());
+    let state = read_state_json(dir.path());
+    assert!(
+        state["recovery_records"]
+            .as_object()
+            .is_none_or(|records| records.is_empty())
+    );
+}
+
+#[tokio::test]
+async fn sweep_rolls_forward_completed_schema_apply() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    write_applyable_state(dir.path());
+    // The schema apply completed on the graph out-of-process...
+    let graph_uri = derived_graph_uri(dir.path(), "knowledge");
+    let db = Omnigraph::open(&graph_uri).await.unwrap();
+    db.apply_schema(SCHEMA_V2).await.unwrap();
+    // ...the desired config matches it, and the sidecar records the intent.
+    fs::write(dir.path().join("people.pg"), SCHEMA_V2).unwrap();
+    let desired = validate_config_dir(dir.path());
+    let v2_digest = desired.resource_digests["schema.knowledge"].clone();
+    let sidecar = write_schema_apply_sidecar(dir.path(), "knowledge", &v2_digest, "01SROW3");
+
+    let out = apply_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "cluster_recovery_rolled_forward")
+    );
+    assert!(!sidecar.exists());
+    let state = read_state_json(dir.path());
+    assert_eq!(
+        state["applied_revision"]["resources"]["schema.knowledge"]["digest"],
+        v2_digest
+    );
+    assert!(
             state["recovery_records"]
                 .as_object()
                 .unwrap()
@@ -2810,327 +2832,337 @@ graphs:
                 .any(|record| record["kind"] == "schema_apply"
                     && record["outcome"] == "rolled_forward")
         );
-        assert!(out.converged, "{out:?}");
-    }
+    assert!(out.converged, "{out:?}");
+}
 
-    #[tokio::test]
-    async fn sweep_flags_unexpected_schema_apply_state_as_pending() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await; // live = v1
-        write_state_resources(dir.path(), &[("schema.knowledge", "stale-digest")]);
-        // Sidecar intended a digest that is neither live nor recorded.
-        let sidecar =
-            write_schema_apply_sidecar(dir.path(), "knowledge", "intended-digest", "01SROW6");
+#[tokio::test]
+async fn sweep_flags_unexpected_schema_apply_state_as_pending() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await; // live = v1
+    write_state_resources(dir.path(), &[("schema.knowledge", "stale-digest")]);
+    // Sidecar intended a digest that is neither live nor recorded.
+    let sidecar = write_schema_apply_sidecar(dir.path(), "knowledge", "intended-digest", "01SROW6");
 
-        let out = apply_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics); // warnings only
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "cluster_recovery_pending")
-        );
-        assert!(sidecar.exists());
-        let state = read_state_json(dir.path());
-        assert_eq!(
-            state["resource_statuses"]["schema.knowledge"]["status"],
-            "drifted"
-        );
-    }
+    let out = apply_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics); // warnings only
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "cluster_recovery_pending")
+    );
+    assert!(sidecar.exists());
+    let state = read_state_json(dir.path());
+    assert_eq!(
+        state["resource_statuses"]["schema.knowledge"]["status"],
+        "drifted"
+    );
+}
 
-    #[tokio::test]
-    async fn sweep_keeps_schema_sidecar_for_unopenable_root() {
-        let dir = fixture();
-        write_applyable_state(dir.path());
-        let root = dir.path().join(CLUSTER_GRAPHS_DIR).join("knowledge.omni");
-        fs::create_dir_all(&root).unwrap(); // exists, won't open
-        let sidecar =
-            write_schema_apply_sidecar(dir.path(), "knowledge", "whatever", "01SROWX");
+#[tokio::test]
+async fn sweep_keeps_schema_sidecar_for_unopenable_root() {
+    let dir = fixture();
+    write_applyable_state(dir.path());
+    let root = dir.path().join(CLUSTER_GRAPHS_DIR).join("knowledge.omni");
+    fs::create_dir_all(&root).unwrap(); // exists, won't open
+    let sidecar = write_schema_apply_sidecar(dir.path(), "knowledge", "whatever", "01SROWX");
 
-        let out = apply_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics); // warning: cannot verify
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "cluster_recovery_pending")
-        );
-        assert!(sidecar.exists());
-    }
+    let out = apply_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics); // warning: cannot verify
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "cluster_recovery_pending")
+    );
+    assert!(sidecar.exists());
+}
 
-    /// Seed: converged knowledge subtree + a stale `old` graph subtree with a
-    /// real directory on disk.
-    async fn seed_deletable_state(config_dir: &Path) {
-        write_applyable_state(config_dir);
-        let state = read_state_json(config_dir);
-        let g = state["applied_revision"]["resources"]["graph.knowledge"]["digest"]
-            .as_str()
-            .unwrap()
-            .to_string();
-        let sc = state["applied_revision"]["resources"]["schema.knowledge"]["digest"]
-            .as_str()
-            .unwrap()
-            .to_string();
-        let old_streaming_digest = streaming_digest("old", false);
-        write_state_resources(
-            config_dir,
-            &[
-                ("graph.knowledge", g.as_str()),
-                ("schema.knowledge", sc.as_str()),
-                ("graph.old", "3333"),
-                ("schema.old", "4444"),
-                ("query.old.q", "5555"),
-                ("streaming.old", old_streaming_digest.as_str()),
-            ],
-        );
-        let mut state = read_state_json(config_dir);
-        let old_streaming = &mut state["applied_revision"]["resources"]["streaming.old"];
-        old_streaming["streaming_enabled"] = json!(false);
-        old_streaming["declaration_revision"] = json!(streaming_declaration_revision(
-            "old",
-            &old_streaming_digest
-        ));
-        old_streaming["profile_mode"] = json!("DISABLED");
-        old_streaming["profile_revision"] = json!(1);
-        state["resource_statuses"] = json!({
-            "streaming.old": {
-                "status": "applied",
-                "conditions": [],
-                "message": "stale streaming child"
-            }
-        });
-        fs::write(
-            config_dir.join(CLUSTER_STATE_FILE),
-            serde_json::to_string_pretty(&state).unwrap(),
-        )
+/// Seed: converged knowledge subtree + a stale `old` graph subtree with a
+/// real directory on disk.
+async fn seed_deletable_state(config_dir: &Path) {
+    write_applyable_state(config_dir);
+    let state = read_state_json(config_dir);
+    let g = state["applied_revision"]["resources"]["graph.knowledge"]["digest"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let sc = state["applied_revision"]["resources"]["schema.knowledge"]["digest"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let old_streaming_digest = streaming_digest("old", false);
+    write_state_resources(
+        config_dir,
+        &[
+            ("graph.knowledge", g.as_str()),
+            ("schema.knowledge", sc.as_str()),
+            ("graph.old", "3333"),
+            ("schema.old", "4444"),
+            ("query.old.q", "5555"),
+            ("streaming.old", old_streaming_digest.as_str()),
+        ],
+    );
+    let mut state = read_state_json(config_dir);
+    let old_streaming = &mut state["applied_revision"]["resources"]["streaming.old"];
+    old_streaming["streaming_enabled"] = json!(false);
+    old_streaming["declaration_revision"] =
+        json!(streaming_declaration_revision("old", &old_streaming_digest));
+    old_streaming["profile_mode"] = json!("DISABLED");
+    old_streaming["profile_revision"] = json!(1);
+    state["resource_statuses"] = json!({
+        "streaming.old": {
+            "status": "applied",
+            "conditions": [],
+            "message": "stale streaming child"
+        }
+    });
+    fs::write(
+        config_dir.join(CLUSTER_STATE_FILE),
+        serde_json::to_string_pretty(&state).unwrap(),
+    )
+    .unwrap();
+    let root = config_dir.join(CLUSTER_GRAPHS_DIR).join("old.omni");
+    fs::create_dir_all(root.parent().unwrap()).unwrap();
+    Omnigraph::init(root.to_string_lossy().as_ref(), SCHEMA)
+        .await
         .unwrap();
-        let root = config_dir.join(CLUSTER_GRAPHS_DIR).join("old.omni");
-        fs::create_dir_all(root.parent().unwrap()).unwrap();
-        Omnigraph::init(root.to_string_lossy().as_ref(), SCHEMA)
-            .await
-            .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn apply_executes_approved_graph_delete() {
+    struct PausingExportWriter {
+        started: Option<tokio::sync::oneshot::Sender<()>>,
+        release: Option<std::sync::mpsc::Receiver<()>>,
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn apply_executes_approved_graph_delete() {
-        struct PausingExportWriter {
-            started: Option<tokio::sync::oneshot::Sender<()>>,
-            release: Option<std::sync::mpsc::Receiver<()>>,
+    impl std::io::Write for PausingExportWriter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            if let Some(started) = self.started.take() {
+                let _ = started.send(());
+                self.release
+                    .take()
+                    .expect("first export write must own its release receiver")
+                    .recv()
+                    .map_err(std::io::Error::other)?;
+            }
+            Ok(bytes.len())
         }
 
-        impl std::io::Write for PausingExportWriter {
-            fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
-                if let Some(started) = self.started.take() {
-                    let _ = started.send(());
-                    self.release
-                        .take()
-                        .expect("first export write must own its release receiver")
-                        .recv()
-                        .map_err(std::io::Error::other)?;
-                }
-                Ok(bytes.len())
-            }
-
-            fn flush(&mut self) -> std::io::Result<()> {
-                Ok(())
-            }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
         }
+    }
 
-        let dir = fixture();
-        seed_deletable_state(dir.path()).await;
-        let approved = approve_config_dir(dir.path(), "graph.old", "andrew").await;
-        assert!(approved.ok, "{:?}", approved.diagnostics);
-        let approval_id = approved.approval_id.clone().unwrap();
+    let dir = fixture();
+    seed_deletable_state(dir.path()).await;
+    let approved = approve_config_dir(dir.path(), "graph.old", "andrew").await;
+    assert!(approved.ok, "{:?}", approved.diagnostics);
+    let approval_id = approved.approval_id.clone().unwrap();
 
-        let old_root = dir.path().join(CLUSTER_GRAPHS_DIR).join("old.omni");
-        let old_uri = derived_graph_uri(dir.path(), "old");
-        let export_db = Omnigraph::open(&old_uri).await.unwrap();
-        let mut seed_params = omnigraph_compiler::ir::ParamMap::new();
-        seed_params.insert(
-            "name".to_string(),
-            omnigraph_compiler::query::ast::Literal::String("export-cut".to_string()),
-        );
-        export_db
-            .mutate(
-                "main",
-                r#"
+    let old_root = dir.path().join(CLUSTER_GRAPHS_DIR).join("old.omni");
+    let old_uri = derived_graph_uri(dir.path(), "old");
+    let export_db = Omnigraph::open(&old_uri).await.unwrap();
+    let mut seed_params = omnigraph_compiler::ir::ParamMap::new();
+    seed_params.insert(
+        "name".to_string(),
+        omnigraph_compiler::query::ast::Literal::String("export-cut".to_string()),
+    );
+    export_db
+        .mutate(
+            "main",
+            r#"
 query seed($name: String) {
   insert Person { name: $name }
 }
 "#,
-                "seed",
-                &seed_params,
-            )
+            "seed",
+            &seed_params,
+        )
+        .await
+        .unwrap();
+    let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = std::sync::mpsc::channel();
+    let export_task = tokio::spawn(async move {
+        let mut writer = PausingExportWriter {
+            started: Some(started_tx),
+            release: Some(release_rx),
+        };
+        export_db
+            .export_jsonl_to_writer("main", &[], &[], &mut writer)
             .await
-            .unwrap();
-        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
-        let (release_tx, release_rx) = std::sync::mpsc::channel();
-        let export_task = tokio::spawn(async move {
-            let mut writer = PausingExportWriter {
-                started: Some(started_tx),
-                release: Some(release_rx),
-            };
-            export_db
-                .export_jsonl_to_writer("main", &[], &[], &mut writer)
-                .await
-        });
-        tokio::time::timeout(std::time::Duration::from_secs(5), started_rx)
-            .await
-            .expect("export did not reach its first write")
-            .expect("export exited before its first write");
-        let blocked = apply_config_dir(dir.path()).await;
-        release_tx.send(()).unwrap();
-        export_task.await.unwrap().unwrap();
-        assert!(!blocked.ok && !blocked.converged, "{blocked:?}");
-        assert!(blocked.diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == "graph_delete_export_in_progress"
-                && diagnostic.path == "graph.old"
-        }));
-        assert!(
-            old_root.exists(),
-            "a live immutable export cut must preserve the exact graph root"
-        );
-        let blocked_state = read_state_json(dir.path());
-        assert!(
-            blocked_state["applied_revision"]["resources"]
-                .get("graph.old")
-                .is_some(),
-            "the blocked delete must leave the graph subtree authoritative"
-        );
-        let out = apply_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert!(out.converged, "{out:?}");
-        let by_resource: BTreeMap<&str, &PlanChange> = out
-            .changes
+    });
+    tokio::time::timeout(std::time::Duration::from_secs(5), started_rx)
+        .await
+        .expect("export did not reach its first write")
+        .expect("export exited before its first write");
+    let blocked = apply_config_dir(dir.path()).await;
+    release_tx.send(()).unwrap();
+    export_task.await.unwrap().unwrap();
+    assert!(!blocked.ok && !blocked.converged, "{blocked:?}");
+    assert!(blocked.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "graph_delete_export_in_progress" && diagnostic.path == "graph.old"
+    }));
+    assert!(
+        old_root.exists(),
+        "a live immutable export cut must preserve the exact graph root"
+    );
+    let blocked_state = read_state_json(dir.path());
+    assert!(
+        blocked_state["applied_revision"]["resources"]
+            .get("graph.old")
+            .is_some(),
+        "the blocked delete must leave the graph subtree authoritative"
+    );
+    let out = apply_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert!(out.converged, "{out:?}");
+    let by_resource: BTreeMap<&str, &PlanChange> = out
+        .changes
+        .iter()
+        .map(|change| (change.resource.as_str(), change))
+        .collect();
+    assert_eq!(
+        by_resource["graph.old"].disposition,
+        Some(ApplyDisposition::Applied)
+    );
+    assert_eq!(
+        by_resource["schema.old"].disposition,
+        Some(ApplyDisposition::Applied)
+    );
+    assert_eq!(
+        by_resource["query.old.q"].disposition,
+        Some(ApplyDisposition::Applied)
+    );
+    // The root is gone; the subtree is tombstoned out of the ledger.
+    assert!(!old_root.exists());
+    let state = read_state_json(dir.path());
+    let resources = state["applied_revision"]["resources"].as_object().unwrap();
+    assert!(!resources.contains_key("graph.old"));
+    assert!(!resources.contains_key("schema.old"));
+    assert!(!resources.contains_key("query.old.q"));
+    assert!(!resources.contains_key("streaming.old"));
+    assert!(
+        !state["resource_statuses"]
+            .as_object()
+            .unwrap()
+            .contains_key("streaming.old")
+    );
+    assert_eq!(state["observations"]["graph.old"]["kind"], "tombstone");
+    assert_eq!(
+        state["observations"]["graph.old"]["approval_id"],
+        approval_id
+    );
+    // Approval consumed in BOTH stores: ledger summary + artifact file.
+    assert!(state["approval_records"][&approval_id]["consumed_at"].is_string());
+    let artifact: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(
+            dir.path()
+                .join(CLUSTER_APPROVALS_DIR)
+                .join(format!("{approval_id}.json")),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert!(artifact["consumed_at"].is_string(), "{artifact}");
+    // Sidecar retired.
+    assert!(
+        fs::read_dir(dir.path().join(CLUSTER_RECOVERIES_DIR))
+            .map(|mut entries| entries.next().is_none())
+            .unwrap_or(true)
+    );
+    // A consumed approval authorizes nothing further (idempotent re-apply).
+    let again = apply_config_dir(dir.path()).await;
+    assert!(
+        again.ok && again.converged && !again.state_written,
+        "{again:?}"
+    );
+}
+
+fn write_delete_sidecar(
+    config_dir: &Path,
+    graph_id: &str,
+    approval_id: Option<&str>,
+    operation_id: &str,
+) -> PathBuf {
+    let dir = config_dir.join(CLUSTER_RECOVERIES_DIR);
+    fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(format!("{operation_id}.json"));
+    fs::write(
+        &path,
+        serde_json::to_string_pretty(&json!({
+            "schema_version": 1,
+            "operation_id": operation_id,
+            "started_at": "1970-01-01T00:00:00Z",
+            "kind": "graph_delete",
+            "graph_id": graph_id,
+            "graph_uri": derived_graph_uri(config_dir, graph_id),
+            "desired_schema_digest": "",
+            "approval_id": approval_id,
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    path
+}
+
+#[tokio::test]
+async fn sweep_retires_delete_sidecar_when_tombstoned() {
+    let dir = fixture();
+    write_applyable_state(dir.path()); // no graph.old in state, no root
+    let sidecar = write_delete_sidecar(dir.path(), "old", None, "01DROW7");
+
+    let out = apply_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert!(!sidecar.exists());
+    let state = read_state_json(dir.path());
+    assert!(
+        state["recovery_records"]
+            .as_object()
+            .is_none_or(|records| records.is_empty())
+    );
+}
+
+#[tokio::test]
+async fn sweep_rolls_forward_completed_delete() {
+    let dir = fixture();
+    seed_deletable_state(dir.path()).await;
+    // Approve, then simulate: root removed, state stale, sidecar present.
+    let approved = approve_config_dir(dir.path(), "graph.old", "andrew").await;
+    let approval_id = approved.approval_id.unwrap();
+    fs::remove_dir_all(dir.path().join(CLUSTER_GRAPHS_DIR).join("old.omni")).unwrap();
+    let sidecar = write_delete_sidecar(dir.path(), "old", Some(&approval_id), "01DROW7B");
+
+    // Refresh runs the recovery sweep directly, without the ordinary
+    // planned-delete path independently removing child resources first.
+    let out = refresh_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert!(
+        out.diagnostics
             .iter()
-            .map(|change| (change.resource.as_str(), change))
-            .collect();
-        assert_eq!(by_resource["graph.old"].disposition, Some(ApplyDisposition::Applied));
-        assert_eq!(by_resource["schema.old"].disposition, Some(ApplyDisposition::Applied));
-        assert_eq!(by_resource["query.old.q"].disposition, Some(ApplyDisposition::Applied));
-        // The root is gone; the subtree is tombstoned out of the ledger.
-        assert!(!old_root.exists());
-        let state = read_state_json(dir.path());
-        let resources = state["applied_revision"]["resources"].as_object().unwrap();
-        assert!(!resources.contains_key("graph.old"));
-        assert!(!resources.contains_key("schema.old"));
-        assert!(!resources.contains_key("query.old.q"));
-        assert!(!resources.contains_key("streaming.old"));
-        assert!(
-            !state["resource_statuses"]
-                .as_object()
-                .unwrap()
-                .contains_key("streaming.old")
-        );
-        assert_eq!(state["observations"]["graph.old"]["kind"], "tombstone");
-        assert_eq!(state["observations"]["graph.old"]["approval_id"], approval_id);
-        // Approval consumed in BOTH stores: ledger summary + artifact file.
-        assert!(state["approval_records"][&approval_id]["consumed_at"].is_string());
-        let artifact: serde_json::Value = serde_json::from_str(
-            &fs::read_to_string(
-                dir.path()
-                    .join(CLUSTER_APPROVALS_DIR)
-                    .join(format!("{approval_id}.json")),
-            )
-            .unwrap(),
-        )
-        .unwrap();
-        assert!(artifact["consumed_at"].is_string(), "{artifact}");
-        // Sidecar retired.
-        assert!(
-            fs::read_dir(dir.path().join(CLUSTER_RECOVERIES_DIR))
-                .map(|mut entries| entries.next().is_none())
-                .unwrap_or(true)
-        );
-        // A consumed approval authorizes nothing further (idempotent re-apply).
-        let again = apply_config_dir(dir.path()).await;
-        assert!(again.ok && again.converged && !again.state_written, "{again:?}");
-    }
-
-    fn write_delete_sidecar(
-        config_dir: &Path,
-        graph_id: &str,
-        approval_id: Option<&str>,
-        operation_id: &str,
-    ) -> PathBuf {
-        let dir = config_dir.join(CLUSTER_RECOVERIES_DIR);
-        fs::create_dir_all(&dir).unwrap();
-        let path = dir.join(format!("{operation_id}.json"));
-        fs::write(
-            &path,
-            serde_json::to_string_pretty(&json!({
-                "schema_version": 1,
-                "operation_id": operation_id,
-                "started_at": "1970-01-01T00:00:00Z",
-                "kind": "graph_delete",
-                "graph_id": graph_id,
-                "graph_uri": derived_graph_uri(config_dir, graph_id),
-                "desired_schema_digest": "",
-                "approval_id": approval_id,
-            }))
-            .unwrap(),
-        )
-        .unwrap();
-        path
-    }
-
-    #[tokio::test]
-    async fn sweep_retires_delete_sidecar_when_tombstoned() {
-        let dir = fixture();
-        write_applyable_state(dir.path()); // no graph.old in state, no root
-        let sidecar = write_delete_sidecar(dir.path(), "old", None, "01DROW7");
-
-        let out = apply_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert!(!sidecar.exists());
-        let state = read_state_json(dir.path());
-        assert!(
-            state["recovery_records"]
-                .as_object()
-                .is_none_or(|records| records.is_empty())
-        );
-    }
-
-    #[tokio::test]
-    async fn sweep_rolls_forward_completed_delete() {
-        let dir = fixture();
-        seed_deletable_state(dir.path()).await;
-        // Approve, then simulate: root removed, state stale, sidecar present.
-        let approved = approve_config_dir(dir.path(), "graph.old", "andrew").await;
-        let approval_id = approved.approval_id.unwrap();
-        fs::remove_dir_all(dir.path().join(CLUSTER_GRAPHS_DIR).join("old.omni")).unwrap();
-        let sidecar = write_delete_sidecar(dir.path(), "old", Some(&approval_id), "01DROW7B");
-
-        // Refresh runs the recovery sweep directly, without the ordinary
-        // planned-delete path independently removing child resources first.
-        let out = refresh_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "cluster_recovery_rolled_forward")
-        );
-        assert!(!sidecar.exists());
-        let state = read_state_json(dir.path());
-        assert!(
-            !state["applied_revision"]["resources"]
-                .as_object()
-                .unwrap()
-                .contains_key("graph.old")
-        );
-        assert!(
-            !state["applied_revision"]["resources"]
-                .as_object()
-                .unwrap()
-                .contains_key("streaming.old")
-        );
-        assert!(
-            !state["resource_statuses"]
-                .as_object()
-                .unwrap()
-                .contains_key("streaming.old")
-        );
-        assert_eq!(state["observations"]["graph.old"]["kind"], "tombstone");
-        assert!(state["approval_records"][&approval_id]["consumed_at"].is_string());
-        assert!(
+            .any(|diagnostic| diagnostic.code == "cluster_recovery_rolled_forward")
+    );
+    assert!(!sidecar.exists());
+    let state = read_state_json(dir.path());
+    assert!(
+        !state["applied_revision"]["resources"]
+            .as_object()
+            .unwrap()
+            .contains_key("graph.old")
+    );
+    assert!(
+        !state["applied_revision"]["resources"]
+            .as_object()
+            .unwrap()
+            .contains_key("streaming.old")
+    );
+    assert!(
+        !state["resource_statuses"]
+            .as_object()
+            .unwrap()
+            .contains_key("streaming.old")
+    );
+    assert_eq!(state["observations"]["graph.old"]["kind"], "tombstone");
+    assert!(state["approval_records"][&approval_id]["consumed_at"].is_string());
+    assert!(
             state["recovery_records"]
                 .as_object()
                 .unwrap()
@@ -3138,74 +3170,84 @@ query seed($name: String) {
                 .any(|record| record["kind"] == "graph_delete"
                     && record["outcome"] == "rolled_forward")
         );
-        // The artifact file is marked consumed post-CAS.
-        let artifact: serde_json::Value = serde_json::from_str(
-            &fs::read_to_string(
-                dir.path()
-                    .join(CLUSTER_APPROVALS_DIR)
-                    .join(format!("{approval_id}.json")),
-            )
-            .unwrap(),
+    // The artifact file is marked consumed post-CAS.
+    let artifact: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(
+            dir.path()
+                .join(CLUSTER_APPROVALS_DIR)
+                .join(format!("{approval_id}.json")),
         )
-        .unwrap();
-        assert!(artifact["consumed_at"].is_string());
-    }
+        .unwrap(),
+    )
+    .unwrap();
+    assert!(artifact["consumed_at"].is_string());
+}
 
-    #[tokio::test]
-    async fn sweep_reproposes_incomplete_delete() {
-        let dir = fixture();
-        seed_deletable_state(dir.path()).await; // root present
-        let approved = approve_config_dir(dir.path(), "graph.old", "andrew").await;
-        assert!(approved.ok);
-        let sidecar = write_delete_sidecar(dir.path(), "old", approved.approval_id.as_deref(), "01DROW8");
+#[tokio::test]
+async fn sweep_reproposes_incomplete_delete() {
+    let dir = fixture();
+    seed_deletable_state(dir.path()).await; // root present
+    let approved = approve_config_dir(dir.path(), "graph.old", "andrew").await;
+    assert!(approved.ok);
+    let sidecar = write_delete_sidecar(
+        dir.path(),
+        "old",
+        approved.approval_id.as_deref(),
+        "01DROW8",
+    );
 
-        // Row 8: the stale intent is retired with a warning, and the same run
-        // re-executes the still-approved delete to completion.
-        let out = apply_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "graph_delete_incomplete")
-        );
-        assert!(!sidecar.exists());
-        assert!(!dir.path().join(CLUSTER_GRAPHS_DIR).join("old.omni").exists());
-        assert!(out.converged, "{out:?}");
-    }
+    // Row 8: the stale intent is retired with a warning, and the same run
+    // re-executes the still-approved delete to completion.
+    let out = apply_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "graph_delete_incomplete")
+    );
+    assert!(!sidecar.exists());
+    assert!(
+        !dir.path()
+            .join(CLUSTER_GRAPHS_DIR)
+            .join("old.omni")
+            .exists()
+    );
+    assert!(out.converged, "{out:?}");
+}
 
-    // ---- policy bindings in the applied revision (5A) ----
+// ---- policy bindings in the applied revision (5A) ----
 
-    #[tokio::test]
-    async fn apply_records_policy_bindings() {
-        let dir = fixture();
-        write_applyable_state(dir.path());
+#[tokio::test]
+async fn apply_records_policy_bindings() {
+    let dir = fixture();
+    write_applyable_state(dir.path());
 
-        let out = apply_config_dir(dir.path()).await;
-        assert!(out.ok && out.converged, "{:?}", out.diagnostics);
-        let state = read_state_json(dir.path());
-        assert_eq!(
-            state["applied_revision"]["resources"]["policy.base"]["applies_to"],
-            serde_json::json!(["graph.knowledge"]),
-            "{state}"
-        );
-        // Non-policy entries carry no bindings field at all.
-        assert!(
-            state["applied_revision"]["resources"]["query.knowledge.find_person"]
-                .get("applies_to")
-                .is_none()
-        );
-    }
+    let out = apply_config_dir(dir.path()).await;
+    assert!(out.ok && out.converged, "{:?}", out.diagnostics);
+    let state = read_state_json(dir.path());
+    assert_eq!(
+        state["applied_revision"]["resources"]["policy.base"]["applies_to"],
+        serde_json::json!(["graph.knowledge"]),
+        "{state}"
+    );
+    // Non-policy entries carry no bindings field at all.
+    assert!(
+        state["applied_revision"]["resources"]["query.knowledge.find_person"]
+            .get("applies_to")
+            .is_none()
+    );
+}
 
-    #[tokio::test]
-    async fn binding_change_is_a_visible_plan_change() {
-        let dir = fixture();
-        write_applyable_state(dir.path());
-        let converge = apply_config_dir(dir.path()).await;
-        assert!(converge.converged, "{converge:?}");
-        // Edit ONLY applies_to: the policy file digest is unchanged.
-        fs::write(
-            dir.path().join(CLUSTER_CONFIG_FILE),
-            r#"
+#[tokio::test]
+async fn binding_change_is_a_visible_plan_change() {
+    let dir = fixture();
+    write_applyable_state(dir.path());
+    let converge = apply_config_dir(dir.path()).await;
+    assert!(converge.converged, "{converge:?}");
+    // Edit ONLY applies_to: the policy file digest is unchanged.
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        r#"
 version: 1
 metadata:
   name: test
@@ -3223,310 +3265,317 @@ policies:
     file: ./base.policy.yaml
     applies_to: [cluster, knowledge]
 "#,
-        )
-        .unwrap();
+    )
+    .unwrap();
 
-        let plan = plan_config_dir(dir.path()).await;
-        let change = plan
-            .changes
+    let plan = plan_config_dir(dir.path()).await;
+    let change = plan
+        .changes
+        .iter()
+        .find(|change| change.resource == "policy.base")
+        .expect("binding change must be visible in plan");
+    assert!(change.binding_change);
+    assert_eq!(
+        change.metadata_change,
+        Some(PlanMetadataChange::PolicyBindings)
+    );
+    assert_eq!(change.operation, PlanOperation::Update);
+    assert_eq!(change.before_digest, change.after_digest);
+
+    let out = apply_config_dir(dir.path()).await;
+    assert!(out.ok && out.converged, "{out:?}");
+    let state = read_state_json(dir.path());
+    assert_eq!(
+        state["applied_revision"]["resources"]["policy.base"]["applies_to"],
+        serde_json::json!(["cluster", "graph.knowledge"])
+    );
+    // Idempotent: a second run sees no changes.
+    let again = apply_config_dir(dir.path()).await;
+    assert!(
+        again.changes.is_empty() && !again.state_written,
+        "{again:?}"
+    );
+}
+
+#[tokio::test]
+async fn pre_5a_state_backfills_bindings() {
+    let dir = fixture();
+    write_applyable_state(dir.path());
+    let converge = apply_config_dir(dir.path()).await;
+    assert!(converge.converged, "{converge:?}");
+    // Strip the bindings from the state entry (a pre-5A ledger).
+    let mut state: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(dir.path().join(CLUSTER_STATE_FILE)).unwrap())
+            .unwrap();
+    state["applied_revision"]["resources"]["policy.base"]
+        .as_object_mut()
+        .unwrap()
+        .remove("applies_to");
+    fs::write(
+        dir.path().join(CLUSTER_STATE_FILE),
+        serde_json::to_string_pretty(&state).unwrap(),
+    )
+    .unwrap();
+
+    let plan = plan_config_dir(dir.path()).await;
+    assert!(
+        plan.changes
             .iter()
-            .find(|change| change.resource == "policy.base")
-            .expect("binding change must be visible in plan");
-        assert!(change.binding_change);
-        assert_eq!(
-            change.metadata_change,
-            Some(PlanMetadataChange::PolicyBindings)
-        );
-        assert_eq!(change.operation, PlanOperation::Update);
-        assert_eq!(change.before_digest, change.after_digest);
-
-        let out = apply_config_dir(dir.path()).await;
-        assert!(out.ok && out.converged, "{out:?}");
-        let state = read_state_json(dir.path());
-        assert_eq!(
-            state["applied_revision"]["resources"]["policy.base"]["applies_to"],
-            serde_json::json!(["cluster", "graph.knowledge"])
-        );
-        // Idempotent: a second run sees no changes.
-        let again = apply_config_dir(dir.path()).await;
-        assert!(again.changes.is_empty() && !again.state_written, "{again:?}");
-    }
-
-    #[tokio::test]
-    async fn pre_5a_state_backfills_bindings() {
-        let dir = fixture();
-        write_applyable_state(dir.path());
-        let converge = apply_config_dir(dir.path()).await;
-        assert!(converge.converged, "{converge:?}");
-        // Strip the bindings from the state entry (a pre-5A ledger).
-        let mut state: serde_json::Value = serde_json::from_str(
-            &fs::read_to_string(dir.path().join(CLUSTER_STATE_FILE)).unwrap(),
-        )
-        .unwrap();
-        state["applied_revision"]["resources"]["policy.base"]
-            .as_object_mut()
-            .unwrap()
-            .remove("applies_to");
-        fs::write(
-            dir.path().join(CLUSTER_STATE_FILE),
-            serde_json::to_string_pretty(&state).unwrap(),
-        )
-        .unwrap();
-
-        let plan = plan_config_dir(dir.path()).await;
-        assert!(
-            plan.changes.iter().any(|change| change.resource == "policy.base"
+            .any(|change| change.resource == "policy.base"
                 && change.binding_change
                 && change.metadata_change == Some(PlanMetadataChange::PolicyBindings)),
-            "{plan:?}"
-        );
-        let out = apply_config_dir(dir.path()).await;
-        assert!(out.ok && out.converged, "{out:?}");
-        let healed = read_state_json(dir.path());
-        assert_eq!(
-            healed["applied_revision"]["resources"]["policy.base"]["applies_to"],
-            serde_json::json!(["graph.knowledge"])
-        );
-    }
+        "{plan:?}"
+    );
+    let out = apply_config_dir(dir.path()).await;
+    assert!(out.ok && out.converged, "{out:?}");
+    let healed = read_state_json(dir.path());
+    assert_eq!(
+        healed["applied_revision"]["resources"]["policy.base"]["applies_to"],
+        serde_json::json!(["graph.knowledge"])
+    );
+}
 
-    #[tokio::test]
-    async fn pre_5a_state_backfills_embedding_profile() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await;
-        write_mock_embedding_cluster(dir.path(), "recorded-x");
-        write_applyable_state(dir.path());
-        let converge = apply_config_dir(dir.path()).await;
-        assert!(converge.converged, "{converge:?}");
+#[tokio::test]
+async fn pre_5a_state_backfills_embedding_profile() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    write_mock_embedding_cluster(dir.path(), "recorded-x");
+    write_applyable_state(dir.path());
+    let converge = apply_config_dir(dir.path()).await;
+    assert!(converge.converged, "{converge:?}");
 
-        let mut state = read_state_json(dir.path());
-        state["applied_revision"]["resources"]["provider.embedding.default"]
-            .as_object_mut()
-            .unwrap()
-            .remove("embedding_profile");
-        fs::write(
-            dir.path().join(CLUSTER_STATE_FILE),
-            serde_json::to_string_pretty(&state).unwrap(),
-        )
-        .unwrap();
+    let mut state = read_state_json(dir.path());
+    state["applied_revision"]["resources"]["provider.embedding.default"]
+        .as_object_mut()
+        .unwrap()
+        .remove("embedding_profile");
+    fs::write(
+        dir.path().join(CLUSTER_STATE_FILE),
+        serde_json::to_string_pretty(&state).unwrap(),
+    )
+    .unwrap();
 
-        let plan = plan_config_dir(dir.path()).await;
-        let change = plan
-            .changes
+    let plan = plan_config_dir(dir.path()).await;
+    let change = plan
+        .changes
+        .iter()
+        .find(|change| change.resource == "provider.embedding.default")
+        .expect("embedding profile backfill must be visible in plan");
+    assert_eq!(change.operation, PlanOperation::Update);
+    assert_eq!(change.before_digest, change.after_digest);
+    assert_eq!(
+        change.metadata_change,
+        Some(PlanMetadataChange::EmbeddingProfile)
+    );
+
+    let out = apply_config_dir(dir.path()).await;
+    assert!(out.ok && out.converged, "{out:?}");
+    let healed = read_state_json(dir.path());
+    assert_eq!(
+        healed["applied_revision"]["resources"]["provider.embedding.default"]["embedding_profile"]
+            ["model"],
+        serde_json::json!("recorded-x")
+    );
+    let snapshot = read_serving_snapshot(dir.path()).await.unwrap();
+    let profile = snapshot.graphs[0].embedding.as_ref().unwrap();
+    assert_eq!(profile.model.as_deref(), Some("recorded-x"));
+}
+
+#[tokio::test]
+async fn bindings_survive_refresh() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    write_applyable_state(dir.path());
+    let converge = apply_config_dir(dir.path()).await;
+    assert!(converge.converged, "{converge:?}");
+
+    let refresh = refresh_config_dir(dir.path()).await;
+    assert!(refresh.ok, "{:?}", refresh.diagnostics);
+    let state = read_state_json(dir.path());
+    assert_eq!(
+        state["applied_revision"]["resources"]["policy.base"]["applies_to"],
+        serde_json::json!(["graph.knowledge"])
+    );
+}
+
+// ---- serving snapshot (5B read-only loader) ----
+
+// ---- storage: root (RFC-006) ----
+
+#[tokio::test]
+async fn storage_root_defaults_to_config_dir_layout() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    write_applyable_state(dir.path());
+    let out = apply_config_dir(dir.path()).await;
+    assert!(out.converged, "{out:?}");
+    // No storage: key — the original on-disk layout, byte-compatible.
+    assert!(dir.path().join(CLUSTER_STATE_FILE).exists());
+    assert!(dir.path().join(CLUSTER_RESOURCES_DIR).exists());
+    assert!(dir.path().join("graphs/knowledge.omni").exists());
+}
+
+#[tokio::test]
+async fn storage_root_file_uri_relocates_the_cluster() {
+    let dir = fixture();
+    let storage = tempfile::tempdir().unwrap();
+    let storage_path = storage.path().to_string_lossy().to_string();
+    let mut config = fs::read_to_string(dir.path().join("cluster.yaml")).unwrap();
+    config = config.replace(
+        "version: 1\n",
+        &format!("version: 1\nstorage: {storage_path}\n"),
+    );
+    fs::write(dir.path().join("cluster.yaml"), config).unwrap();
+
+    let import = import_config_dir(dir.path()).await;
+    assert!(import.ok, "{:?}", import.diagnostics);
+    let out = apply_config_dir(dir.path()).await;
+    assert!(out.ok && out.converged, "{:?}", out.diagnostics);
+
+    // Everything lives under the declared root; nothing under config dir.
+    assert!(storage.path().join("__cluster/state.json").exists());
+    assert!(storage.path().join("graphs/knowledge.omni").exists());
+    assert!(storage.path().join(CLUSTER_RESOURCES_DIR).exists());
+    assert!(!dir.path().join(CLUSTER_STATE_FILE).exists());
+    assert!(!dir.path().join("graphs").exists());
+
+    // The serving snapshot follows the root.
+    let snapshot = read_serving_snapshot(dir.path()).await.unwrap();
+    assert!(
+        snapshot.graphs[0].root.starts_with(storage.path()),
+        "{:?}",
+        snapshot.graphs[0].root
+    );
+}
+
+#[test]
+fn storage_root_invalid_uri_fails_validation() {
+    let dir = fixture();
+    let mut config = fs::read_to_string(dir.path().join("cluster.yaml")).unwrap();
+    config = config.replace("version: 1\n", "version: 1\nstorage: \"s3://\"\n");
+    fs::write(dir.path().join("cluster.yaml"), config).unwrap();
+    let out = validate_config_dir(dir.path());
+    assert!(!out.ok);
+    assert!(
+        out.diagnostics
             .iter()
-            .find(|change| change.resource == "provider.embedding.default")
-            .expect("embedding profile backfill must be visible in plan");
-        assert_eq!(change.operation, PlanOperation::Update);
-        assert_eq!(change.before_digest, change.after_digest);
-        assert_eq!(
-            change.metadata_change,
-            Some(PlanMetadataChange::EmbeddingProfile)
-        );
+            .any(|diagnostic| diagnostic.code == "invalid_storage_root"),
+        "{:?}",
+        out.diagnostics
+    );
+}
 
-        let out = apply_config_dir(dir.path()).await;
-        assert!(out.ok && out.converged, "{out:?}");
-        let healed = read_state_json(dir.path());
-        assert_eq!(
-            healed["applied_revision"]["resources"]["provider.embedding.default"]
-                ["embedding_profile"]["model"],
-            serde_json::json!("recorded-x")
-        );
-        let snapshot = read_serving_snapshot(dir.path()).await.unwrap();
-        let profile = snapshot.graphs[0].embedding.as_ref().unwrap();
-        assert_eq!(profile.model.as_deref(), Some("recorded-x"));
-    }
+#[tokio::test]
+async fn serving_snapshot_reads_converged_cluster() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    write_applyable_state(dir.path());
+    let converge = apply_config_dir(dir.path()).await;
+    assert!(converge.converged, "{converge:?}");
 
-    #[tokio::test]
-    async fn bindings_survive_refresh() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await;
-        write_applyable_state(dir.path());
-        let converge = apply_config_dir(dir.path()).await;
-        assert!(converge.converged, "{converge:?}");
+    let snapshot = read_serving_snapshot(dir.path())
+        .await
+        .expect("converged cluster must serve");
+    assert_eq!(snapshot.graphs.len(), 1);
+    assert_eq!(snapshot.graphs[0].graph_id, "knowledge");
+    assert!(snapshot.graphs[0].root.ends_with("graphs/knowledge.omni"));
+    assert_eq!(snapshot.queries.len(), 1);
+    assert_eq!(snapshot.queries[0].name, "find_person");
+    assert!(snapshot.queries[0].source.contains("query find_person"));
+    assert_eq!(snapshot.policies.len(), 1);
+    assert_eq!(snapshot.policies[0].applies_to, vec!["graph.knowledge"]);
+    // Content, not a path: the catalog may live on object storage.
+    // The fixture bundle is `rules: []` — assert the verified text.
+    assert!(snapshot.policies[0].source.contains("rules:"));
+}
 
-        let refresh = refresh_config_dir(dir.path()).await;
-        assert!(refresh.ok, "{:?}", refresh.diagnostics);
-        let state = read_state_json(dir.path());
-        assert_eq!(
-            state["applied_revision"]["resources"]["policy.base"]["applies_to"],
-            serde_json::json!(["graph.knowledge"])
-        );
-    }
+#[tokio::test]
+async fn serving_snapshot_uses_applied_embedding_provider_profile() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    write_mock_embedding_cluster(dir.path(), "recorded-x");
+    write_applyable_state(dir.path());
+    let converge = apply_config_dir(dir.path()).await;
+    assert!(converge.converged, "{converge:?}");
 
-    // ---- serving snapshot (5B read-only loader) ----
+    let snapshot = read_serving_snapshot(dir.path()).await.unwrap();
+    let profile = snapshot.graphs[0].embedding.as_ref().unwrap();
+    assert_eq!(profile.kind.as_deref(), Some("mock"));
+    assert_eq!(profile.model.as_deref(), Some("recorded-x"));
+}
 
-    // ---- storage: root (RFC-006) ----
+#[tokio::test]
+async fn serving_snapshot_refuses_missing_embedding_provider_metadata() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    write_mock_embedding_cluster(dir.path(), "recorded-x");
+    write_applyable_state(dir.path());
+    let converge = apply_config_dir(dir.path()).await;
+    assert!(converge.converged, "{converge:?}");
 
-    #[tokio::test]
-    async fn storage_root_defaults_to_config_dir_layout() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await;
-        write_applyable_state(dir.path());
-        let out = apply_config_dir(dir.path()).await;
-        assert!(out.converged, "{out:?}");
-        // No storage: key — the original on-disk layout, byte-compatible.
-        assert!(dir.path().join(CLUSTER_STATE_FILE).exists());
-        assert!(dir.path().join(CLUSTER_RESOURCES_DIR).exists());
-        assert!(dir.path().join("graphs/knowledge.omni").exists());
-    }
+    let mut state = read_state_json(dir.path());
+    state["applied_revision"]["resources"]["provider.embedding.default"]
+        .as_object_mut()
+        .unwrap()
+        .remove("embedding_profile");
+    fs::write(
+        dir.path().join(CLUSTER_STATE_FILE),
+        serde_json::to_string_pretty(&state).unwrap(),
+    )
+    .unwrap();
 
-    #[tokio::test]
-    async fn storage_root_file_uri_relocates_the_cluster() {
-        let dir = fixture();
-        let storage = tempfile::tempdir().unwrap();
-        let storage_path = storage.path().to_string_lossy().to_string();
-        let mut config = fs::read_to_string(dir.path().join("cluster.yaml")).unwrap();
-        config = config.replace("version: 1\n", &format!("version: 1\nstorage: {storage_path}\n"));
-        fs::write(dir.path().join("cluster.yaml"), config).unwrap();
+    let err = read_serving_snapshot(dir.path()).await.unwrap_err();
+    assert!(
+        err.iter()
+            .any(|diagnostic| diagnostic.code == "embedding_provider_profile_missing"),
+        "{err:?}"
+    );
+    assert!(
+        err.iter()
+            .any(|diagnostic| diagnostic.code == "embedding_provider_missing"),
+        "{err:?}"
+    );
+}
 
-        let import = import_config_dir(dir.path()).await;
-        assert!(import.ok, "{:?}", import.diagnostics);
-        let out = apply_config_dir(dir.path()).await;
-        assert!(out.ok && out.converged, "{:?}", out.diagnostics);
+#[tokio::test]
+async fn serving_snapshot_refuses_missing_state() {
+    let dir = fixture();
+    let err = read_serving_snapshot(dir.path()).await.unwrap_err();
+    assert!(
+        err.iter()
+            .any(|diagnostic| diagnostic.code == "cluster_state_missing"),
+        "{err:?}"
+    );
+}
 
-        // Everything lives under the declared root; nothing under config dir.
-        assert!(storage.path().join("__cluster/state.json").exists());
-        assert!(storage.path().join("graphs/knowledge.omni").exists());
-        assert!(storage.path().join(CLUSTER_RESOURCES_DIR).exists());
-        assert!(!dir.path().join(CLUSTER_STATE_FILE).exists());
-        assert!(!dir.path().join("graphs").exists());
+#[tokio::test]
+async fn serving_snapshot_refuses_pending_recovery() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    write_applyable_state(dir.path());
+    apply_config_dir(dir.path()).await;
+    write_schema_apply_sidecar(dir.path(), "knowledge", "whatever", "01SERVE");
 
-        // The serving snapshot follows the root.
-        let snapshot = read_serving_snapshot(dir.path()).await.unwrap();
-        assert!(
-            snapshot.graphs[0]
-                .root
-                .starts_with(storage.path()),
-            "{:?}",
-            snapshot.graphs[0].root
-        );
-    }
+    let err = read_serving_snapshot(dir.path()).await.unwrap_err();
+    assert!(
+        err.iter()
+            .any(|diagnostic| diagnostic.code == "cluster_no_healthy_graphs"),
+        "{err:?}"
+    );
+    assert!(
+        err.iter().any(|diagnostic| {
+            diagnostic.code == "cluster_recovery_pending" && diagnostic.path == "graph.knowledge"
+        }),
+        "{err:?}"
+    );
+}
 
-    #[test]
-    fn storage_root_invalid_uri_fails_validation() {
-        let dir = fixture();
-        let mut config = fs::read_to_string(dir.path().join("cluster.yaml")).unwrap();
-        config = config.replace("version: 1\n", "version: 1\nstorage: \"s3://\"\n");
-        fs::write(dir.path().join("cluster.yaml"), config).unwrap();
-        let out = validate_config_dir(dir.path());
-        assert!(!out.ok);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "invalid_storage_root"),
-            "{:?}",
-            out.diagnostics
-        );
-    }
-
-    #[tokio::test]
-    async fn serving_snapshot_reads_converged_cluster() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await;
-        write_applyable_state(dir.path());
-        let converge = apply_config_dir(dir.path()).await;
-        assert!(converge.converged, "{converge:?}");
-
-        let snapshot = read_serving_snapshot(dir.path()).await.expect("converged cluster must serve");
-        assert_eq!(snapshot.graphs.len(), 1);
-        assert_eq!(snapshot.graphs[0].graph_id, "knowledge");
-        assert!(snapshot.graphs[0].root.ends_with("graphs/knowledge.omni"));
-        assert_eq!(snapshot.queries.len(), 1);
-        assert_eq!(snapshot.queries[0].name, "find_person");
-        assert!(snapshot.queries[0].source.contains("query find_person"));
-        assert_eq!(snapshot.policies.len(), 1);
-        assert_eq!(snapshot.policies[0].applies_to, vec!["graph.knowledge"]);
-        // Content, not a path: the catalog may live on object storage.
-        // The fixture bundle is `rules: []` — assert the verified text.
-        assert!(snapshot.policies[0].source.contains("rules:"));
-    }
-
-    #[tokio::test]
-    async fn serving_snapshot_uses_applied_embedding_provider_profile() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await;
-        write_mock_embedding_cluster(dir.path(), "recorded-x");
-        write_applyable_state(dir.path());
-        let converge = apply_config_dir(dir.path()).await;
-        assert!(converge.converged, "{converge:?}");
-
-        let snapshot = read_serving_snapshot(dir.path()).await.unwrap();
-        let profile = snapshot.graphs[0].embedding.as_ref().unwrap();
-        assert_eq!(profile.kind.as_deref(), Some("mock"));
-        assert_eq!(profile.model.as_deref(), Some("recorded-x"));
-    }
-
-    #[tokio::test]
-    async fn serving_snapshot_refuses_missing_embedding_provider_metadata() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await;
-        write_mock_embedding_cluster(dir.path(), "recorded-x");
-        write_applyable_state(dir.path());
-        let converge = apply_config_dir(dir.path()).await;
-        assert!(converge.converged, "{converge:?}");
-
-        let mut state = read_state_json(dir.path());
-        state["applied_revision"]["resources"]["provider.embedding.default"]
-            .as_object_mut()
-            .unwrap()
-            .remove("embedding_profile");
-        fs::write(
-            dir.path().join(CLUSTER_STATE_FILE),
-            serde_json::to_string_pretty(&state).unwrap(),
-        )
-        .unwrap();
-
-        let err = read_serving_snapshot(dir.path()).await.unwrap_err();
-        assert!(
-            err.iter()
-                .any(|diagnostic| diagnostic.code == "embedding_provider_profile_missing"),
-            "{err:?}"
-        );
-        assert!(
-            err.iter()
-                .any(|diagnostic| diagnostic.code == "embedding_provider_missing"),
-            "{err:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn serving_snapshot_refuses_missing_state() {
-        let dir = fixture();
-        let err = read_serving_snapshot(dir.path()).await.unwrap_err();
-        assert!(
-            err.iter().any(|diagnostic| diagnostic.code == "cluster_state_missing"),
-            "{err:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn serving_snapshot_refuses_pending_recovery() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await;
-        write_applyable_state(dir.path());
-        apply_config_dir(dir.path()).await;
-        write_schema_apply_sidecar(dir.path(), "knowledge", "whatever", "01SERVE");
-
-        let err = read_serving_snapshot(dir.path()).await.unwrap_err();
-        assert!(
-            err.iter()
-                .any(|diagnostic| diagnostic.code == "cluster_no_healthy_graphs"),
-            "{err:?}"
-        );
-        assert!(
-            err.iter().any(|diagnostic| {
-                diagnostic.code == "cluster_recovery_pending"
-                    && diagnostic.path == "graph.knowledge"
-            }),
-            "{err:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn serving_snapshot_quarantines_one_graph_with_pending_recovery() {
-        let dir = fixture();
-        fs::write(
-            dir.path().join(CLUSTER_CONFIG_FILE),
-            r#"
+#[tokio::test]
+async fn serving_snapshot_quarantines_one_graph_with_pending_recovery() {
+    let dir = fixture();
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        r#"
 version: 1
 metadata:
   name: test
@@ -3539,370 +3588,395 @@ graphs:
   archive:
     schema: ./people.pg
 "#,
-        )
-        .unwrap();
-        let graph_dir = dir.path().join(CLUSTER_GRAPHS_DIR);
-        fs::create_dir_all(&graph_dir).unwrap();
-        Omnigraph::init(
-            graph_dir.join("knowledge.omni").to_string_lossy().as_ref(),
-            SCHEMA,
-        )
-        .await
-        .unwrap();
-        Omnigraph::init(
-            graph_dir.join("archive.omni").to_string_lossy().as_ref(),
-            SCHEMA,
-        )
-        .await
-        .unwrap();
-        let desired = validate_config_dir(dir.path());
-        assert!(desired.ok, "{:?}", desired.diagnostics);
-        let schema_digest = desired.resource_digests["schema.knowledge"].clone();
-        let empty_queries = BTreeMap::new();
-        let knowledge_digest = graph_digest(
-            "knowledge",
-            Some(&schema_digest),
-            Some(&empty_queries),
-            None,
-            None,
-        );
-        let archive_digest = graph_digest(
-            "archive",
-            Some(&schema_digest),
-            Some(&empty_queries),
-            None,
-            None,
-        );
-        write_state_resources(
-            dir.path(),
-            &[
-                ("graph.knowledge", knowledge_digest.as_str()),
-                ("schema.knowledge", schema_digest.as_str()),
-                ("graph.archive", archive_digest.as_str()),
-                ("schema.archive", schema_digest.as_str()),
-            ],
-        );
-        write_schema_apply_sidecar(dir.path(), "knowledge", "whatever", "01SERVE2");
+    )
+    .unwrap();
+    let graph_dir = dir.path().join(CLUSTER_GRAPHS_DIR);
+    fs::create_dir_all(&graph_dir).unwrap();
+    Omnigraph::init(
+        graph_dir.join("knowledge.omni").to_string_lossy().as_ref(),
+        SCHEMA,
+    )
+    .await
+    .unwrap();
+    Omnigraph::init(
+        graph_dir.join("archive.omni").to_string_lossy().as_ref(),
+        SCHEMA,
+    )
+    .await
+    .unwrap();
+    let desired = validate_config_dir(dir.path());
+    assert!(desired.ok, "{:?}", desired.diagnostics);
+    let schema_digest = desired.resource_digests["schema.knowledge"].clone();
+    let empty_queries = BTreeMap::new();
+    let knowledge_digest = graph_digest(
+        "knowledge",
+        Some(&schema_digest),
+        Some(&empty_queries),
+        None,
+        None,
+    );
+    let archive_digest = graph_digest(
+        "archive",
+        Some(&schema_digest),
+        Some(&empty_queries),
+        None,
+        None,
+    );
+    write_state_resources(
+        dir.path(),
+        &[
+            ("graph.knowledge", knowledge_digest.as_str()),
+            ("schema.knowledge", schema_digest.as_str()),
+            ("graph.archive", archive_digest.as_str()),
+            ("schema.archive", schema_digest.as_str()),
+        ],
+    );
+    write_schema_apply_sidecar(dir.path(), "knowledge", "whatever", "01SERVE2");
 
-        let snapshot = read_serving_snapshot(dir.path()).await.unwrap();
-        assert_eq!(snapshot.graphs.len(), 1);
-        assert_eq!(snapshot.graphs[0].graph_id, "archive");
-        assert!(snapshot.queries.is_empty());
-        assert!(snapshot.policies.is_empty());
-        assert!(snapshot.diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == "cluster_recovery_pending"
-                && diagnostic.path == "graph.knowledge"
-                && diagnostic.severity == DiagnosticSeverity::Warning
-        }));
-    }
+    let snapshot = read_serving_snapshot(dir.path()).await.unwrap();
+    assert_eq!(snapshot.graphs.len(), 1);
+    assert_eq!(snapshot.graphs[0].graph_id, "archive");
+    assert!(snapshot.queries.is_empty());
+    assert!(snapshot.policies.is_empty());
+    assert!(snapshot.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "cluster_recovery_pending"
+            && diagnostic.path == "graph.knowledge"
+            && diagnostic.severity == DiagnosticSeverity::Warning
+    }));
+}
 
-    #[tokio::test]
-    async fn serving_snapshot_refuses_tampered_blob_and_stripped_bindings() {
-        let dir = fixture();
-        init_derived_graph(dir.path()).await;
-        write_applyable_state(dir.path());
-        apply_config_dir(dir.path()).await;
-        // Tamper with the query blob...
-        let snapshot = read_serving_snapshot(dir.path()).await.unwrap();
-        let desired = validate_config_dir(dir.path());
-        let query_digest = &desired.resource_digests["query.knowledge.find_person"];
-        let blob = dir
-            .path()
-            .join(CLUSTER_RESOURCES_DIR)
-            .join("query/knowledge/find_person")
-            .join(format!("{query_digest}.gq"));
-        fs::write(&blob, "tampered").unwrap();
-        // ...and strip the policy bindings (pre-5A ledger).
-        let mut state: serde_json::Value = serde_json::from_str(
-            &fs::read_to_string(dir.path().join(CLUSTER_STATE_FILE)).unwrap(),
-        )
-        .unwrap();
-        state["applied_revision"]["resources"]["policy.base"]
-            .as_object_mut()
-            .unwrap()
-            .remove("applies_to");
-        fs::write(
-            dir.path().join(CLUSTER_STATE_FILE),
-            serde_json::to_string_pretty(&state).unwrap(),
-        )
-        .unwrap();
+#[tokio::test]
+async fn serving_snapshot_refuses_tampered_blob_and_stripped_bindings() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    write_applyable_state(dir.path());
+    apply_config_dir(dir.path()).await;
+    // Tamper with the query blob...
+    let snapshot = read_serving_snapshot(dir.path()).await.unwrap();
+    let desired = validate_config_dir(dir.path());
+    let query_digest = &desired.resource_digests["query.knowledge.find_person"];
+    let blob = dir
+        .path()
+        .join(CLUSTER_RESOURCES_DIR)
+        .join("query/knowledge/find_person")
+        .join(format!("{query_digest}.gq"));
+    fs::write(&blob, "tampered").unwrap();
+    // ...and strip the policy bindings (pre-5A ledger).
+    let mut state: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(dir.path().join(CLUSTER_STATE_FILE)).unwrap())
+            .unwrap();
+    state["applied_revision"]["resources"]["policy.base"]
+        .as_object_mut()
+        .unwrap()
+        .remove("applies_to");
+    fs::write(
+        dir.path().join(CLUSTER_STATE_FILE),
+        serde_json::to_string_pretty(&state).unwrap(),
+    )
+    .unwrap();
 
-        let err = read_serving_snapshot(dir.path()).await.unwrap_err();
-        assert!(
-            err.iter()
-                .any(|diagnostic| diagnostic.code == "catalog_payload_digest_mismatch"),
-            "{err:?}"
-        );
-        assert!(
-            err.iter().any(|diagnostic| diagnostic.code == "policy_bindings_missing"),
-            "{err:?}"
-        );
-        let _ = snapshot; // the pre-tamper read succeeded
-    }
+    let err = read_serving_snapshot(dir.path()).await.unwrap_err();
+    assert!(
+        err.iter()
+            .any(|diagnostic| diagnostic.code == "catalog_payload_digest_mismatch"),
+        "{err:?}"
+    );
+    assert!(
+        err.iter()
+            .any(|diagnostic| diagnostic.code == "policy_bindings_missing"),
+        "{err:?}"
+    );
+    let _ = snapshot; // the pre-tamper read succeeded
+}
 
-    #[tokio::test]
-    async fn serving_snapshot_refuses_empty_cluster() {
-        let dir = fixture();
-        write_state_resources(dir.path(), &[]); // state exists, no graphs
+#[tokio::test]
+async fn serving_snapshot_refuses_empty_cluster() {
+    let dir = fixture();
+    write_state_resources(dir.path(), &[]); // state exists, no graphs
 
-        let err = read_serving_snapshot(dir.path()).await.unwrap_err();
-        assert!(
-            err.iter().any(|diagnostic| diagnostic.code == "cluster_empty"),
-            "{err:?}"
-        );
-    }
+    let err = read_serving_snapshot(dir.path()).await.unwrap_err();
+    assert!(
+        err.iter()
+            .any(|diagnostic| diagnostic.code == "cluster_empty"),
+        "{err:?}"
+    );
+}
 
-    // ---- query discovery (Terraform-style declaration) ----
+// ---- query discovery (Terraform-style declaration) ----
 
-    #[test]
-    fn queries_directory_discovers_every_declaration() {
-        let dir = tempfile::tempdir().unwrap();
-        fs::write(dir.path().join("people.pg"), "\nnode Person {\n  name: String @key\n}\n").unwrap();
-        fs::create_dir(dir.path().join("queries")).unwrap();
-        fs::write(
+#[test]
+fn queries_directory_discovers_every_declaration() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("people.pg"),
+        "\nnode Person {\n  name: String @key\n}\n",
+    )
+    .unwrap();
+    fs::create_dir(dir.path().join("queries")).unwrap();
+    fs::write(
             dir.path().join("queries/people.gq"),
             "\nquery find_person($name: String) {\n  match { $p: Person { name: $name } }\n  return { $p.name }\n}\n\nquery all_people() {\n  match { $p: Person }\n  return { $p.name }\n}\n",
         )
         .unwrap();
-        fs::write(
-            dir.path().join("queries/extra.gq"),
-            "\nquery count_people() {\n  match { $p: Person }\n  return { count($p) }\n}\n",
-        )
-        .unwrap();
-        fs::write(dir.path().join("queries/notes.txt"), "ignored").unwrap();
-        fs::write(
-            dir.path().join("cluster.yaml"),
-            "version: 1\ngraphs:\n  knowledge:\n    schema: ./people.pg\n    queries: ./queries/\n",
-        )
-        .unwrap();
+    fs::write(
+        dir.path().join("queries/extra.gq"),
+        "\nquery count_people() {\n  match { $p: Person }\n  return { count($p) }\n}\n",
+    )
+    .unwrap();
+    fs::write(dir.path().join("queries/notes.txt"), "ignored").unwrap();
+    fs::write(
+        dir.path().join("cluster.yaml"),
+        "version: 1\ngraphs:\n  knowledge:\n    schema: ./people.pg\n    queries: ./queries/\n",
+    )
+    .unwrap();
 
-        let out = validate_config_dir(dir.path());
-        assert!(out.ok, "{:?}", out.diagnostics);
-        let names: Vec<&str> = out
-            .resource_digests
-            .keys()
-            .filter_map(|address| address.strip_prefix("query.knowledge."))
-            .collect();
-        assert_eq!(names, vec!["all_people", "count_people", "find_person"]);
-    }
+    let out = validate_config_dir(dir.path());
+    assert!(out.ok, "{:?}", out.diagnostics);
+    let names: Vec<&str> = out
+        .resource_digests
+        .keys()
+        .filter_map(|address| address.strip_prefix("query.knowledge."))
+        .collect();
+    assert_eq!(names, vec!["all_people", "count_people", "find_person"]);
+}
 
-    #[test]
-    fn queries_list_and_single_file_forms_discover() {
-        let dir = tempfile::tempdir().unwrap();
-        fs::write(dir.path().join("people.pg"), "\nnode Person {\n  name: String @key\n}\n").unwrap();
-        fs::write(
+#[test]
+fn queries_list_and_single_file_forms_discover() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("people.pg"),
+        "\nnode Person {\n  name: String @key\n}\n",
+    )
+    .unwrap();
+    fs::write(
             dir.path().join("a.gq"),
             "\nquery find_person($name: String) {\n  match { $p: Person { name: $name } }\n  return { $p.name }\n}\n",
         )
         .unwrap();
-        fs::write(
-            dir.path().join("b.gq"),
-            "\nquery all_people() {\n  match { $p: Person }\n  return { $p.name }\n}\n",
-        )
-        .unwrap();
-        fs::write(
+    fs::write(
+        dir.path().join("b.gq"),
+        "\nquery all_people() {\n  match { $p: Person }\n  return { $p.name }\n}\n",
+    )
+    .unwrap();
+    fs::write(
             dir.path().join("cluster.yaml"),
             "version: 1\ngraphs:\n  knowledge:\n    schema: ./people.pg\n    queries: [./a.gq, ./b.gq]\n",
         )
         .unwrap();
-        let out = validate_config_dir(dir.path());
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert!(out.resource_digests.contains_key("query.knowledge.find_person"));
-        assert!(out.resource_digests.contains_key("query.knowledge.all_people"));
+    let out = validate_config_dir(dir.path());
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert!(
+        out.resource_digests
+            .contains_key("query.knowledge.find_person")
+    );
+    assert!(
+        out.resource_digests
+            .contains_key("query.knowledge.all_people")
+    );
 
-        // Single-file string form
-        fs::write(
-            dir.path().join("cluster.yaml"),
-            "version: 1\ngraphs:\n  knowledge:\n    schema: ./people.pg\n    queries: ./a.gq\n",
-        )
-        .unwrap();
-        let out = validate_config_dir(dir.path());
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert!(out.resource_digests.contains_key("query.knowledge.find_person"));
-        assert!(!out.resource_digests.contains_key("query.knowledge.all_people"));
-    }
+    // Single-file string form
+    fs::write(
+        dir.path().join("cluster.yaml"),
+        "version: 1\ngraphs:\n  knowledge:\n    schema: ./people.pg\n    queries: ./a.gq\n",
+    )
+    .unwrap();
+    let out = validate_config_dir(dir.path());
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert!(
+        out.resource_digests
+            .contains_key("query.knowledge.find_person")
+    );
+    assert!(
+        !out.resource_digests
+            .contains_key("query.knowledge.all_people")
+    );
+}
 
-    #[test]
-    fn query_discovery_rejects_duplicates_and_parse_errors() {
-        let dir = tempfile::tempdir().unwrap();
-        fs::write(dir.path().join("people.pg"), "\nnode Person {\n  name: String @key\n}\n").unwrap();
-        let decl = "\nquery find_person($name: String) {\n  match { $p: Person { name: $name } }\n  return { $p.name }\n}\n";
-        fs::write(dir.path().join("a.gq"), decl).unwrap();
-        fs::write(dir.path().join("b.gq"), decl).unwrap();
-        fs::write(
+#[test]
+fn query_discovery_rejects_duplicates_and_parse_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("people.pg"),
+        "\nnode Person {\n  name: String @key\n}\n",
+    )
+    .unwrap();
+    let decl = "\nquery find_person($name: String) {\n  match { $p: Person { name: $name } }\n  return { $p.name }\n}\n";
+    fs::write(dir.path().join("a.gq"), decl).unwrap();
+    fs::write(dir.path().join("b.gq"), decl).unwrap();
+    fs::write(
             dir.path().join("cluster.yaml"),
             "version: 1\ngraphs:\n  knowledge:\n    schema: ./people.pg\n    queries: [./a.gq, ./b.gq]\n",
         )
         .unwrap();
-        let out = validate_config_dir(dir.path());
-        assert!(!out.ok);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "duplicate_query_name"),
-            "{:?}",
-            out.diagnostics
-        );
-
-        fs::write(dir.path().join("broken.gq"), "query {{{ nope").unwrap();
-        fs::write(
-            dir.path().join("cluster.yaml"),
-            "version: 1\ngraphs:\n  knowledge:\n    schema: ./people.pg\n    queries: ./broken.gq\n",
-        )
-        .unwrap();
-        let out = validate_config_dir(dir.path());
-        assert!(!out.ok);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "query_parse_error"),
-            "{:?}",
-            out.diagnostics
-        );
-    }
-
-    #[tokio::test]
-    async fn status_warns_on_pending_recovery_sidecar() {
-        let dir = fixture();
-        write_applyable_state(dir.path());
-        write_create_sidecar(dir.path(), "knowledge", "irrelevant", "01STATUS");
-
-        let out = status_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert!(
-            out.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "cluster_recovery_pending"
-                    && diagnostic.severity == DiagnosticSeverity::Warning)
-        );
-    }
-
-    #[tokio::test]
-    async fn read_only_commands_ignore_missing_recovery_sidecar_dir() {
-        let dir = fixture();
-        write_applyable_state(dir.path());
-        assert!(!dir.path().join(CLUSTER_RECOVERIES_DIR).exists());
-
-        let status = status_config_dir(dir.path()).await;
-        assert!(status.ok, "{:?}", status.diagnostics);
-        assert!(
-            !status.diagnostics.iter().any(|diagnostic| matches!(
-                diagnostic.code.as_str(),
-                "recovery_sidecar_read_error" | "cluster_recovery_pending"
-            )),
-            "{:?}",
-            status.diagnostics
-        );
-
-        let plan = plan_config_dir(dir.path()).await;
-        assert!(plan.ok, "{:?}", plan.diagnostics);
-        assert!(
-            !plan.diagnostics.iter().any(|diagnostic| matches!(
-                diagnostic.code.as_str(),
-                "recovery_sidecar_read_error" | "cluster_recovery_pending"
-            )),
-            "{:?}",
-            plan.diagnostics
-        );
-    }
-
-    #[tokio::test]
-    async fn read_only_commands_warn_on_pending_recovery_sidecar_in_storage_root() {
-        let dir = fixture();
-        let storage = tempfile::tempdir().unwrap();
-        let storage_path = storage.path().to_string_lossy().to_string();
-        let mut config = fs::read_to_string(dir.path().join(CLUSTER_CONFIG_FILE)).unwrap();
-        config = config.replace(
-            "version: 1\n",
-            &format!("version: 1\nstorage: {storage_path}\n"),
-        );
-        fs::write(dir.path().join(CLUSTER_CONFIG_FILE), config).unwrap();
-
-        let desired = validate_config_dir(dir.path());
-        assert!(desired.ok, "{:?}", desired.diagnostics);
-        let schema_digest = desired
-            .resource_digests
-            .get("schema.knowledge")
-            .unwrap()
-            .clone();
-        let graph_composite = graph_digest(
-            "knowledge",
-            Some(&schema_digest),
-            Some(&BTreeMap::new()),
-            None,
-            None,
-        );
-        write_state_resources(
-            storage.path(),
-            &[
-                ("graph.knowledge", graph_composite.as_str()),
-                ("schema.knowledge", schema_digest.as_str()),
-            ],
-        );
-        write_create_sidecar(storage.path(), "knowledge", "irrelevant", "01STORAGE");
-
-        let status = status_config_dir(dir.path()).await;
-        assert!(status.ok, "{:?}", status.diagnostics);
-        assert!(
-            status
-                .diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "cluster_recovery_pending"
-                    && diagnostic.path.contains("01STORAGE.json")),
-            "{:?}",
-            status.diagnostics
-        );
-
-        let plan = plan_config_dir(dir.path()).await;
-        assert!(plan.ok, "{:?}", plan.diagnostics);
-        assert!(
-            plan.diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "cluster_recovery_pending"
-                    && diagnostic.path.contains("01STORAGE.json")),
-            "{:?}",
-            plan.diagnostics
-        );
-
-        assert!(!dir.path().join(CLUSTER_RECOVERIES_DIR).exists());
-    }
-
-    #[tokio::test]
-    async fn plan_annotates_apply_dispositions() {
-        let dir = fixture();
-        let out = plan_config_dir(dir.path()).await;
-        assert!(out.ok, "{:?}", out.diagnostics);
-        let by_resource: BTreeMap<&str, &PlanChange> = out
-            .changes
+    let out = validate_config_dir(dir.path());
+    assert!(!out.ok);
+    assert!(
+        out.diagnostics
             .iter()
-            .map(|change| (change.resource.as_str(), change))
-            .collect();
-        // Stage 4A: graph/schema creates are executable, and dependents ride
-        // the same run — plan previews exactly that.
-        assert_eq!(
-            by_resource["graph.knowledge"].disposition,
-            Some(ApplyDisposition::Applied)
-        );
-        assert_eq!(
-            by_resource["schema.knowledge"].disposition,
-            Some(ApplyDisposition::Applied)
-        );
-        assert_eq!(
-            by_resource["query.knowledge.find_person"].disposition,
-            Some(ApplyDisposition::Applied)
-        );
-        assert_eq!(
-            by_resource["policy.base"].disposition,
-            Some(ApplyDisposition::Applied)
-        );
-    }
+            .any(|diagnostic| diagnostic.code == "duplicate_query_name"),
+        "{:?}",
+        out.diagnostics
+    );
 
-    // ---- RFC-026 §4.7 P1: streaming enablement (slice 1) ----
+    fs::write(dir.path().join("broken.gq"), "query {{{ nope").unwrap();
+    fs::write(
+        dir.path().join("cluster.yaml"),
+        "version: 1\ngraphs:\n  knowledge:\n    schema: ./people.pg\n    queries: ./broken.gq\n",
+    )
+    .unwrap();
+    let out = validate_config_dir(dir.path());
+    assert!(!out.ok);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "query_parse_error"),
+        "{:?}",
+        out.diagnostics
+    );
+}
 
-    fn write_streaming_cluster(config_dir: &Path, streaming: Option<bool>) {
-        fs::write(
-            config_dir.join("base.policy.yaml"),
-            r#"
+#[tokio::test]
+async fn status_warns_on_pending_recovery_sidecar() {
+    let dir = fixture();
+    write_applyable_state(dir.path());
+    write_create_sidecar(dir.path(), "knowledge", "irrelevant", "01STATUS");
+
+    let out = status_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "cluster_recovery_pending"
+                && diagnostic.severity == DiagnosticSeverity::Warning)
+    );
+}
+
+#[tokio::test]
+async fn read_only_commands_ignore_missing_recovery_sidecar_dir() {
+    let dir = fixture();
+    write_applyable_state(dir.path());
+    assert!(!dir.path().join(CLUSTER_RECOVERIES_DIR).exists());
+
+    let status = status_config_dir(dir.path()).await;
+    assert!(status.ok, "{:?}", status.diagnostics);
+    assert!(
+        !status.diagnostics.iter().any(|diagnostic| matches!(
+            diagnostic.code.as_str(),
+            "recovery_sidecar_read_error" | "cluster_recovery_pending"
+        )),
+        "{:?}",
+        status.diagnostics
+    );
+
+    let plan = plan_config_dir(dir.path()).await;
+    assert!(plan.ok, "{:?}", plan.diagnostics);
+    assert!(
+        !plan.diagnostics.iter().any(|diagnostic| matches!(
+            diagnostic.code.as_str(),
+            "recovery_sidecar_read_error" | "cluster_recovery_pending"
+        )),
+        "{:?}",
+        plan.diagnostics
+    );
+}
+
+#[tokio::test]
+async fn read_only_commands_warn_on_pending_recovery_sidecar_in_storage_root() {
+    let dir = fixture();
+    let storage = tempfile::tempdir().unwrap();
+    let storage_path = storage.path().to_string_lossy().to_string();
+    let mut config = fs::read_to_string(dir.path().join(CLUSTER_CONFIG_FILE)).unwrap();
+    config = config.replace(
+        "version: 1\n",
+        &format!("version: 1\nstorage: {storage_path}\n"),
+    );
+    fs::write(dir.path().join(CLUSTER_CONFIG_FILE), config).unwrap();
+
+    let desired = validate_config_dir(dir.path());
+    assert!(desired.ok, "{:?}", desired.diagnostics);
+    let schema_digest = desired
+        .resource_digests
+        .get("schema.knowledge")
+        .unwrap()
+        .clone();
+    let graph_composite = graph_digest(
+        "knowledge",
+        Some(&schema_digest),
+        Some(&BTreeMap::new()),
+        None,
+        None,
+    );
+    write_state_resources(
+        storage.path(),
+        &[
+            ("graph.knowledge", graph_composite.as_str()),
+            ("schema.knowledge", schema_digest.as_str()),
+        ],
+    );
+    write_create_sidecar(storage.path(), "knowledge", "irrelevant", "01STORAGE");
+
+    let status = status_config_dir(dir.path()).await;
+    assert!(status.ok, "{:?}", status.diagnostics);
+    assert!(
+        status
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "cluster_recovery_pending"
+                && diagnostic.path.contains("01STORAGE.json")),
+        "{:?}",
+        status.diagnostics
+    );
+
+    let plan = plan_config_dir(dir.path()).await;
+    assert!(plan.ok, "{:?}", plan.diagnostics);
+    assert!(
+        plan.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "cluster_recovery_pending"
+                && diagnostic.path.contains("01STORAGE.json")),
+        "{:?}",
+        plan.diagnostics
+    );
+
+    assert!(!dir.path().join(CLUSTER_RECOVERIES_DIR).exists());
+}
+
+#[tokio::test]
+async fn plan_annotates_apply_dispositions() {
+    let dir = fixture();
+    let out = plan_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    let by_resource: BTreeMap<&str, &PlanChange> = out
+        .changes
+        .iter()
+        .map(|change| (change.resource.as_str(), change))
+        .collect();
+    // Stage 4A: graph/schema creates are executable, and dependents ride
+    // the same run — plan previews exactly that.
+    assert_eq!(
+        by_resource["graph.knowledge"].disposition,
+        Some(ApplyDisposition::Applied)
+    );
+    assert_eq!(
+        by_resource["schema.knowledge"].disposition,
+        Some(ApplyDisposition::Applied)
+    );
+    assert_eq!(
+        by_resource["query.knowledge.find_person"].disposition,
+        Some(ApplyDisposition::Applied)
+    );
+    assert_eq!(
+        by_resource["policy.base"].disposition,
+        Some(ApplyDisposition::Applied)
+    );
+}
+
+// ---- RFC-026 §4.7 P1: streaming enablement (slice 1) ----
+
+fn write_streaming_cluster(config_dir: &Path, streaming: Option<bool>) {
+    fs::write(
+        config_dir.join("base.policy.yaml"),
+        r#"
 version: 1
 groups:
   stream_operators: [stream-operator]
@@ -3912,16 +3986,16 @@ rules:
       actors: { group: stream_operators }
       actions: [stream_manage]
 "#,
-        )
-        .unwrap();
-        let streaming_line = match streaming {
-            Some(enabled) => format!("    streaming: {enabled}\n"),
-            None => String::new(),
-        };
-        fs::write(
-            config_dir.join(CLUSTER_CONFIG_FILE),
-            format!(
-                r#"
+    )
+    .unwrap();
+    let streaming_line = match streaming {
+        Some(enabled) => format!("    streaming: {enabled}\n"),
+        None => String::new(),
+    };
+    fs::write(
+        config_dir.join(CLUSTER_CONFIG_FILE),
+        format!(
+            r#"
 version: 1
 metadata:
   name: test
@@ -3939,577 +4013,588 @@ policies:
     file: ./base.policy.yaml
     applies_to: [knowledge]
 "#
-            ),
-        )
-        .unwrap();
-    }
+        ),
+    )
+    .unwrap();
+}
 
-    async fn confirmed_streaming_apply(config_dir: &Path) -> ApplyOutput {
-        apply_config_dir_with_options(
-            config_dir,
-            ApplyOptions {
-                actor: Some("stream-operator".to_string()),
-                confirm_stream_offline: true,
-            },
-        )
+async fn confirmed_streaming_apply(config_dir: &Path) -> ApplyOutput {
+    apply_config_dir_with_options(
+        config_dir,
+        ApplyOptions {
+            actor: Some("stream-operator".to_string()),
+            confirm_stream_offline: true,
+        },
+    )
+    .await
+}
+
+async fn live_streaming_enabled(config_dir: &Path) -> bool {
+    let graph_uri = format!("{}/graphs/knowledge.omni", config_dir.display());
+    let db = Omnigraph::open_read_only(&graph_uri).await.unwrap();
+    db.snapshot_of(omnigraph::db::ReadTarget::branch("main"))
         .await
-    }
+        .unwrap()
+        .streaming_status()
+        .enabled
+}
 
-    async fn live_streaming_enabled(config_dir: &Path) -> bool {
-        let graph_uri = format!("{}/graphs/knowledge.omni", config_dir.display());
-        let db = Omnigraph::open_read_only(&graph_uri).await.unwrap();
-        db.snapshot_of(omnigraph::db::ReadTarget::branch("main"))
-            .await
-            .unwrap()
-            .streaming_status()
-            .enabled
-    }
+#[test]
+fn unreadable_pre_schema_stream_probe_is_unknown_not_safe() {
+    assert_eq!(
+        classify_pre_schema_stream_probe(Err::<&str, ()>(())),
+        PreSchemaStreamProbe::Unknown
+    );
+    assert_eq!(
+        classify_pre_schema_stream_probe(Ok::<&str, ()>("DISABLING")),
+        PreSchemaStreamProbe::Disabling
+    );
+    assert_eq!(
+        classify_pre_schema_stream_probe(Ok::<&str, ()>("ENABLED")),
+        PreSchemaStreamProbe::Other
+    );
+}
 
-    #[test]
-    fn unreadable_pre_schema_stream_probe_is_unknown_not_safe() {
-        assert_eq!(
-            classify_pre_schema_stream_probe(Err::<&str, ()>(())),
-            PreSchemaStreamProbe::Unknown
-        );
-        assert_eq!(
-            classify_pre_schema_stream_probe(Ok::<&str, ()>("DISABLING")),
-            PreSchemaStreamProbe::Disabling
-        );
-        assert_eq!(
-            classify_pre_schema_stream_probe(Ok::<&str, ()>("ENABLED")),
-            PreSchemaStreamProbe::Other
-        );
-    }
+#[test]
+fn streaming_config_accepts_bool_and_rejects_non_bool() {
+    let dir = fixture();
+    write_streaming_cluster(dir.path(), Some(true));
+    let out = validate_config_dir(dir.path());
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert!(
+        out.resource_digests.contains_key("streaming.knowledge"),
+        "declared streaming must emit its first-class resource: {:?}",
+        out.resource_digests
+    );
 
-    #[test]
-    fn streaming_config_accepts_bool_and_rejects_non_bool() {
-        let dir = fixture();
-        write_streaming_cluster(dir.path(), Some(true));
-        let out = validate_config_dir(dir.path());
-        assert!(out.ok, "{:?}", out.diagnostics);
-        assert!(
-            out.resource_digests.contains_key("streaming.knowledge"),
-            "declared streaming must emit its first-class resource: {:?}",
-            out.resource_digests
-        );
+    // Absent = unmanaged: no resource, and (load-bearing for approvals)
+    // the config digest must be byte-identical to a pre-streaming config.
+    write_streaming_cluster(dir.path(), None);
+    let unmanaged = validate_config_dir(dir.path());
+    assert!(unmanaged.ok);
+    assert!(
+        !unmanaged
+            .resource_digests
+            .contains_key("streaming.knowledge")
+    );
 
-        // Absent = unmanaged: no resource, and (load-bearing for approvals)
-        // the config digest must be byte-identical to a pre-streaming config.
-        write_streaming_cluster(dir.path(), None);
-        let unmanaged = validate_config_dir(dir.path());
-        assert!(unmanaged.ok);
-        assert!(!unmanaged.resource_digests.contains_key("streaming.knowledge"));
-
-        fs::write(
-            dir.path().join(CLUSTER_CONFIG_FILE),
-            r#"
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        r#"
 version: 1
 graphs:
   knowledge:
     schema: ./people.pg
     streaming: "yes"
 "#,
-        )
-        .unwrap();
-        let rejected = validate_config_dir(dir.path());
-        assert!(
-            !rejected.ok,
-            "a non-boolean streaming declaration must be a validation error"
-        );
-    }
+    )
+    .unwrap();
+    let rejected = validate_config_dir(dir.path());
+    assert!(
+        !rejected.ok,
+        "a non-boolean streaming declaration must be a validation error"
+    );
+}
 
-    #[test]
-    fn streaming_classifies_first_class_and_drain_pending_blocks() {
-        // The dedicated resource kind parses, and a drain-pending graph
-        // blocks the flip with the §4.7 P1 disposition — the shape later
-        // slices populate from live observation. Delete stays Applied
-        // (unmanage = ledger-row removal, never an engine call).
-        assert_eq!(
-            resource_kind("streaming.knowledge"),
-            ResourceKind::Streaming("knowledge".to_string())
-        );
-        let mut changes = vec![
-            PlanChange {
-                resource: "streaming.knowledge".to_string(),
-                operation: PlanOperation::Update,
-                before_digest: Some("a".to_string()),
-                after_digest: Some("b".to_string()),
-                disposition: None,
-                reason: None,
-                binding_change: false,
-                metadata_change: None,
-                migration: None,
-            },
-            PlanChange {
-                resource: "streaming.other".to_string(),
-                operation: PlanOperation::Delete,
-                before_digest: Some("a".to_string()),
-                after_digest: None,
-                disposition: None,
-                reason: None,
-                binding_change: false,
-                metadata_change: None,
-                migration: None,
-            },
-        ];
-        let drain_pending = BTreeSet::from(["knowledge".to_string(), "other".to_string()]);
-        classify_changes(
-            &mut changes,
-            &[],
-            &BTreeSet::new(),
-            &BTreeSet::new(),
-            &drain_pending,
-        );
-        assert_eq!(changes[0].disposition, Some(ApplyDisposition::Blocked));
-        assert_eq!(changes[0].reason.as_deref(), Some("streaming_drain_pending"));
-        assert_eq!(changes[1].disposition, Some(ApplyDisposition::Applied));
-        assert_eq!(changes[1].reason, None);
-    }
+#[test]
+fn streaming_classifies_first_class_and_drain_pending_blocks() {
+    // The dedicated resource kind parses, and a drain-pending graph
+    // blocks the flip with the §4.7 P1 disposition — the shape later
+    // slices populate from live observation. Delete stays Applied
+    // (unmanage = ledger-row removal, never an engine call).
+    assert_eq!(
+        resource_kind("streaming.knowledge"),
+        ResourceKind::Streaming("knowledge".to_string())
+    );
+    let mut changes = vec![
+        PlanChange {
+            resource: "streaming.knowledge".to_string(),
+            operation: PlanOperation::Update,
+            before_digest: Some("a".to_string()),
+            after_digest: Some("b".to_string()),
+            disposition: None,
+            reason: None,
+            binding_change: false,
+            metadata_change: None,
+            migration: None,
+        },
+        PlanChange {
+            resource: "streaming.other".to_string(),
+            operation: PlanOperation::Delete,
+            before_digest: Some("a".to_string()),
+            after_digest: None,
+            disposition: None,
+            reason: None,
+            binding_change: false,
+            metadata_change: None,
+            migration: None,
+        },
+    ];
+    let drain_pending = BTreeSet::from(["knowledge".to_string(), "other".to_string()]);
+    classify_changes(
+        &mut changes,
+        &[],
+        &BTreeSet::new(),
+        &BTreeSet::new(),
+        &drain_pending,
+    );
+    assert_eq!(changes[0].disposition, Some(ApplyDisposition::Blocked));
+    assert_eq!(
+        changes[0].reason.as_deref(),
+        Some("streaming_drain_pending")
+    );
+    assert_eq!(changes[1].disposition, Some(ApplyDisposition::Applied));
+    assert_eq!(changes[1].reason, None);
+}
 
-    #[tokio::test]
-    async fn streaming_apply_requires_lock_confirmation_and_actor_before_graph_effects() {
-        let dir = fixture();
-        write_streaming_cluster(dir.path(), Some(true));
-        write_state_resources(dir.path(), &[]);
+#[tokio::test]
+async fn streaming_apply_requires_lock_confirmation_and_actor_before_graph_effects() {
+    let dir = fixture();
+    write_streaming_cluster(dir.path(), Some(true));
+    write_state_resources(dir.path(), &[]);
 
-        let unconfirmed = apply_config_dir(dir.path()).await;
-        assert!(!unconfirmed.ok, "{unconfirmed:?}");
-        assert!(unconfirmed.diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == "streaming_offline_confirmation_required"
-        }));
-        assert!(unconfirmed
+    let unconfirmed = apply_config_dir(dir.path()).await;
+    assert!(!unconfirmed.ok, "{unconfirmed:?}");
+    assert!(
+        unconfirmed
             .diagnostics
             .iter()
-            .any(|diagnostic| diagnostic.code == "streaming_apply_actor_required"));
-        assert!(
-            !dir.path().join("graphs/knowledge.omni").exists(),
-            "profile-authority refusal must precede graph effects"
-        );
-
-        let config = fs::read_to_string(dir.path().join(CLUSTER_CONFIG_FILE)).unwrap();
-        fs::write(
-            dir.path().join(CLUSTER_CONFIG_FILE),
-            config.replace("  lock: true", "  lock: false"),
-        )
-        .unwrap();
-        let unlocked = confirmed_streaming_apply(dir.path()).await;
-        assert!(!unlocked.ok, "{unlocked:?}");
-        assert!(unlocked
+            .any(|diagnostic| { diagnostic.code == "streaming_offline_confirmation_required" })
+    );
+    assert!(
+        unconfirmed
             .diagnostics
             .iter()
-            .any(|diagnostic| diagnostic.code == "streaming_requires_state_lock"));
-        assert!(
-            !dir.path().join("graphs/knowledge.omni").exists(),
-            "missing-lock refusal must precede graph effects"
-        );
-    }
+            .any(|diagnostic| diagnostic.code == "streaming_apply_actor_required")
+    );
+    assert!(
+        !dir.path().join("graphs/knowledge.omni").exists(),
+        "profile-authority refusal must precede graph effects"
+    );
 
-    #[test]
-    fn streaming_profile_operation_identity_is_stable_and_target_bound() {
-        let state_cas = format!("sha256:{}", "a".repeat(64));
-        let first = stream_profile_operation_id(
+    let config = fs::read_to_string(dir.path().join(CLUSTER_CONFIG_FILE)).unwrap();
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        config.replace("  lock: true", "  lock: false"),
+    )
+    .unwrap();
+    let unlocked = confirmed_streaming_apply(dir.path()).await;
+    assert!(!unlocked.ok, "{unlocked:?}");
+    assert!(
+        unlocked
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "streaming_requires_state_lock")
+    );
+    assert!(
+        !dir.path().join("graphs/knowledge.omni").exists(),
+        "missing-lock refusal must precede graph effects"
+    );
+}
+
+#[test]
+fn streaming_profile_operation_identity_is_stable_and_target_bound() {
+    let state_cas = format!("sha256:{}", "a".repeat(64));
+    let first = stream_profile_operation_id(
+        &state_cas,
+        "config-revision",
+        "declaration-digest",
+        "knowledge",
+        "/cluster/graphs/knowledge.omni",
+        true,
+    );
+    assert_eq!(
+        first,
+        stream_profile_operation_id(
             &state_cas,
             "config-revision",
             "declaration-digest",
             "knowledge",
             "/cluster/graphs/knowledge.omni",
             true,
-        );
-        assert_eq!(
-            first,
-            stream_profile_operation_id(
-                &state_cas,
-                "config-revision",
-                "declaration-digest",
-                "knowledge",
-                "/cluster/graphs/knowledge.omni",
-                true,
-            )
-        );
-        assert_ne!(
-            first,
-            stream_profile_operation_id(
-                &state_cas,
-                "config-revision",
-                "declaration-digest",
-                "knowledge",
-                "/cluster/graphs/knowledge.omni",
-                false,
-            )
-        );
-    }
-
-    #[tokio::test]
-    async fn apply_propagates_streaming_flag_and_disable() {
-        let dir = fixture();
-        write_streaming_cluster(dir.path(), Some(true));
-        write_state_resources(dir.path(), &[]);
-
-        // First apply creates the real graph and must land the flag in the
-        // graph's __manifest — the engine-obeyed authority — not just the
-        // ledger. The change classifies Applied, never Derived (the
-        // fake-convergence trap this resource kind exists to avoid).
-        let out = confirmed_streaming_apply(dir.path()).await;
-        assert!(out.ok && out.converged, "{out:?}");
-        let streaming_change = out
-            .changes
-            .iter()
-            .find(|change| change.resource == "streaming.knowledge")
-            .expect("streaming change visible in apply");
-        assert_eq!(streaming_change.disposition, Some(ApplyDisposition::Applied));
-        assert!(live_streaming_enabled(dir.path()).await);
-        let state = read_state_json(dir.path());
-        assert_eq!(
-            state["applied_revision"]["resources"]["streaming.knowledge"]["streaming_enabled"],
-            serde_json::json!(true)
-        );
-        assert_eq!(
-            state["applied_revision"]["resources"]["streaming.knowledge"]["profile_revision"],
-            serde_json::json!(2)
-        );
-        assert_eq!(
-            state["applied_revision"]["resources"]["streaming.knowledge"]["profile_mode"],
-            serde_json::json!("ENABLED")
-        );
-        let declaration_digest = streaming_digest("knowledge", true);
-        let declaration_revision =
-            streaming_declaration_revision("knowledge", &declaration_digest);
-        assert_eq!(
-            state["applied_revision"]["resources"]["streaming.knowledge"]
-                ["declaration_revision"],
-            serde_json::json!(declaration_revision.clone())
-        );
-        let original_config_digest = state["applied_revision"]["config_digest"].clone();
-        let serving = read_serving_snapshot(dir.path()).await.unwrap();
-        let binding = serving.graphs[0]
-            .stream_runtime_authority
-            .as_ref()
-            .expect("enabled served graph carries validated binding evidence");
-        assert!(serving.graphs[0].stream_served_export_authority.is_none());
-        assert_eq!(binding.graph_id(), "knowledge");
-        assert_eq!(binding.profile_revision(), 2);
-        assert_eq!(binding.declaration_revision(), declaration_revision);
-
-        // Idempotent: a second run sees no changes and calls no engine.
-        let again = confirmed_streaming_apply(dir.path()).await;
-        assert!(again.changes.is_empty() && !again.state_written, "{again:?}");
-
-        // An unrelated cluster resource may advance the global applied config
-        // without invalidating this graph's unchanged fold delegation.
-        let policy_path = dir.path().join("base.policy.yaml");
-        let current_policy = fs::read_to_string(&policy_path).unwrap();
-        fs::write(
-            policy_path,
-            format!("{current_policy}\n# unrelated policy revision\n"),
         )
-        .unwrap();
-        let unrelated = confirmed_streaming_apply(dir.path()).await;
-        assert!(unrelated.ok && unrelated.converged, "{unrelated:?}");
-        let state = read_state_json(dir.path());
-        assert_ne!(
-            state["applied_revision"]["config_digest"],
-            original_config_digest
-        );
-        assert_eq!(
-            state["applied_revision"]["resources"]["streaming.knowledge"]
-                ["declaration_revision"],
-            serde_json::json!(declaration_revision.clone())
-        );
-        let serving = read_serving_snapshot(dir.path()).await.unwrap();
-        let binding = serving.graphs[0]
-            .stream_runtime_authority
-            .as_ref()
-            .expect("unrelated apply preserves the enabled runtime binding");
-        assert!(serving.graphs[0].stream_served_export_authority.is_none());
-        assert_eq!(binding.declaration_revision(), declaration_revision);
-        assert_eq!(binding.profile_revision(), 2);
-
-        // A stale cluster row must converge from the engine's no-op result,
-        // including the discriminated mode and declaration binding.
-        let mut state = read_state_json(dir.path());
-        let stale_digest = streaming_digest("knowledge", false);
-        let stale = &mut state["applied_revision"]["resources"]["streaming.knowledge"];
-        stale["digest"] = serde_json::json!(stale_digest.clone());
-        stale["declaration_revision"] = serde_json::json!(
-            streaming_declaration_revision("knowledge", &stale_digest)
-        );
-        stale["streaming_enabled"] = serde_json::json!(false);
-        stale["profile_mode"] = serde_json::json!("DISABLED");
-        fs::write(
-            dir.path().join(CLUSTER_STATE_FILE),
-            serde_json::to_string_pretty(&state).unwrap(),
+    );
+    assert_ne!(
+        first,
+        stream_profile_operation_id(
+            &state_cas,
+            "config-revision",
+            "declaration-digest",
+            "knowledge",
+            "/cluster/graphs/knowledge.omni",
+            false,
         )
-        .unwrap();
-        let reconciled_noop = confirmed_streaming_apply(dir.path()).await;
-        assert!(
-            reconciled_noop.ok && reconciled_noop.converged,
-            "{reconciled_noop:?}"
-        );
-        let state = read_state_json(dir.path());
-        let row = &state["applied_revision"]["resources"]["streaming.knowledge"];
-        assert_eq!(row["streaming_enabled"], serde_json::json!(true));
-        assert_eq!(row["profile_mode"], serde_json::json!("ENABLED"));
-        assert_eq!(
-            row["declaration_revision"],
-            serde_json::json!(declaration_revision.clone())
-        );
-        assert_eq!(row["profile_revision"], serde_json::json!(2));
+    );
+}
 
-        // Explicit `streaming: false` disables (clean graph → converges now).
-        write_streaming_cluster(dir.path(), Some(false));
-        let out = confirmed_streaming_apply(dir.path()).await;
-        assert!(out.ok && out.converged, "{out:?}");
-        assert!(!live_streaming_enabled(dir.path()).await);
-        let serving = read_serving_snapshot(dir.path()).await.unwrap();
-        assert!(serving.graphs[0].stream_runtime_authority.is_none());
-        let terminal = serving.graphs[0]
+#[tokio::test]
+async fn apply_propagates_streaming_flag_and_disable() {
+    let dir = fixture();
+    write_streaming_cluster(dir.path(), Some(true));
+    write_state_resources(dir.path(), &[]);
+
+    // First apply creates the real graph and must land the flag in the
+    // graph's __manifest — the engine-obeyed authority — not just the
+    // ledger. The change classifies Applied, never Derived (the
+    // fake-convergence trap this resource kind exists to avoid).
+    let out = confirmed_streaming_apply(dir.path()).await;
+    assert!(out.ok && out.converged, "{out:?}");
+    let streaming_change = out
+        .changes
+        .iter()
+        .find(|change| change.resource == "streaming.knowledge")
+        .expect("streaming change visible in apply");
+    assert_eq!(
+        streaming_change.disposition,
+        Some(ApplyDisposition::Applied)
+    );
+    assert!(live_streaming_enabled(dir.path()).await);
+    let state = read_state_json(dir.path());
+    assert_eq!(
+        state["applied_revision"]["resources"]["streaming.knowledge"]["streaming_enabled"],
+        serde_json::json!(true)
+    );
+    assert_eq!(
+        state["applied_revision"]["resources"]["streaming.knowledge"]["profile_revision"],
+        serde_json::json!(2)
+    );
+    assert_eq!(
+        state["applied_revision"]["resources"]["streaming.knowledge"]["profile_mode"],
+        serde_json::json!("ENABLED")
+    );
+    let declaration_digest = streaming_digest("knowledge", true);
+    let declaration_revision = streaming_declaration_revision("knowledge", &declaration_digest);
+    assert_eq!(
+        state["applied_revision"]["resources"]["streaming.knowledge"]["declaration_revision"],
+        serde_json::json!(declaration_revision.clone())
+    );
+    let original_config_digest = state["applied_revision"]["config_digest"].clone();
+    let serving = read_serving_snapshot(dir.path()).await.unwrap();
+    let binding = serving.graphs[0]
+        .stream_runtime_authority
+        .as_ref()
+        .expect("enabled served graph carries validated binding evidence");
+    assert!(serving.graphs[0].stream_served_export_authority.is_none());
+    assert_eq!(binding.graph_id(), "knowledge");
+    assert_eq!(binding.profile_revision(), 2);
+    assert_eq!(binding.declaration_revision(), declaration_revision);
+
+    // Idempotent: a second run sees no changes and calls no engine.
+    let again = confirmed_streaming_apply(dir.path()).await;
+    assert!(
+        again.changes.is_empty() && !again.state_written,
+        "{again:?}"
+    );
+
+    // An unrelated cluster resource may advance the global applied config
+    // without invalidating this graph's unchanged fold delegation.
+    let policy_path = dir.path().join("base.policy.yaml");
+    let current_policy = fs::read_to_string(&policy_path).unwrap();
+    fs::write(
+        policy_path,
+        format!("{current_policy}\n# unrelated policy revision\n"),
+    )
+    .unwrap();
+    let unrelated = confirmed_streaming_apply(dir.path()).await;
+    assert!(unrelated.ok && unrelated.converged, "{unrelated:?}");
+    let state = read_state_json(dir.path());
+    assert_ne!(
+        state["applied_revision"]["config_digest"],
+        original_config_digest
+    );
+    assert_eq!(
+        state["applied_revision"]["resources"]["streaming.knowledge"]["declaration_revision"],
+        serde_json::json!(declaration_revision.clone())
+    );
+    let serving = read_serving_snapshot(dir.path()).await.unwrap();
+    let binding = serving.graphs[0]
+        .stream_runtime_authority
+        .as_ref()
+        .expect("unrelated apply preserves the enabled runtime binding");
+    assert!(serving.graphs[0].stream_served_export_authority.is_none());
+    assert_eq!(binding.declaration_revision(), declaration_revision);
+    assert_eq!(binding.profile_revision(), 2);
+
+    // A stale cluster row must converge from the engine's no-op result,
+    // including the discriminated mode and declaration binding.
+    let mut state = read_state_json(dir.path());
+    let stale_digest = streaming_digest("knowledge", false);
+    let stale = &mut state["applied_revision"]["resources"]["streaming.knowledge"];
+    stale["digest"] = serde_json::json!(stale_digest.clone());
+    stale["declaration_revision"] =
+        serde_json::json!(streaming_declaration_revision("knowledge", &stale_digest));
+    stale["streaming_enabled"] = serde_json::json!(false);
+    stale["profile_mode"] = serde_json::json!("DISABLED");
+    fs::write(
+        dir.path().join(CLUSTER_STATE_FILE),
+        serde_json::to_string_pretty(&state).unwrap(),
+    )
+    .unwrap();
+    let reconciled_noop = confirmed_streaming_apply(dir.path()).await;
+    assert!(
+        reconciled_noop.ok && reconciled_noop.converged,
+        "{reconciled_noop:?}"
+    );
+    let state = read_state_json(dir.path());
+    let row = &state["applied_revision"]["resources"]["streaming.knowledge"];
+    assert_eq!(row["streaming_enabled"], serde_json::json!(true));
+    assert_eq!(row["profile_mode"], serde_json::json!("ENABLED"));
+    assert_eq!(
+        row["declaration_revision"],
+        serde_json::json!(declaration_revision.clone())
+    );
+    assert_eq!(row["profile_revision"], serde_json::json!(2));
+
+    // Explicit `streaming: false` disables (clean graph → converges now).
+    write_streaming_cluster(dir.path(), Some(false));
+    let out = confirmed_streaming_apply(dir.path()).await;
+    assert!(out.ok && out.converged, "{out:?}");
+    assert!(!live_streaming_enabled(dir.path()).await);
+    let serving = read_serving_snapshot(dir.path()).await.unwrap();
+    assert!(serving.graphs[0].stream_runtime_authority.is_none());
+    let terminal = serving.graphs[0]
+        .stream_served_export_authority
+        .as_ref()
+        .expect("disabled served graph carries checked export binding evidence");
+    assert_eq!(terminal.graph_id(), "knowledge");
+    assert_eq!(
+        terminal.managed_profile().map(|(mode, _)| mode),
+        Some("DISABLED")
+    );
+
+    // Removing an active declaration cannot bypass the durable disable.
+    write_streaming_cluster(dir.path(), Some(true));
+    let out = confirmed_streaming_apply(dir.path()).await;
+    assert!(out.ok && out.converged, "{out:?}");
+    assert!(live_streaming_enabled(dir.path()).await);
+    write_streaming_cluster(dir.path(), None);
+    let blocked = confirmed_streaming_apply(dir.path()).await;
+    let change = blocked
+        .changes
+        .iter()
+        .find(|change| change.resource == "streaming.knowledge")
+        .unwrap();
+    assert_eq!(change.disposition, Some(ApplyDisposition::Blocked));
+    assert_eq!(
+        change.reason.as_deref(),
+        Some("streaming_profile_must_disable_first")
+    );
+    assert!(!blocked.converged);
+    assert!(live_streaming_enabled(dir.path()).await);
+
+    // Explicit false reaches terminal DISABLED; only then may a second
+    // apply remove the declaration as configuration-only unmanagement.
+    write_streaming_cluster(dir.path(), Some(false));
+    let disabled = confirmed_streaming_apply(dir.path()).await;
+    assert!(disabled.ok && disabled.converged, "{disabled:?}");
+    let serving = read_serving_snapshot(dir.path()).await.unwrap();
+    assert!(serving.graphs[0].stream_runtime_authority.is_none());
+    assert_eq!(
+        serving.graphs[0]
             .stream_served_export_authority
             .as_ref()
-            .expect("disabled served graph carries checked export binding evidence");
-        assert_eq!(terminal.graph_id(), "knowledge");
-        assert_eq!(
-            terminal.managed_profile().map(|(mode, _)| mode),
-            Some("DISABLED")
-        );
+            .expect("terminal managed graph keeps served export evidence")
+            .managed_profile()
+            .map(|(mode, _)| mode),
+        Some("DISABLED")
+    );
+    write_streaming_cluster(dir.path(), None);
+    let out = confirmed_streaming_apply(dir.path()).await;
+    assert!(out.ok && out.converged, "{out:?}");
+    let state = read_state_json(dir.path());
+    assert!(
+        state["applied_revision"]["resources"]
+            .get("streaming.knowledge")
+            .is_none(),
+        "unmanaged flag must drop its ledger row"
+    );
+    assert!(
+        !live_streaming_enabled(dir.path()).await,
+        "unmanaging after explicit disable must preserve DISABLED"
+    );
+    let serving = read_serving_snapshot(dir.path()).await.unwrap();
+    assert!(serving.graphs[0].stream_runtime_authority.is_none());
+    assert!(
+        serving.graphs[0]
+            .stream_served_export_authority
+            .as_ref()
+            .is_some_and(|binding| binding.is_unmanaged_terminal()),
+        "an unmanaged graph keeps exact graph/state evidence so server startup can bind it only for RETIRED or enrolled DISABLED"
+    );
+}
 
-        // Removing an active declaration cannot bypass the durable disable.
-        write_streaming_cluster(dir.path(), Some(true));
-        let out = confirmed_streaming_apply(dir.path()).await;
-        assert!(out.ok && out.converged, "{out:?}");
-        assert!(live_streaming_enabled(dir.path()).await);
-        write_streaming_cluster(dir.path(), None);
-        let blocked = confirmed_streaming_apply(dir.path()).await;
-        let change = blocked
-            .changes
-            .iter()
-            .find(|change| change.resource == "streaming.knowledge")
-            .unwrap();
-        assert_eq!(change.disposition, Some(ApplyDisposition::Blocked));
-        assert_eq!(
-            change.reason.as_deref(),
-            Some("streaming_profile_must_disable_first")
-        );
-        assert!(!blocked.converged);
-        assert!(live_streaming_enabled(dir.path()).await);
+#[cfg(feature = "failpoints")]
+#[test]
+#[serial_test::serial]
+fn blocked_disable_persists_exact_disabling_correction_authority() {
+    on_big_stack(blocked_disable_persists_exact_disabling_correction_authority_body);
+}
 
-        // Explicit false reaches terminal DISABLED; only then may a second
-        // apply remove the declaration as configuration-only unmanagement.
-        write_streaming_cluster(dir.path(), Some(false));
-        let disabled = confirmed_streaming_apply(dir.path()).await;
-        assert!(disabled.ok && disabled.converged, "{disabled:?}");
-        let serving = read_serving_snapshot(dir.path()).await.unwrap();
-        assert!(serving.graphs[0].stream_runtime_authority.is_none());
-        assert_eq!(
-            serving.graphs[0]
-                .stream_served_export_authority
-                .as_ref()
-                .expect("terminal managed graph keeps served export evidence")
-                .managed_profile()
-                .map(|(mode, _)| mode),
-            Some("DISABLED")
-        );
-        write_streaming_cluster(dir.path(), None);
-        let out = confirmed_streaming_apply(dir.path()).await;
-        assert!(out.ok && out.converged, "{out:?}");
-        let state = read_state_json(dir.path());
-        assert!(
-            state["applied_revision"]["resources"]
-                .get("streaming.knowledge")
-                .is_none(),
-            "unmanaged flag must drop its ledger row"
-        );
-        assert!(
-            !live_streaming_enabled(dir.path()).await,
-            "unmanaging after explicit disable must preserve DISABLED"
-        );
-        let serving = read_serving_snapshot(dir.path()).await.unwrap();
-        assert!(serving.graphs[0].stream_runtime_authority.is_none());
-        assert!(
-            serving.graphs[0]
-                .stream_served_export_authority
-                .as_ref()
-                .is_some_and(|binding| binding.is_unmanaged_terminal()),
-            "an unmanaged graph keeps exact graph/state evidence so server startup can bind it only for RETIRED or enrolled DISABLED"
-        );
-    }
-
-    #[cfg(feature = "failpoints")]
-    #[test]
-    #[serial_test::serial]
-    fn blocked_disable_persists_exact_disabling_correction_authority() {
-        on_big_stack(blocked_disable_persists_exact_disabling_correction_authority_body);
-    }
-
-    #[cfg(feature = "failpoints")]
-    async fn prepare_blocked_disable_data_block(dir: &Path) -> std::path::PathBuf {
-        fs::write(
-            dir.join("people.pg"),
-            r#"
+#[cfg(feature = "failpoints")]
+async fn prepare_blocked_disable_data_block(dir: &Path) -> std::path::PathBuf {
+    fs::write(
+        dir.join("people.pg"),
+        r#"
 node Person {
   name: String @key
   age: I32
   @unique(age)
 }
 "#,
-        )
-        .unwrap();
-        write_streaming_cluster(dir, Some(false));
-        write_state_resources(dir, &[]);
-        let created = confirmed_streaming_apply(dir).await;
-        assert!(created.ok && created.converged, "{created:?}");
+    )
+    .unwrap();
+    write_streaming_cluster(dir, Some(false));
+    write_state_resources(dir, &[]);
+    let created = confirmed_streaming_apply(dir).await;
+    assert!(created.ok && created.converged, "{created:?}");
 
-        let graph_root = dir.join("graphs/knowledge.omni");
-        let db = Arc::new(Omnigraph::open(graph_root.to_str().unwrap()).await.unwrap());
-        let mut params = ParamMap::new();
-        params.insert("name".to_string(), Literal::String("base".to_string()));
-        params.insert("age".to_string(), Literal::Integer(7));
-        db.mutate(
-            "main",
-            r#"
+    let graph_root = dir.join("graphs/knowledge.omni");
+    let db = Arc::new(Omnigraph::open(graph_root.to_str().unwrap()).await.unwrap());
+    let mut params = ParamMap::new();
+    params.insert("name".to_string(), Literal::String("base".to_string()));
+    params.insert("age".to_string(), Literal::Integer(7));
+    db.mutate(
+        "main",
+        r#"
 query seed($name: String, $age: I32) {
   insert Person { name: $name, age: $age }
 }
 "#,
-            "seed",
-            &params,
-        )
+        "seed",
+        &params,
+    )
+    .await
+    .unwrap();
+    db.failpoint_enroll_stream_table_for_test("node:Person")
         .await
         .unwrap();
-        db.failpoint_enroll_stream_table_for_test("node:Person")
-            .await
-            .unwrap();
-        drop(db);
+    drop(db);
 
-        write_streaming_cluster(dir, Some(true));
-        let enabled = confirmed_streaming_apply(dir).await;
-        assert!(enabled.ok && enabled.converged, "{enabled:?}");
-        let serving = read_serving_snapshot(dir).await.unwrap();
-        let binding = serving.graphs[0]
-            .stream_runtime_authority
-            .clone()
-            .expect("enabled graph carries runtime authority");
-        let runtime_guard = mint_runtime_guard(
-            binding,
-            "cluster-blocked-disable-fixture",
-            "stream-operator",
-        )
-        .await
-        .unwrap();
-        let db = Arc::new(
-            Omnigraph::open(graph_root.to_str().unwrap())
-                .await
-                .unwrap()
-                .with_checked_cluster_stream_runtime(runtime_guard)
-                .await
-                .unwrap(),
-        );
-        let incarnation = db
-            .failpoint_stream_incarnation_for_test("node:Person")
-            .await
-            .unwrap();
-        let row = serde_json::to_vec(&serde_json::json!({
-            "$stream": {
-                "stream_incarnation_id": incarnation,
-                "write_id": "b1b1b1b1-b1b1-41b1-81b1-b1b1b1b1b1b1",
-                "predecessor_token": null,
-            },
-            "id": "stream-conflict",
-            "name": "stream-conflict",
-            "age": 7,
-        }))
-        .unwrap();
-        db.failpoint_stream_ingest_one_as_for_test(
-            "node:Person",
-            &row,
-            0,
-            "stream-operator",
-        )
-        .await
-        .expect("the conflicting row remains durable until the disable fold validates it");
-        db.shutdown_stream_fold_driver()
-            .await
-            .expect("runtime shutdown must fence and settle detached stream producers");
-        drop(db);
-
-        graph_root
-    }
-
-    #[cfg(feature = "failpoints")]
-    async fn blocked_disable_persists_exact_disabling_correction_authority_body() {
-        let _scenario = fail::FailScenario::setup();
-        let dir = fixture();
-        // Heap-bound the setup future: inlining its state into this already-large
-        // test future exceeds rustc's default layout-query recursion limit on Linux.
-        let graph_root = Box::pin(prepare_blocked_disable_data_block(dir.path())).await;
-        let _dead_letter_object_overflow = omnigraph::failpoints::ScopedFailPoint::new(
-            omnigraph::failpoints::names::STREAM_DEAD_LETTER_FORCE_OBJECT_LIMIT,
-            "1*return",
-        );
-
-        write_streaming_cluster(dir.path(), Some(false));
-        let blocked = confirmed_streaming_apply(dir.path()).await;
-        assert!(blocked.ok && !blocked.converged, "{blocked:?}");
-        let change = blocked
-            .changes
-            .iter()
-            .find(|change| change.resource == "streaming.knowledge")
-            .unwrap();
-        assert_eq!(change.disposition, Some(ApplyDisposition::Blocked));
-        assert_eq!(change.reason.as_deref(), Some("streaming_data_blocked"));
-        assert!(blocked.diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == "streaming_data_blocked"
-                && diagnostic.message.contains("inspect and correct")
-        }));
-
-        let observed_digest = observed_streaming_digest("knowledge", "DISABLING");
-        let state = read_state_json(dir.path());
-        let streaming = &state["applied_revision"]["resources"]["streaming.knowledge"];
-        assert_eq!(streaming["digest"], serde_json::json!(observed_digest));
-        assert_eq!(streaming["streaming_enabled"], serde_json::json!(false));
-        assert_eq!(streaming["profile_mode"], serde_json::json!("DISABLING"));
-        assert_eq!(streaming["profile_revision"], serde_json::json!(3));
-        assert_eq!(
-            streaming["declaration_revision"],
-            serde_json::json!(streaming_declaration_revision(
-                "knowledge",
-                streaming["digest"].as_str().unwrap()
-            ))
-        );
-        assert_ne!(
-            streaming["digest"],
-            serde_json::json!(streaming_digest("knowledge", false))
-        );
-
-        let live = Omnigraph::open_read_only(graph_root.to_str().unwrap())
+    write_streaming_cluster(dir, Some(true));
+    let enabled = confirmed_streaming_apply(dir).await;
+    assert!(enabled.ok && enabled.converged, "{enabled:?}");
+    let serving = read_serving_snapshot(dir).await.unwrap();
+    let binding = serving.graphs[0]
+        .stream_runtime_authority
+        .clone()
+        .expect("enabled graph carries runtime authority");
+    let runtime_guard = mint_runtime_guard(
+        binding,
+        "cluster-blocked-disable-fixture",
+        "stream-operator",
+    )
+    .await
+    .unwrap();
+    let db = Arc::new(
+        Omnigraph::open(graph_root.to_str().unwrap())
             .await
             .unwrap()
-            .stream_status()
+            .with_checked_cluster_stream_runtime(runtime_guard)
             .await
-            .unwrap();
-        let block_token = live.tables[0]
-            .strict_block_token
-            .as_deref()
-            .expect("disable must retain the strict block");
-        let shown = show_stream_data_block_config_dir(
-            dir.path(),
-            "knowledge",
-            block_token,
-            None,
-            StreamBlockControlOptions {
-                actor: Some("stream-operator".to_string()),
-                confirm_stream_offline: true,
-            },
-        )
-        .await;
-        assert!(shown.ok && shown.page.is_some(), "{shown:?}");
+            .unwrap(),
+    );
+    let incarnation = db
+        .failpoint_stream_incarnation_for_test("node:Person")
+        .await
+        .unwrap();
+    let row = serde_json::to_vec(&serde_json::json!({
+        "$stream": {
+            "stream_incarnation_id": incarnation,
+            "write_id": "b1b1b1b1-b1b1-41b1-81b1-b1b1b1b1b1b1",
+            "predecessor_token": null,
+        },
+        "id": "stream-conflict",
+        "name": "stream-conflict",
+        "age": 7,
+    }))
+    .unwrap();
+    db.failpoint_stream_ingest_one_as_for_test("node:Person", &row, 0, "stream-operator")
+        .await
+        .expect("the conflicting row remains durable until the disable fold validates it");
+    db.shutdown_stream_fold_driver()
+        .await
+        .expect("runtime shutdown must fence and settle detached stream producers");
+    drop(db);
 
-        // A desired schema edit must not run ahead of the parked disable.
-        // The pre-schema attempt resumes the exact continuation, then the
-        // ordinary streaming phase still owns the blocked observation and
-        // persists the same DISABLING revision for correction authority.
-        fs::write(
-            dir.path().join("people.pg"),
-            r#"
+    graph_root
+}
+
+#[cfg(feature = "failpoints")]
+async fn blocked_disable_persists_exact_disabling_correction_authority_body() {
+    let _scenario = fail::FailScenario::setup();
+    let dir = fixture();
+    // Heap-bound the setup future: inlining its state into this already-large
+    // test future exceeds rustc's default layout-query recursion limit on Linux.
+    let graph_root = Box::pin(prepare_blocked_disable_data_block(dir.path())).await;
+    let _dead_letter_object_overflow = omnigraph::failpoints::ScopedFailPoint::new(
+        omnigraph::failpoints::names::STREAM_DEAD_LETTER_FORCE_OBJECT_LIMIT,
+        "1*return",
+    );
+
+    write_streaming_cluster(dir.path(), Some(false));
+    let blocked = confirmed_streaming_apply(dir.path()).await;
+    assert!(blocked.ok && !blocked.converged, "{blocked:?}");
+    let change = blocked
+        .changes
+        .iter()
+        .find(|change| change.resource == "streaming.knowledge")
+        .unwrap();
+    assert_eq!(change.disposition, Some(ApplyDisposition::Blocked));
+    assert_eq!(change.reason.as_deref(), Some("streaming_data_blocked"));
+    assert!(blocked.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "streaming_data_blocked"
+            && diagnostic.message.contains("inspect and correct")
+    }));
+
+    let observed_digest = observed_streaming_digest("knowledge", "DISABLING");
+    let state = read_state_json(dir.path());
+    let streaming = &state["applied_revision"]["resources"]["streaming.knowledge"];
+    assert_eq!(streaming["digest"], serde_json::json!(observed_digest));
+    assert_eq!(streaming["streaming_enabled"], serde_json::json!(false));
+    assert_eq!(streaming["profile_mode"], serde_json::json!("DISABLING"));
+    assert_eq!(streaming["profile_revision"], serde_json::json!(3));
+    assert_eq!(
+        streaming["declaration_revision"],
+        serde_json::json!(streaming_declaration_revision(
+            "knowledge",
+            streaming["digest"].as_str().unwrap()
+        ))
+    );
+    assert_ne!(
+        streaming["digest"],
+        serde_json::json!(streaming_digest("knowledge", false))
+    );
+
+    let live = Omnigraph::open_read_only(graph_root.to_str().unwrap())
+        .await
+        .unwrap()
+        .stream_status()
+        .await
+        .unwrap();
+    let block_token = live.tables[0]
+        .strict_block_token
+        .as_deref()
+        .expect("disable must retain the strict block");
+    let shown = show_stream_data_block_config_dir(
+        dir.path(),
+        "knowledge",
+        block_token,
+        None,
+        StreamBlockControlOptions {
+            actor: Some("stream-operator".to_string()),
+            confirm_stream_offline: true,
+        },
+    )
+    .await;
+    assert!(shown.ok && shown.page.is_some(), "{shown:?}");
+
+    // A desired schema edit must not run ahead of the parked disable.
+    // The pre-schema attempt resumes the exact continuation, then the
+    // ordinary streaming phase still owns the blocked observation and
+    // persists the same DISABLING revision for correction authority.
+    fs::write(
+        dir.path().join("people.pg"),
+        r#"
 node Person {
   name: String @key
   age: I32
@@ -4517,114 +4602,118 @@ node Person {
   @unique(age)
 }
 "#,
-        )
+    )
+    .unwrap();
+    let schema_parked = confirmed_streaming_apply(dir.path()).await;
+    assert!(
+        schema_parked.ok && !schema_parked.converged,
+        "{schema_parked:?}"
+    );
+    let schema_change = schema_parked
+        .changes
+        .iter()
+        .find(|change| change.resource == "schema.knowledge")
+        .expect("desired schema edit remains planned");
+    assert_eq!(schema_change.disposition, Some(ApplyDisposition::Blocked));
+    assert_eq!(
+        schema_change.reason.as_deref(),
+        Some("streaming_disable_continuation_pending")
+    );
+    let streaming_change = schema_parked
+        .changes
+        .iter()
+        .find(|change| change.resource == "streaming.knowledge")
+        .expect("desired false remains unresolved beside DISABLING");
+    assert_eq!(
+        streaming_change.disposition,
+        Some(ApplyDisposition::Blocked)
+    );
+    assert_eq!(
+        streaming_change.reason.as_deref(),
+        Some("streaming_data_blocked")
+    );
+
+    let state_after_schema_attempt = read_state_json(dir.path());
+    assert_eq!(
+        state_after_schema_attempt["applied_revision"]["resources"]["streaming.knowledge"],
+        state["applied_revision"]["resources"]["streaming.knowledge"]
+    );
+    let live_after_schema_attempt = Omnigraph::open_read_only(graph_root.to_str().unwrap())
+        .await
         .unwrap();
-        let schema_parked = confirmed_streaming_apply(dir.path()).await;
-        assert!(schema_parked.ok && !schema_parked.converged, "{schema_parked:?}");
-        let schema_change = schema_parked
-            .changes
-            .iter()
-            .find(|change| change.resource == "schema.knowledge")
-            .expect("desired schema edit remains planned");
-        assert_eq!(
-            schema_change.disposition,
-            Some(ApplyDisposition::Blocked)
-        );
-        assert_eq!(
-            schema_change.reason.as_deref(),
-            Some("streaming_disable_continuation_pending")
-        );
-        let streaming_change = schema_parked
-            .changes
-            .iter()
-            .find(|change| change.resource == "streaming.knowledge")
-            .expect("desired false remains unresolved beside DISABLING");
-        assert_eq!(
-            streaming_change.disposition,
-            Some(ApplyDisposition::Blocked)
-        );
-        assert_eq!(
-            streaming_change.reason.as_deref(),
-            Some("streaming_data_blocked")
-        );
+    assert!(
+        !live_after_schema_attempt
+            .schema_source()
+            .contains("nickname"),
+        "schema movement must wait until the disable continuation reaches DISABLED"
+    );
 
-        let state_after_schema_attempt = read_state_json(dir.path());
-        assert_eq!(
-            state_after_schema_attempt["applied_revision"]["resources"]
-                ["streaming.knowledge"],
-            state["applied_revision"]["resources"]["streaming.knowledge"]
-        );
-        let live_after_schema_attempt =
-            Omnigraph::open_read_only(graph_root.to_str().unwrap())
-                .await
-                .unwrap();
-        assert!(
-            !live_after_schema_attempt.schema_source().contains("nickname"),
-            "schema movement must wait until the disable continuation reaches DISABLED"
-        );
-
-        let shown_page = shown.page.expect("the graph-level block page is present");
-        let correction = omnigraph::db::StreamDataCorrectionRequest {
-            protocol_version: 1,
-            block_token: shown_page.block_token.clone(),
-            correction_id: "abababab-abab-4bab-8bab-abababababab".to_string(),
-            expected_lifecycle_revision: shown_page.lifecycle_revision,
-            actions: shown_page
-                .entries
-                .iter()
-                .map(|entry| omnigraph::db::StreamDataCorrectionAction::Withdraw {
+    let shown_page = shown.page.expect("the graph-level block page is present");
+    let correction = omnigraph::db::StreamDataCorrectionRequest {
+        protocol_version: 1,
+        block_token: shown_page.block_token.clone(),
+        correction_id: "abababab-abab-4bab-8bab-abababababab".to_string(),
+        expected_lifecycle_revision: shown_page.lifecycle_revision,
+        actions: shown_page
+            .entries
+            .iter()
+            .map(
+                |entry| omnigraph::db::StreamDataCorrectionAction::Withdraw {
                     ordinal: entry.ordinal,
                     logical_key: entry.logical_key.clone(),
                     current_blocked_winner_stream_token: entry
                         .current_blocked_winner_stream_token
                         .clone(),
-                })
-                .collect(),
-            expected_plan_digest: None,
-        };
-        let options = StreamBlockControlOptions {
-            actor: Some("stream-operator".to_string()),
-            confirm_stream_offline: true,
-        };
-        let corrected = correct_stream_data_block_config_dir(
-            dir.path(),
-            "knowledge",
-            correction.clone(),
-            options.clone(),
-        )
-        .await;
-        assert!(corrected.ok, "{corrected:?}");
-        assert!(corrected.result.as_ref().is_some_and(|result| result.changed));
-
-        // The exact retry has no current block or caller-supplied table alias
-        // to resolve. It must discover the receipt across enrolled immutable
-        // identities before inspecting current lifecycle authority.
-        let replayed = correct_stream_data_block_config_dir(
-            dir.path(),
-            "knowledge",
-            correction,
-            options,
-        )
-        .await;
-        assert!(replayed.ok, "{replayed:?}");
-        assert!(replayed
+                },
+            )
+            .collect(),
+        expected_plan_digest: None,
+    };
+    let options = StreamBlockControlOptions {
+        actor: Some("stream-operator".to_string()),
+        confirm_stream_offline: true,
+    };
+    let corrected = correct_stream_data_block_config_dir(
+        dir.path(),
+        "knowledge",
+        correction.clone(),
+        options.clone(),
+    )
+    .await;
+    assert!(corrected.ok, "{corrected:?}");
+    assert!(
+        corrected
             .result
             .as_ref()
-            .is_some_and(|result| !result.changed));
-        assert_eq!(
-            corrected.result.as_ref().map(|result| &result.plan_digest),
-            replayed.result.as_ref().map(|result| &result.plan_digest)
-        );
-    }
+            .is_some_and(|result| result.changed)
+    );
 
-    #[tokio::test]
-    async fn streaming_apply_enforces_bound_graph_policy() {
-        let dir = fixture();
-        write_streaming_cluster(dir.path(), Some(true));
-        write_state_resources(dir.path(), &[]);
-        fs::write(
-            dir.path().join("base.policy.yaml"),
-            r#"
+    // The exact retry has no current block or caller-supplied table alias
+    // to resolve. It must discover the receipt across enrolled immutable
+    // identities before inspecting current lifecycle authority.
+    let replayed =
+        correct_stream_data_block_config_dir(dir.path(), "knowledge", correction, options).await;
+    assert!(replayed.ok, "{replayed:?}");
+    assert!(
+        replayed
+            .result
+            .as_ref()
+            .is_some_and(|result| !result.changed)
+    );
+    assert_eq!(
+        corrected.result.as_ref().map(|result| &result.plan_digest),
+        replayed.result.as_ref().map(|result| &result.plan_digest)
+    );
+}
+
+#[tokio::test]
+async fn streaming_apply_enforces_bound_graph_policy() {
+    let dir = fixture();
+    write_streaming_cluster(dir.path(), Some(true));
+    write_state_resources(dir.path(), &[]);
+    fs::write(
+        dir.path().join("base.policy.yaml"),
+        r#"
 version: 1
 groups:
   observers: [stream-operator]
@@ -4634,48 +4723,48 @@ rules:
       actors: { group: observers }
       actions: [read]
 "#,
-        )
-        .unwrap();
+    )
+    .unwrap();
 
-        let denied = confirmed_streaming_apply(dir.path()).await;
-        let change = denied
-            .changes
-            .iter()
-            .find(|change| change.resource == "streaming.knowledge")
-            .expect("streaming change remains visible");
-        assert_eq!(change.disposition, Some(ApplyDisposition::Blocked));
-        assert_eq!(change.reason.as_deref(), Some("streaming_apply_failed"));
-        assert!(
-            denied.diagnostics.iter().any(|diagnostic| {
-                diagnostic.code == "streaming_apply_failed"
-                    && diagnostic.message.contains("policy denied")
-            }),
-            "{:?}",
-            denied.diagnostics
-        );
-        assert!(
-            !live_streaming_enabled(dir.path()).await,
-            "Cedar refusal must precede the profile receipt and manifest effect"
-        );
-    }
+    let denied = confirmed_streaming_apply(dir.path()).await;
+    let change = denied
+        .changes
+        .iter()
+        .find(|change| change.resource == "streaming.knowledge")
+        .expect("streaming change remains visible");
+    assert_eq!(change.disposition, Some(ApplyDisposition::Blocked));
+    assert_eq!(change.reason.as_deref(), Some("streaming_apply_failed"));
+    assert!(
+        denied.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "streaming_apply_failed"
+                && diagnostic.message.contains("policy denied")
+        }),
+        "{:?}",
+        denied.diagnostics
+    );
+    assert!(
+        !live_streaming_enabled(dir.path()).await,
+        "Cedar refusal must precede the profile receipt and manifest effect"
+    );
+}
 
-    #[tokio::test]
-    async fn blocked_stream_profile_preserves_policy_authority_for_retry() {
-        let dir = fixture();
-        write_streaming_cluster(dir.path(), Some(true));
-        write_state_resources(dir.path(), &[]);
-        let enabled = confirmed_streaming_apply(dir.path()).await;
-        assert!(enabled.ok && enabled.converged, "{enabled:?}");
-        let allowing_policy_digest = read_state_json(dir.path())["applied_revision"]["resources"]
-            ["policy.base"]["digest"]
+#[tokio::test]
+async fn blocked_stream_profile_preserves_policy_authority_for_retry() {
+    let dir = fixture();
+    write_streaming_cluster(dir.path(), Some(true));
+    write_state_resources(dir.path(), &[]);
+    let enabled = confirmed_streaming_apply(dir.path()).await;
+    assert!(enabled.ok && enabled.converged, "{enabled:?}");
+    let allowing_policy_digest =
+        read_state_json(dir.path())["applied_revision"]["resources"]["policy.base"]["digest"]
             .as_str()
             .unwrap()
             .to_string();
 
-        write_streaming_cluster(dir.path(), Some(false));
-        fs::write(
-            dir.path().join("base.policy.yaml"),
-            r#"
+    write_streaming_cluster(dir.path(), Some(false));
+    fs::write(
+        dir.path().join("base.policy.yaml"),
+        r#"
 version: 1
 groups:
   observers: [stream-operator]
@@ -4685,151 +4774,151 @@ rules:
       actors: { group: observers }
       actions: [read]
 "#,
-        )
-        .unwrap();
+    )
+    .unwrap();
 
-        let denied = confirmed_streaming_apply(dir.path()).await;
-        let by_resource: BTreeMap<&str, &PlanChange> = denied
-            .changes
-            .iter()
-            .map(|change| (change.resource.as_str(), change))
-            .collect();
-        assert_eq!(
-            by_resource["streaming.knowledge"].reason.as_deref(),
-            Some("streaming_apply_failed")
-        );
-        assert_eq!(
-            by_resource["policy.base"].disposition,
-            Some(ApplyDisposition::Blocked)
-        );
-        assert_eq!(
-            by_resource["policy.base"].reason.as_deref(),
-            Some("streaming_profile_not_applied")
-        );
-        assert!(
-            live_streaming_enabled(dir.path()).await,
-            "denied disable must leave the live profile enabled"
-        );
-        assert_eq!(
-            read_state_json(dir.path())["applied_revision"]["resources"]["policy.base"]["digest"],
-            json!(allowing_policy_digest),
-            "the state CAS must retain the policy that can authorize a retry"
-        );
+    let denied = confirmed_streaming_apply(dir.path()).await;
+    let by_resource: BTreeMap<&str, &PlanChange> = denied
+        .changes
+        .iter()
+        .map(|change| (change.resource.as_str(), change))
+        .collect();
+    assert_eq!(
+        by_resource["streaming.knowledge"].reason.as_deref(),
+        Some("streaming_apply_failed")
+    );
+    assert_eq!(
+        by_resource["policy.base"].disposition,
+        Some(ApplyDisposition::Blocked)
+    );
+    assert_eq!(
+        by_resource["policy.base"].reason.as_deref(),
+        Some("streaming_profile_not_applied")
+    );
+    assert!(
+        live_streaming_enabled(dir.path()).await,
+        "denied disable must leave the live profile enabled"
+    );
+    assert_eq!(
+        read_state_json(dir.path())["applied_revision"]["resources"]["policy.base"]["digest"],
+        json!(allowing_policy_digest),
+        "the state CAS must retain the policy that can authorize a retry"
+    );
 
-        // Restoring the prior desired policy must now make the very next apply
-        // able to finish the pending disable. If the denying policy had landed
-        // in state, old+new conjunction would deny this retry again.
-        write_streaming_cluster(dir.path(), Some(false));
-        let retried = confirmed_streaming_apply(dir.path()).await;
-        assert!(retried.ok && retried.converged, "{retried:?}");
-        assert!(!live_streaming_enabled(dir.path()).await);
-    }
+    // Restoring the prior desired policy must now make the very next apply
+    // able to finish the pending disable. If the denying policy had landed
+    // in state, old+new conjunction would deny this retry again.
+    write_streaming_cluster(dir.path(), Some(false));
+    let retried = confirmed_streaming_apply(dir.path()).await;
+    assert!(retried.ok && retried.converged, "{retried:?}");
+    assert!(!live_streaming_enabled(dir.path()).await);
+}
 
-    #[tokio::test]
-    async fn live_profile_blocks_unmanage_when_cluster_state_is_stale_or_missing() {
-        let dir = fixture();
-        write_streaming_cluster(dir.path(), Some(true));
-        write_state_resources(dir.path(), &[]);
-        let enabled = confirmed_streaming_apply(dir.path()).await;
-        assert!(enabled.ok && enabled.converged, "{enabled:?}");
+#[tokio::test]
+async fn live_profile_blocks_unmanage_when_cluster_state_is_stale_or_missing() {
+    let dir = fixture();
+    write_streaming_cluster(dir.path(), Some(true));
+    write_state_resources(dir.path(), &[]);
+    let enabled = confirmed_streaming_apply(dir.path()).await;
+    assert!(enabled.ok && enabled.converged, "{enabled:?}");
 
-        // Model the engine-commit/state-CAS crash window: the manifest is
-        // ENABLED, while the persisted cluster row still claims DISABLED.
-        let mut state = read_state_json(dir.path());
-        let disabled_digest = streaming_digest("knowledge", false);
-        let streaming = &mut state["applied_revision"]["resources"]["streaming.knowledge"];
-        streaming["digest"] = json!(disabled_digest.clone());
-        streaming["streaming_enabled"] = json!(false);
-        streaming["declaration_revision"] = json!(streaming_declaration_revision(
-            "knowledge",
-            &disabled_digest
-        ));
-        streaming["profile_mode"] = json!("DISABLED");
-        streaming["profile_revision"] = json!(1);
-        fs::write(
-            dir.path().join(CLUSTER_STATE_FILE),
-            serde_json::to_string_pretty(&state).unwrap(),
-        )
-        .unwrap();
-        write_streaming_cluster(dir.path(), None);
+    // Model the engine-commit/state-CAS crash window: the manifest is
+    // ENABLED, while the persisted cluster row still claims DISABLED.
+    let mut state = read_state_json(dir.path());
+    let disabled_digest = streaming_digest("knowledge", false);
+    let streaming = &mut state["applied_revision"]["resources"]["streaming.knowledge"];
+    streaming["digest"] = json!(disabled_digest.clone());
+    streaming["streaming_enabled"] = json!(false);
+    streaming["declaration_revision"] = json!(streaming_declaration_revision(
+        "knowledge",
+        &disabled_digest
+    ));
+    streaming["profile_mode"] = json!("DISABLED");
+    streaming["profile_revision"] = json!(1);
+    fs::write(
+        dir.path().join(CLUSTER_STATE_FILE),
+        serde_json::to_string_pretty(&state).unwrap(),
+    )
+    .unwrap();
+    write_streaming_cluster(dir.path(), None);
 
-        let blocked = confirmed_streaming_apply(dir.path()).await;
-        let change = blocked
-            .changes
-            .iter()
-            .find(|change| change.resource == "streaming.knowledge")
-            .expect("live manifest must preserve a blocked control-plane row");
-        assert_eq!(change.disposition, Some(ApplyDisposition::Blocked));
-        assert_eq!(
-            change.reason.as_deref(),
-            Some("streaming_profile_must_disable_first")
-        );
-        assert!(!blocked.converged, "{blocked:?}");
-        assert!(live_streaming_enabled(dir.path()).await);
-        let state = read_state_json(dir.path());
-        let streaming = &state["applied_revision"]["resources"]["streaming.knowledge"];
-        assert_eq!(streaming["profile_mode"], json!("ENABLED"));
-        assert_eq!(streaming["streaming_enabled"], json!(true));
-        assert_eq!(streaming["profile_revision"], json!(2));
+    let blocked = confirmed_streaming_apply(dir.path()).await;
+    let change = blocked
+        .changes
+        .iter()
+        .find(|change| change.resource == "streaming.knowledge")
+        .expect("live manifest must preserve a blocked control-plane row");
+    assert_eq!(change.disposition, Some(ApplyDisposition::Blocked));
+    assert_eq!(
+        change.reason.as_deref(),
+        Some("streaming_profile_must_disable_first")
+    );
+    assert!(!blocked.converged, "{blocked:?}");
+    assert!(live_streaming_enabled(dir.path()).await);
+    let state = read_state_json(dir.path());
+    let streaming = &state["applied_revision"]["resources"]["streaming.knowledge"];
+    assert_eq!(streaming["profile_mode"], json!("ENABLED"));
+    assert_eq!(streaming["streaming_enabled"], json!(true));
+    assert_eq!(streaming["profile_revision"], json!(2));
 
-        // Losing the row entirely is equally unsafe. Apply must rediscover
-        // the active profile rather than treating the absent digest as proof
-        // that there is nothing left to manage.
-        let mut state = state;
-        state["applied_revision"]["resources"]
-            .as_object_mut()
-            .unwrap()
-            .remove("streaming.knowledge");
-        state["resource_statuses"]
-            .as_object_mut()
-            .unwrap()
-            .remove("streaming.knowledge");
-        fs::write(
-            dir.path().join(CLUSTER_STATE_FILE),
-            serde_json::to_string_pretty(&state).unwrap(),
-        )
-        .unwrap();
+    // Losing the row entirely is equally unsafe. Apply must rediscover
+    // the active profile rather than treating the absent digest as proof
+    // that there is nothing left to manage.
+    let mut state = state;
+    state["applied_revision"]["resources"]
+        .as_object_mut()
+        .unwrap()
+        .remove("streaming.knowledge");
+    state["resource_statuses"]
+        .as_object_mut()
+        .unwrap()
+        .remove("streaming.knowledge");
+    fs::write(
+        dir.path().join(CLUSTER_STATE_FILE),
+        serde_json::to_string_pretty(&state).unwrap(),
+    )
+    .unwrap();
 
-        let blocked = confirmed_streaming_apply(dir.path()).await;
-        assert!(
-            blocked.changes.iter().any(|change| {
-                change.resource == "streaming.knowledge"
-                    && change.disposition == Some(ApplyDisposition::Blocked)
-            }),
-            "{blocked:?}"
-        );
-        let state = read_state_json(dir.path());
-        assert_eq!(
-            state["applied_revision"]["resources"]["streaming.knowledge"]["profile_mode"],
-            json!("ENABLED")
-        );
-    }
+    let blocked = confirmed_streaming_apply(dir.path()).await;
+    assert!(
+        blocked.changes.iter().any(|change| {
+            change.resource == "streaming.knowledge"
+                && change.disposition == Some(ApplyDisposition::Blocked)
+        }),
+        "{blocked:?}"
+    );
+    let state = read_state_json(dir.path());
+    assert_eq!(
+        state["applied_revision"]["resources"]["streaming.knowledge"]["profile_mode"],
+        json!("ENABLED")
+    );
+}
 
-    #[tokio::test]
-    async fn live_profile_blocks_approved_graph_delete_when_streaming_row_is_missing() {
-        let dir = fixture();
-        write_streaming_cluster(dir.path(), Some(true));
-        write_state_resources(dir.path(), &[]);
-        let enabled = confirmed_streaming_apply(dir.path()).await;
-        assert!(enabled.ok && enabled.converged, "{enabled:?}");
+#[tokio::test]
+async fn live_profile_blocks_approved_graph_delete_when_streaming_row_is_missing() {
+    let dir = fixture();
+    write_streaming_cluster(dir.path(), Some(true));
+    write_state_resources(dir.path(), &[]);
+    let enabled = confirmed_streaming_apply(dir.path()).await;
+    assert!(enabled.ok && enabled.converged, "{enabled:?}");
 
-        let mut state = read_state_json(dir.path());
-        state["applied_revision"]["resources"]
-            .as_object_mut()
-            .unwrap()
-            .remove("streaming.knowledge");
-        state["resource_statuses"]
-            .as_object_mut()
-            .unwrap()
-            .remove("streaming.knowledge");
-        fs::write(
-            dir.path().join(CLUSTER_STATE_FILE),
-            serde_json::to_string_pretty(&state).unwrap(),
-        )
-        .unwrap();
-        fs::write(
-            dir.path().join(CLUSTER_CONFIG_FILE),
-            r#"
+    let mut state = read_state_json(dir.path());
+    state["applied_revision"]["resources"]
+        .as_object_mut()
+        .unwrap()
+        .remove("streaming.knowledge");
+    state["resource_statuses"]
+        .as_object_mut()
+        .unwrap()
+        .remove("streaming.knowledge");
+    fs::write(
+        dir.path().join(CLUSTER_STATE_FILE),
+        serde_json::to_string_pretty(&state).unwrap(),
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        r#"
 version: 1
 metadata:
   name: test
@@ -4839,381 +4928,384 @@ state:
 graphs: {}
 policies: {}
 "#,
-        )
-        .unwrap();
+    )
+    .unwrap();
 
-        let approved = approve_config_dir(dir.path(), "graph.knowledge", "andrew").await;
-        assert!(approved.ok, "{approved:?}");
-        let blocked = apply_config_dir(dir.path()).await;
-        let by_resource: BTreeMap<&str, &PlanChange> = blocked
-            .changes
+    let approved = approve_config_dir(dir.path(), "graph.knowledge", "andrew").await;
+    assert!(approved.ok, "{approved:?}");
+    let blocked = apply_config_dir(dir.path()).await;
+    let by_resource: BTreeMap<&str, &PlanChange> = blocked
+        .changes
+        .iter()
+        .map(|change| (change.resource.as_str(), change))
+        .collect();
+    assert_eq!(
+        by_resource["graph.knowledge"].disposition,
+        Some(ApplyDisposition::Blocked)
+    );
+    assert_eq!(
+        by_resource["graph.knowledge"].reason.as_deref(),
+        Some("streaming_profile_must_disable_first")
+    );
+    assert!(
+        dir.path()
+            .join(CLUSTER_GRAPHS_DIR)
+            .join("knowledge.omni")
+            .exists(),
+        "an approval based on stale cluster state must not erase a live active profile"
+    );
+    let state = read_state_json(dir.path());
+    assert_eq!(
+        state["applied_revision"]["resources"]["streaming.knowledge"]["profile_mode"],
+        json!("ENABLED")
+    );
+}
+
+#[tokio::test]
+async fn refresh_recreates_unmanaged_active_profile_metadata_and_surfaces_drift() {
+    let dir = fixture();
+    write_streaming_cluster(dir.path(), Some(true));
+    write_state_resources(dir.path(), &[]);
+    let enabled = confirmed_streaming_apply(dir.path()).await;
+    assert!(enabled.ok && enabled.converged, "{enabled:?}");
+
+    let mut state = read_state_json(dir.path());
+    state["applied_revision"]["resources"]
+        .as_object_mut()
+        .unwrap()
+        .remove("streaming.knowledge");
+    state["resource_statuses"]
+        .as_object_mut()
+        .unwrap()
+        .remove("streaming.knowledge");
+    fs::write(
+        dir.path().join(CLUSTER_STATE_FILE),
+        serde_json::to_string_pretty(&state).unwrap(),
+    )
+    .unwrap();
+    write_streaming_cluster(dir.path(), None);
+
+    let refreshed = refresh_config_dir(dir.path()).await;
+    assert!(refreshed.ok, "{refreshed:?}");
+    assert_eq!(
+        refreshed.resource_statuses["streaming.knowledge"].status,
+        ResourceLifecycleStatus::Drifted
+    );
+    assert!(
+        refreshed.resource_statuses["streaming.knowledge"]
+            .conditions
+            .contains(&"streaming_profile_must_disable_first".to_string())
+    );
+    let state = read_state_json(dir.path());
+    let streaming = &state["applied_revision"]["resources"]["streaming.knowledge"];
+    assert_eq!(streaming["profile_mode"], json!("ENABLED"));
+    assert_eq!(streaming["streaming_enabled"], json!(true));
+    assert_eq!(streaming["profile_revision"], json!(2));
+}
+
+#[tokio::test]
+async fn streaming_survives_refresh_and_converges_to_engine_truth() {
+    let dir = fixture();
+    write_streaming_cluster(dir.path(), Some(true));
+    write_state_resources(dir.path(), &[]);
+    let out = confirmed_streaming_apply(dir.path()).await;
+    assert!(out.ok && out.converged, "{out:?}");
+
+    // Wipe the streaming row (a crashed apply / pre-streaming ledger).
+    let mut state = read_state_json(dir.path());
+    state["applied_revision"]["resources"]
+        .as_object_mut()
+        .unwrap()
+        .remove("streaming.knowledge");
+    state["resource_statuses"]["streaming.knowledge"] = serde_json::json!({
+        "status": "blocked",
+        "conditions": ["stale_streaming_status"],
+        "message": "stale streaming status",
+    });
+    fs::write(
+        dir.path().join(CLUSTER_STATE_FILE),
+        serde_json::to_string_pretty(&state).unwrap(),
+    )
+    .unwrap();
+
+    // Refresh reads the live graph and regains the row from ENGINE truth.
+    let out = refresh_config_dir(dir.path()).await;
+    assert!(out.ok, "{out:?}");
+    assert_eq!(
+        out.resource_statuses["streaming.knowledge"].status,
+        ResourceLifecycleStatus::Applied
+    );
+    assert!(
+        out.resource_statuses["streaming.knowledge"]
+            .conditions
+            .is_empty(),
+        "refresh must clear stale streaming conditions after observing a match"
+    );
+    assert!(
+        out.resource_statuses["streaming.knowledge"]
+            .message
+            .is_none(),
+        "refresh must clear the stale streaming status message"
+    );
+    let state = read_state_json(dir.path());
+    assert_eq!(
+        state["applied_revision"]["resources"]["streaming.knowledge"]["streaming_enabled"],
+        serde_json::json!(true)
+    );
+    assert_eq!(
+        state["applied_revision"]["resources"]["streaming.knowledge"]["profile_revision"],
+        serde_json::json!(2)
+    );
+    assert_eq!(
+        state["applied_revision"]["resources"]["streaming.knowledge"]["profile_mode"],
+        serde_json::json!("ENABLED")
+    );
+    let enabled_digest = streaming_digest("knowledge", true);
+    assert_eq!(
+        state["applied_revision"]["resources"]["streaming.knowledge"]["declaration_revision"],
+        serde_json::json!(streaming_declaration_revision("knowledge", &enabled_digest))
+    );
+
+    // Model a stale ledger around a supported offline disable: move
+    // engine truth through cluster apply, then restore a stale enabled
+    // ledger row. Refresh must rederive false from the manifest.
+    write_streaming_cluster(dir.path(), Some(false));
+    let disabled = confirmed_streaming_apply(dir.path()).await;
+    assert!(disabled.ok && disabled.converged, "{disabled:?}");
+    let mut state = read_state_json(dir.path());
+    state["applied_revision"]["resources"]["streaming.knowledge"]["streaming_enabled"] =
+        serde_json::json!(true);
+    state["applied_revision"]["resources"]["streaming.knowledge"]["digest"] =
+        serde_json::json!(streaming_digest("knowledge", true));
+    fs::write(
+        dir.path().join(CLUSTER_STATE_FILE),
+        serde_json::to_string_pretty(&state).unwrap(),
+    )
+    .unwrap();
+    write_streaming_cluster(dir.path(), Some(true));
+    let out = refresh_config_dir(dir.path()).await;
+    assert!(out.ok, "{out:?}");
+    let streaming_status = &out.resource_statuses["streaming.knowledge"];
+    assert_eq!(streaming_status.status, ResourceLifecycleStatus::Drifted);
+    assert!(
+        streaming_status
+            .conditions
+            .contains(&"streaming_mismatch".to_string())
+    );
+    let state = read_state_json(dir.path());
+    assert_eq!(
+        state["applied_revision"]["resources"]["streaming.knowledge"]["streaming_enabled"],
+        serde_json::json!(false)
+    );
+    let plan = plan_config_dir(dir.path()).await;
+    let drift = plan
+        .changes
+        .iter()
+        .find(|change| change.resource == "streaming.knowledge")
+        .expect("observed/declared streaming drift must be a visible plan change");
+    assert_eq!(drift.operation, PlanOperation::Update);
+
+    // And apply re-converges to the declaration.
+    let out = confirmed_streaming_apply(dir.path()).await;
+    assert!(out.ok && out.converged, "{out:?}");
+    assert!(live_streaming_enabled(dir.path()).await);
+}
+
+#[tokio::test]
+async fn enabled_streaming_without_exact_profile_revision_is_quarantined() {
+    let dir = fixture();
+    write_streaming_cluster(dir.path(), Some(true));
+    write_state_resources(dir.path(), &[]);
+    let out = confirmed_streaming_apply(dir.path()).await;
+    assert!(out.ok && out.converged, "{out:?}");
+
+    let mut state = read_state_json(dir.path());
+    state["applied_revision"]["resources"]["streaming.knowledge"]
+        .as_object_mut()
+        .unwrap()
+        .remove("profile_revision");
+    fs::write(
+        dir.path().join(CLUSTER_STATE_FILE),
+        serde_json::to_string_pretty(&state).unwrap(),
+    )
+    .unwrap();
+
+    let diagnostics = read_serving_snapshot(dir.path()).await.unwrap_err();
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "stream_runtime_profile_revision_missing"
+            && diagnostic.severity == DiagnosticSeverity::Warning
+    }));
+    assert!(
+        diagnostics
             .iter()
-            .map(|change| (change.resource.as_str(), change))
-            .collect();
-        assert_eq!(
-            by_resource["graph.knowledge"].disposition,
-            Some(ApplyDisposition::Blocked)
-        );
-        assert_eq!(
-            by_resource["graph.knowledge"].reason.as_deref(),
-            Some("streaming_profile_must_disable_first")
-        );
-        assert!(
-            dir.path()
-                .join(CLUSTER_GRAPHS_DIR)
-                .join("knowledge.omni")
-                .exists(),
-            "an approval based on stale cluster state must not erase a live active profile"
-        );
-        let state = read_state_json(dir.path());
-        assert_eq!(
-            state["applied_revision"]["resources"]["streaming.knowledge"]["profile_mode"],
-            json!("ENABLED")
-        );
-    }
+            .any(|diagnostic| diagnostic.code == "cluster_no_healthy_graphs")
+    );
 
-    #[tokio::test]
-    async fn refresh_recreates_unmanaged_active_profile_metadata_and_surfaces_drift() {
-        let dir = fixture();
-        write_streaming_cluster(dir.path(), Some(true));
-        write_state_resources(dir.path(), &[]);
-        let enabled = confirmed_streaming_apply(dir.path()).await;
-        assert!(enabled.ok && enabled.converged, "{enabled:?}");
+    state["applied_revision"]["resources"]["streaming.knowledge"]["profile_revision"] =
+        serde_json::json!(2);
+    state["applied_revision"]["resources"]["streaming.knowledge"]
+        .as_object_mut()
+        .unwrap()
+        .remove("declaration_revision");
+    fs::write(
+        dir.path().join(CLUSTER_STATE_FILE),
+        serde_json::to_string_pretty(&state).unwrap(),
+    )
+    .unwrap();
+    let diagnostics = read_serving_snapshot(dir.path()).await.unwrap_err();
+    assert!(diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "stream_runtime_declaration_revision_missing"
+            && diagnostic.severity == DiagnosticSeverity::Warning
+    }));
+}
 
-        let mut state = read_state_json(dir.path());
-        state["applied_revision"]["resources"]
-            .as_object_mut()
-            .unwrap()
-            .remove("streaming.knowledge");
-        state["resource_statuses"]
-            .as_object_mut()
-            .unwrap()
-            .remove("streaming.knowledge");
-        fs::write(
-            dir.path().join(CLUSTER_STATE_FILE),
-            serde_json::to_string_pretty(&state).unwrap(),
-        )
-        .unwrap();
-        write_streaming_cluster(dir.path(), None);
+#[tokio::test]
+async fn disabling_profile_stays_plannable_and_refuses_normal_server_boot() {
+    let dir = fixture();
+    write_streaming_cluster(dir.path(), Some(true));
+    write_state_resources(dir.path(), &[]);
+    let out = confirmed_streaming_apply(dir.path()).await;
+    assert!(out.ok && out.converged, "{out:?}");
 
-        let refreshed = refresh_config_dir(dir.path()).await;
-        assert!(refreshed.ok, "{refreshed:?}");
-        assert_eq!(
-            refreshed.resource_statuses["streaming.knowledge"].status,
-            ResourceLifecycleStatus::Drifted
-        );
-        assert!(
-            refreshed.resource_statuses["streaming.knowledge"]
-                .conditions
-                .contains(&"streaming_profile_must_disable_first".to_string())
-        );
-        let state = read_state_json(dir.path());
-        let streaming = &state["applied_revision"]["resources"]["streaming.knowledge"];
-        assert_eq!(streaming["profile_mode"], json!("ENABLED"));
-        assert_eq!(streaming["streaming_enabled"], json!(true));
-        assert_eq!(streaming["profile_revision"], json!(2));
-    }
+    let mut state = read_state_json(dir.path());
+    let row = &mut state["applied_revision"]["resources"]["streaming.knowledge"];
+    row["streaming_enabled"] = serde_json::json!(false);
+    row["profile_mode"] = serde_json::json!("DISABLING");
+    row["profile_revision"] = serde_json::json!(3);
+    row["digest"] = serde_json::json!("durable-disabling-plan");
+    fs::write(
+        dir.path().join(CLUSTER_STATE_FILE),
+        serde_json::to_string_pretty(&state).unwrap(),
+    )
+    .unwrap();
+    write_streaming_cluster(dir.path(), Some(false));
 
-    #[tokio::test]
-    async fn streaming_survives_refresh_and_converges_to_engine_truth() {
-        let dir = fixture();
-        write_streaming_cluster(dir.path(), Some(true));
-        write_state_resources(dir.path(), &[]);
-        let out = confirmed_streaming_apply(dir.path()).await;
-        assert!(out.ok && out.converged, "{out:?}");
+    let plan = plan_config_dir(dir.path()).await;
+    let continuation = plan
+        .changes
+        .iter()
+        .find(|change| change.resource == "streaming.knowledge")
+        .expect("DISABLING must remain a visible continuation");
+    assert_eq!(continuation.operation, PlanOperation::Update);
+    assert_eq!(continuation.disposition, Some(ApplyDisposition::Applied));
 
-        // Wipe the streaming row (a crashed apply / pre-streaming ledger).
-        let mut state = read_state_json(dir.path());
-        state["applied_revision"]["resources"]
-            .as_object_mut()
-            .unwrap()
-            .remove("streaming.knowledge");
-        state["resource_statuses"]["streaming.knowledge"] = serde_json::json!({
-            "status": "blocked",
-            "conditions": ["stale_streaming_status"],
-            "message": "stale streaming status",
-        });
-        fs::write(
-            dir.path().join(CLUSTER_STATE_FILE),
-            serde_json::to_string_pretty(&state).unwrap(),
-        )
+    let diagnostics = read_serving_snapshot(dir.path()).await.unwrap_err();
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "stream_profile_disabling")
+    );
+    assert_ne!(
+        observed_streaming_digest("knowledge", "DISABLING"),
+        streaming_digest("knowledge", false)
+    );
+    assert!(!streaming_mode_matches_desired("DISABLING", false));
+}
+
+#[tokio::test]
+async fn streaming_applies_over_an_imported_preexisting_graph() {
+    // The CLI lifecycle shape: a graph exists BEFORE the cluster manages
+    // it; import records observed truth (disabled), apply must flip it.
+    let dir = fixture();
+    write_streaming_cluster(dir.path(), Some(true));
+    let graphs_dir = dir.path().join("graphs");
+    fs::create_dir_all(&graphs_dir).unwrap();
+    let graph_uri = graphs_dir.join("knowledge.omni");
+    Omnigraph::init(graph_uri.to_str().unwrap(), SCHEMA)
+        .await
         .unwrap();
 
-        // Refresh reads the live graph and regains the row from ENGINE truth.
-        let out = refresh_config_dir(dir.path()).await;
-        assert!(out.ok, "{out:?}");
-        assert_eq!(
-            out.resource_statuses["streaming.knowledge"].status,
-            ResourceLifecycleStatus::Applied
-        );
-        assert!(
-            out.resource_statuses["streaming.knowledge"]
-                .conditions
-                .is_empty(),
-            "refresh must clear stale streaming conditions after observing a match"
-        );
-        assert!(
-            out.resource_statuses["streaming.knowledge"]
+    let import = import_config_dir(dir.path()).await;
+    assert!(import.ok, "{import:?}");
+    let out = confirmed_streaming_apply(dir.path()).await;
+    assert!(out.ok && out.converged, "{out:?}");
+    assert!(
+        live_streaming_enabled(dir.path()).await,
+        "import→apply must flip the pre-existing graph: {out:?}"
+    );
+}
+
+#[tokio::test]
+async fn authority_retirement_preflight_requires_actor_confirmation_and_declared_graph() {
+    let dir = fixture();
+    let missing_authority = plan_stream_authority_retirement_config_dir(
+        dir.path(),
+        "knowledge",
+        StreamAuthorityRetirementOptions::default(),
+    )
+    .await;
+    assert!(!missing_authority.ok);
+    assert!(
+        missing_authority
+            .diagnostics
+            .iter()
+            .any(|diagnostic| { diagnostic.code == "stream_authority_retirement_actor_required" })
+    );
+    assert!(
+        missing_authority
+            .diagnostics
+            .iter()
+            .any(|diagnostic| { diagnostic.code == "streaming_offline_confirmation_required" })
+    );
+    assert!(
+        !dir.path().join(CLUSTER_LOCK_FILE).exists(),
+        "preflight refusal must happen before lock acquisition"
+    );
+
+    let unknown_graph = plan_stream_authority_retirement_config_dir(
+        dir.path(),
+        "other",
+        StreamAuthorityRetirementOptions {
+            actor: Some("stream-operator".to_string()),
+            confirm_stream_offline: true,
+        },
+    )
+    .await;
+    assert!(!unknown_graph.ok);
+    assert!(unknown_graph.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "stream_authority_retirement_graph_not_declared"
+            && diagnostic.path == "graphs.other"
+    }));
+    assert!(
+        !dir.path().join(CLUSTER_LOCK_FILE).exists(),
+        "unknown graph refusal must happen before lock acquisition"
+    );
+
+    // Once config/state/actor/offline authority are valid, the command
+    // must reach the engine under the dedicated lock. A fresh disabled,
+    // unenrolled graph is intentionally not retireable, so the exact
+    // engine precondition gives this test a harmless terminal outcome.
+    write_streaming_cluster(dir.path(), Some(false));
+    init_derived_graph(dir.path()).await;
+    let import = import_config_dir(dir.path()).await;
+    assert!(import.ok, "{import:?}");
+    let engine_refusal = plan_stream_authority_retirement_config_dir(
+        dir.path(),
+        "knowledge",
+        StreamAuthorityRetirementOptions {
+            actor: Some("stream-operator".to_string()),
+            confirm_stream_offline: true,
+        },
+    )
+    .await;
+    assert!(!engine_refusal.ok);
+    assert!(engine_refusal.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "stream_authority_retirement_plan_failed"
+            && diagnostic
                 .message
-                .is_none(),
-            "refresh must clear the stale streaming status message"
-        );
-        let state = read_state_json(dir.path());
-        assert_eq!(
-            state["applied_revision"]["resources"]["streaming.knowledge"]["streaming_enabled"],
-            serde_json::json!(true)
-        );
-        assert_eq!(
-            state["applied_revision"]["resources"]["streaming.knowledge"]["profile_revision"],
-            serde_json::json!(2)
-        );
-        assert_eq!(
-            state["applied_revision"]["resources"]["streaming.knowledge"]["profile_mode"],
-            serde_json::json!("ENABLED")
-        );
-        let enabled_digest = streaming_digest("knowledge", true);
-        assert_eq!(
-            state["applied_revision"]["resources"]["streaming.knowledge"]
-                ["declaration_revision"],
-            serde_json::json!(streaming_declaration_revision(
-                "knowledge",
-                &enabled_digest
-            ))
-        );
+                .contains("at least one current WITHDRAWN or DEAD_LETTERED token")
+    }));
+    assert!(
+        !dir.path().join(CLUSTER_LOCK_FILE).exists(),
+        "engine refusal must release the dedicated retirement lock"
+    );
+}
 
-        // Model a stale ledger around a supported offline disable: move
-        // engine truth through cluster apply, then restore a stale enabled
-        // ledger row. Refresh must rederive false from the manifest.
-        write_streaming_cluster(dir.path(), Some(false));
-        let disabled = confirmed_streaming_apply(dir.path()).await;
-        assert!(disabled.ok && disabled.converged, "{disabled:?}");
-        let mut state = read_state_json(dir.path());
-        state["applied_revision"]["resources"]["streaming.knowledge"]["streaming_enabled"] =
-            serde_json::json!(true);
-        state["applied_revision"]["resources"]["streaming.knowledge"]["digest"] =
-            serde_json::json!(streaming_digest("knowledge", true));
-        fs::write(
-            dir.path().join(CLUSTER_STATE_FILE),
-            serde_json::to_string_pretty(&state).unwrap(),
-        )
-        .unwrap();
-        write_streaming_cluster(dir.path(), Some(true));
-        let out = refresh_config_dir(dir.path()).await;
-        assert!(out.ok, "{out:?}");
-        let streaming_status = &out.resource_statuses["streaming.knowledge"];
-        assert_eq!(
-            streaming_status.status,
-            ResourceLifecycleStatus::Drifted
-        );
-        assert!(
-            streaming_status
-                .conditions
-                .contains(&"streaming_mismatch".to_string())
-        );
-        let state = read_state_json(dir.path());
-        assert_eq!(
-            state["applied_revision"]["resources"]["streaming.knowledge"]["streaming_enabled"],
-            serde_json::json!(false)
-        );
-        let plan = plan_config_dir(dir.path()).await;
-        let drift = plan
-            .changes
-            .iter()
-            .find(|change| change.resource == "streaming.knowledge")
-            .expect("observed/declared streaming drift must be a visible plan change");
-        assert_eq!(drift.operation, PlanOperation::Update);
-
-        // And apply re-converges to the declaration.
-        let out = confirmed_streaming_apply(dir.path()).await;
-        assert!(out.ok && out.converged, "{out:?}");
-        assert!(live_streaming_enabled(dir.path()).await);
-    }
-
-    #[tokio::test]
-    async fn enabled_streaming_without_exact_profile_revision_is_quarantined() {
-        let dir = fixture();
-        write_streaming_cluster(dir.path(), Some(true));
-        write_state_resources(dir.path(), &[]);
-        let out = confirmed_streaming_apply(dir.path()).await;
-        assert!(out.ok && out.converged, "{out:?}");
-
-        let mut state = read_state_json(dir.path());
-        state["applied_revision"]["resources"]["streaming.knowledge"]
-            .as_object_mut()
-            .unwrap()
-            .remove("profile_revision");
-        fs::write(
-            dir.path().join(CLUSTER_STATE_FILE),
-            serde_json::to_string_pretty(&state).unwrap(),
-        )
-        .unwrap();
-
-        let diagnostics = read_serving_snapshot(dir.path()).await.unwrap_err();
-        assert!(diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == "stream_runtime_profile_revision_missing"
-                && diagnostic.severity == DiagnosticSeverity::Warning
-        }));
-        assert!(diagnostics
-            .iter()
-            .any(|diagnostic| diagnostic.code == "cluster_no_healthy_graphs"));
-
-        state["applied_revision"]["resources"]["streaming.knowledge"]["profile_revision"] =
-            serde_json::json!(2);
-        state["applied_revision"]["resources"]["streaming.knowledge"]
-            .as_object_mut()
-            .unwrap()
-            .remove("declaration_revision");
-        fs::write(
-            dir.path().join(CLUSTER_STATE_FILE),
-            serde_json::to_string_pretty(&state).unwrap(),
-        )
-        .unwrap();
-        let diagnostics = read_serving_snapshot(dir.path()).await.unwrap_err();
-        assert!(diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == "stream_runtime_declaration_revision_missing"
-                && diagnostic.severity == DiagnosticSeverity::Warning
-        }));
-    }
-
-    #[tokio::test]
-    async fn disabling_profile_stays_plannable_and_refuses_normal_server_boot() {
-        let dir = fixture();
-        write_streaming_cluster(dir.path(), Some(true));
-        write_state_resources(dir.path(), &[]);
-        let out = confirmed_streaming_apply(dir.path()).await;
-        assert!(out.ok && out.converged, "{out:?}");
-
-        let mut state = read_state_json(dir.path());
-        let row = &mut state["applied_revision"]["resources"]["streaming.knowledge"];
-        row["streaming_enabled"] = serde_json::json!(false);
-        row["profile_mode"] = serde_json::json!("DISABLING");
-        row["profile_revision"] = serde_json::json!(3);
-        row["digest"] = serde_json::json!("durable-disabling-plan");
-        fs::write(
-            dir.path().join(CLUSTER_STATE_FILE),
-            serde_json::to_string_pretty(&state).unwrap(),
-        )
-        .unwrap();
-        write_streaming_cluster(dir.path(), Some(false));
-
-        let plan = plan_config_dir(dir.path()).await;
-        let continuation = plan
-            .changes
-            .iter()
-            .find(|change| change.resource == "streaming.knowledge")
-            .expect("DISABLING must remain a visible continuation");
-        assert_eq!(continuation.operation, PlanOperation::Update);
-        assert_eq!(continuation.disposition, Some(ApplyDisposition::Applied));
-
-        let diagnostics = read_serving_snapshot(dir.path()).await.unwrap_err();
-        assert!(diagnostics
-            .iter()
-            .any(|diagnostic| diagnostic.code == "stream_profile_disabling"));
-        assert_ne!(
-            observed_streaming_digest("knowledge", "DISABLING"),
-            streaming_digest("knowledge", false)
-        );
-        assert!(!streaming_mode_matches_desired("DISABLING", false));
-    }
-
-    #[tokio::test]
-    async fn streaming_applies_over_an_imported_preexisting_graph() {
-        // The CLI lifecycle shape: a graph exists BEFORE the cluster manages
-        // it; import records observed truth (disabled), apply must flip it.
-        let dir = fixture();
-        write_streaming_cluster(dir.path(), Some(true));
-        let graphs_dir = dir.path().join("graphs");
-        fs::create_dir_all(&graphs_dir).unwrap();
-        let graph_uri = graphs_dir.join("knowledge.omni");
-        Omnigraph::init(graph_uri.to_str().unwrap(), SCHEMA)
-            .await
-            .unwrap();
-
-        let import = import_config_dir(dir.path()).await;
-        assert!(import.ok, "{import:?}");
-        let out = confirmed_streaming_apply(dir.path()).await;
-        assert!(out.ok && out.converged, "{out:?}");
-        assert!(
-            live_streaming_enabled(dir.path()).await,
-            "import→apply must flip the pre-existing graph: {out:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn authority_retirement_preflight_requires_actor_confirmation_and_declared_graph() {
-        let dir = fixture();
-        let missing_authority = plan_stream_authority_retirement_config_dir(
-            dir.path(),
-            "knowledge",
-            StreamAuthorityRetirementOptions::default(),
-        )
-        .await;
-        assert!(!missing_authority.ok);
-        assert!(missing_authority.diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == "stream_authority_retirement_actor_required"
-        }));
-        assert!(missing_authority.diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == "streaming_offline_confirmation_required"
-        }));
-        assert!(
-            !dir.path().join(CLUSTER_LOCK_FILE).exists(),
-            "preflight refusal must happen before lock acquisition"
-        );
-
-        let unknown_graph = plan_stream_authority_retirement_config_dir(
-            dir.path(),
-            "other",
-            StreamAuthorityRetirementOptions {
-                actor: Some("stream-operator".to_string()),
-                confirm_stream_offline: true,
-            },
-        )
-        .await;
-        assert!(!unknown_graph.ok);
-        assert!(unknown_graph.diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == "stream_authority_retirement_graph_not_declared"
-                && diagnostic.path == "graphs.other"
-        }));
-        assert!(
-            !dir.path().join(CLUSTER_LOCK_FILE).exists(),
-            "unknown graph refusal must happen before lock acquisition"
-        );
-
-        // Once config/state/actor/offline authority are valid, the command
-        // must reach the engine under the dedicated lock. A fresh disabled,
-        // unenrolled graph is intentionally not retireable, so the exact
-        // engine precondition gives this test a harmless terminal outcome.
-        write_streaming_cluster(dir.path(), Some(false));
-        init_derived_graph(dir.path()).await;
-        let import = import_config_dir(dir.path()).await;
-        assert!(import.ok, "{import:?}");
-        let engine_refusal = plan_stream_authority_retirement_config_dir(
-            dir.path(),
-            "knowledge",
-            StreamAuthorityRetirementOptions {
-                actor: Some("stream-operator".to_string()),
-                confirm_stream_offline: true,
-            },
-        )
-        .await;
-        assert!(!engine_refusal.ok);
-        assert!(engine_refusal.diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == "stream_authority_retirement_plan_failed"
-                && diagnostic
-                    .message
-                    .contains("at least one current WITHDRAWN or DEAD_LETTERED token")
-        }));
-        assert!(
-            !dir.path().join(CLUSTER_LOCK_FILE).exists(),
-            "engine refusal must release the dedicated retirement lock"
-        );
-    }
-
-    #[cfg(feature = "failpoints")]
-    #[test]
-    #[serial_test::serial]
-    fn authority_retirement_confirm_converges_applied_state_to_retired() {
-        on_big_stack(|| async {
+#[cfg(feature = "failpoints")]
+#[test]
+#[serial_test::serial]
+fn authority_retirement_confirm_converges_applied_state_to_retired() {
+    on_big_stack(|| async {
         let _scenario = fail::FailScenario::setup();
         let dir = fixture();
         write_streaming_cluster(dir.path(), Some(false));
@@ -5266,14 +5358,9 @@ policies: {}
             "age": 42,
         }))
         .unwrap();
-        db.failpoint_stream_ingest_one_as_for_test(
-            "node:Person",
-            &row,
-            0,
-            "stream-operator",
-        )
-        .await
-        .unwrap();
+        db.failpoint_stream_ingest_one_as_for_test("node:Person", &row, 0, "stream-operator")
+            .await
+            .unwrap();
         db.shutdown_stream_fold_driver().await.unwrap();
         drop(db);
 
@@ -5282,8 +5369,7 @@ policies: {}
         assert!(disabled.ok && disabled.converged, "{disabled:?}");
         let before = read_state_json(dir.path());
         let before_state_revision = before["state_revision"].as_u64().unwrap();
-        let before_streaming =
-            &before["applied_revision"]["resources"]["streaming.knowledge"];
+        let before_streaming = &before["applied_revision"]["resources"]["streaming.knowledge"];
         assert_eq!(before_streaming["profile_mode"], json!("DISABLED"));
         let declaration_digest = before_streaming["digest"].clone();
         let declaration_revision = before_streaming["declaration_revision"].clone();
@@ -5302,12 +5388,9 @@ policies: {}
             actor: Some("stream-operator".to_string()),
             confirm_stream_offline: true,
         };
-        let plan = plan_stream_authority_retirement_config_dir(
-            dir.path(),
-            "knowledge",
-            options.clone(),
-        )
-        .await;
+        let plan =
+            plan_stream_authority_retirement_config_dir(dir.path(), "knowledge", options.clone())
+                .await;
         assert!(plan.ok, "{plan:?}");
         let plan = plan.plan.expect("successful retirement plan");
         let retirement_id = "73737373-7373-4373-8373-737373737373";
@@ -5316,10 +5399,8 @@ policies: {}
         let state_race = omnigraph::failpoints::ScopedFailPoint::with_callback(
             crate::failpoints::names::CLUSTER_STREAM_RETIREMENT_BEFORE_STATE_WRITE,
             move || {
-                let mut concurrent: serde_json::Value = serde_json::from_str(
-                    &fs::read_to_string(&race_path).unwrap(),
-                )
-                .unwrap();
+                let mut concurrent: serde_json::Value =
+                    serde_json::from_str(&fs::read_to_string(&race_path).unwrap()).unwrap();
                 concurrent["state_revision"] = json!(raced_state_revision);
                 concurrent["applied_revision"]["resources"]["streaming.knowledge"]
                     .as_object_mut()
@@ -5342,9 +5423,12 @@ policies: {}
         .await;
         drop(state_race);
         assert!(!raced.ok, "the stale cluster-state CAS must fail closed");
-        assert!(raced.diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == "state_cas_mismatch"
-        }));
+        assert!(
+            raced
+                .diagnostics
+                .iter()
+                .any(|diagnostic| { diagnostic.code == "state_cas_mismatch" })
+        );
         let raced_result = raced
             .result
             .as_ref()
@@ -5360,8 +5444,7 @@ policies: {}
             "the concurrent malformed row makes the retry prove deterministic backfill"
         );
         assert_eq!(
-            raced_state["applied_revision"]["resources"]["streaming.knowledge"]
-                ["profile_mode"],
+            raced_state["applied_revision"]["resources"]["streaming.knowledge"]["profile_mode"],
             json!("DISABLED")
         );
         assert_eq!(
@@ -5385,12 +5468,14 @@ policies: {}
         .await;
         assert!(confirmed.ok, "{confirmed:?}");
         let result = confirmed.result.expect("successful retirement result");
-        assert!(!result.changed, "retry must replay the exact durable receipt");
+        assert!(
+            !result.changed,
+            "retry must replay the exact durable receipt"
+        );
         assert_eq!(result.profile_revision, raced_profile_revision);
 
         let after = read_state_json(dir.path());
-        let after_streaming =
-            &after["applied_revision"]["resources"]["streaming.knowledge"];
+        let after_streaming = &after["applied_revision"]["resources"]["streaming.knowledge"];
         assert_eq!(after["state_revision"], json!(raced_state_revision + 1));
         assert_eq!(after_streaming["digest"], declaration_digest);
         assert_eq!(
@@ -5438,8 +5523,7 @@ policies: {}
             json!(result.profile_revision)
         );
         assert_eq!(
-            refreshed_state["observations"]["graph.knowledge"]
-                ["streaming_matches_desired"],
+            refreshed_state["observations"]["graph.knowledge"]["streaming_matches_desired"],
             json!(true)
         );
         let next_plan = plan_config_dir(dir.path()).await;
@@ -5450,334 +5534,332 @@ policies: {}
                 .all(|change| change.resource != "streaming.knowledge"),
             "RETIRED must remain converged with desired streaming:false: {next_plan:?}"
         );
-        });
-    }
+    });
+}
 
-    #[tokio::test]
-    async fn stream_block_preflight_requires_actor_confirmation_and_declared_graph() {
-        let dir = fixture();
-        let missing_authority = show_stream_data_block_config_dir(
-            dir.path(),
-            "knowledge",
-            "block-1",
-            None,
-            StreamBlockControlOptions::default(),
-        )
-        .await;
-        assert!(!missing_authority.ok);
-        assert!(missing_authority
+#[tokio::test]
+async fn stream_block_preflight_requires_actor_confirmation_and_declared_graph() {
+    let dir = fixture();
+    let missing_authority = show_stream_data_block_config_dir(
+        dir.path(),
+        "knowledge",
+        "block-1",
+        None,
+        StreamBlockControlOptions::default(),
+    )
+    .await;
+    assert!(!missing_authority.ok);
+    assert!(
+        missing_authority
             .diagnostics
             .iter()
-            .any(|diagnostic| diagnostic.code == "stream_block_actor_required"));
-        assert!(missing_authority.diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == "streaming_offline_confirmation_required"
-        }));
-        assert!(
-            !dir.path().join(CLUSTER_LOCK_FILE).exists(),
-            "preflight refusal must happen before lock acquisition"
-        );
+            .any(|diagnostic| diagnostic.code == "stream_block_actor_required")
+    );
+    assert!(
+        missing_authority
+            .diagnostics
+            .iter()
+            .any(|diagnostic| { diagnostic.code == "streaming_offline_confirmation_required" })
+    );
+    assert!(
+        !dir.path().join(CLUSTER_LOCK_FILE).exists(),
+        "preflight refusal must happen before lock acquisition"
+    );
 
-        let unknown_graph = show_stream_data_block_config_dir(
-            dir.path(),
-            "other",
-            "block-1",
-            None,
-            StreamBlockControlOptions {
-                actor: Some("stream-operator".to_string()),
-                confirm_stream_offline: true,
-            },
-        )
-        .await;
-        assert!(!unknown_graph.ok);
-        assert!(unknown_graph.diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == "stream_block_graph_not_declared"
-                && diagnostic.path == "graphs.other"
-        }));
-        assert!(
-            !dir.path().join(CLUSTER_LOCK_FILE).exists(),
-            "unknown graph refusal must happen before lock acquisition"
-        );
-
-        init_derived_graph(dir.path()).await;
-        let import = import_config_dir(dir.path()).await;
-        assert!(import.ok, "{import:?}");
-        let unapplied_profile = show_stream_data_block_config_dir(
-            dir.path(),
-            "knowledge",
-            "block-1",
-            None,
-            StreamBlockControlOptions {
-                actor: Some("stream-operator".to_string()),
-                confirm_stream_offline: true,
-            },
-        )
-        .await;
-        assert!(!unapplied_profile.ok);
-        assert!(unapplied_profile.diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == "stream_block_profile_not_applied"
-                && diagnostic.path == "streaming.knowledge"
-        }));
-        assert!(
-            !dir.path().join(CLUSTER_LOCK_FILE).exists(),
-            "applied-profile refusal must release the state lock"
-        );
-    }
-
-    #[tokio::test]
-    async fn stream_dead_letter_preflight_requires_actor_confirmation_and_declared_graph() {
-        let dir = fixture();
-        let missing_authority = list_stream_dead_letters_config_dir(
-            dir.path(),
-            "knowledge",
-            None,
-            StreamDeadLetterControlOptions::default(),
-        )
-        .await;
-        assert!(!missing_authority.ok);
-        assert!(
-            missing_authority
-                .diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.code == "stream_dead_letter_actor_required")
-        );
-        assert!(missing_authority.diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == "streaming_offline_confirmation_required"
-        }));
-        assert!(
-            !dir.path().join(CLUSTER_LOCK_FILE).exists(),
-            "dead-letter preflight refusal must happen before lock acquisition"
-        );
-
-        let unknown_graph = list_stream_dead_letters_config_dir(
-            dir.path(),
-            "other",
-            None,
-            StreamDeadLetterControlOptions {
-                actor: Some("stream-operator".to_string()),
-                confirm_stream_offline: true,
-            },
-        )
-        .await;
-        assert!(!unknown_graph.ok);
-        assert!(unknown_graph.diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == "stream_dead_letter_graph_not_declared"
-                && diagnostic.path == "graphs.other"
-        }));
-        assert!(
-            !dir.path().join(CLUSTER_LOCK_FILE).exists(),
-            "unknown dead-letter graph refusal must happen before lock acquisition"
-        );
-
-        write_streaming_cluster(dir.path(), Some(true));
-        write_state_resources(dir.path(), &[]);
-        let applied = confirmed_streaming_apply(dir.path()).await;
-        assert!(applied.ok && applied.converged, "{applied:?}");
-        let mut stale_state = read_state_json(dir.path());
-        let recorded_revision = stale_state["applied_revision"]["resources"]
-            ["streaming.knowledge"]["profile_revision"]
-            .as_u64()
-            .unwrap();
-        stale_state["applied_revision"]["resources"]["streaming.knowledge"]
-            ["profile_revision"] = json!(recorded_revision + 1);
-        fs::write(
-            dir.path().join(CLUSTER_STATE_FILE),
-            serde_json::to_string_pretty(&stale_state).unwrap(),
-        )
-        .unwrap();
-        let stale_options = StreamDeadLetterControlOptions {
+    let unknown_graph = show_stream_data_block_config_dir(
+        dir.path(),
+        "other",
+        "block-1",
+        None,
+        StreamBlockControlOptions {
             actor: Some("stream-operator".to_string()),
             confirm_stream_offline: true,
-        };
-        let stale_list = list_stream_dead_letters_config_dir(
-            dir.path(),
-            "knowledge",
-            None,
-            stale_options.clone(),
-        )
-        .await;
-        assert!(!stale_list.ok);
-        assert!(stale_list.diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == "stream_dead_letter_list_failed"
-                && diagnostic
-                    .message
-                    .contains("offline graph streaming authority is unavailable or changed")
-        }));
-        let stale_export = export_stream_dead_letters_config_dir(
-            dir.path(),
-            "knowledge",
-            None,
-            stale_options,
-        )
-        .await;
-        assert!(!stale_export.ok);
-        assert!(stale_export.diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == "stream_dead_letter_export_failed"
-                && diagnostic
-                    .message
-                    .contains("offline graph streaming authority is unavailable or changed")
-        }));
-    }
+        },
+    )
+    .await;
+    assert!(!unknown_graph.ok);
+    assert!(unknown_graph.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "stream_block_graph_not_declared" && diagnostic.path == "graphs.other"
+    }));
+    assert!(
+        !dir.path().join(CLUSTER_LOCK_FILE).exists(),
+        "unknown graph refusal must happen before lock acquisition"
+    );
 
-    #[cfg(feature = "failpoints")]
-    #[tokio::test]
-    #[serial_test::serial]
-    async fn stream_block_authority_and_shape_refusals_precede_recovery() {
-        let _scenario = fail::FailScenario::setup();
+    init_derived_graph(dir.path()).await;
+    let import = import_config_dir(dir.path()).await;
+    assert!(import.ok, "{import:?}");
+    let unapplied_profile = show_stream_data_block_config_dir(
+        dir.path(),
+        "knowledge",
+        "block-1",
+        None,
+        StreamBlockControlOptions {
+            actor: Some("stream-operator".to_string()),
+            confirm_stream_offline: true,
+        },
+    )
+    .await;
+    assert!(!unapplied_profile.ok);
+    assert!(unapplied_profile.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "stream_block_profile_not_applied"
+            && diagnostic.path == "streaming.knowledge"
+    }));
+    assert!(
+        !dir.path().join(CLUSTER_LOCK_FILE).exists(),
+        "applied-profile refusal must release the state lock"
+    );
+}
 
-        fn graph_tree(root: &Path) -> std::collections::BTreeMap<std::path::PathBuf, Vec<u8>> {
-            fn visit(
-                root: &Path,
-                current: &Path,
-                files: &mut std::collections::BTreeMap<std::path::PathBuf, Vec<u8>>,
-            ) {
-                let mut entries = fs::read_dir(current)
-                    .unwrap()
-                    .map(|entry| entry.unwrap().path())
-                    .collect::<Vec<_>>();
-                entries.sort();
-                for path in entries {
-                    if path.is_dir() {
-                        visit(root, &path, files);
-                    } else {
-                        files.insert(
-                            path.strip_prefix(root).unwrap().to_path_buf(),
-                            fs::read(path).unwrap(),
-                        );
-                    }
+#[tokio::test]
+async fn stream_dead_letter_preflight_requires_actor_confirmation_and_declared_graph() {
+    let dir = fixture();
+    let missing_authority = list_stream_dead_letters_config_dir(
+        dir.path(),
+        "knowledge",
+        None,
+        StreamDeadLetterControlOptions::default(),
+    )
+    .await;
+    assert!(!missing_authority.ok);
+    assert!(
+        missing_authority
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "stream_dead_letter_actor_required")
+    );
+    assert!(
+        missing_authority
+            .diagnostics
+            .iter()
+            .any(|diagnostic| { diagnostic.code == "streaming_offline_confirmation_required" })
+    );
+    assert!(
+        !dir.path().join(CLUSTER_LOCK_FILE).exists(),
+        "dead-letter preflight refusal must happen before lock acquisition"
+    );
+
+    let unknown_graph = list_stream_dead_letters_config_dir(
+        dir.path(),
+        "other",
+        None,
+        StreamDeadLetterControlOptions {
+            actor: Some("stream-operator".to_string()),
+            confirm_stream_offline: true,
+        },
+    )
+    .await;
+    assert!(!unknown_graph.ok);
+    assert!(unknown_graph.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "stream_dead_letter_graph_not_declared"
+            && diagnostic.path == "graphs.other"
+    }));
+    assert!(
+        !dir.path().join(CLUSTER_LOCK_FILE).exists(),
+        "unknown dead-letter graph refusal must happen before lock acquisition"
+    );
+
+    write_streaming_cluster(dir.path(), Some(true));
+    write_state_resources(dir.path(), &[]);
+    let applied = confirmed_streaming_apply(dir.path()).await;
+    assert!(applied.ok && applied.converged, "{applied:?}");
+    let mut stale_state = read_state_json(dir.path());
+    let recorded_revision =
+        stale_state["applied_revision"]["resources"]["streaming.knowledge"]["profile_revision"]
+            .as_u64()
+            .unwrap();
+    stale_state["applied_revision"]["resources"]["streaming.knowledge"]["profile_revision"] =
+        json!(recorded_revision + 1);
+    fs::write(
+        dir.path().join(CLUSTER_STATE_FILE),
+        serde_json::to_string_pretty(&stale_state).unwrap(),
+    )
+    .unwrap();
+    let stale_options = StreamDeadLetterControlOptions {
+        actor: Some("stream-operator".to_string()),
+        confirm_stream_offline: true,
+    };
+    let stale_list =
+        list_stream_dead_letters_config_dir(dir.path(), "knowledge", None, stale_options.clone())
+            .await;
+    assert!(!stale_list.ok);
+    assert!(stale_list.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "stream_dead_letter_list_failed"
+            && diagnostic
+                .message
+                .contains("offline graph streaming authority is unavailable or changed")
+    }));
+    let stale_export =
+        export_stream_dead_letters_config_dir(dir.path(), "knowledge", None, stale_options).await;
+    assert!(!stale_export.ok);
+    assert!(stale_export.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "stream_dead_letter_export_failed"
+            && diagnostic
+                .message
+                .contains("offline graph streaming authority is unavailable or changed")
+    }));
+}
+
+#[cfg(feature = "failpoints")]
+#[tokio::test]
+#[serial_test::serial]
+async fn stream_block_authority_and_shape_refusals_precede_recovery() {
+    let _scenario = fail::FailScenario::setup();
+
+    fn graph_tree(root: &Path) -> std::collections::BTreeMap<std::path::PathBuf, Vec<u8>> {
+        fn visit(
+            root: &Path,
+            current: &Path,
+            files: &mut std::collections::BTreeMap<std::path::PathBuf, Vec<u8>>,
+        ) {
+            let mut entries = fs::read_dir(current)
+                .unwrap()
+                .map(|entry| entry.unwrap().path())
+                .collect::<Vec<_>>();
+            entries.sort();
+            for path in entries {
+                if path.is_dir() {
+                    visit(root, &path, files);
+                } else {
+                    files.insert(
+                        path.strip_prefix(root).unwrap().to_path_buf(),
+                        fs::read(path).unwrap(),
+                    );
                 }
             }
-
-            let mut files = std::collections::BTreeMap::new();
-            visit(root, root, &mut files);
-            files
         }
 
-        let dir = fixture();
-        write_streaming_cluster(dir.path(), Some(true));
-        write_state_resources(dir.path(), &[]);
-        let applied = confirmed_streaming_apply(dir.path()).await;
-        assert!(applied.ok && applied.converged, "{applied:?}");
-        let serving = read_serving_snapshot(dir.path()).await.unwrap();
-        let runtime_binding = serving.graphs[0]
-            .stream_runtime_authority
-            .clone()
-            .expect("enabled graph carries a validated runtime binding");
-        let graph_root = dir.path().join("graphs/knowledge.omni");
-        let runtime_guard = mint_runtime_guard(
-            runtime_binding.clone(),
-            "stream-block-recovery-fixture",
-            "stream-operator",
-        )
+        let mut files = std::collections::BTreeMap::new();
+        visit(root, root, &mut files);
+        files
+    }
+
+    let dir = fixture();
+    write_streaming_cluster(dir.path(), Some(true));
+    write_state_resources(dir.path(), &[]);
+    let applied = confirmed_streaming_apply(dir.path()).await;
+    assert!(applied.ok && applied.converged, "{applied:?}");
+    let serving = read_serving_snapshot(dir.path()).await.unwrap();
+    let runtime_binding = serving.graphs[0]
+        .stream_runtime_authority
+        .clone()
+        .expect("enabled graph carries a validated runtime binding");
+    let graph_root = dir.path().join("graphs/knowledge.omni");
+    let runtime_guard = mint_runtime_guard(
+        runtime_binding.clone(),
+        "stream-block-recovery-fixture",
+        "stream-operator",
+    )
+    .await
+    .unwrap();
+    let db = Omnigraph::open(graph_root.to_str().unwrap())
+        .await
+        .unwrap()
+        .with_checked_cluster_stream_runtime(runtime_guard)
         .await
         .unwrap();
-        let db = Omnigraph::open(graph_root.to_str().unwrap())
-            .await
-            .unwrap()
-            .with_checked_cluster_stream_runtime(runtime_guard)
-            .await
-            .unwrap();
-        db.branch_create("recovery-fixture").await.unwrap();
-        let mut params = ParamMap::new();
-        params.insert(
-            "name".to_string(),
-            Literal::String("pending-recovery".to_string()),
+    db.branch_create("recovery-fixture").await.unwrap();
+    let mut params = ParamMap::new();
+    params.insert(
+        "name".to_string(),
+        Literal::String("pending-recovery".to_string()),
+    );
+    params.insert("age".to_string(), Literal::Integer(42));
+    let mutation_error = {
+        let _failpoint = omnigraph::failpoints::ScopedFailPoint::new(
+            omnigraph::failpoints::names::MUTATION_POST_SIDECAR_PRE_FORK,
+            "return",
         );
-        params.insert("age".to_string(), Literal::Integer(42));
-        let mutation_error = {
-            let _failpoint = omnigraph::failpoints::ScopedFailPoint::new(
-                omnigraph::failpoints::names::MUTATION_POST_SIDECAR_PRE_FORK,
-                "return",
-            );
-            db.mutate(
-                "recovery-fixture",
-                r#"
+        db.mutate(
+            "recovery-fixture",
+            r#"
 query arm_recovery($name: String, $age: I32) {
   insert Person { name: $name, age: $age }
 }
 "#,
-                "arm_recovery",
-                &params,
-            )
-            .await
-            .expect_err("the fixture must retain one arm-only graph recovery sidecar")
-        };
-        assert!(
-            matches!(
-                mutation_error,
-                omnigraph::error::OmniError::RecoveryRequired { .. }
-            ),
-            "{mutation_error:?}"
-        );
-        drop(db);
-        let recovery_dir = graph_root.join("__recovery");
-        assert_eq!(fs::read_dir(&recovery_dir).unwrap().count(), 1);
-        let before_graph = graph_tree(&graph_root);
-        let runtime_guard = mint_runtime_guard(
-            runtime_binding.clone(),
-            "stream-block-runtime-owner",
-            "operator:runtime-owner",
+            "arm_recovery",
+            &params,
         )
         .await
-        .unwrap();
+        .expect_err("the fixture must retain one arm-only graph recovery sidecar")
+    };
+    assert!(
+        matches!(
+            mutation_error,
+            omnigraph::error::OmniError::RecoveryRequired { .. }
+        ),
+        "{mutation_error:?}"
+    );
+    drop(db);
+    let recovery_dir = graph_root.join("__recovery");
+    assert_eq!(fs::read_dir(&recovery_dir).unwrap().count(), 1);
+    let before_graph = graph_tree(&graph_root);
+    let runtime_guard = mint_runtime_guard(
+        runtime_binding.clone(),
+        "stream-block-runtime-owner",
+        "operator:runtime-owner",
+    )
+    .await
+    .unwrap();
 
-        let request = omnigraph::db::StreamDataCorrectionRequest {
-            protocol_version: 1,
-            block_token: format!("sha256:{}", "a".repeat(64)),
-            correction_id: "abababab-abab-4bab-8bab-abababababab".to_string(),
-            expected_lifecycle_revision: 1,
-            actions: Vec::new(),
-            expected_plan_digest: None,
-        };
-        let refused = correct_stream_data_block_config_dir(
-            dir.path(),
-            "knowledge",
-            request.clone(),
-            StreamBlockControlOptions {
-                actor: Some("stream-operator".to_string()),
-                confirm_stream_offline: true,
-            },
-        )
-        .await;
-        assert!(!refused.ok, "{refused:?}");
-        assert!(refused.diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == "stream_block_correct_failed"
-                && diagnostic.message.contains("live runtime")
-        }));
-        assert_eq!(
-            graph_tree(&graph_root),
-            before_graph,
-            "runtime exclusion must reject before RW open can resolve the sidecar or move any graph physical/manifest file"
-        );
-        assert_eq!(fs::read_dir(&recovery_dir).unwrap().count(), 1);
-        assert!(
-            !dir.path().join(CLUSTER_LOCK_FILE).exists(),
-            "runtime refusal must release the cluster state lock"
-        );
+    let request = omnigraph::db::StreamDataCorrectionRequest {
+        protocol_version: 1,
+        block_token: format!("sha256:{}", "a".repeat(64)),
+        correction_id: "abababab-abab-4bab-8bab-abababababab".to_string(),
+        expected_lifecycle_revision: 1,
+        actions: Vec::new(),
+        expected_plan_digest: None,
+    };
+    let refused = correct_stream_data_block_config_dir(
+        dir.path(),
+        "knowledge",
+        request.clone(),
+        StreamBlockControlOptions {
+            actor: Some("stream-operator".to_string()),
+            confirm_stream_offline: true,
+        },
+    )
+    .await;
+    assert!(!refused.ok, "{refused:?}");
+    assert!(refused.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "stream_block_correct_failed"
+            && diagnostic.message.contains("live runtime")
+    }));
+    assert_eq!(
+        graph_tree(&graph_root),
+        before_graph,
+        "runtime exclusion must reject before RW open can resolve the sidecar or move any graph physical/manifest file"
+    );
+    assert_eq!(fs::read_dir(&recovery_dir).unwrap().count(), 1);
+    assert!(
+        !dir.path().join(CLUSTER_LOCK_FILE).exists(),
+        "runtime refusal must release the cluster state lock"
+    );
 
-        drop(runtime_guard);
-        let malformed = correct_stream_data_block_config_dir(
-            dir.path(),
-            "knowledge",
-            request,
-            StreamBlockControlOptions {
-                actor: Some("stream-operator".to_string()),
-                confirm_stream_offline: true,
-            },
-        )
-        .await;
-        assert!(!malformed.ok, "{malformed:?}");
-        assert!(malformed.diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == "stream_block_correct_failed"
-                && diagnostic.message.contains("request is invalid")
-        }));
-        assert_eq!(
-            graph_tree(&graph_root),
-            before_graph,
-            "request-shape refusal must happen before pending graph recovery can move any physical or manifest file"
-        );
-        assert_eq!(fs::read_dir(&recovery_dir).unwrap().count(), 1);
-        assert!(
-            !dir.path().join(CLUSTER_LOCK_FILE).exists(),
-            "shape refusal must release the cluster state lock"
-        );
-    }
+    drop(runtime_guard);
+    let malformed = correct_stream_data_block_config_dir(
+        dir.path(),
+        "knowledge",
+        request,
+        StreamBlockControlOptions {
+            actor: Some("stream-operator".to_string()),
+            confirm_stream_offline: true,
+        },
+    )
+    .await;
+    assert!(!malformed.ok, "{malformed:?}");
+    assert!(malformed.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "stream_block_correct_failed"
+            && diagnostic.message.contains("request is invalid")
+    }));
+    assert_eq!(
+        graph_tree(&graph_root),
+        before_graph,
+        "request-shape refusal must happen before pending graph recovery can move any physical or manifest file"
+    );
+    assert_eq!(fs::read_dir(&recovery_dir).unwrap().count(), 1);
+    assert!(
+        !dir.path().join(CLUSTER_LOCK_FILE).exists(),
+        "shape refusal must release the cluster state lock"
+    );
+}

--- a/crates/omnigraph-cluster/tests/failpoints.rs
+++ b/crates/omnigraph-cluster/tests/failpoints.rs
@@ -114,7 +114,10 @@ async fn failpoint_wiring_returns_injected_diagnostic() {
     let dir = fixture();
     seed_applyable_state(dir.path());
 
-    let _failpoint = ScopedFailPoint::new(omnigraph_cluster::failpoints::names::CLUSTER_APPLY_AFTER_PAYLOAD_PHASE, "return");
+    let _failpoint = ScopedFailPoint::new(
+        omnigraph_cluster::failpoints::names::CLUSTER_APPLY_AFTER_PAYLOAD_PHASE,
+        "return",
+    );
     let out = apply_config_dir(dir.path()).await;
     assert!(!out.ok);
     assert!(out.diagnostics.iter().any(|diagnostic| {
@@ -139,7 +142,10 @@ async fn apply_crash_after_payload_phase_leaves_state_unmoved_then_recovers() {
     let state_before = fs::read(state_path(dir.path())).unwrap();
 
     {
-        let _failpoint = ScopedFailPoint::new(omnigraph_cluster::failpoints::names::CLUSTER_APPLY_AFTER_PAYLOAD_PHASE, "return");
+        let _failpoint = ScopedFailPoint::new(
+            omnigraph_cluster::failpoints::names::CLUSTER_APPLY_AFTER_PAYLOAD_PHASE,
+            "return",
+        );
         let out = apply_config_dir(dir.path()).await;
         assert!(!out.ok);
         assert!(!out.state_written);
@@ -185,12 +191,15 @@ async fn apply_cas_race_surfaces_state_cas_mismatch() {
     // after apply read it but before apply writes. RAII-guarded so a panic
     // inside apply cannot leak the callback into the global registry.
     let race_path = state_path(dir.path());
-    let failpoint = ScopedFailPoint::with_callback(omnigraph_cluster::failpoints::names::CLUSTER_APPLY_BEFORE_STATE_WRITE, move || {
-        let mut state: serde_json::Value =
-            serde_json::from_str(&fs::read_to_string(&race_path).unwrap()).unwrap();
-        state["state_revision"] = serde_json::json!(99);
-        fs::write(&race_path, serde_json::to_string_pretty(&state).unwrap()).unwrap();
-    });
+    let failpoint = ScopedFailPoint::with_callback(
+        omnigraph_cluster::failpoints::names::CLUSTER_APPLY_BEFORE_STATE_WRITE,
+        move || {
+            let mut state: serde_json::Value =
+                serde_json::from_str(&fs::read_to_string(&race_path).unwrap()).unwrap();
+            state["state_revision"] = serde_json::json!(99);
+            fs::write(&race_path, serde_json::to_string_pretty(&state).unwrap()).unwrap();
+        },
+    );
 
     let out = apply_config_dir(dir.path()).await;
     drop(failpoint);
@@ -269,7 +278,10 @@ async fn create_crash_before_init_recovers_via_sweep() {
     seed_empty_state(dir.path());
 
     {
-        let _failpoint = ScopedFailPoint::new(omnigraph_cluster::failpoints::names::CLUSTER_APPLY_BEFORE_GRAPH_CREATE, "return");
+        let _failpoint = ScopedFailPoint::new(
+            omnigraph_cluster::failpoints::names::CLUSTER_APPLY_BEFORE_GRAPH_CREATE,
+            "return",
+        );
         let out = apply_config_dir(dir.path()).await;
         assert!(!out.ok);
         assert!(out.diagnostics.iter().any(|diagnostic| {
@@ -313,7 +325,10 @@ async fn create_crash_after_init_rolls_state_forward() {
     let state_before = fs::read(dir.path().join("__cluster/state.json")).unwrap();
 
     {
-        let _failpoint = ScopedFailPoint::new(omnigraph_cluster::failpoints::names::CLUSTER_APPLY_AFTER_GRAPH_CREATE, "return");
+        let _failpoint = ScopedFailPoint::new(
+            omnigraph_cluster::failpoints::names::CLUSTER_APPLY_AFTER_GRAPH_CREATE,
+            "return",
+        );
         let out = apply_config_dir(dir.path()).await;
         assert!(!out.ok);
         assert!(!out.state_written);
@@ -402,7 +417,10 @@ async fn schema_crash_before_apply_recovers_via_sweep() {
     fs::write(dir.path().join("people.pg"), SCHEMA_V2).unwrap();
 
     {
-        let _failpoint = ScopedFailPoint::new(omnigraph_cluster::failpoints::names::CLUSTER_APPLY_BEFORE_SCHEMA_APPLY, "return");
+        let _failpoint = ScopedFailPoint::new(
+            omnigraph_cluster::failpoints::names::CLUSTER_APPLY_BEFORE_SCHEMA_APPLY,
+            "return",
+        );
         let out = apply_config_dir_with_options(
             dir.path(),
             ApplyOptions {
@@ -444,7 +462,10 @@ async fn schema_apply_error_before_graph_movement_removes_sidecar() {
     fs::write(dir.path().join("people.pg"), SCHEMA_V2).unwrap();
 
     {
-        let _failpoint = ScopedFailPoint::new(omnigraph::failpoints::names::SCHEMA_APPLY_BEFORE_STAGING_WRITE, "return");
+        let _failpoint = ScopedFailPoint::new(
+            omnigraph::failpoints::names::SCHEMA_APPLY_BEFORE_STAGING_WRITE,
+            "return",
+        );
         let out = apply_config_dir(dir.path()).await;
         assert!(!out.ok);
         assert!(
@@ -485,7 +506,10 @@ async fn schema_apply_error_after_graph_movement_keeps_sidecar() {
     let v2_digest = desired.resource_digests["schema.knowledge"].clone();
 
     {
-        let _failpoint = ScopedFailPoint::new(omnigraph::failpoints::names::SCHEMA_APPLY_AFTER_MANIFEST_COMMIT, "return");
+        let _failpoint = ScopedFailPoint::new(
+            omnigraph::failpoints::names::SCHEMA_APPLY_AFTER_MANIFEST_COMMIT,
+            "return",
+        );
         let out = apply_config_dir(dir.path()).await;
         assert!(!out.ok);
         assert!(
@@ -564,7 +588,10 @@ async fn schema_crash_after_apply_rolls_state_forward() {
     let v2_digest = desired.resource_digests["schema.knowledge"].clone();
 
     {
-        let _failpoint = ScopedFailPoint::new(omnigraph_cluster::failpoints::names::CLUSTER_APPLY_AFTER_SCHEMA_APPLY, "return");
+        let _failpoint = ScopedFailPoint::new(
+            omnigraph_cluster::failpoints::names::CLUSTER_APPLY_AFTER_SCHEMA_APPLY,
+            "return",
+        );
         let out = apply_config_dir(dir.path()).await;
         assert!(!out.ok);
         assert!(!out.state_written);
@@ -666,7 +693,10 @@ async fn delete_crash_before_removal_reproposes() {
     let approval_id = seed_approved_delete(dir.path()).await;
 
     {
-        let _failpoint = ScopedFailPoint::new(omnigraph_cluster::failpoints::names::CLUSTER_APPLY_BEFORE_GRAPH_DELETE, "return");
+        let _failpoint = ScopedFailPoint::new(
+            omnigraph_cluster::failpoints::names::CLUSTER_APPLY_BEFORE_GRAPH_DELETE,
+            "return",
+        );
         let out = apply_config_dir(dir.path()).await;
         assert!(!out.ok);
         assert!(dir.path().join("graphs/old.omni").exists());
@@ -710,7 +740,10 @@ async fn delete_crash_after_removal_rolls_forward() {
     let state_before = fs::read(state_path(dir.path())).unwrap();
 
     {
-        let _failpoint = ScopedFailPoint::new(omnigraph_cluster::failpoints::names::CLUSTER_APPLY_AFTER_GRAPH_DELETE, "return");
+        let _failpoint = ScopedFailPoint::new(
+            omnigraph_cluster::failpoints::names::CLUSTER_APPLY_AFTER_GRAPH_DELETE,
+            "return",
+        );
         let out = apply_config_dir(dir.path()).await;
         assert!(!out.ok);
         assert!(!out.state_written);

--- a/crates/omnigraph-compiler/src/schema/mod.rs
+++ b/crates/omnigraph-compiler/src/schema/mod.rs
@@ -15,9 +15,9 @@ pub(crate) fn is_reserved_storage_system_column(name: &str) -> bool {
         || matches!(
             name,
             "_rowid"
-            | "_rowaddr"
-            | "_rowoffset"
-            | "_row_created_at_version"
-            | "_row_last_updated_at_version"
+                | "_rowaddr"
+                | "_rowoffset"
+                | "_row_created_at_version"
+                | "_row_last_updated_at_version"
         )
 }

--- a/crates/omnigraph-server/src/handlers.rs
+++ b/crates/omnigraph-server/src/handlers.rs
@@ -84,7 +84,9 @@ pub(crate) async fn server_graphs_list(
     Ok(Json(GraphListResponse { graphs }))
 }
 
-pub(crate) async fn server_openapi(State(state): State<AppState>) -> Json<utoipa::openapi::OpenApi> {
+pub(crate) async fn server_openapi(
+    State(state): State<AppState>,
+) -> Json<utoipa::openapi::OpenApi> {
     // `served_openapi` is the single nesting source — the protected
     // routes always live under `/graphs/{graph_id}/...` (public/management
     // paths `/healthz`, `/graphs` stay flat). Building from it here means
@@ -293,7 +295,11 @@ pub(crate) async fn resolve_graph_handle(
     Ok(next.run(request).await)
 }
 
-pub(crate) fn log_policy_decision(actor_id: &str, request: &PolicyRequest, decision: &PolicyDecision) {
+pub(crate) fn log_policy_decision(
+    actor_id: &str,
+    request: &PolicyRequest,
+    decision: &PolicyDecision,
+) {
     info!(
         actor_id = actor_id,
         action = %request.action,
@@ -509,7 +515,9 @@ pub(crate) fn deprecation_headers(successor_link: &'static str) -> [(HeaderName,
     ),
     security(("bearer_token" = [])),
 )]
-#[deprecated(note = "use POST /query instead; /read is kept indefinitely for byte-stable back-compat")]
+#[deprecated(
+    note = "use POST /query instead; /read is kept indefinitely for byte-stable back-compat"
+)]
 /// **Deprecated** — use [`POST /query`](#tag/queries/operation/query) instead.
 ///
 /// Execute a GQ read query. Behavior is unchanged from prior releases; the
@@ -1024,8 +1032,8 @@ pub(crate) async fn server_stream_ingest(
             Box::pin(chunks),
         )
         .await;
-    let start = start
-        .map_err(|error| ApiError::from_graph_stream_start(error, precondition_supplied))?;
+    let start =
+        start.map_err(|error| ApiError::from_graph_stream_start(error, precondition_supplied))?;
 
     match start {
         omnigraph::db::GraphStreamIngestStart::TokenRequired { authority_token } => {
@@ -1101,10 +1109,8 @@ pub(crate) async fn run_mutate(
     // estimated bytes per actor. Cedar runs FIRST so denied requests
     // don't consume admission slots. Estimate uses the request body
     // size as a coarse proxy; engine memory pressure can run higher.
-    let est_bytes = query.len() as u64
-        + params_json
-            .map(|p| p.to_string().len() as u64)
-            .unwrap_or(0);
+    let est_bytes =
+        query.len() as u64 + params_json.map(|p| p.to_string().len() as u64).unwrap_or(0);
     let _admission = state
         .workload
         .try_admit(&actor_arc, est_bytes)
@@ -1178,8 +1184,8 @@ pub(crate) async fn run_query(
             target_branch: None,
         },
     )?;
-    let query_decl =
-        select_named_query_decl(query, name).map_err(|err| ApiError::bad_request(err.to_string()))?;
+    let query_decl = select_named_query_decl(query, name)
+        .map_err(|err| ApiError::bad_request(err.to_string()))?;
     if reject_mutations && !query_decl.mutations.is_empty() {
         return Err(ApiError::bad_request(format!(
             "query '{}' contains mutations (insert/update/delete); use POST /mutate for write queries",
@@ -2055,8 +2061,12 @@ pub(crate) async fn server_branch_merge(
             .map_err(ApiError::from_omni)?
     };
     let (branch_deleted, branch_delete_error) = if request.delete_branch {
-        match delete_merged_source_branch(&handle, actor.as_ref().map(|Extension(a)| a), &request.source)
-            .await
+        match delete_merged_source_branch(
+            &handle,
+            actor.as_ref().map(|Extension(a)| a),
+            &request.source,
+        )
+        .await
         {
             Ok(()) => (Some(true), None),
             Err(message) => (Some(false), Some(message)),
@@ -2207,7 +2217,10 @@ pub(crate) async fn server_commit_show(
     Ok(Json(api::commit_output(&commit)))
 }
 
-pub(crate) fn read_target_from_request(branch: Option<String>, snapshot: Option<String>) -> ReadTarget {
+pub(crate) fn read_target_from_request(
+    branch: Option<String>,
+    snapshot: Option<String>,
+) -> ReadTarget {
     if let Some(snapshot) = snapshot {
         ReadTarget::snapshot(omnigraph::db::SnapshotId::new(snapshot))
     } else {

--- a/crates/omnigraph-server/src/lib.rs
+++ b/crates/omnigraph-server/src/lib.rs
@@ -243,8 +243,7 @@ pub struct GraphStartupConfig {
     /// Cloneable serving-snapshot evidence for a terminal stream profile.
     /// This is not export authority; `open_single_graph` rereads canonical
     /// cluster state and consumes it into a non-cloneable served-export guard.
-    pub stream_served_export_authority:
-        Option<omnigraph_cluster::ServedExportAuthorityBinding>,
+    pub stream_served_export_authority: Option<omnigraph_cluster::ServedExportAuthorityBinding>,
     /// Pre-resolved embedding config from an applied cluster provider profile.
     /// Legacy config paths leave this unset and continue to use env resolution.
     pub embedding: Option<omnigraph::embedding::EmbeddingConfig>,
@@ -2060,18 +2059,15 @@ async fn open_single_graph(cfg: GraphStartupConfig) -> Result<OpenedGraph> {
                 graph_id.as_str(),
                 binding.state_revision()
             );
-            let guard = omnigraph_cluster::mint_runtime_guard(
-                binding,
-                &operation_id,
-                "omnigraph:server",
-            )
-            .await
-            .map_err(|err| {
-                color_eyre::eyre::eyre!(
-                    "validate stream runtime authority for graph '{}': {err}",
-                    graph_id
-                )
-            })?;
+            let guard =
+                omnigraph_cluster::mint_runtime_guard(binding, &operation_id, "omnigraph:server")
+                    .await
+                    .map_err(|err| {
+                        color_eyre::eyre::eyre!(
+                            "validate stream runtime authority for graph '{}': {err}",
+                            graph_id
+                        )
+                    })?;
             db.with_checked_cluster_stream_runtime(guard)
                 .await
                 .map_err(|err| {

--- a/crates/omnigraph-server/src/queries.rs
+++ b/crates/omnigraph-server/src/queries.rs
@@ -106,30 +106,28 @@ impl QueryRegistry {
 
         for spec in specs {
             match parse_query(&spec.source) {
-                Ok(file) => {
-                    match file.queries.into_iter().find(|q| q.name == spec.name) {
-                        Some(decl) => {
-                            by_name.insert(
-                                spec.name.clone(),
-                                StoredQuery {
-                                    name: spec.name,
-                                    source: Arc::from(spec.source),
-                                    decl,
-                                    expose: spec.expose,
-                                    tool_name: spec.tool_name,
-                                },
-                            );
-                        }
-                        None => errors.push(LoadError {
-                            query: Some(spec.name.clone()),
-                            message: format!(
-                                "no `query {}` declaration found in its `.gq` file \
-                                 (the registry key must match the query symbol)",
-                                spec.name
-                            ),
-                        }),
+                Ok(file) => match file.queries.into_iter().find(|q| q.name == spec.name) {
+                    Some(decl) => {
+                        by_name.insert(
+                            spec.name.clone(),
+                            StoredQuery {
+                                name: spec.name,
+                                source: Arc::from(spec.source),
+                                decl,
+                                expose: spec.expose,
+                                tool_name: spec.tool_name,
+                            },
+                        );
                     }
-                }
+                    None => errors.push(LoadError {
+                        query: Some(spec.name.clone()),
+                        message: format!(
+                            "no `query {}` declaration found in its `.gq` file \
+                                 (the registry key must match the query symbol)",
+                            spec.name
+                        ),
+                    }),
+                },
                 Err(err) => errors.push(LoadError {
                     query: Some(spec.name),
                     message: format!("parse error: {err}"),
@@ -366,7 +364,10 @@ mod tests {
         let q = reg.lookup("b").unwrap();
         assert_eq!(q.name, "b");
         assert_eq!(q.decl.params[0].name, "y");
-        assert!(reg.lookup("a").is_none(), "only the selected symbol is registered");
+        assert!(
+            reg.lookup("a").is_none(),
+            "only the selected symbol is registered"
+        );
     }
 
     #[test]
@@ -375,8 +376,18 @@ mod tests {
         // the catalog key space — refused at load, naming both queries and
         // the contested tool.
         let errors = QueryRegistry::from_specs(vec![
-            spec_tool("a", "query a() { match { $u: User } return { $u.name } }", true, "dup"),
-            spec_tool("b", "query b() { match { $u: User } return { $u.name } }", true, "dup"),
+            spec_tool(
+                "a",
+                "query a() { match { $u: User } return { $u.name } }",
+                true,
+                "dup",
+            ),
+            spec_tool(
+                "b",
+                "query b() { match { $u: User } return { $u.name } }",
+                true,
+                "dup",
+            ),
         ])
         .unwrap_err();
         assert_eq!(errors.len(), 1);
@@ -391,8 +402,18 @@ mod tests {
         // Unexposed queries have no MCP tool, so a shared effective tool
         // name is inert — must not error (pins the exposed-only scope).
         let reg = QueryRegistry::from_specs(vec![
-            spec_tool("a", "query a() { match { $u: User } return { $u.name } }", false, "dup"),
-            spec_tool("b", "query b() { match { $u: User } return { $u.name } }", false, "dup"),
+            spec_tool(
+                "a",
+                "query a() { match { $u: User } return { $u.name } }",
+                false,
+                "dup",
+            ),
+            spec_tool(
+                "b",
+                "query b() { match { $u: User } return { $u.name } }",
+                false,
+                "dup",
+            ),
         ])
         .unwrap();
         assert_eq!(reg.len(), 2);
@@ -410,8 +431,16 @@ mod tests {
     #[test]
     fn errors_collect_rather_than_fail_fast() {
         let errors = QueryRegistry::from_specs(vec![
-            spec("good", "query good() { match { $u: User } return { $u.name } }", false),
-            spec("mismatch", "query other() { match { $u: User } return { $u.name } }", false),
+            spec(
+                "good",
+                "query good() { match { $u: User } return { $u.name } }",
+                false,
+            ),
+            spec(
+                "mismatch",
+                "query other() { match { $u: User } return { $u.name } }",
+                false,
+            ),
             spec("broken", "query broken(", false),
         ])
         .unwrap_err();
@@ -493,8 +522,16 @@ embedding: Vector(4)
     #[test]
     fn check_collects_every_breakage_not_fail_fast() {
         let reg = QueryRegistry::from_specs(vec![
-            spec("a", "query a() { match { $w: Widget } return { $w.x } }", false),
-            spec("b", "query b() { match { $g: Gadget } return { $g.y } }", false),
+            spec(
+                "a",
+                "query a() { match { $w: Widget } return { $w.x } }",
+                false,
+            ),
+            spec(
+                "b",
+                "query b() { match { $g: Gadget } return { $g.y } }",
+                false,
+            ),
             spec(
                 "ok",
                 "query ok() { match { $u: User } return { $u.name } }",
@@ -503,7 +540,12 @@ embedding: Vector(4)
         ])
         .unwrap();
         let report = check(&reg, &test_catalog());
-        assert_eq!(report.breakages.len(), 2, "both bad queries reported: {:?}", report);
+        assert_eq!(
+            report.breakages.len(),
+            2,
+            "both bad queries reported: {:?}",
+            report
+        );
     }
 
     #[test]
@@ -547,7 +589,11 @@ embedding: Vector(4)
         )])
         .unwrap();
         let report = check(&reg, &test_catalog());
-        assert!(report.is_clean(), "no breakage or warning expected: {:?}", report);
+        assert!(
+            report.is_clean(),
+            "no breakage or warning expected: {:?}",
+            report
+        );
     }
 
     // --- catalog projection (api::query_catalog_entry) ---
@@ -573,7 +619,11 @@ embedding: Vector(4)
             entry.params.iter().map(|p| (p.name.as_str(), p)).collect();
         assert_eq!(by["s"].kind, ParamKind::String);
         assert_eq!(by["i"].kind, ParamKind::Int);
-        assert_eq!(by["big"].kind, ParamKind::BigInt, "I64 → bigint (string on the wire)");
+        assert_eq!(
+            by["big"].kind,
+            ParamKind::BigInt,
+            "I64 → bigint (string on the wire)"
+        );
         assert_eq!(by["u"].kind, ParamKind::BigInt, "U64 → bigint");
         assert_eq!(by["f"].kind, ParamKind::Float);
         assert_eq!(by["b"].kind, ParamKind::Bool);
@@ -583,7 +633,11 @@ embedding: Vector(4)
         assert!(!by["s"].nullable);
         assert!(by["opt"].nullable, "String? → nullable");
         assert_eq!(by["list"].kind, ParamKind::List);
-        assert_eq!(by["list"].item_kind, Some(ParamKind::Int), "[I32] → list of int");
+        assert_eq!(
+            by["list"].item_kind,
+            Some(ParamKind::Int),
+            "[I32] → list of int"
+        );
         assert_eq!(by["vec"].kind, ParamKind::Vector);
         assert_eq!(by["vec"].vector_dim, Some(4));
     }
@@ -609,5 +663,4 @@ embedding: Vector(4)
         let entry2 = api::query_catalog_entry(reg2.lookup("no_params").unwrap());
         assert!(entry2.params.is_empty(), "no declared params → empty list");
     }
-
 }

--- a/crates/omnigraph-server/tests/auth_policy.rs
+++ b/crates/omnigraph-server/tests/auth_policy.rs
@@ -13,12 +13,12 @@ use omnigraph::db::{Omnigraph, ReadTarget};
 use omnigraph::error::OmniError;
 use omnigraph::loader::LoadMode;
 use omnigraph_server::api::{
-    BranchCreateRequest, BranchMergeRequest, ChangeRequest, ErrorOutput, ExportRequest, ReadRequest, SchemaApplyRequest,
+    BranchCreateRequest, BranchMergeRequest, ChangeRequest, ErrorOutput, ExportRequest,
+    ReadRequest, SchemaApplyRequest,
 };
 use omnigraph_server::{AppState, build_app};
 use serde_json::{Value, json};
 use tower::ServiceExt;
-
 
 mod support;
 use support::*;

--- a/crates/omnigraph-server/tests/boot_settings.rs
+++ b/crates/omnigraph-server/tests/boot_settings.rs
@@ -11,7 +11,6 @@ use omnigraph_server::{AppState, build_app};
 use serde_json::Value;
 use tower::ServiceExt;
 
-
 mod support;
 use support::*;
 
@@ -296,7 +295,6 @@ mod multi_graph_startup {
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 
-
     #[tokio::test(flavor = "multi_thread")]
     async fn registry_rejects_duplicate_normalized_graph_uris() {
         let dir = tempfile::tempdir().unwrap();
@@ -395,7 +393,6 @@ mod multi_graph_startup {
              Body: {body_str}",
         );
     }
-
 
     /// `GET /graphs` requires bearer auth when tokens are configured.
     #[tokio::test(flavor = "multi_thread")]
@@ -558,5 +555,4 @@ rules:
             "viewer must be denied graph_list (Cedar gate)"
         );
     }
-
 }

--- a/crates/omnigraph-server/tests/data_routes.rs
+++ b/crates/omnigraph-server/tests/data_routes.rs
@@ -19,7 +19,6 @@ use serde_json::{Value, json};
 use serial_test::serial;
 use tower::ServiceExt;
 
-
 mod support;
 use support::*;
 
@@ -1279,7 +1278,10 @@ async fn branch_merge_delete_branch_refusal_is_non_fatal() {
     )
     .await;
     assert_eq!(list_status, StatusCode::OK);
-    assert_eq!(list_body["branches"], json!(["feature", "feature-child", "main"]));
+    assert_eq!(
+        list_body["branches"],
+        json!(["feature", "feature-child", "main"])
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/omnigraph-server/tests/schema_routes.rs
+++ b/crates/omnigraph-server/tests/schema_routes.rs
@@ -16,7 +16,6 @@ use omnigraph_server::{
 };
 use serde_json::json;
 
-
 mod support;
 use support::*;
 

--- a/crates/omnigraph-server/tests/stored_queries.rs
+++ b/crates/omnigraph-server/tests/stored_queries.rs
@@ -1,12 +1,10 @@
 //! Stored-query registry boot, /queries listing, and invocation routes.
 //! Moved verbatim from tests/server.rs in the modularization.
 
-
 use axum::body::Body;
 use axum::http::StatusCode;
 use omnigraph_server::AppState;
 use serde_json::json;
-
 
 mod support;
 use support::*;
@@ -29,7 +27,11 @@ async fn server_boots_with_a_valid_stored_query_registry() {
         registry,
     )
     .await;
-    assert!(state.is_ok(), "valid registry should boot: {:?}", state.err());
+    assert!(
+        state.is_ok(),
+        "valid registry should boot: {:?}",
+        state.err()
+    );
 }
 
 #[tokio::test]
@@ -56,7 +58,10 @@ async fn server_refuses_boot_on_type_broken_stored_query() {
         Err(err) => err,
     };
     let msg = err.to_string();
-    assert!(msg.contains("ghost"), "error should name the broken query: {msg}");
+    assert!(
+        msg.contains("ghost"),
+        "error should name the broken query: {msg}"
+    );
     assert!(
         msg.contains("schema check"),
         "error should mention the schema check: {msg}"
@@ -73,12 +78,19 @@ async fn invoke_stored_read_returns_rows() {
     .await;
     let (status, body) = json_response(
         &app,
-        invoke_request("find_person", "t-invoke", json!({ "params": { "name": "Alice" } })),
+        invoke_request(
+            "find_person",
+            "t-invoke",
+            json!({ "params": { "name": "Alice" } }),
+        ),
     )
     .await;
     assert_eq!(status, StatusCode::OK, "body: {body}");
     assert_eq!(body["query_name"], "find_person");
-    assert_eq!(body["row_count"], 1, "Alice is in the fixture; body: {body}");
+    assert_eq!(
+        body["row_count"], 1,
+        "Alice is in the fixture; body: {body}"
+    );
     assert!(body["rows"].is_array(), "read envelope shape; body: {body}");
 }
 
@@ -130,7 +142,11 @@ async fn invoke_with_matching_expected_kind_runs() {
         ),
     )
     .await;
-    assert_eq!(status, StatusCode::OK, "matching kind should run; body: {body}");
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "matching kind should run; body: {body}"
+    );
     assert_eq!(body["query_name"], "find_person");
 }
 
@@ -213,7 +229,11 @@ async fn invoke_stored_mutation_double_gates_on_change() {
     // Has invoke_query but NOT change → the inner change gate denies (403).
     let (status, body) = json_response(
         &app,
-        invoke_request("add_person", "t-invoke", json!({ "params": { "name": "Eve" } })),
+        invoke_request(
+            "add_person",
+            "t-invoke",
+            json!({ "params": { "name": "Eve" } }),
+        ),
     )
     .await;
     assert_eq!(
@@ -225,7 +245,11 @@ async fn invoke_stored_mutation_double_gates_on_change() {
     // Has invoke_query + change → applied.
     let (status, body) = json_response(
         &app,
-        invoke_request("add_person", "t-full", json!({ "params": { "name": "Eve" } })),
+        invoke_request(
+            "add_person",
+            "t-full",
+            json!({ "params": { "name": "Eve" } }),
+        ),
     )
     .await;
     assert_eq!(status, StatusCode::OK, "body: {body}");
@@ -243,7 +267,11 @@ async fn invoke_stored_query_bad_param_is_400() {
     // `name` is declared String; pass a number.
     let (status, body) = json_response(
         &app,
-        invoke_request("find_person", "t-invoke", json!({ "params": { "name": 123 } })),
+        invoke_request(
+            "find_person",
+            "t-invoke",
+            json!({ "params": { "name": 123 } }),
+        ),
     )
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST, "body: {body}");
@@ -263,12 +291,19 @@ async fn invoke_unknown_query_and_denied_actor_return_identical_404() {
     .await;
 
     // Authorized actor, unknown query name → 404.
-    let (unknown_status, unknown_body) =
-        json_response(&app, invoke_request("does_not_exist", "t-invoke", json!({}))).await;
+    let (unknown_status, unknown_body) = json_response(
+        &app,
+        invoke_request("does_not_exist", "t-invoke", json!({})),
+    )
+    .await;
     // Denied actor (no invoke_query), real query name → 404.
     let (denied_status, denied_body) = json_response(
         &app,
-        invoke_request("find_person", "t-noinvoke", json!({ "params": { "name": "Alice" } })),
+        invoke_request(
+            "find_person",
+            "t-noinvoke",
+            json!({ "params": { "name": "Alice" } }),
+        ),
     )
     .await;
 
@@ -295,17 +330,28 @@ async fn invoke_query_holder_without_read_sees_403_not_404() {
     .await;
     let (exists_status, _) = json_response(
         &app,
-        invoke_request("find_person", "t-invokeonly", json!({ "params": { "name": "Alice" } })),
+        invoke_request(
+            "find_person",
+            "t-invokeonly",
+            json!({ "params": { "name": "Alice" } }),
+        ),
     )
     .await;
-    let (absent_status, _) =
-        json_response(&app, invoke_request("does_not_exist", "t-invokeonly", json!({}))).await;
+    let (absent_status, _) = json_response(
+        &app,
+        invoke_request("does_not_exist", "t-invokeonly", json!({})),
+    )
+    .await;
     assert_eq!(
         exists_status,
         StatusCode::FORBIDDEN,
         "an existing read query the holder can't read → inner-gate 403"
     );
-    assert_eq!(absent_status, StatusCode::NOT_FOUND, "unknown query still 404s");
+    assert_eq!(
+        absent_status,
+        StatusCode::NOT_FOUND,
+        "unknown query still 404s"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -318,7 +364,11 @@ async fn list_queries_returns_only_exposed_with_typed_params() {
                 "query add_person($name: String) { insert Person { name: $name } }",
                 true,
             ),
-            ("hidden", "query hidden() { match { $p: Person } return { $p.name } }", false),
+            (
+                "hidden",
+                "query hidden() { match { $p: Person } return { $p.name } }",
+                false,
+            ),
         ],
         &[("act-invoke", "t-invoke")],
         INVOKE_POLICY_YAML,
@@ -328,12 +378,18 @@ async fn list_queries_returns_only_exposed_with_typed_params() {
     assert_eq!(status, StatusCode::OK, "body: {body}");
 
     let entries = body["queries"].as_array().unwrap();
-    let names: Vec<&str> = entries.iter().map(|q| q["name"].as_str().unwrap()).collect();
+    let names: Vec<&str> = entries
+        .iter()
+        .map(|q| q["name"].as_str().unwrap())
+        .collect();
     assert!(
         names.contains(&"find_person") && names.contains(&"add_person"),
         "exposed queries listed: {names:?}"
     );
-    assert!(!names.contains(&"hidden"), "non-exposed query hidden from the catalog: {names:?}");
+    assert!(
+        !names.contains(&"hidden"),
+        "non-exposed query hidden from the catalog: {names:?}"
+    );
 
     let fp = entries.iter().find(|q| q["name"] == "find_person").unwrap();
     assert_eq!(fp["mutation"], false);
@@ -382,7 +438,11 @@ async fn list_queries_surfaces_query_description_and_instruction() {
     let (_temp, app) = app_with_stored_queries(
         &[
             ("described", described, true),
-            ("bare", "query bare() { match { $p: Person } return { $p.name } }", true),
+            (
+                "bare",
+                "query bare() { match { $p: Person } return { $p.name } }",
+                true,
+            ),
         ],
         &[("act-invoke", "t-invoke")],
         INVOKE_POLICY_YAML,
@@ -398,8 +458,7 @@ async fn list_queries_surfaces_query_description_and_instruction() {
         "query @description surfaces over GET /queries: {described}"
     );
     assert_eq!(
-        described["instruction"],
-        "Use for exact lookups; prefer search for fuzzy matches.",
+        described["instruction"], "Use for exact lookups; prefer search for fuzzy matches.",
         "query @instruction surfaces over GET /queries: {described}"
     );
 

--- a/crates/omnigraph/benches/scenarios.rs
+++ b/crates/omnigraph/benches/scenarios.rs
@@ -891,7 +891,11 @@ fn seeded_vector(seed: u64, slug: &str, dims: usize, pole: f32) -> Vec<f32> {
         // Dominate the direction with the pole while keeping per-row jitter.
         v[0] = pole * 10.0;
     }
-    let norm = v.iter().map(|x| (*x as f64) * (*x as f64)).sum::<f64>().sqrt() as f32;
+    let norm = v
+        .iter()
+        .map(|x| (*x as f64) * (*x as f64))
+        .sum::<f64>()
+        .sqrt() as f32;
     if norm > f32::EPSILON {
         for x in &mut v {
             *x /= norm;
@@ -947,11 +951,21 @@ async fn merge_all_changed(args: &Args) -> serde_json::Value {
     {
         let mut jsonl = String::new();
         let slug = "doc-main-diverge";
-        let _ = write!(jsonl, r#"{{"type":"Doc","data":{{"slug":"{slug}","embedding":"#);
-        push_vector_json(&mut jsonl, &seeded_vector(args.seed ^ 0x5eed, slug, args.dims, 0.0));
-        jsonl.push_str("}}
-");
-        db.load("main", &jsonl, LoadMode::Merge).await.expect("diverge main");
+        let _ = write!(
+            jsonl,
+            r#"{{"type":"Doc","data":{{"slug":"{slug}","embedding":"#
+        );
+        push_vector_json(
+            &mut jsonl,
+            &seeded_vector(args.seed ^ 0x5eed, slug, args.dims, 0.0),
+        );
+        jsonl.push_str(
+            "}}
+",
+        );
+        db.load("main", &jsonl, LoadMode::Merge)
+            .await
+            .expect("diverge main");
     }
 
     // Rewrite every row's vector on the branch (same keys, new seed).
@@ -970,7 +984,10 @@ async fn merge_all_changed(args: &Args) -> serde_json::Value {
 
     // The measured window: the merge alone.
     let merge_start = Instant::now();
-    let outcome = db.branch_merge("bench", "main").await.expect("branch_merge");
+    let outcome = db
+        .branch_merge("bench", "main")
+        .await
+        .expect("branch_merge");
     let merge_ms = merge_start.elapsed().as_millis() as u64;
 
     serde_json::json!({
@@ -997,11 +1014,16 @@ async fn load_vector_rows(
         let mut jsonl = String::with_capacity(batch_rows * (args.dims * 12 + 64));
         for i in row..end {
             let slug = format!("doc-{i:08}");
-            let _ = write!(jsonl, r#"{{"type":"Doc","data":{{"slug":"{slug}","embedding":"#);
+            let _ = write!(
+                jsonl,
+                r#"{{"type":"Doc","data":{{"slug":"{slug}","embedding":"#
+            );
             push_vector_json(&mut jsonl, &seeded_vector(seed, &slug, args.dims, pole));
             jsonl.push_str("}}\n");
         }
-        db.load(branch, &jsonl, LoadMode::Merge).await.expect("load batch");
+        db.load(branch, &jsonl, LoadMode::Merge)
+            .await
+            .expect("load batch");
         row = end;
     }
 }
@@ -1049,10 +1071,15 @@ async fn nearest_prefilter(args: &Args) -> serde_json::Value {
                 jsonl,
                 r#"{{"type":"Doc","data":{{"slug":"{slug}","status":"{status}","embedding":"#
             );
-            push_vector_json(&mut jsonl, &seeded_vector(args.seed, &slug, args.dims, pole));
+            push_vector_json(
+                &mut jsonl,
+                &seeded_vector(args.seed, &slug, args.dims, pole),
+            );
             jsonl.push_str("}}\n");
         }
-        db.load("main", &jsonl, LoadMode::Merge).await.expect("load batch");
+        db.load("main", &jsonl, LoadMode::Merge)
+            .await
+            .expect("load batch");
         row = end;
     }
     let seed_ms = seed_start.elapsed().as_millis() as u64;
@@ -1089,7 +1116,12 @@ async fn nearest_prefilter(args: &Args) -> serde_json::Value {
     for i in 0..QUERY_ITERS {
         let q_start = Instant::now();
         let result = db
-            .query(ReadTarget::branch("main"), &query_src, "filtered_nearest", &params)
+            .query(
+                ReadTarget::branch("main"),
+                &query_src,
+                "filtered_nearest",
+                &params,
+            )
             .await
             .expect("filtered nearest query");
         total_ms += q_start.elapsed().as_millis() as u64;

--- a/crates/omnigraph/benches/scenarios/rfc023.rs
+++ b/crates/omnigraph/benches/scenarios/rfc023.rs
@@ -95,8 +95,7 @@ pub(super) fn validate_args(args: &Args) -> Result<(), String> {
             let source_batch_rows = general_merge_batch_rows(args.dims);
             let source_transaction_count = args.delta_rows.div_ceil(source_batch_rows);
             if args.source_mode == "insert"
-                && source_transaction_count
-                    > rfc023_limits::PURE_INSERT_HISTORY_MAX_VERSIONS
+                && source_transaction_count > rfc023_limits::PURE_INSERT_HISTORY_MAX_VERSIONS
             {
                 return Err(format!(
                     "--source-mode insert needs {source_transaction_count} source transactions at \
@@ -124,11 +123,9 @@ pub(super) fn validate_args(args: &Args) -> Result<(), String> {
         }
         _ => {
             if args.phase.is_some() || args.fixture_root.is_some() {
-                return Err(
-                    "--phase/--fixture-root require fenced-adopt-all-new or \
+                return Err("--phase/--fixture-root require fenced-adopt-all-new or \
                      general-merge-updates"
-                        .to_string(),
-                );
+                    .to_string());
             }
         }
     }
@@ -1467,10 +1464,7 @@ const GENERAL_MERGE_SOURCE_BRANCH: &str = "update-source";
 fn general_merge_batch_rows(dims: usize) -> usize {
     // (dims + 1) * 4 offsets + dims * 4 values, plus generous room for the
     // slug string, its offset, and per-row bookkeeping.
-    let per_row = (dims as u64)
-        .saturating_mul(8)
-        .saturating_add(128)
-        .max(1);
+    let per_row = (dims as u64).saturating_mul(8).saturating_add(128).max(1);
     // Spend only 90% of the ceiling so a future accounting tweak does not put
     // the fixture back on the cliff.
     let by_bytes = rfc023_limits::KEYED_WRITE_MAX_BYTES
@@ -1571,12 +1565,8 @@ pub(super) async fn general_merge_setup(args: &Args) -> serde_json::Value {
     let target_divergence_start = args.rows - GENERAL_MERGE_TARGET_DELTA_ROWS;
     let diverge_vectors = vector_json_patterns(args.dims, args.seed ^ 0x0230_0385);
     let diverge_start = Instant::now();
-    let diverge_jsonl = graph_jsonl_chunk(
-        "base",
-        target_divergence_start,
-        args.rows,
-        &diverge_vectors,
-    );
+    let diverge_jsonl =
+        graph_jsonl_chunk("base", target_divergence_start, args.rows, &diverge_vectors);
     db.load("main", &diverge_jsonl, LoadMode::Merge)
         .await
         .expect("advance main after the branch forked");
@@ -1873,14 +1863,8 @@ pub(super) async fn general_merge_verify(args: &Args) -> serde_json::Value {
     } else {
         "base"
     };
-    let source_delta_row = verify_fixture_row(
-        &table,
-        source_prefix,
-        0,
-        args.dims,
-        args.seed ^ 0x0230_0384,
-    )
-    .await;
+    let source_delta_row =
+        verify_fixture_row(&table, source_prefix, 0, args.dims, args.seed ^ 0x0230_0384).await;
     let target_delta_row = verify_fixture_row(
         &table,
         "base",

--- a/crates/omnigraph/examples/bench_expand.rs
+++ b/crates/omnigraph/examples/bench_expand.rs
@@ -252,7 +252,9 @@ query sel($name: String) {
             let dir = tempfile::tempdir().unwrap();
             let uri = dir.path().to_str().unwrap();
             let mut db = Omnigraph::init(uri, SCHEMA).await.unwrap();
-            load_jsonl(&mut db, &jsonl, LoadMode::Overwrite).await.unwrap();
+            load_jsonl(&mut db, &jsonl, LoadMode::Overwrite)
+                .await
+                .unwrap();
             // SAFE: example main drives queries sequentially; no concurrent env reader.
             unsafe { std::env::set_var("OMNIGRAPH_TRAVERSAL_MODE", mode) };
 

--- a/crates/omnigraph/src/db/manifest/stream.rs
+++ b/crates/omnigraph/src/db/manifest/stream.rs
@@ -84,8 +84,7 @@ const CLAIM_RECEIPT_LOOKUP_DOMAIN: &[u8] = b"omnigraph.stream-claim-receipt-look
 const CLAIM_RECEIPT_RECORD_DOMAIN: &[u8] = b"omnigraph.stream-claim-receipt-record.v1\0";
 const RECEIPT_CHAIN_STEP_DOMAIN: &[u8] = b"omnigraph.stream-receipt-chain-step.v1\0";
 const BINDING_RECEIPT_DIGEST_DOMAIN: &[u8] = b"omnigraph.stream-binding-receipt-result.v1\0";
-const RETAINED_SHARD_SET_DIGEST_DOMAIN: &[u8] =
-    b"omnigraph.stream-retained-shard-set.v1\0";
+const RETAINED_SHARD_SET_DIGEST_DOMAIN: &[u8] = b"omnigraph.stream-retained-shard-set.v1\0";
 const STRICT_DATA_BLOCK_TOKEN_DOMAIN: &[u8] = b"omnigraph.stream-data-block-token.v1\0";
 const MAX_RECEIPT_JSON_BYTES: usize = 16 * 1024;
 pub(crate) const MAX_SELECTED_BINDING_CHAIN_RECORDS: u64 = 1_024;
@@ -2116,14 +2115,12 @@ impl BindingReceipt {
         Ok(self
             .retained_shard_count
             .zip(self.retained_shard_set_digest.clone())
-            .map(
-                |(retained_shard_count, retained_shard_set_digest)| {
-                    RetainedShardInventoryCommitment {
-                        retained_shard_count,
-                        retained_shard_set_digest,
-                    }
-                },
-            ))
+            .map(|(retained_shard_count, retained_shard_set_digest)| {
+                RetainedShardInventoryCommitment {
+                    retained_shard_count,
+                    retained_shard_set_digest,
+                }
+            }))
     }
 
     fn validate_retained_shard_inventory_context(&self) -> Result<()> {
@@ -5347,31 +5344,17 @@ mod tests {
             stream_disable_drain_adoption_id("disable-operation", identity, &drain, 4).unwrap(),
             adoption
         );
-        let operation_id = stream_disable_drain_adoption_operation_id(
-            "disable-operation",
-            identity,
-            &drain,
-            3,
-        )
-        .unwrap();
+        let operation_id =
+            stream_disable_drain_adoption_operation_id("disable-operation", identity, &drain, 3)
+                .unwrap();
         assert_eq!(
-            stream_disable_drain_adoption_operation_id(
-                "disable-operation",
-                identity,
-                &drain,
-                3,
-            )
-            .unwrap(),
+            stream_disable_drain_adoption_operation_id("disable-operation", identity, &drain, 3,)
+                .unwrap(),
             operation_id
         );
         assert_ne!(
-            stream_disable_drain_adoption_operation_id(
-                "disable-operation",
-                identity,
-                &drain,
-                4,
-            )
-            .unwrap(),
+            stream_disable_drain_adoption_operation_id("disable-operation", identity, &drain, 4,)
+                .unwrap(),
             operation_id
         );
         let parsed = ShardId::parse_str(&operation_id).unwrap();
@@ -5834,8 +5817,7 @@ mod tests {
         );
 
         let old_shard = ShardId::parse_str(&base.binding.shard_ids[0]).unwrap();
-        let new_shard =
-            ShardId::parse_str("88888888-8888-4888-8888-888888888888").unwrap();
+        let new_shard = ShardId::parse_str("88888888-8888-4888-8888-888888888888").unwrap();
         let forward = retained_shard_inventory_commitment(&[old_shard, new_shard]).unwrap();
         let reverse = retained_shard_inventory_commitment(&[new_shard, old_shard]).unwrap();
         assert_eq!(forward, reverse);

--- a/crates/omnigraph/src/db/manifest/token_store.rs
+++ b/crates/omnigraph/src/db/manifest/token_store.rs
@@ -1589,7 +1589,10 @@ fn collect_requested_lifecycle_ledger_records(
         ));
     }
     for (lookup_key, tag) in requested {
-        for (name, value) in [("record tag", *tag), ("record lookup key", lookup_key.as_str())] {
+        for (name, value) in [
+            ("record tag", *tag),
+            ("record lookup key", lookup_key.as_str()),
+        ] {
             if value.is_empty() || value.trim() != value {
                 return Err(OmniError::manifest_internal(format!(
                     "lifecycle ledger {name} must be non-empty canonical text"
@@ -1641,10 +1644,9 @@ pub(crate) async fn lookup_lifecycle_ledger_records_batched(
     collect_requested_lifecycle_ledger_records(requested, Vec::new())?;
 
     let mut scanner = dataset.scan();
-    scanner.filter_expr(col("record_lookup_key").in_list(
-        requested.keys().cloned().map(lit).collect(),
-        false,
-    ));
+    scanner.filter_expr(
+        col("record_lookup_key").in_list(requested.keys().cloned().map(lit).collect(), false),
+    );
     scanner.batch_size(MAX_LIFECYCLE_LEDGER_RECORDS_PER_TRANSACTION);
     scanner.batch_size_bytes(MAX_LIFECYCLE_LEDGER_TRANSACTION_ARROW_BYTES);
     scanner
@@ -3253,16 +3255,22 @@ mod tests {
             (second.record_lookup_key.clone(), records[1].record_tag()),
         ]);
 
-        let duplicate = collect_requested_lifecycle_ledger_records(
-            &requested,
-            vec![first.clone(), first],
-        )
-        .expect_err("one unenforced lookup key may not resolve twice");
-        assert!(duplicate.to_string().contains("duplicate record lookup key"));
+        let duplicate =
+            collect_requested_lifecycle_ledger_records(&requested, vec![first.clone(), first])
+                .expect_err("one unenforced lookup key may not resolve twice");
+        assert!(
+            duplicate
+                .to_string()
+                .contains("duplicate record lookup key")
+        );
 
         let unexpected = collect_requested_lifecycle_ledger_records(&requested, vec![third])
             .expect_err("the structured scan may not return an unrequested key");
-        assert!(unexpected.to_string().contains("unexpected record lookup key"));
+        assert!(
+            unexpected
+                .to_string()
+                .contains("unexpected record lookup key")
+        );
 
         let too_many = (0..=MAX_LIFECYCLE_LEDGER_LOOKUP_KEYS_PER_SCAN)
             .map(|ordinal| {

--- a/crates/omnigraph/src/db/mod.rs
+++ b/crates/omnigraph/src/db/mod.rs
@@ -24,6 +24,9 @@ pub use omnigraph::{
     StreamDeadLetterPayloadPage, StreamExportCut, StreamStatus, StreamTableStatus,
     StreamingProfileResult, TableCleanupStats, TableOptimizeStats, TableRepairStats,
 };
+pub(crate) use omnigraph::{
+    DeferredTableFork, StreamAuthorityRetirementExportProvenance, WriteAuthorityToken, WriteTxn,
+};
 #[doc(hidden)]
 pub use omnigraph::{
     GraphStreamChunkSource, GraphStreamDeclaration, GraphStreamDeclarationStatus,
@@ -32,9 +35,6 @@ pub use omnigraph::{
     GraphStreamLastFoldStatus, GraphStreamOperationalStatus, GraphStreamOptimizeResult,
     GraphStreamPendingStatus, GraphStreamRebuildBlocker, GraphStreamRebuildStatus,
     GraphStreamResumeResult, GraphStreamStrictBlockStatus, GraphStreamTokenCounts,
-};
-pub(crate) use omnigraph::{
-    DeferredTableFork, StreamAuthorityRetirementExportProvenance, WriteAuthorityToken, WriteTxn,
 };
 #[cfg(test)]
 pub(crate) use omnigraph::{
@@ -76,9 +76,7 @@ pub struct StreamExportRootExclusion {
 /// graph deletion without exposing the engine's queue manager or a capability
 /// that can read, write, or delete storage.
 #[doc(hidden)]
-pub fn reserve_stream_export_root_exclusion(
-    graph_uri: &str,
-) -> Result<StreamExportRootExclusion> {
+pub fn reserve_stream_export_root_exclusion(graph_uri: &str) -> Result<StreamExportRootExclusion> {
     let normalized = crate::storage::normalize_root_uri(graph_uri)?;
     let identity = crate::storage::write_queue_root_identity(&normalized)?;
     let manager = write_queue::WriteQueueManager::for_root(&identity);

--- a/crates/omnigraph/src/db/omnigraph.rs
+++ b/crates/omnigraph/src/db/omnigraph.rs
@@ -97,6 +97,13 @@ pub use stream_retirement::{
     StreamAuthorityRetirementPlan, StreamAuthorityRetirementResult, StreamDeadLetterEntry,
     StreamDeadLetterPage, StreamDeadLetterPayloadEntry, StreamDeadLetterPayloadPage,
 };
+#[doc(hidden)]
+pub use stream_status::{
+    GraphStreamDeclaration, GraphStreamDeclarationStatus, GraphStreamDrainStatus,
+    GraphStreamDriverErrorStatus, GraphStreamDriverStatus, GraphStreamLastFoldStatus,
+    GraphStreamOperationalStatus, GraphStreamPendingStatus, GraphStreamRebuildBlocker,
+    GraphStreamRebuildStatus, GraphStreamStrictBlockStatus, GraphStreamTokenCounts,
+};
 #[cfg(feature = "failpoints")]
 #[doc(hidden)]
 pub use stream_status::{
@@ -107,13 +114,6 @@ pub use stream_status::{
     StreamShardOperationalStatus, StreamStrictBlockOperationalStatus, StreamTableOperationalStatus,
     StreamTablePhysicalOperationalStatus, StreamTerminalTokenOperationalStatus,
     StreamTokenIndexCoverageStatus, StreamTokenLedgerOperationalStatus,
-};
-#[doc(hidden)]
-pub use stream_status::{
-    GraphStreamDeclaration, GraphStreamDeclarationStatus, GraphStreamDrainStatus,
-    GraphStreamDriverErrorStatus, GraphStreamDriverStatus, GraphStreamLastFoldStatus,
-    GraphStreamOperationalStatus, GraphStreamPendingStatus, GraphStreamRebuildBlocker,
-    GraphStreamRebuildStatus, GraphStreamStrictBlockStatus, GraphStreamTokenCounts,
 };
 pub use stream_status::{StreamStatus, StreamTableStatus};
 pub use table_ops::PendingIndex;

--- a/crates/omnigraph/src/db/omnigraph/repair.rs
+++ b/crates/omnigraph/src/db/omnigraph/repair.rs
@@ -141,11 +141,7 @@ pub async fn repair_all_tables(db: &Omnigraph, options: RepairOptions) -> Result
     // then revalidate the complete capture under schema -> main -> table
     // ordering before repair can adopt any physical HEAD into the manifest.
     let admission_txn = db.open_write_txn(None).await?;
-    if let Some(error) = db
-        .current_canonical_stream_profile()
-        .await?
-        .retired_error()
-    {
+    if let Some(error) = db.current_canonical_stream_profile().await?.retired_error() {
         return Err(error);
     }
     let stream_admission_keys = Omnigraph::stream_admission_keys_for_snapshot(&admission_txn.base);

--- a/crates/omnigraph/src/db/omnigraph/stream_ndjson.rs
+++ b/crates/omnigraph/src/db/omnigraph/stream_ndjson.rs
@@ -2796,11 +2796,7 @@ mod tests {
         assert_eq!(original.0, 7);
         assert_eq!(original.1, start + GRAPH_STREAM_RUN_MAX_COALESCE_DELAY);
 
-        sync_graph_run_flush_deadline_at(
-            &mut deadline,
-            Some(7),
-            start + Duration::from_millis(40),
-        );
+        sync_graph_run_flush_deadline_at(&mut deadline, Some(7), start + Duration::from_millis(40));
         assert_eq!(
             deadline,
             Some(original),

--- a/crates/omnigraph/src/db/omnigraph/stream_profile.rs
+++ b/crates/omnigraph/src/db/omnigraph/stream_profile.rs
@@ -246,8 +246,7 @@ pub struct CheckedClusterServedExportAuthority {
 
 impl CheckedClusterServedExportAuthority {
     pub(super) fn validate_profile(&self, profile: &StreamProfileEntry) -> Result<()> {
-        if profile.mode() != self.profile_mode
-            || profile.profile_revision != self.profile_revision
+        if profile.mode() != self.profile_mode || profile.profile_revision != self.profile_revision
         {
             return Err(OmniError::StreamingAuthorityMismatch {
                 reason: format!(

--- a/crates/omnigraph/src/db/write_queue.rs
+++ b/crates/omnigraph/src/db/write_queue.rs
@@ -386,9 +386,7 @@ impl WriteQueueManager {
     /// This remains deliberately non-waiting: F6b5 places its bounded
     /// transport-reservation deadline before this same slot and never creates
     /// a second cut owner.
-    pub(crate) fn try_acquire_stream_export_cut(
-        self: &Arc<Self>,
-    ) -> Option<StreamExportCutPermit> {
+    pub(crate) fn try_acquire_stream_export_cut(self: &Arc<Self>) -> Option<StreamExportCutPermit> {
         let permit = Arc::clone(&self.stream_export_gate)
             .try_write_owned()
             .ok()?;
@@ -407,9 +405,7 @@ impl WriteQueueManager {
     pub(crate) fn try_acquire_stream_export_destructive(
         self: &Arc<Self>,
     ) -> Option<StreamExportDestructivePermit> {
-        let permit = Arc::clone(&self.stream_export_gate)
-            .try_read_owned()
-            .ok()?;
+        let permit = Arc::clone(&self.stream_export_gate).try_read_owned().ok()?;
         Some(StreamExportDestructivePermit {
             _manager: Arc::clone(self),
             _permit: permit,

--- a/crates/omnigraph/src/embedding.rs
+++ b/crates/omnigraph/src/embedding.rs
@@ -104,13 +104,17 @@ impl EmbeddingConfig {
         let model =
             env_string("OMNIGRAPH_EMBED_MODEL").unwrap_or_else(|| default_model.to_string());
 
-        let api_key = key_envs.iter().copied().find_map(env_string).ok_or_else(|| {
-            OmniError::manifest_internal(format!(
-                "{} is required for the {} embedding provider",
-                key_envs.join(" or "),
-                alias.as_deref().unwrap_or("openai-compatible")
-            ))
-        })?;
+        let api_key = key_envs
+            .iter()
+            .copied()
+            .find_map(env_string)
+            .ok_or_else(|| {
+                OmniError::manifest_internal(format!(
+                    "{} is required for the {} embedding provider",
+                    key_envs.join(" or "),
+                    alias.as_deref().unwrap_or("openai-compatible")
+                ))
+            })?;
 
         Ok(Self {
             provider,
@@ -268,7 +272,8 @@ impl EmbeddingClient {
     }
 
     pub async fn embed_document_text(&self, input: &str, expected_dim: usize) -> Result<Vec<f32>> {
-        self.embed_text(input, expected_dim, EmbedRole::Document).await
+        self.embed_text(input, expected_dim, EmbedRole::Document)
+            .await
     }
 
     async fn embed_text(
@@ -423,7 +428,10 @@ impl EmbeddingClient {
             Ok(body) => body,
             Err(err) => {
                 return Err(EmbedCallError {
-                    message: format!("embedding response read failed (status {}): {}", status, err),
+                    message: format!(
+                        "embedding response read failed (status {}): {}",
+                        status, err
+                    ),
                     retryable: status.is_server_error() || status.as_u16() == 429,
                 });
             }
@@ -432,7 +440,10 @@ impl EmbeddingClient {
         if !status.is_success() {
             let message = parse_google_error_message(&body).unwrap_or(body);
             return Err(EmbedCallError {
-                message: format!("embedding request failed with status {}: {}", status, message),
+                message: format!(
+                    "embedding request failed with status {}: {}",
+                    status, message
+                ),
                 retryable: status.is_server_error() || status.as_u16() == 429,
             });
         }
@@ -460,7 +471,11 @@ impl EmbeddingClient {
             .http
             .post(format!("{}/embeddings", self.config.base_url))
             .bearer_auth(&self.config.api_key)
-            .json(&build_openai_request(&self.config.model, input, expected_dim))
+            .json(&build_openai_request(
+                &self.config.model,
+                input,
+                expected_dim,
+            ))
             .send()
             .await;
         let response = match response {
@@ -479,7 +494,10 @@ impl EmbeddingClient {
             Ok(body) => body,
             Err(err) => {
                 return Err(EmbedCallError {
-                    message: format!("embedding response read failed (status {}): {}", status, err),
+                    message: format!(
+                        "embedding response read failed (status {}): {}",
+                        status, err
+                    ),
                     retryable: status.is_server_error() || status.as_u16() == 429,
                 });
             }
@@ -488,7 +506,10 @@ impl EmbeddingClient {
         if !status.is_success() {
             let message = parse_openai_error_message(&body).unwrap_or(body);
             return Err(EmbedCallError {
-                message: format!("embedding request failed with status {}: {}", status, message),
+                message: format!(
+                    "embedding request failed with status {}: {}",
+                    status, message
+                ),
                 retryable: status.is_server_error() || status.as_u16() == 429,
             });
         }
@@ -625,7 +646,12 @@ fn parse_openai_error_message(body: &str) -> Option<String> {
 /// (not the enum) determines the key-env order here.
 fn provider_profile(
     alias: Option<&str>,
-) -> Result<(Provider, &'static str, &'static str, &'static [&'static str])> {
+) -> Result<(
+    Provider,
+    &'static str,
+    &'static str,
+    &'static [&'static str],
+)> {
     Ok(match alias {
         None | Some("openai-compatible") => (
             Provider::OpenAiCompatible,
@@ -834,12 +860,14 @@ mod tests {
         // An Inf component must be rejected — not normalized into 0s + NaN.
         let err = validate_and_normalize_embedding(vec![f32::INFINITY, 1.0], 2).unwrap_err();
         assert!(err.contains("finite"), "Inf must be rejected, got: {err}");
-        let err =
-            validate_and_normalize_embedding(vec![1.0, f32::NEG_INFINITY], 2).unwrap_err();
+        let err = validate_and_normalize_embedding(vec![1.0, f32::NEG_INFINITY], 2).unwrap_err();
         assert!(err.contains("finite"), "-Inf must be rejected, got: {err}");
         // An all-zero vector has no direction — undefined under cosine/ANN.
         let err = validate_and_normalize_embedding(vec![0.0, 0.0], 2).unwrap_err();
-        assert!(err.contains("zero"), "zero vector must be rejected, got: {err}");
+        assert!(
+            err.contains("zero"),
+            "zero vector must be rejected, got: {err}"
+        );
     }
 
     #[test]
@@ -1017,9 +1045,13 @@ mod tests {
         // must resolve to model X — it is what the query-time same-space check
         // compares against. Env cleared so the assertion isolates the arg.
         let _guard = cleared_env(&[]);
-        let pinned =
-            EmbeddingConfig::from_parts(Some("mock"), None, Some("recorded-x".to_string()), String::new())
-                .unwrap();
+        let pinned = EmbeddingConfig::from_parts(
+            Some("mock"),
+            None,
+            Some("recorded-x".to_string()),
+            String::new(),
+        )
+        .unwrap();
         assert_eq!(pinned.provider, Provider::Mock);
         assert_eq!(pinned.model, "recorded-x");
         // With no explicit model, mock falls back to its env-based default (here
@@ -1081,7 +1113,10 @@ mod tests {
     fn from_env_errors_when_no_key_present() {
         let _guard = cleared_env(&[]);
         let err = EmbeddingConfig::from_env().unwrap_err();
-        assert!(err.to_string().contains("OPENROUTER_API_KEY or OPENAI_API_KEY"));
+        assert!(
+            err.to_string()
+                .contains("OPENROUTER_API_KEY or OPENAI_API_KEY")
+        );
     }
 
     #[test]

--- a/crates/omnigraph/src/exec/query.rs
+++ b/crates/omnigraph/src/exec/query.rs
@@ -162,9 +162,10 @@ async fn extract_search_mode(
             property,
             query,
         } => {
-            let vec =
-                resolve_nearest_query_vec(ir, catalog, variable, property, query, params, embedding)
-                    .await?;
+            let vec = resolve_nearest_query_vec(
+                ir, catalog, variable, property, query, params, embedding,
+            )
+            .await?;
             let k = ir.limit.ok_or_else(|| {
                 OmniError::manifest("nearest() ordering requires a limit clause".to_string())
             })? as usize;
@@ -241,9 +242,10 @@ async fn extract_sub_search_mode(
             property,
             query,
         } => {
-            let vec =
-                resolve_nearest_query_vec(ir, catalog, variable, property, query, params, embedding)
-                    .await?;
+            let vec = resolve_nearest_query_vec(
+                ir, catalog, variable, property, query, params, embedding,
+            )
+            .await?;
             let k = limit.unwrap_or(100) as usize;
             Ok(SearchMode {
                 nearest: Some((variable.clone(), property.clone(), vec, k)),
@@ -790,10 +792,7 @@ fn referenced_edge_types(
         .collect()
 }
 
-fn collect_referenced_edge_names(
-    pipeline: &[IROp],
-    out: &mut std::collections::BTreeSet<String>,
-) {
+fn collect_referenced_edge_names(pipeline: &[IROp], out: &mut std::collections::BTreeSet<String>) {
     for op in pipeline {
         match op {
             IROp::Expand { edge_type, .. } => {
@@ -865,12 +864,12 @@ impl<'a> GraphIndexHandle<'a> {
             .get_or_try_init(|| async {
                 match &self.builder {
                     GraphIndexBuilder::None => Ok::<Option<Arc<GraphIndex>>, OmniError>(None),
-                    GraphIndexBuilder::Cached(db, resolved, edge_types) => {
-                        Ok(Some(db.graph_index_for_resolved(resolved, edge_types).await?))
-                    }
-                    GraphIndexBuilder::Direct(snapshot, edge_types) => {
-                        Ok(Some(Arc::new(GraphIndex::build(snapshot, edge_types).await?)))
-                    }
+                    GraphIndexBuilder::Cached(db, resolved, edge_types) => Ok(Some(
+                        db.graph_index_for_resolved(resolved, edge_types).await?,
+                    )),
+                    GraphIndexBuilder::Direct(snapshot, edge_types) => Ok(Some(Arc::new(
+                        GraphIndex::build(snapshot, edge_types).await?,
+                    ))),
                 }
             })
             .await?;
@@ -1211,8 +1210,19 @@ async fn execute_expand(
             OmniError::manifest("graph index required for CSR traversal".to_string())
         })?;
         return execute_expand_csr(
-            wide, gi, snapshot, catalog, src_var, dst_var, edge_type, direction, dst_type,
-            min_hops, max_hops, dst_filters, params,
+            wide,
+            gi,
+            snapshot,
+            catalog,
+            src_var,
+            dst_var,
+            edge_type,
+            direction,
+            dst_type,
+            min_hops,
+            max_hops,
+            dst_filters,
+            params,
         )
         .await;
     }
@@ -1260,8 +1270,19 @@ async fn execute_expand(
                     OmniError::manifest("graph index required for CSR traversal".to_string())
                 })?;
                 return execute_expand_csr(
-                    wide, gi, snapshot, catalog, src_var, dst_var, edge_type, direction, dst_type,
-                    min_hops, max_hops, dst_filters, params,
+                    wide,
+                    gi,
+                    snapshot,
+                    catalog,
+                    src_var,
+                    dst_var,
+                    edge_type,
+                    direction,
+                    dst_type,
+                    min_hops,
+                    max_hops,
+                    dst_filters,
+                    params,
                 )
                 .await;
             }
@@ -1279,8 +1300,19 @@ async fn execute_expand(
     // Surface the C6 silent scalar-index fallback once, now that coverage is known.
     warn_on_degraded_coverage(&coverage, key_col, edge_type);
     execute_expand_indexed(
-        wide, snapshot, catalog, src_var, dst_var, edge_type, direction, dst_type, min_hops,
-        max_hops, dst_filters, params, edge_ds,
+        wide,
+        snapshot,
+        catalog,
+        src_var,
+        dst_var,
+        edge_type,
+        direction,
+        dst_type,
+        min_hops,
+        max_hops,
+        dst_filters,
+        params,
+        edge_ds,
     )
     .await
 }
@@ -1395,7 +1427,10 @@ async fn execute_expand_indexed(
         let mut neighbor_map: HashMap<u32, Vec<u32>> = HashMap::new();
         for &(key_col, opp_col) in probes {
             let batches = crate::table_store::TableStore::scan_edges_by_endpoint(
-                &edge_ds, key_col, opp_col, &union_keys,
+                &edge_ds,
+                key_col,
+                opp_col,
+                &union_keys,
             )
             .await?;
             for batch in &batches {
@@ -1406,7 +1441,9 @@ async fn execute_expand_indexed(
                     })?
                     .as_any()
                     .downcast_ref::<StringArray>()
-                    .ok_or_else(|| OmniError::manifest(format!("edge '{}' is not Utf8", key_col)))?;
+                    .ok_or_else(|| {
+                        OmniError::manifest(format!("edge '{}' is not Utf8", key_col))
+                    })?;
                 let opps = batch
                     .column_by_name(opp_col)
                     .ok_or_else(|| {
@@ -1414,7 +1451,9 @@ async fn execute_expand_indexed(
                     })?
                     .as_any()
                     .downcast_ref::<StringArray>()
-                    .ok_or_else(|| OmniError::manifest(format!("edge '{}' is not Utf8", opp_col)))?;
+                    .ok_or_else(|| {
+                        OmniError::manifest(format!("edge '{}' is not Utf8", opp_col))
+                    })?;
                 for r in 0..batch.num_rows() {
                     let k = interner.get_or_insert(keys.value(r));
                     let o = interner.get_or_insert(opps.value(r));
@@ -1458,7 +1497,15 @@ async fn execute_expand_indexed(
         .collect();
 
     expand_hydrate_and_align(
-        wide, src_indices, dst_ids, snapshot, catalog, dst_type, dst_var, dst_filters, params,
+        wide,
+        src_indices,
+        dst_ids,
+        snapshot,
+        catalog,
+        dst_type,
+        dst_var,
+        dst_filters,
+        params,
     )
     .await
 }
@@ -1496,8 +1543,15 @@ async fn expand_hydrate_and_align(
             }
         }
     }
-    let dst_batch =
-        hydrate_nodes(snapshot, catalog, dst_type, &unique_dst_list, dst_filters, params).await?;
+    let dst_batch = hydrate_nodes(
+        snapshot,
+        catalog,
+        dst_type,
+        &unique_dst_list,
+        dst_filters,
+        params,
+    )
+    .await?;
 
     // id -> row index in the hydrated batch.
     let dst_batch_id_col = dst_batch
@@ -1591,11 +1645,9 @@ async fn execute_expand_csr(
     // Undirected: additionally walk incoming edges (CSC); the BFS gates below
     // dedup pairs that exist in both directions and self-loops.
     let adj_rev = match direction {
-        Direction::Both => Some(
-            graph_index
-                .csc(edge_type)
-                .ok_or_else(|| OmniError::manifest(format!("no adjacency index for edge '{}'", edge_type)))?,
-        ),
+        Direction::Both => Some(graph_index.csc(edge_type).ok_or_else(|| {
+            OmniError::manifest(format!("no adjacency index for edge '{}'", edge_type))
+        })?),
         _ => None,
     };
 
@@ -1710,7 +1762,8 @@ async fn hydrate_nodes(
     // `id IN (ids)` AND any pushable destination filters, as a structured Expr.
     let id_list: Vec<datafusion::prelude::Expr> = ids.iter().map(|id| lit(id.clone())).collect();
     let mut filter_expr = col("id").in_list(id_list, false);
-    if let Some(dst_expr) = build_lance_filter_expr(dst_filters, params, Some(&node_type.arrow_schema))
+    if let Some(dst_expr) =
+        build_lance_filter_expr(dst_filters, params, Some(&node_type.arrow_schema))
     {
         filter_expr = filter_expr.and(dst_expr);
     }
@@ -1944,7 +1997,9 @@ async fn execute_anti_join(
         }
     }
 
-    let keep_mask: Vec<bool> = (0..num_rows as u32).map(|i| !matched.contains(&i)).collect();
+    let keep_mask: Vec<bool> = (0..num_rows as u32)
+        .map(|i| !matched.contains(&i))
+        .collect();
     let mask = BooleanArray::from(keep_mask);
     *wide = arrow_select::filter::filter_record_batch(wide, &mask)
         .map_err(|e| OmniError::Lance(e.to_string()))?;
@@ -2512,7 +2567,13 @@ mod expand_chooser_tests {
     fn selective_frontier_on_large_graph_picks_indexed() {
         // 50 source rows against 1M source vertices, one hop: tiny selectivity —
         // the PR #149 win the chooser must preserve.
-        let m = choose_expand_mode(&inputs(50, 10_000_000, 1_000_000, 1, IndexCoverage::Indexed));
+        let m = choose_expand_mode(&inputs(
+            50,
+            10_000_000,
+            1_000_000,
+            1,
+            IndexCoverage::Indexed,
+        ));
         assert_eq!(m, ExpandMode::IndexedScan);
     }
 
@@ -2521,8 +2582,13 @@ mod expand_chooser_tests {
         // Same selectivity (frontier/|V_src|), 1000× difference in |E|. Indexed
         // cost is independent of |E|, so the choice must not flip.
         let small = choose_expand_mode(&inputs(50, 100_000, 1_000_000, 1, IndexCoverage::Indexed));
-        let huge =
-            choose_expand_mode(&inputs(50, 100_000_000, 1_000_000, 1, IndexCoverage::Indexed));
+        let huge = choose_expand_mode(&inputs(
+            50,
+            100_000_000,
+            1_000_000,
+            1,
+            IndexCoverage::Indexed,
+        ));
         assert_eq!(small, ExpandMode::IndexedScan);
         assert_eq!(huge, ExpandMode::IndexedScan);
     }
@@ -2538,13 +2604,25 @@ mod expand_chooser_tests {
     #[test]
     fn frontier_over_hard_cap_picks_csr() {
         // 2000 > 1024 ceiling, even though the selectivity is tiny.
-        let m = choose_expand_mode(&inputs(2000, 10_000_000, 1_000_000, 1, IndexCoverage::Indexed));
+        let m = choose_expand_mode(&inputs(
+            2000,
+            10_000_000,
+            1_000_000,
+            1,
+            IndexCoverage::Indexed,
+        ));
         assert_eq!(m, ExpandMode::Csr);
     }
 
     #[test]
     fn hops_over_hard_cap_picks_csr() {
-        let m = choose_expand_mode(&inputs(10, 10_000_000, 1_000_000, 8, IndexCoverage::Indexed));
+        let m = choose_expand_mode(&inputs(
+            10,
+            10_000_000,
+            1_000_000,
+            8,
+            IndexCoverage::Indexed,
+        ));
         assert_eq!(m, ExpandMode::Csr);
     }
 
@@ -2599,7 +2677,13 @@ mod expand_chooser_tests {
         // Consequence: a selective frontier where the requested 5 hops would
         // (wrongly) flip cross-type to CSR, but the capped 1 hop — what actually
         // runs — keeps it indexed.
-        let mut i = inputs(50, 10_000, 100, cost_effective_hops(5, false), IndexCoverage::Indexed);
+        let mut i = inputs(
+            50,
+            10_000,
+            100,
+            cost_effective_hops(5, false),
+            IndexCoverage::Indexed,
+        );
         assert_eq!(choose_expand_mode(&i), ExpandMode::IndexedScan);
         i.effective_max_hops = 5; // as if the cross-type cap were not applied
         assert_eq!(choose_expand_mode(&i), ExpandMode::Csr);
@@ -2730,8 +2814,9 @@ mod literal_lowering_tests {
             matches!(dt, Expr::Literal(ScalarValue::Date64(Some(_)), ..)),
             "DateTime vs Date64 column must coerce to a typed Date64, got {dt:?}"
         );
-        let d = literal_to_expr_coerced(&Literal::Date("2024-06-01".into()), Some(&DataType::Date32))
-            .unwrap();
+        let d =
+            literal_to_expr_coerced(&Literal::Date("2024-06-01".into()), Some(&DataType::Date32))
+                .unwrap();
         assert!(
             matches!(d, Expr::Literal(ScalarValue::Date32(Some(_)), ..)),
             "Date vs Date32 column must coerce to a typed Date32, got {d:?}"
@@ -2766,12 +2851,14 @@ mod literal_lowering_tests {
     #[test]
     fn integer_literal_coerces_to_narrow_column_type() {
         use arrow_schema::DataType;
-        let i32_lit = literal_to_expr_coerced(&Literal::Integer(5), Some(&DataType::Int32)).unwrap();
+        let i32_lit =
+            literal_to_expr_coerced(&Literal::Integer(5), Some(&DataType::Int32)).unwrap();
         assert!(
             matches!(i32_lit, Expr::Literal(ScalarValue::Int32(Some(5)), ..)),
             "integer literal vs Int32 column must lower to Int32, got {i32_lit:?}"
         );
-        let u32_lit = literal_to_expr_coerced(&Literal::Integer(7), Some(&DataType::UInt32)).unwrap();
+        let u32_lit =
+            literal_to_expr_coerced(&Literal::Integer(7), Some(&DataType::UInt32)).unwrap();
         assert!(
             matches!(u32_lit, Expr::Literal(ScalarValue::UInt32(Some(7)), ..)),
             "integer literal vs UInt32 column must lower to UInt32, got {u32_lit:?}"
@@ -2821,7 +2908,10 @@ mod literal_lowering_tests {
         let e = literal_to_expr_coerced(&Literal::Integer(3_000_000_000), Some(&DataType::Int32))
             .unwrap();
         assert!(
-            matches!(e, Expr::Literal(ScalarValue::Int64(Some(3_000_000_000)), ..)),
+            matches!(
+                e,
+                Expr::Literal(ScalarValue::Int64(Some(3_000_000_000)), ..)
+            ),
             "out-of-range integer vs Int32 must fall back to natural Int64, got {e:?}"
         );
     }

--- a/crates/omnigraph/src/table_store/mem_wal.rs
+++ b/crates/omnigraph/src/table_store/mem_wal.rs
@@ -1596,7 +1596,10 @@ fn documented_manifest_staging(relative: &str) -> bool {
         return false;
     };
     let canonical_manifest = format!("manifest/{manifest_name}");
-    if !matches!(documented_manifest_version(&canonical_manifest), Some(Some(1..))) {
+    if !matches!(
+        documented_manifest_version(&canonical_manifest),
+        Some(Some(1..))
+    ) {
         return false;
     }
     ShardId::parse_str(temporary_id)

--- a/crates/omnigraph/tests/consistency.rs
+++ b/crates/omnigraph/tests/consistency.rs
@@ -844,9 +844,7 @@ node ExternalID {
     // message reads `(external_id, source)`; assert order-agnostically that
     // both composite columns are named (not just the first, as pre-fix).
     assert!(
-        msg.contains("@unique violation")
-            && msg.contains("source")
-            && msg.contains("external_id"),
+        msg.contains("@unique violation") && msg.contains("source") && msg.contains("external_id"),
         "composite violation must name both columns (got: {msg})"
     );
 }

--- a/crates/omnigraph/tests/durable_head_lookup_cost.rs
+++ b/crates/omnigraph/tests/durable_head_lookup_cost.rs
@@ -38,9 +38,7 @@ use futures::{FutureExt, TryStreamExt};
 use lance::Dataset;
 use lance::dataset::optimize::{CompactionOptions, compact_files};
 use lance::dataset::scanner::ExecutionSummaryCounts;
-use lance::dataset::{
-    MergeInsertBuilder, WhenMatched, WhenNotMatched, WriteMode, WriteParams,
-};
+use lance::dataset::{MergeInsertBuilder, WhenMatched, WhenNotMatched, WriteMode, WriteParams};
 use lance::datatypes::LANCE_UNENFORCED_PRIMARY_KEY;
 use lance::index::DatasetIndexExt;
 use lance::session::Session;
@@ -242,8 +240,14 @@ impl HeadFixture {
             .execute_reader(Box::new(reader))
             .await
             .unwrap_or_else(|err| panic!("fixture publish at depth {next_depth} failed: {err}"));
-        assert_eq!(stats.num_inserted_rows, 2, "journal rows must be immutable inserts");
-        assert_eq!(stats.num_updated_rows, 2, "table + graph heads must update in place");
+        assert_eq!(
+            stats.num_inserted_rows, 2,
+            "journal rows must be immutable inserts"
+        );
+        assert_eq!(
+            stats.num_updated_rows, 2,
+            "table + graph heads must update in place"
+        );
         self.dataset = Arc::try_unwrap(dataset).unwrap_or_else(|arc| (*arc).clone());
         self.journal_depth = next_depth;
     }
@@ -329,12 +333,10 @@ impl HeadFixture {
 }
 
 fn manifest_schema() -> SchemaRef {
-    let object_id_metadata: HashMap<String, String> = [(
-        LANCE_UNENFORCED_PRIMARY_KEY.to_string(),
-        "true".to_string(),
-    )]
-    .into_iter()
-    .collect();
+    let object_id_metadata: HashMap<String, String> =
+        [(LANCE_UNENFORCED_PRIMARY_KEY.to_string(), "true".to_string())]
+            .into_iter()
+            .collect();
     Arc::new(Schema::new(vec![
         Field::new("object_id", DataType::Utf8, false).with_metadata(object_id_metadata),
         Field::new("object_type", DataType::Utf8, false),
@@ -459,9 +461,7 @@ fn lineage_rows(graph_commit: u64) -> [ManifestRow; 2] {
             object_id: "graph_head:main".to_string(),
             object_type: "graph_head".to_string(),
             location: None,
-            metadata: Some(
-                serde_json::json!({ "head_commit_id": commit_id }).to_string(),
-            ),
+            metadata: Some(serde_json::json!({ "head_commit_id": commit_id }).to_string()),
             table_key: String::new(),
             stable_table_id: None,
             table_incarnation_id: None,
@@ -491,7 +491,9 @@ fn rows_to_batch(rows: &[ManifestRow], schema: &SchemaRef) -> RecordBatch {
             new_null_array(list_type, rows.len()),
             Arc::new(StringArray::from(table_keys)),
             Arc::new(UInt64Array::from(
-                rows.iter().map(|row| row.stable_table_id).collect::<Vec<_>>(),
+                rows.iter()
+                    .map(|row| row.stable_table_id)
+                    .collect::<Vec<_>>(),
             )),
             Arc::new(UInt64Array::from(
                 rows.iter()
@@ -528,12 +530,14 @@ async fn execute_head_lookup(
     scanner
         .project(&LOOKUP_COLUMNS)
         .unwrap()
-        .filter_expr(col("object_id").in_list(
-            (1..=catalog_width)
-                .map(|stable_id| lit(format!("table_head:{stable_id}")))
-                .collect(),
-            false,
-        ))
+        .filter_expr(
+            col("object_id").in_list(
+                (1..=catalog_width)
+                    .map(|stable_id| lit(format!("table_head:{stable_id}")))
+                    .collect(),
+                false,
+            ),
+        )
         .use_scalar_index(true)
         .scan_stats_callback(Arc::new(move |summary| {
             callback_summaries.lock().unwrap().push(summary.clone());
@@ -649,7 +653,10 @@ fn validate_heads(batches: &[RecordBatch], expected_versions: &[u64]) {
         .enumerate()
         .map(|(offset, version)| (offset as u64 + 1, *version))
         .collect();
-    assert_eq!(actual, expected, "lookup must return each exact current head once");
+    assert_eq!(
+        actual, expected,
+        "lookup must return each exact current head once"
+    );
 }
 
 async fn record_state(
@@ -660,10 +667,13 @@ async fn record_state(
     index_state: IndexState,
     backend: StorageBackend,
 ) {
-    let (total_fragments, uncovered_fragments) = fixture
-        .index_coverage()
-        .await
-        .unwrap_or_else(|| (fixture.dataset.fragments().len() as u64, fixture.dataset.fragments().len() as u64));
+    let (total_fragments, uncovered_fragments) =
+        fixture.index_coverage().await.unwrap_or_else(|| {
+            (
+                fixture.dataset.fragments().len() as u64,
+                fixture.dataset.fragments().len() as u64,
+            )
+        });
     for (access, cost) in fixture.lookup_pair().await {
         let point = CurvePoint {
             base_depth,
@@ -699,11 +709,7 @@ async fn record_state(
     }
 }
 
-async fn run_matrix(
-    base_uri: &str,
-    depths: &[u64],
-    backend: StorageBackend,
-) -> LookupCurve {
+async fn run_matrix(base_uri: &str, depths: &[u64], backend: StorageBackend) -> LookupCurve {
     let mut curve = Vec::new();
     for layout in [HistoryLayout::Uncompacted, HistoryLayout::Compacted] {
         for &depth in depths {
@@ -758,10 +764,7 @@ async fn run_matrix(
             for _ in 1..UNRECONCILED_TAIL {
                 fixture.publish_one().await;
             }
-            assert_eq!(
-                fixture.index_coverage().await.unwrap().1,
-                UNRECONCILED_TAIL
-            );
+            assert_eq!(fixture.index_coverage().await.unwrap().1, UNRECONCILED_TAIL);
             record_state(
                 &mut curve,
                 &fixture,
@@ -841,31 +844,15 @@ fn assert_bounded_pair(label: &str, shallow: u64, deep: u64, ceiling: u64) {
     );
 }
 
-fn assert_reconciled_slopes(
-    curve: &[CurvePoint],
-    depths: &[u64],
-    backend: StorageBackend,
-) {
+fn assert_reconciled_slopes(curve: &[CurvePoint], depths: &[u64], backend: StorageBackend) {
     let shallow_depth = depths[0];
     let deep_depth = *depths.last().unwrap();
     assert!(deep_depth > shallow_depth);
 
     for layout in [HistoryLayout::Uncompacted, HistoryLayout::Compacted] {
         for access in [AccessMode::ColdOpen, AccessMode::WarmRepeat] {
-            let shallow = point(
-                curve,
-                shallow_depth,
-                layout,
-                IndexState::Reconciled,
-                access,
-            );
-            let deep = point(
-                curve,
-                deep_depth,
-                layout,
-                IndexState::Reconciled,
-                access,
-            );
+            let shallow = point(curve, shallow_depth, layout, IndexState::Reconciled, access);
+            let deep = point(curve, deep_depth, layout, IndexState::Reconciled, access);
 
             assert_flat(
                 "reconciled rows_scanned proxy",
@@ -940,11 +927,7 @@ fn assert_reconciled_slopes(
             }
 
             match (layout, access, backend) {
-                (
-                    HistoryLayout::Uncompacted,
-                    AccessMode::ColdOpen,
-                    StorageBackend::Local,
-                ) => {
+                (HistoryLayout::Uncompacted, AccessMode::ColdOpen, StorageBackend::Local) => {
                     // Local filesystem manifest discovery is outside the range
                     // read wrapper.  This is a control, not evidence that remote
                     // cold open is flat.
@@ -959,11 +942,7 @@ fn assert_reconciled_slopes(
                         deep.cost.object_store_read_bytes,
                     );
                 }
-                (
-                    HistoryLayout::Uncompacted,
-                    AccessMode::ColdOpen,
-                    StorageBackend::S3,
-                ) => {
+                (HistoryLayout::Uncompacted, AccessMode::ColdOpen, StorageBackend::S3) => {
                     // Known RFC-024 no-go: opening latest on object storage
                     // still walks history-dependent manifest metadata before
                     // the flat BTREE lookup begins.
@@ -991,11 +970,7 @@ fn assert_reconciled_slopes(
                         128,
                     );
                 }
-                (
-                    HistoryLayout::Compacted,
-                    AccessMode::ColdOpen,
-                    StorageBackend::Local,
-                ) => {
+                (HistoryLayout::Compacted, AccessMode::ColdOpen, StorageBackend::Local) => {
                     assert_non_growing(
                         "compacted cold object reads",
                         shallow.cost.object_store_reads,
@@ -1011,11 +986,7 @@ fn assert_reconciled_slopes(
                         8 * 1024,
                     );
                 }
-                (
-                    HistoryLayout::Compacted,
-                    AccessMode::ColdOpen,
-                    StorageBackend::S3,
-                ) => {
+                (HistoryLayout::Compacted, AccessMode::ColdOpen, StorageBackend::S3) => {
                     assert_flat(
                         "S3 compacted cold object reads",
                         shallow.cost.object_store_reads,
@@ -1029,11 +1000,7 @@ fn assert_reconciled_slopes(
                         deep.cost.object_store_read_bytes,
                     );
                 }
-                (
-                    HistoryLayout::Compacted,
-                    AccessMode::WarmRepeat,
-                    StorageBackend::Local,
-                ) => {
+                (HistoryLayout::Compacted, AccessMode::WarmRepeat, StorageBackend::Local) => {
                     assert_flat(
                         "local compacted warm object reads",
                         shallow.cost.object_store_reads,
@@ -1045,11 +1012,7 @@ fn assert_reconciled_slopes(
                         deep.cost.object_store_read_bytes,
                     );
                 }
-                (
-                    HistoryLayout::Compacted,
-                    AccessMode::WarmRepeat,
-                    StorageBackend::S3,
-                ) => {
+                (HistoryLayout::Compacted, AccessMode::WarmRepeat, StorageBackend::S3) => {
                     assert_flat(
                         "S3 compacted warm object reads",
                         shallow.cost.object_store_reads,
@@ -1066,11 +1029,7 @@ fn assert_reconciled_slopes(
     }
 }
 
-fn assert_matrix_contract(
-    curve: &[CurvePoint],
-    depths: &[u64],
-    backend: StorageBackend,
-) {
+fn assert_matrix_contract(curve: &[CurvePoint], depths: &[u64], backend: StorageBackend) {
     assert_eq!(curve.len(), depths.len() * 2 * 5 * 2);
     for &depth in depths {
         for layout in [HistoryLayout::Uncompacted, HistoryLayout::Compacted] {
@@ -1111,14 +1070,10 @@ fn assert_matrix_contract(
 
                 assert_eq!(tail.uncovered_fragments, UNRECONCILED_TAIL);
                 assert!(
-                    tail.cost.fragments_scanned
-                        <= full.cost.fragments_scanned + UNRECONCILED_TAIL
+                    tail.cost.fragments_scanned <= full.cost.fragments_scanned + UNRECONCILED_TAIL
                 );
                 assert!(tail.cost.rows_scanned >= CATALOG_WIDTH as u64);
-                assert!(
-                    tail.cost.rows_scanned
-                        <= CATALOG_WIDTH as u64 + UNRECONCILED_TAIL * 4
-                );
+                assert!(tail.cost.rows_scanned <= CATALOG_WIDTH as u64 + UNRECONCILED_TAIL * 4);
                 assert!(
                     tail.cost.rows_scanned > one.cost.rows_scanned,
                     "growing uncovered tail must be visible in rows_scanned"
@@ -1130,13 +1085,11 @@ fn assert_matrix_contract(
 
                 assert_eq!(reconciled_after_tail.uncovered_fragments, 0);
                 assert_eq!(
-                    reconciled_after_tail.cost.rows_scanned,
-                    CATALOG_WIDTH as u64,
+                    reconciled_after_tail.cost.rows_scanned, CATALOG_WIDTH as u64,
                     "index reconciliation must restore catalog-width rows_scanned"
                 );
                 assert_eq!(
-                    reconciled_after_tail.cost.ranges_scanned,
-                    CATALOG_WIDTH as u64,
+                    reconciled_after_tail.cost.ranges_scanned, CATALOG_WIDTH as u64,
                     "index reconciliation must remove uncovered-tail range work"
                 );
                 if access == AccessMode::ColdOpen {
@@ -1305,11 +1258,6 @@ async fn local_durable_head_lookup_matrix_at_one_thousand_commits() {
     let dir = tempfile::tempdir().unwrap();
     let base_uri = dir.path().join("rfc024-head-cost-decision");
     let depths = [10, 100, 1_000];
-    let curve = run_matrix(
-        base_uri.to_str().unwrap(),
-        &depths,
-        StorageBackend::Local,
-    )
-    .await;
+    let curve = run_matrix(base_uri.to_str().unwrap(), &depths, StorageBackend::Local).await;
     assert_matrix_contract(&curve, &depths, StorageBackend::Local);
 }

--- a/crates/omnigraph/tests/forbidden_apis.rs
+++ b/crates/omnigraph/tests/forbidden_apis.rs
@@ -362,10 +362,7 @@ const READ_ONLY_SURFACES: &[(&str, &str)] = &[
         "db/omnigraph/stream_profile.rs",
         "with_checked_cluster_served_export",
     ),
-    (
-        "db/omnigraph/export.rs",
-        "capture_served_export_cut",
-    ),
+    ("db/omnigraph/export.rs", "capture_served_export_cut"),
     (
         "db/omnigraph/stream_ingest.rs",
         "failpoint_stream_incarnation_for_test",

--- a/crates/omnigraph/tests/lance_surface_guards.rs
+++ b/crates/omnigraph/tests/lance_surface_guards.rs
@@ -889,13 +889,11 @@ impl BlockNextPut {
     }
 
     async fn wait_until_reached(&self) {
-        let permit = tokio::time::timeout(
-            std::time::Duration::from_secs(10),
-            self.reached.acquire(),
-        )
-        .await
-        .expect("generation N+1 WAL append never reached the object-store barrier")
-        .expect("put-barrier semaphore closed");
+        let permit =
+            tokio::time::timeout(std::time::Duration::from_secs(10), self.reached.acquire())
+                .await
+                .expect("generation N+1 WAL append never reached the object-store barrier")
+                .expect("put-barrier semaphore closed");
         permit.forget();
     }
 
@@ -959,11 +957,7 @@ impl ObjectStore for BlockNextPutStore {
         self.target.put_multipart_opts(location, options).await
     }
 
-    async fn get_opts(
-        &self,
-        location: &Path,
-        options: GetOptions,
-    ) -> ObjectStoreResult<GetResult> {
+    async fn get_opts(&self, location: &Path, options: GetOptions) -> ObjectStoreResult<GetResult> {
         self.target.get_opts(location, options).await
     }
 
@@ -974,10 +968,7 @@ impl ObjectStore for BlockNextPutStore {
         self.target.delete_stream(locations)
     }
 
-    fn list(
-        &self,
-        prefix: Option<&Path>,
-    ) -> BoxStream<'static, ObjectStoreResult<ObjectMeta>> {
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, ObjectStoreResult<ObjectMeta>> {
         self.target.list(prefix)
     }
 
@@ -989,10 +980,7 @@ impl ObjectStore for BlockNextPutStore {
         self.target.list_with_offset(prefix, offset)
     }
 
-    async fn list_with_delimiter(
-        &self,
-        prefix: Option<&Path>,
-    ) -> ObjectStoreResult<ListResult> {
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> ObjectStoreResult<ListResult> {
         self.target.list_with_delimiter(prefix).await
     }
 
@@ -1234,7 +1222,12 @@ async fn mem_wal_watcher_watermark_is_not_generation_scoped_on_pinned_lance() {
         .load()
         .await
         .unwrap();
-    dataset.initialize_mem_wal().unsharded().execute().await.unwrap();
+    dataset
+        .initialize_mem_wal()
+        .unsharded()
+        .execute()
+        .await
+        .unwrap();
 
     let shard_id = ShardId::new_v4();
     let config = ShardWriterConfig::new(shard_id)

--- a/crates/omnigraph/tests/lifecycle.rs
+++ b/crates/omnigraph/tests/lifecycle.rs
@@ -142,9 +142,7 @@ async fn init_creates_graph() {
     );
     assert_eq!(
         person
-            .count_rows(Some(
-                "name = '__omnigraph_stream_v1$'".to_string(),
-            ))
+            .count_rows(Some("name = '__omnigraph_stream_v1$'".to_string(),))
             .await
             .unwrap(),
         0,
@@ -198,16 +196,20 @@ async fn public_snapshot_wildcard_omits_protocol_metadata() {
     let person = snapshot.open("node:Person").await.unwrap();
     let mut scanner = person.scan();
     scanner.project(&["*"]).unwrap();
-    let batches: Vec<arrow_array::RecordBatch> = futures::TryStreamExt::try_collect(
-        scanner.try_into_stream().await.unwrap(),
-    )
-    .await
-    .unwrap();
-    assert_eq!(batches.iter().map(|batch| batch.num_rows()).sum::<usize>(), 1);
-    assert!(batches.iter().all(|batch| batch
-        .schema()
-        .field_with_name("__omnigraph_stream_v1$")
-        .is_err()));
+    let batches: Vec<arrow_array::RecordBatch> =
+        futures::TryStreamExt::try_collect(scanner.try_into_stream().await.unwrap())
+            .await
+            .unwrap();
+    assert_eq!(
+        batches.iter().map(|batch| batch.num_rows()).sum::<usize>(),
+        1
+    );
+    assert!(batches.iter().all(|batch| {
+        batch
+            .schema()
+            .field_with_name("__omnigraph_stream_v1$")
+            .is_err()
+    }));
 }
 
 #[tokio::test]

--- a/crates/omnigraph/tests/lineage_projection.rs
+++ b/crates/omnigraph/tests/lineage_projection.rs
@@ -43,12 +43,7 @@ async fn head_id(root: &str, branch: Option<&str>) -> String {
         Some(branch) => CommitGraph::open_at_branch(root, branch).await.unwrap(),
         None => CommitGraph::open(root).await.unwrap(),
     };
-    graph
-        .head_commit()
-        .await
-        .unwrap()
-        .unwrap()
-        .graph_commit_id
+    graph.head_commit().await.unwrap().unwrap().graph_commit_id
 }
 
 #[tokio::test]
@@ -269,10 +264,7 @@ async fn graph_lineage_lives_only_in_manifest() {
     // main's authored commits: Alice, Bob, Erin (direct) + the merge (act-merger)
     // = 4. Carol/Dave were authored on the feature branch, not main. Genesis has
     // no actor.
-    let authored = main_commits
-        .iter()
-        .filter(|c| c.actor_id.is_some())
-        .count();
+    let authored = main_commits.iter().filter(|c| c.actor_id.is_some()).count();
     assert!(
         authored >= 4,
         "expected the authored commits to surface their actor in the projection, saw {authored}"

--- a/crates/omnigraph/tests/literal_filters.rs
+++ b/crates/omnigraph/tests/literal_filters.rs
@@ -35,12 +35,16 @@ const DATA: &str = r#"{"type":"Metric","data":{"name":"m1","score":2.5,"ratio":0
 async fn metric_db(dir: &tempfile::TempDir) -> Omnigraph {
     let uri = dir.path().to_str().unwrap();
     let mut db = Omnigraph::init(uri, SCHEMA).await.unwrap();
-    load_jsonl(&mut db, DATA, LoadMode::Overwrite).await.unwrap();
+    load_jsonl(&mut db, DATA, LoadMode::Overwrite)
+        .await
+        .unwrap();
     db
 }
 
 async fn sorted_metric_names(db: &mut Omnigraph, queries: &str, name: &str) -> Vec<String> {
-    let r = query_main(db, queries, name, &ParamMap::new()).await.unwrap();
+    let r = query_main(db, queries, name, &ParamMap::new())
+        .await
+        .unwrap();
     if r.num_rows() == 0 {
         return Vec::new();
     }
@@ -61,9 +65,15 @@ query le() { match { $m: Metric  $m.ratio <= 0.25 } return { $m.name } }
 query inline() { match { $m: Metric { score: 3.0 } } return { $m.name } }
 "#;
     // F64 standalone: scores 2.5, 3.0 > 1.5
-    assert_eq!(sorted_metric_names(&mut db, q, "gt").await, vec!["m1", "m3"]);
+    assert_eq!(
+        sorted_metric_names(&mut db, q, "gt").await,
+        vec!["m1", "m3"]
+    );
     // F32 standalone: ratios 0.25, 0.1 <= 0.25
-    assert_eq!(sorted_metric_names(&mut db, q, "le").await, vec!["m2", "m4"]);
+    assert_eq!(
+        sorted_metric_names(&mut db, q, "le").await,
+        vec!["m2", "m4"]
+    );
     // F64 inline-binding pushdown: score == 3.0
     assert_eq!(sorted_metric_names(&mut db, q, "inline").await, vec!["m3"]);
 }
@@ -83,9 +93,15 @@ query ratio_eq() { match { $m: Metric { ratio: 0.25 } } return { $m.name } }
 query count_ge() { match { $m: Metric  $m.count >= 3 } return { $m.name } }
 "#;
     // I32 column, integer literal coerced Int64 -> Int32: count == 2 is m2 only.
-    assert_eq!(sorted_metric_names(&mut db, q, "count_eq").await, vec!["m2"]);
+    assert_eq!(
+        sorted_metric_names(&mut db, q, "count_eq").await,
+        vec!["m2"]
+    );
     // F32 column, float literal coerced Float64 -> Float32: ratio == 0.25 is m2.
-    assert_eq!(sorted_metric_names(&mut db, q, "ratio_eq").await, vec!["m2"]);
+    assert_eq!(
+        sorted_metric_names(&mut db, q, "ratio_eq").await,
+        vec!["m2"]
+    );
     // Range on the I32 column: count 3,4 >= 3 -> m3, m4 (coercion is op-independent).
     assert_eq!(
         sorted_metric_names(&mut db, q, "count_ge").await,
@@ -121,9 +137,18 @@ query standalone() { match { $m: Metric  $m.active = true } return { $m.name } }
 query inline() { match { $m: Metric { active: true } } return { $m.name } }
 query negated() { match { $m: Metric  $m.active != true } return { $m.name } }
 "#;
-    assert_eq!(sorted_metric_names(&mut db, q, "standalone").await, vec!["m1", "m3"]);
-    assert_eq!(sorted_metric_names(&mut db, q, "inline").await, vec!["m1", "m3"]);
-    assert_eq!(sorted_metric_names(&mut db, q, "negated").await, vec!["m2", "m4"]);
+    assert_eq!(
+        sorted_metric_names(&mut db, q, "standalone").await,
+        vec!["m1", "m3"]
+    );
+    assert_eq!(
+        sorted_metric_names(&mut db, q, "inline").await,
+        vec!["m1", "m3"]
+    );
+    assert_eq!(
+        sorted_metric_names(&mut db, q, "negated").await,
+        vec!["m2", "m4"]
+    );
 }
 
 #[tokio::test]
@@ -137,9 +162,15 @@ query born_eq() { match { $m: Metric { born: date("2024-06-01") } } return { $m.
 query seen_eq() { match { $m: Metric { seen: datetime("2024-06-01T12:00:00Z") } } return { $m.name } }
 "#;
     // born: m1 2024-06, m3 2025 >= 2024-01-01
-    assert_eq!(sorted_metric_names(&mut db, q, "born_ge").await, vec!["m1", "m3"]);
+    assert_eq!(
+        sorted_metric_names(&mut db, q, "born_ge").await,
+        vec!["m1", "m3"]
+    );
     // seen: m2 2023, m4 2022 < 2024-01-01
-    assert_eq!(sorted_metric_names(&mut db, q, "seen_lt").await, vec!["m2", "m4"]);
+    assert_eq!(
+        sorted_metric_names(&mut db, q, "seen_lt").await,
+        vec!["m2", "m4"]
+    );
     // Inline-binding equality exercises the Lance-pushdown arm with a typed
     // Date32/Date64 literal: the epoch conversion must select exactly m1.
     assert_eq!(sorted_metric_names(&mut db, q, "born_eq").await, vec!["m1"]);
@@ -163,11 +194,18 @@ async fn camelcase_property_filter_executes() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
     let mut db = Omnigraph::init(uri, CC_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, CC_DATA, LoadMode::Overwrite).await.unwrap();
+    load_jsonl(&mut db, CC_DATA, LoadMode::Overwrite)
+        .await
+        .unwrap();
 
-    let q = r#"query by_repo($r: String) { match { $d: Doc { repoName: $r } } return { $d.slug } }"#;
+    let q =
+        r#"query by_repo($r: String) { match { $d: Doc { repoName: $r } } return { $d.slug } }"#;
     let r = query_main(&mut db, q, "by_repo", &params(&[("$r", "acme")]))
         .await
         .expect("camelCase property filter must execute, not fail at the Lance scan");
-    assert_eq!(r.num_rows(), 1, "expected exactly the d1 row for repoName=acme");
+    assert_eq!(
+        r.num_rows(),
+        1,
+        "expected exactly the d1 row for repoName=acme"
+    );
 }

--- a/crates/omnigraph/tests/merge_fast_forward.rs
+++ b/crates/omnigraph/tests/merge_fast_forward.rs
@@ -54,10 +54,9 @@ async fn append_only_fast_forward_merge_uses_fenced_insert() {
     append_new_persons(&mut feature, "feature", 5).await;
 
     let probes = MergeWriteProbes::default();
-    let outcome =
-        with_merge_write_probes(probes.clone(), main.branch_merge("feature", "main"))
-            .await
-            .unwrap();
+    let outcome = with_merge_write_probes(probes.clone(), main.branch_merge("feature", "main"))
+        .await
+        .unwrap();
     assert_eq!(outcome, MergeOutcome::FastForward);
 
     assert_eq!(
@@ -704,7 +703,10 @@ async fn fast_forward_merge_defers_vector_index_to_reconciler() {
         ));
     }
     let feature = Omnigraph::open(uri).await.unwrap();
-    feature.load("feature", &rows, LoadMode::Merge).await.unwrap();
+    feature
+        .load("feature", &rows, LoadMode::Merge)
+        .await
+        .unwrap();
 
     // Merge, asserting that its publish path stages no vector-index artifact.
     let probes = MergeWriteProbes::default();
@@ -724,7 +726,8 @@ async fn fast_forward_merge_defers_vector_index_to_reconciler() {
     assert_eq!(count_rows(&main, "node:Chunk").await, 24);
 }
 
-const BLOB_SCHEMA: &str = "node Document {\n  title: String @key\n  content: Blob?\n  note: String?\n}\n";
+const BLOB_SCHEMA: &str =
+    "node Document {\n  title: String @key\n  content: Blob?\n  note: String?\n}\n";
 const BLOB_INSERT: &str = r#"
 query insert_doc($title: String, $content: Blob, $note: String) {
     insert Document { title: $title, content: $content, note: $note }
@@ -772,7 +775,10 @@ async fn fast_forward_merge_streams_blob_columns() {
     assert_eq!(outcome, MergeOutcome::FastForward);
 
     // The new blob row's bytes survive the streaming keyed write; the base row stays intact.
-    let readme = main.read_blob("Document", "readme", "content").await.unwrap();
+    let readme = main
+        .read_blob("Document", "readme", "content")
+        .await
+        .unwrap();
     assert_eq!(&readme.read().await.unwrap()[..], b"Hello");
     let seed = main.read_blob("Document", "seed", "content").await.unwrap();
     assert_eq!(&seed.read().await.unwrap()[..], b"Seed");

--- a/crates/omnigraph/tests/ordering.rs
+++ b/crates/omnigraph/tests/ordering.rs
@@ -38,7 +38,9 @@ fn names_in_order(result: &QueryResult) -> Vec<String> {
 async fn init_people(dir: &tempfile::TempDir, jsonl: &str) -> Omnigraph {
     let uri = dir.path().to_str().unwrap();
     let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, jsonl, LoadMode::Overwrite).await.unwrap();
+    load_jsonl(&mut db, jsonl, LoadMode::Overwrite)
+        .await
+        .unwrap();
     db
 }
 
@@ -117,7 +119,11 @@ query q() {
     order { $p.age asc }
 }
 "#;
-    let got_asc = names_in_order(&query_main(&mut db, asc, "q", &ParamMap::new()).await.unwrap());
+    let got_asc = names_in_order(
+        &query_main(&mut db, asc, "q", &ParamMap::new())
+            .await
+            .unwrap(),
+    );
     // ASC: nulls_first -> Bob(null), then 25, 30.
     assert_eq!(got_asc, vec!["Bob", "Charlie", "Alice"]);
 
@@ -128,7 +134,11 @@ query q() {
     order { $p.age desc }
 }
 "#;
-    let got_desc = names_in_order(&query_main(&mut db, desc, "q", &ParamMap::new()).await.unwrap());
+    let got_desc = names_in_order(
+        &query_main(&mut db, desc, "q", &ParamMap::new())
+            .await
+            .unwrap(),
+    );
     // DESC: nulls last -> 30, 25, then Bob(null).
     assert_eq!(got_desc, vec!["Alice", "Charlie", "Bob"]);
 }

--- a/crates/omnigraph/tests/proptest_equivalence.rs
+++ b/crates/omnigraph/tests/proptest_equivalence.rs
@@ -80,7 +80,7 @@ query unemployed() {
 struct GenGraph {
     persons: Vec<String>,
     companies: Vec<String>,
-    knows: Vec<(usize, usize)>,    // indices into persons (self-loops & cycles allowed)
+    knows: Vec<(usize, usize)>, // indices into persons (self-loops & cycles allowed)
     works_at: Vec<(usize, usize)>, // (person idx, company idx)
 }
 
@@ -88,10 +88,14 @@ impl GenGraph {
     fn to_jsonl(&self) -> String {
         let mut s = String::new();
         for p in &self.persons {
-            s.push_str(&format!("{{\"type\":\"Person\",\"data\":{{\"name\":\"{p}\"}}}}\n"));
+            s.push_str(&format!(
+                "{{\"type\":\"Person\",\"data\":{{\"name\":\"{p}\"}}}}\n"
+            ));
         }
         for c in &self.companies {
-            s.push_str(&format!("{{\"type\":\"Company\",\"data\":{{\"name\":\"{c}\"}}}}\n"));
+            s.push_str(&format!(
+                "{{\"type\":\"Company\",\"data\":{{\"name\":\"{c}\"}}}}\n"
+            ));
         }
         // Dedup exact-duplicate edge rows (the loader rejects intra-batch
         // duplicate keys); collisions/cycles/self-loops are unaffected.
@@ -144,7 +148,6 @@ fn config() -> Config {
         ..Config::default()
     }
 }
-
 
 async fn load_graph(graph: &GenGraph) -> (tempfile::TempDir, Omnigraph) {
     let dir = tempfile::tempdir().unwrap();
@@ -214,11 +217,7 @@ fn prop_expand_indexed_eq_csr() {
                 }
                 None
             });
-            prop_assert!(
-                mismatch.is_none(),
-                "Expand mode divergence: {:?}",
-                mismatch
-            );
+            prop_assert!(mismatch.is_none(), "Expand mode divergence: {:?}", mismatch);
             Ok(())
         })
         .unwrap();

--- a/crates/omnigraph/tests/recovery.rs
+++ b/crates/omnigraph/tests/recovery.rs
@@ -18,8 +18,8 @@ use lance::Dataset;
 use omnigraph::db::Omnigraph;
 
 mod helpers;
-use helpers::snapshot_main;
 use helpers::recovery::{RecoveryExpectation, TableExpectation, assert_post_recovery_invariants};
+use helpers::snapshot_main;
 
 const TEST_SCHEMA: &str = include_str!("fixtures/test.pg");
 
@@ -45,10 +45,7 @@ fn list_recovery_dir(graph_root: &Path) -> Vec<String> {
 /// Resolve one live node table's identity-bound physical URI and serialize the
 /// explicit identity required by every recovery generation. The snapshot owns
 /// the path; the accepted bound catalog owns the same stable/incarnation pair.
-async fn node_table_fixture(
-    db: &Omnigraph,
-    type_name: &str,
-) -> (String, serde_json::Value) {
+async fn node_table_fixture(db: &Omnigraph, type_name: &str) -> (String, serde_json::Value) {
     let table_key = format!("node:{type_name}");
     let snapshot = db
         .snapshot_of(omnigraph::db::ReadTarget::branch("main"))
@@ -384,7 +381,8 @@ async fn read_only_open_skips_recovery_sweep() {
     // Drop a syntactically-valid but invariant-violating sidecar (HEAD < pin
     // would error if classified). Read-only must NOT classify it — it must
     // skip the sweep entirely.
-    let sidecar_json = format!(r#"{{
+    let sidecar_json = format!(
+        r#"{{
         "schema_version": 1,
         "operation_id": "01H000000000000000000000RO",
         "started_at": "0",
@@ -400,7 +398,8 @@ async fn read_only_open_skips_recovery_sweep() {
                 "post_commit_pin": 100
             }}
         ]
-    }}"#);
+    }}"#
+    );
     write_sidecar_file(dir.path(), "01H000000000000000000000RO", &sidecar_json);
 
     // ReadOnly open must succeed — the sweep is skipped, so the bogus
@@ -445,11 +444,7 @@ async fn read_only_open_accepts_only_completed_coherent_v5_schema_apply_sidecar(
     // v5 writes the marker only after its manifest publish. If the target
     // identity is also live, only audit/delete cleanup remains and read-only
     // open can prove that its manifest/catalog pair is coherent.
-    write_sidecar_file(
-        dir.path(),
-        operation_id,
-        &sidecar_json(true, live_hash),
-    );
+    write_sidecar_file(dir.path(), operation_id, &sidecar_json(true, live_hash));
     let read_only = Omnigraph::open_read_only(uri).await.unwrap();
     drop(read_only);
     assert!(
@@ -459,11 +454,7 @@ async fn read_only_open_accepts_only_completed_coherent_v5_schema_apply_sidecar(
 
     // Without the published marker, even a matching target may be an active
     // recovery that still needs its manifest delta; read-only must fail closed.
-    write_sidecar_file(
-        dir.path(),
-        operation_id,
-        &sidecar_json(false, live_hash),
-    );
+    write_sidecar_file(dir.path(), operation_id, &sidecar_json(false, live_hash));
     assert!(Omnigraph::open_read_only(uri).await.is_err());
 
     // A published marker paired with a non-live target is the torn window and

--- a/crates/omnigraph/tests/scalar_indexes.rs
+++ b/crates/omnigraph/tests/scalar_indexes.rs
@@ -9,9 +9,9 @@
 
 mod helpers;
 
+use omnigraph::IndexCoverage;
 use omnigraph::db::Omnigraph;
 use omnigraph::loader::{LoadMode, load_jsonl};
-use omnigraph::IndexCoverage;
 
 use helpers::*;
 
@@ -40,7 +40,9 @@ async fn node_scalar_and_enum_index_columns_get_btree() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
     let mut db = Omnigraph::init(uri, SCHEMA).await.unwrap();
-    load_jsonl(&mut db, DATA, LoadMode::Overwrite).await.unwrap();
+    load_jsonl(&mut db, DATA, LoadMode::Overwrite)
+        .await
+        .unwrap();
     db.ensure_indices().await.unwrap();
 
     let snap = snapshot_main(&db).await.unwrap();

--- a/crates/omnigraph/tests/schema_apply.rs
+++ b/crates/omnigraph/tests/schema_apply.rs
@@ -54,10 +54,11 @@ async fn plan_schema_reports_supported_additive_change() {
         .preview_schema_apply_with_options(&desired, omnigraph::db::SchemaApplyOptions::default())
         .await
         .unwrap();
-    assert!(preview.catalog.node_types.values().all(|node| node
-        .arrow_schema
-        .field_with_name("__omnigraph_stream_v1$")
-        .is_err()));
+    assert!(preview.catalog.node_types.values().all(|node| {
+        node.arrow_schema
+            .field_with_name("__omnigraph_stream_v1$")
+            .is_err()
+    }));
 }
 
 #[tokio::test]

--- a/crates/omnigraph/tests/search.rs
+++ b/crates/omnigraph/tests/search.rs
@@ -214,13 +214,9 @@ async fn deferred_indexes_do_not_block_hybrid_reads() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
     let mut db = Omnigraph::init(uri, MOCK_SEARCH_SCHEMA).await.unwrap();
-    load_jsonl(
-        &mut db,
-        &mock_embedding_seed_data(),
-        LoadMode::Overwrite,
-    )
-    .await
-    .unwrap();
+    load_jsonl(&mut db, &mock_embedding_seed_data(), LoadMode::Overwrite)
+        .await
+        .unwrap();
 
     assert_eq!(
         doc_user_index_count(&db).await,
@@ -460,7 +456,9 @@ query filtered_nearest($q: Vector(4)) {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
     let mut db = Omnigraph::init(uri, SCHEMA).await.unwrap();
-    load_jsonl(&mut db, DATA, LoadMode::Overwrite).await.unwrap();
+    load_jsonl(&mut db, DATA, LoadMode::Overwrite)
+        .await
+        .unwrap();
 
     let result = query_main(
         &mut db,
@@ -800,7 +798,10 @@ async fn nearest_full_rank_order() {
     .await
     .unwrap();
     // [0.1,0.2,0.3,0.4] == ml-intro's embedding (dist 0); the rest by ascending L2.
-    assert_eq!(result_slugs(&result), vec!["ml-intro", "nlp-guide", "rl-intro"]);
+    assert_eq!(
+        result_slugs(&result),
+        vec!["ml-intro", "nlp-guide", "rl-intro"]
+    );
 }
 
 #[tokio::test]
@@ -817,7 +818,10 @@ async fn bm25_full_rank_order() {
     .await
     .unwrap();
     // Descending BM25 score order.
-    assert_eq!(result_slugs(&result), vec!["rl-intro", "ml-intro", "dl-basics"]);
+    assert_eq!(
+        result_slugs(&result),
+        vec!["rl-intro", "ml-intro", "dl-basics"]
+    );
 }
 
 // Characterization: fuzzy() does NOT match under the default tokenizer/index in
@@ -832,9 +836,14 @@ async fn bm25_full_rank_order() {
 async fn fuzzy_does_not_match_under_default_tokenizer() {
     let dir = tempfile::tempdir().unwrap();
     let mut db = init_search_db(&dir).await;
-    let r = query_main(&mut db, SEARCH_QUERIES, "fuzzy_search", &params(&[("$q", "Introductio")]))
-        .await
-        .unwrap();
+    let r = query_main(
+        &mut db,
+        SEARCH_QUERIES,
+        "fuzzy_search",
+        &params(&[("$q", "Introductio")]),
+    )
+    .await
+    .unwrap();
     assert!(
         result_slugs(&r).is_empty(),
         "fuzzy now matches — promote this to a real matched-set/exclusion golden"
@@ -848,9 +857,14 @@ async fn match_text_matches_exact_set_excludes_unrelated() {
     let dir = tempfile::tempdir().unwrap();
     let mut db = init_search_db(&dir).await;
     // "neural" appears only in dl-basics's body ("neural networks").
-    let r = query_main(&mut db, SEARCH_QUERIES, "phrase_search", &params(&[("$q", "neural")]))
-        .await
-        .unwrap();
+    let r = query_main(
+        &mut db,
+        SEARCH_QUERIES,
+        "phrase_search",
+        &params(&[("$q", "neural")]),
+    )
+    .await
+    .unwrap();
     let mut got = result_slugs(&r);
     got.sort();
     assert_eq!(got, vec!["dl-basics"]);
@@ -867,9 +881,14 @@ async fn match_text_matches_exact_set_excludes_unrelated() {
 async fn rrf_fuses_two_fts_fields() {
     let dir = tempfile::tempdir().unwrap();
     let mut db = init_search_db(&dir).await;
-    let r = query_main(&mut db, SEARCH_QUERIES, "rrf_two_fts", &params(&[("$q", "learning")]))
-        .await
-        .unwrap();
+    let r = query_main(
+        &mut db,
+        SEARCH_QUERIES,
+        "rrf_two_fts",
+        &params(&[("$q", "learning")]),
+    )
+    .await
+    .unwrap();
     assert_eq!(result_slugs(&r), vec!["rl-intro", "dl-basics", "ml-intro"]);
 }
 

--- a/crates/omnigraph/tests/traversal.rs
+++ b/crates/omnigraph/tests/traversal.rs
@@ -96,9 +96,14 @@ query reach_both($name: String) {
     // Charlie's only edge is INCOMING (Alice->Charlie). Undirected: hop 1
     // reaches Alice; hop 2 from Alice reaches Bob (out) — Charlie itself is
     // the visited source, never re-emitted.
-    let result = query_main(&mut db, queries, "reach_both", &params(&[("$name", "Charlie")]))
-        .await
-        .unwrap();
+    let result = query_main(
+        &mut db,
+        queries,
+        "reach_both",
+        &params(&[("$name", "Charlie")]),
+    )
+    .await
+    .unwrap();
     assert_eq!(
         first_column_sorted(&result),
         vec!["Alice", "Bob"],
@@ -260,8 +265,16 @@ query slow() {
         v
     };
 
-    let fast = names(query_main(&mut db, queries, "fast", &ParamMap::new()).await.unwrap());
-    let slow = names(query_main(&mut db, queries, "slow", &ParamMap::new()).await.unwrap());
+    let fast = names(
+        query_main(&mut db, queries, "fast", &ParamMap::new())
+            .await
+            .unwrap(),
+    );
+    let slow = names(
+        query_main(&mut db, queries, "slow", &ParamMap::new())
+            .await
+            .unwrap(),
+    );
 
     assert_eq!(fast, slow, "anti-join fast and slow paths must agree");
     // Alice->Acme, Bob->Globex employed; Charlie & Diana have no employer.
@@ -291,7 +304,9 @@ async fn nested_anti_join_with_fanout_correlates_correctly() {
 {"edge":"WorksAt","from":"p2","to":"Globex"}
 {"edge":"WorksAt","from":"p3","to":"Acme"}"#;
     let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, data, LoadMode::Overwrite).await.unwrap();
+    load_jsonl(&mut db, data, LoadMode::Overwrite)
+        .await
+        .unwrap();
 
     let queries = r#"
 query no_nonacme_employer() {
@@ -341,7 +356,9 @@ async fn anti_join_respects_multi_hop_bounds() {
 {"edge":"Knows","from":"c","to":"d"}
 {"edge":"Knows","from":"d","to":"e"}"#;
     let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, data, LoadMode::Overwrite).await.unwrap();
+    load_jsonl(&mut db, data, LoadMode::Overwrite)
+        .await
+        .unwrap();
 
     let queries = r#"
 query no_two_hop() {

--- a/crates/omnigraph/tests/traversal_indexed.rs
+++ b/crates/omnigraph/tests/traversal_indexed.rs
@@ -9,16 +9,21 @@
 
 mod helpers;
 
+use omnigraph::IndexCoverage;
 use omnigraph::db::Omnigraph;
 use omnigraph::instrumentation::with_traversal_mode;
 use omnigraph::loader::{LoadMode, load_jsonl};
-use omnigraph::IndexCoverage;
 use omnigraph_compiler::ir::ParamMap;
 
 use helpers::*;
 
 /// Run `name` on main under the cost-chooser (auto) Expand mode; first column sorted.
-async fn sorted_names(db: &mut Omnigraph, queries: &str, name: &str, params: &ParamMap) -> Vec<String> {
+async fn sorted_names(
+    db: &mut Omnigraph,
+    queries: &str,
+    name: &str,
+    params: &ParamMap,
+) -> Vec<String> {
     first_column_sorted(&query_main(db, queries, name, params).await.unwrap())
 }
 
@@ -27,7 +32,12 @@ async fn sorted_names(db: &mut Omnigraph, queries: &str, name: &str, params: &Pa
 /// scoped `with_traversal_mode` seam; the auto pass exercises `choose_expand_mode`
 /// end to end (whichever path it selects, the rows must match the forced paths —
 /// the chooser changes which path runs, never the result).
-async fn both_modes(db: &mut Omnigraph, queries: &str, name: &str, params: &ParamMap) -> Vec<String> {
+async fn both_modes(
+    db: &mut Omnigraph,
+    queries: &str,
+    name: &str,
+    params: &ParamMap,
+) -> Vec<String> {
     let csr = first_column_sorted(
         &with_traversal_mode("csr", query_main(db, queries, name, params))
             .await
@@ -117,7 +127,13 @@ async fn indexed_matches_csr_one_hop_same_type() {
     let dir = tempfile::tempdir().unwrap();
     let mut db = init_and_load(&dir).await;
     // friends_of: `$p knows $f` (Person -> Person, single hop).
-    let got = both_modes(&mut db, TEST_QUERIES, "friends_of", &params(&[("$name", "Alice")])).await;
+    let got = both_modes(
+        &mut db,
+        TEST_QUERIES,
+        "friends_of",
+        &params(&[("$name", "Alice")]),
+    )
+    .await;
     assert_eq!(got, vec!["Bob", "Charlie"], "Alice knows Bob and Charlie");
 }
 
@@ -171,7 +187,13 @@ query connected($name: String) {
 }
 "#;
     // Alice: outgoing Bob, Charlie; incoming Diana (the fresh unindexed edge).
-    let got = both_modes(&mut db, queries, "connected", &params(&[("$name", "Alice")])).await;
+    let got = both_modes(
+        &mut db,
+        queries,
+        "connected",
+        &params(&[("$name", "Alice")]),
+    )
+    .await;
     assert_eq!(got, vec!["Bob", "Charlie", "Diana"]);
 }
 
@@ -215,7 +237,13 @@ async fn indexed_matches_csr_no_match() {
     let dir = tempfile::tempdir().unwrap();
     let mut db = init_and_load(&dir).await;
     // Diana has no outgoing Knows edges → empty in both modes.
-    let got = both_modes(&mut db, TEST_QUERIES, "friends_of", &params(&[("$name", "Diana")])).await;
+    let got = both_modes(
+        &mut db,
+        TEST_QUERIES,
+        "friends_of",
+        &params(&[("$name", "Diana")]),
+    )
+    .await;
     assert!(got.is_empty(), "Diana knows no one");
 }
 
@@ -241,7 +269,12 @@ async fn indexed_finds_unindexed_appended_edge() {
     let got = first_column_sorted(
         &with_traversal_mode(
             "indexed",
-            query_main(&mut db, TEST_QUERIES, "friends_of", &params(&[("$name", "Alice")])),
+            query_main(
+                &mut db,
+                TEST_QUERIES,
+                "friends_of",
+                &params(&[("$name", "Alice")]),
+            ),
         )
         .await
         .unwrap(),
@@ -291,7 +324,9 @@ query reach($name: String) {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
     let mut db = Omnigraph::init(uri, SCHEMA).await.unwrap();
-    load_jsonl(&mut db, DATA, LoadMode::Overwrite).await.unwrap();
+    load_jsonl(&mut db, DATA, LoadMode::Overwrite)
+        .await
+        .unwrap();
 
     let got = both_modes(&mut db, QUERY, "reach", &params(&[("$name", "alice")])).await;
     assert_eq!(
@@ -328,7 +363,9 @@ async fn variable_hops_terminate_and_dedup_on_cycle() {
 {"edge":"Knows","from":"b","to":"c"}
 {"edge":"Knows","from":"c","to":"a"}"#;
     let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, data, LoadMode::Overwrite).await.unwrap();
+    load_jsonl(&mut db, data, LoadMode::Overwrite)
+        .await
+        .unwrap();
 
     let got = both_modes(&mut db, REACH_5, "reach", &params(&[("$name", "a")])).await;
     // From a: b (1 hop), c (2 hops); the c->a back-edge hits the seeded source
@@ -347,7 +384,9 @@ async fn variable_hops_handle_self_loop() {
 {"edge":"Knows","from":"a","to":"a"}
 {"edge":"Knows","from":"a","to":"b"}"#;
     let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, data, LoadMode::Overwrite).await.unwrap();
+    load_jsonl(&mut db, data, LoadMode::Overwrite)
+        .await
+        .unwrap();
 
     let got = both_modes(&mut db, REACH_5, "reach", &params(&[("$name", "a")])).await;
     // a->a hits the seeded source (pruned); only b is reached.

--- a/crates/omnigraph/tests/validators.rs
+++ b/crates/omnigraph/tests/validators.rs
@@ -166,7 +166,9 @@ async fn non_numeric_vector_element_rejected_on_jsonl_load() {
 
     // A valid row still loads.
     let good = r#"{"type":"Doc","data":{"slug":"d4","embedding":[0.1,0.2,0.3]}}"#;
-    load_jsonl(&mut db, good, LoadMode::Overwrite).await.unwrap();
+    load_jsonl(&mut db, good, LoadMode::Overwrite)
+        .await
+        .unwrap();
 }
 
 // ─── Enum validation ─────────────────────────────────────────────────────────
@@ -613,7 +615,9 @@ query reassign() {
 "#;
     mutate_main(&mut db, Q, "reassign", &params(&[]))
         .await
-        .expect("Alice ends at 'final' and Carol takes the freed 'temp' — final image has no collision");
+        .expect(
+            "Alice ends at 'final' and Carol takes the freed 'temp' — final image has no collision",
+        );
 }
 
 // ─── Edge cardinality ────────────────────────────────────────────────────────

--- a/crates/omnigraph/tests/warm_read_cost.rs
+++ b/crates/omnigraph/tests/warm_read_cost.rs
@@ -30,34 +30,34 @@ use helpers::{
 #[tokio::test]
 async fn warm_same_branch_read_does_no_resolution_opens() {
     cost_harness(async {
-    let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
-    // Deep history: warm-read resolution cost must be flat in commit count.
-    commit_many(&mut db, 20).await;
+        let dir = tempfile::tempdir().unwrap();
+        let mut db = init_and_load(&dir).await;
+        // Deep history: warm-read resolution cost must be flat in commit count.
+        commit_many(&mut db, 20).await;
 
-    let (out, io) = measure(db.query(
-        ReadTarget::branch("main"),
-        TEST_QUERIES,
-        "total_people",
-        &params(&[]),
-    ))
-    .await;
-    out.unwrap();
+        let (out, io) = measure(db.query(
+            ReadTarget::branch("main"),
+            TEST_QUERIES,
+            "total_people",
+            &params(&[]),
+        ))
+        .await;
+        out.unwrap();
 
-    // A warm same-branch read opens nothing from the internal tables, even at
-    // commit-history depth. Fix 1 reuses the coordinator (no re-open: 0
-    // commit-graph opens, exactly 1 cheap version probe). Fix 2 opens the touched
-    // data table by location+version instead of via the namespace, so the
-    // per-table __manifest scan is gone too. Pre-fix, each of these is a deep scan
-    // of an internal table that grows with commit count.
-    assert_eq!(
-        io.manifest_reads, 0,
-        "warm same-branch read must not scan __manifest (resolution or per-table)"
-    );
-    assert_eq!(
-        io.version_probes, 1,
-        "warm same-branch read performs exactly one version probe"
-    );
+        // A warm same-branch read opens nothing from the internal tables, even at
+        // commit-history depth. Fix 1 reuses the coordinator (no re-open: 0
+        // commit-graph opens, exactly 1 cheap version probe). Fix 2 opens the touched
+        // data table by location+version instead of via the namespace, so the
+        // per-table __manifest scan is gone too. Pre-fix, each of these is a deep scan
+        // of an internal table that grows with commit count.
+        assert_eq!(
+            io.manifest_reads, 0,
+            "warm same-branch read must not scan __manifest (resolution or per-table)"
+        );
+        assert_eq!(
+            io.version_probes, 1,
+            "warm same-branch read performs exactly one version probe"
+        );
     })
     .await;
 }
@@ -70,22 +70,22 @@ async fn warm_same_branch_read_does_no_resolution_opens() {
 #[tokio::test]
 async fn multi_table_query_does_no_manifest_scans() {
     cost_harness(async {
-    let dir = tempfile::tempdir().unwrap();
-    let db = init_and_load(&dir).await;
+        let dir = tempfile::tempdir().unwrap();
+        let db = init_and_load(&dir).await;
 
-    let (out, io) = measure(db.query(
-        ReadTarget::branch("main"),
-        TEST_QUERIES,
-        "age_stats",
-        &params(&[]),
-    ))
-    .await;
-    out.unwrap();
+        let (out, io) = measure(db.query(
+            ReadTarget::branch("main"),
+            TEST_QUERIES,
+            "age_stats",
+            &params(&[]),
+        ))
+        .await;
+        out.unwrap();
 
-    assert_eq!(
-        io.manifest_reads, 0,
-        "a multi-table read must not scan __manifest once per touched table"
-    );
+        assert_eq!(
+            io.manifest_reads, 0,
+            "a multi-table read must not scan __manifest once per touched table"
+        );
     })
     .await;
 }
@@ -213,41 +213,41 @@ async fn schema_source_drift_is_caught_on_read() {
 #[tokio::test]
 async fn warm_branch_read_does_no_manifest_scans() {
     cost_harness(async {
-    let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
-    // The canonical-main profile projection must stay warm and bounded at
-    // realistic history depth; a shallow fixture would hide a cold main scan.
-    commit_many(&mut db, 20).await;
-    db.branch_create("feature").await.unwrap();
-    // Write to the branch so its tables are branch-owned (under tree/feature).
-    db.mutate(
-        "feature",
-        MUTATION_QUERIES,
-        "insert_person",
-        &mixed_params(&[("$name", "Eve")], &[("$age", 22)]),
-    )
-    .await
-    .unwrap();
-    // Bind the handle's coordinator to the branch so reads of it take the warm path.
-    db.sync_branch("feature").await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mut db = init_and_load(&dir).await;
+        // The canonical-main profile projection must stay warm and bounded at
+        // realistic history depth; a shallow fixture would hide a cold main scan.
+        commit_many(&mut db, 20).await;
+        db.branch_create("feature").await.unwrap();
+        // Write to the branch so its tables are branch-owned (under tree/feature).
+        db.mutate(
+            "feature",
+            MUTATION_QUERIES,
+            "insert_person",
+            &mixed_params(&[("$name", "Eve")], &[("$age", 22)]),
+        )
+        .await
+        .unwrap();
+        // Bind the handle's coordinator to the branch so reads of it take the warm path.
+        db.sync_branch("feature").await.unwrap();
 
-    let (out, io) = measure(db.query(
-        ReadTarget::branch("feature"),
-        TEST_QUERIES,
-        "total_people",
-        &params(&[]),
-    ))
-    .await;
-    out.unwrap();
+        let (out, io) = measure(db.query(
+            ReadTarget::branch("feature"),
+            TEST_QUERIES,
+            "total_people",
+            &params(&[]),
+        ))
+        .await;
+        out.unwrap();
 
-    assert_eq!(
-        io.manifest_reads, 0,
-        "warm branch read must not scan __manifest (branch-owned table opened by location)"
-    );
-    assert_eq!(
-        io.version_probes, 2,
-        "warm branch read probes the branch and canonical-main profile exactly once each"
-    );
+        assert_eq!(
+            io.manifest_reads, 0,
+            "warm branch read must not scan __manifest (branch-owned table opened by location)"
+        );
+        assert_eq!(
+            io.version_probes, 2,
+            "warm branch read probes the branch and canonical-main profile exactly once each"
+        );
     })
     .await;
 }
@@ -581,109 +581,109 @@ async fn recreated_branch_owned_table_handle_uses_table_etag() {
 #[tokio::test]
 async fn recreated_branch_traversal_uses_graph_index_incarnation() {
     cost_harness(async {
-    let dir = tempfile::tempdir().unwrap();
-    let mut writer = init_and_load(&dir).await;
-    let uri = dir.path().to_str().unwrap();
-    let reader = Omnigraph::open(uri).await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mut writer = init_and_load(&dir).await;
+        let uri = dir.path().to_str().unwrap();
+        let reader = Omnigraph::open(uri).await.unwrap();
 
-    writer.branch_create("feature").await.unwrap();
-    mutate_branch(
-        &mut writer,
-        "feature",
-        MUTATION_QUERIES,
-        "insert_person_and_friend",
-        &mixed_params(
-            &[("$name", "OldWalker"), ("$friend", "Alice")],
-            &[("$age", 41)],
-        ),
-    )
-    .await
-    .unwrap();
-
-    reader.sync_branch("feature").await.unwrap();
-    let old_friends = reader
-        .query(
-            ReadTarget::branch("feature"),
-            TEST_QUERIES,
-            "friends_of",
-            &params(&[("$name", "OldWalker")]),
+        writer.branch_create("feature").await.unwrap();
+        mutate_branch(
+            &mut writer,
+            "feature",
+            MUTATION_QUERIES,
+            "insert_person_and_friend",
+            &mixed_params(
+                &[("$name", "OldWalker"), ("$friend", "Alice")],
+                &[("$age", 41)],
+            ),
         )
         .await
         .unwrap();
-    assert_eq!(first_column_sorted(&old_friends), vec!["Alice"]);
-    let old_edge_entry = reader
-        .snapshot_of(ReadTarget::branch("feature"))
-        .await
-        .unwrap()
-        .entry("edge:Knows")
-        .unwrap()
-        .clone();
-    assert_eq!(old_edge_entry.table_branch.as_deref(), Some("feature"));
 
-    writer.branch_delete("feature").await.unwrap();
-    writer.branch_create("feature").await.unwrap();
-    mutate_branch(
-        &mut writer,
-        "feature",
-        MUTATION_QUERIES,
-        "insert_person_and_friend",
-        &mixed_params(
-            &[("$name", "NewWalker"), ("$friend", "Bob")],
-            &[("$age", 42)],
-        ),
-    )
-    .await
-    .unwrap();
-    let new_edge_entry = writer
-        .snapshot_of(ReadTarget::branch("feature"))
-        .await
-        .unwrap()
-        .entry("edge:Knows")
-        .unwrap()
-        .clone();
-    assert_eq!(new_edge_entry.table_path, old_edge_entry.table_path);
-    assert_eq!(new_edge_entry.table_branch, old_edge_entry.table_branch);
-    assert_eq!(
-        new_edge_entry.table_version, old_edge_entry.table_version,
-        "test setup must force graph-index identity to differ only by snapshot incarnation"
-    );
+        reader.sync_branch("feature").await.unwrap();
+        let old_friends = reader
+            .query(
+                ReadTarget::branch("feature"),
+                TEST_QUERIES,
+                "friends_of",
+                &params(&[("$name", "OldWalker")]),
+            )
+            .await
+            .unwrap();
+        assert_eq!(first_column_sorted(&old_friends), vec!["Alice"]);
+        let old_edge_entry = reader
+            .snapshot_of(ReadTarget::branch("feature"))
+            .await
+            .unwrap()
+            .entry("edge:Knows")
+            .unwrap()
+            .clone();
+        assert_eq!(old_edge_entry.table_branch.as_deref(), Some("feature"));
 
-    let (new_friends, io) = measure(reader.query(
-        ReadTarget::branch("feature"),
-        TEST_QUERIES,
-        "friends_of",
-        &params(&[("$name", "NewWalker")]),
-    ))
-    .await;
-    let new_friends = new_friends.unwrap();
-    assert_eq!(
-        first_column_sorted(&new_friends),
-        vec!["Bob"],
-        "traversal must use the recreated branch's topology, not stale cached graph index"
-    );
-    assert!(
-        io.manifest_reads > 0,
-        "recreated branch traversal must refresh the manifest"
-    );
-    assert_eq!(
-        io.version_probes, 3,
-        "stale branch probes under both locks and the current canonical-main profile once"
-    );
-
-    let stale_old_friends = reader
-        .query(
-            ReadTarget::branch("feature"),
-            TEST_QUERIES,
-            "friends_of",
-            &params(&[("$name", "OldWalker")]),
+        writer.branch_delete("feature").await.unwrap();
+        writer.branch_create("feature").await.unwrap();
+        mutate_branch(
+            &mut writer,
+            "feature",
+            MUTATION_QUERIES,
+            "insert_person_and_friend",
+            &mixed_params(
+                &[("$name", "NewWalker"), ("$friend", "Bob")],
+                &[("$age", 42)],
+            ),
         )
         .await
         .unwrap();
-    assert_eq!(
-        first_column_sorted(&stale_old_friends),
-        Vec::<String>::new(),
-        "old branch topology must not leak after branch recreation"
-    );
+        let new_edge_entry = writer
+            .snapshot_of(ReadTarget::branch("feature"))
+            .await
+            .unwrap()
+            .entry("edge:Knows")
+            .unwrap()
+            .clone();
+        assert_eq!(new_edge_entry.table_path, old_edge_entry.table_path);
+        assert_eq!(new_edge_entry.table_branch, old_edge_entry.table_branch);
+        assert_eq!(
+            new_edge_entry.table_version, old_edge_entry.table_version,
+            "test setup must force graph-index identity to differ only by snapshot incarnation"
+        );
+
+        let (new_friends, io) = measure(reader.query(
+            ReadTarget::branch("feature"),
+            TEST_QUERIES,
+            "friends_of",
+            &params(&[("$name", "NewWalker")]),
+        ))
+        .await;
+        let new_friends = new_friends.unwrap();
+        assert_eq!(
+            first_column_sorted(&new_friends),
+            vec!["Bob"],
+            "traversal must use the recreated branch's topology, not stale cached graph index"
+        );
+        assert!(
+            io.manifest_reads > 0,
+            "recreated branch traversal must refresh the manifest"
+        );
+        assert_eq!(
+            io.version_probes, 3,
+            "stale branch probes under both locks and the current canonical-main profile once"
+        );
+
+        let stale_old_friends = reader
+            .query(
+                ReadTarget::branch("feature"),
+                TEST_QUERIES,
+                "friends_of",
+                &params(&[("$name", "OldWalker")]),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            first_column_sorted(&stale_old_friends),
+            Vec::<String>::new(),
+            "old branch topology must not leak after branch recreation"
+        );
     })
     .await;
 }
@@ -752,44 +752,44 @@ async fn stale_read_refreshes_manifest_only() {
 #[tokio::test]
 async fn repeat_warm_read_reuses_table_handles() {
     cost_harness(async {
-    let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
-    // Deep history: the win must hold regardless of commit count.
-    commit_many(&mut db, 10).await;
+        let dir = tempfile::tempdir().unwrap();
+        let mut db = init_and_load(&dir).await;
+        // Deep history: the win must hold regardless of commit count.
+        commit_many(&mut db, 10).await;
 
-    // Cold first read: opens the touched table.
-    let (cold_out, cold) = measure(db.query(
-        ReadTarget::branch("main"),
-        TEST_QUERIES,
-        "total_people",
-        &params(&[]),
-    ))
-    .await;
-    cold_out.unwrap();
-    assert!(
-        cold.data_reads > 0,
-        "the cold first read must open the table"
-    );
+        // Cold first read: opens the touched table.
+        let (cold_out, cold) = measure(db.query(
+            ReadTarget::branch("main"),
+            TEST_QUERIES,
+            "total_people",
+            &params(&[]),
+        ))
+        .await;
+        cold_out.unwrap();
+        assert!(
+            cold.data_reads > 0,
+            "the cold first read must open the table"
+        );
 
-    // Warm repeat: the held handle is reused, so no open happens through this
-    // query's table wrapper. A fresh `measure()` isolates the warm repeat's cost.
-    let (warm_out, warm) = measure(db.query(
-        ReadTarget::branch("main"),
-        TEST_QUERIES,
-        "total_people",
-        &params(&[]),
-    ))
-    .await;
-    warm_out.unwrap();
-    assert_eq!(
-        warm.data_reads, 0,
-        "a warm repeat read must reuse the held handle (0 table opens)"
-    );
-    assert_eq!(warm.manifest_reads, 0, "warm repeat read: 0 manifest opens");
-    assert_eq!(
-        warm.version_probes, 1,
-        "warm repeat read: exactly one version probe"
-    );
+        // Warm repeat: the held handle is reused, so no open happens through this
+        // query's table wrapper. A fresh `measure()` isolates the warm repeat's cost.
+        let (warm_out, warm) = measure(db.query(
+            ReadTarget::branch("main"),
+            TEST_QUERIES,
+            "total_people",
+            &params(&[]),
+        ))
+        .await;
+        warm_out.unwrap();
+        assert_eq!(
+            warm.data_reads, 0,
+            "a warm repeat read must reuse the held handle (0 table opens)"
+        );
+        assert_eq!(warm.manifest_reads, 0, "warm repeat read: 0 manifest opens");
+        assert_eq!(
+            warm.version_probes, 1,
+            "warm repeat read: exactly one version probe"
+        );
     })
     .await;
 }
@@ -869,7 +869,10 @@ async fn fresh_branch_traversal_reuses_main_graph_index() {
         &mut writer,
         MUTATION_QUERIES,
         "insert_person_and_friend",
-        &mixed_params(&[("$name", "Walker"), ("$friend", "Alice")], &[("$age", 41)]),
+        &mixed_params(
+            &[("$name", "Walker"), ("$friend", "Alice")],
+            &[("$age", 41)],
+        ),
     )
     .await
     .unwrap();
@@ -946,7 +949,10 @@ async fn single_edge_query_builds_only_referenced_edge() {
         &mut db,
         MUTATION_QUERIES,
         "insert_person_and_friend",
-        &mixed_params(&[("$name", "Walker"), ("$friend", "Alice")], &[("$age", 41)]),
+        &mixed_params(
+            &[("$name", "Walker"), ("$friend", "Alice")],
+            &[("$age", 41)],
+        ),
     )
     .await
     .unwrap();

--- a/crates/omnigraph/tests/write_cost.rs
+++ b/crates/omnigraph/tests/write_cost.rs
@@ -48,33 +48,33 @@ async fn internal_table_scans_are_flat_in_history() {
     // so `manifest_reads` includes the warm-coordinator probe (a constant per write
     // that cancels in this depth-difference assertion).
     cost_harness(async {
-    const ACTOR: &str = "act-cost-gate";
-    let dir = tempfile::tempdir().unwrap();
-    let mut db = local_graph(&dir).await;
+        const ACTOR: &str = "act-cost-gate";
+        let dir = tempfile::tempdir().unwrap();
+        let mut db = local_graph(&dir).await;
 
-    let mut curve: Vec<(u64, IoCounts)> = Vec::new();
-    let mut current = 0u64;
-    for d in [10u64, 100] {
-        if d > current {
-            commit_many_as(&mut db, (d - current) as usize, ACTOR).await;
-            current = d;
+        let mut curve: Vec<(u64, IoCounts)> = Vec::new();
+        let mut current = 0u64;
+        for d in [10u64, 100] {
+            if d > current {
+                commit_many_as(&mut db, (d - current) as usize, ACTOR).await;
+                current = d;
+            }
+            // Step 2: compaction folds all three internal tables' O(depth) fragments back
+            // to a small constant, so the following write's scan of them is flat.
+            db.optimize().await.unwrap();
+            let io = measure_insert_as(&mut db, &format!("lock_{d}"), ACTOR).await;
+            current += 1; // the measured write advanced depth by one
+            eprintln!(
+                "depth~{d}: data={} __manifest={}",
+                io.data_reads, io.manifest_reads
+            );
+            curve.push((d, io));
         }
-        // Step 2: compaction folds all three internal tables' O(depth) fragments back
-        // to a small constant, so the following write's scan of them is flat.
-        db.optimize().await.unwrap();
-        let io = measure_insert_as(&mut db, &format!("lock_{d}"), ACTOR).await;
-        current += 1; // the measured write advanced depth by one
-        eprintln!(
-            "depth~{d}: data={} __manifest={}",
-            io.data_reads, io.manifest_reads
-        );
-        curve.push((d, io));
-    }
 
-    // Lineage + actor rows live in `__manifest` now, so this single flat-assertion
-    // gates the whole internal-table scan (including the authenticated path's actor
-    // rows) across history.
-    assert_flat(&curve, |c| c.manifest_reads, 4, "__manifest scan");
+        // Lineage + actor rows live in `__manifest` now, so this single flat-assertion
+        // gates the whole internal-table scan (including the authenticated path's actor
+        // rows) across history.
+        assert_flat(&curve, |c| c.manifest_reads, 4, "__manifest scan");
     })
     .await;
 }
@@ -187,34 +187,39 @@ async fn optimize_manifest_reads_are_flat_in_history() {
 #[tokio::test]
 async fn internal_table_scans_grow_without_compaction() {
     cost_harness(async {
-    const ACTOR: &str = "act-cost-gate-served";
-    let dir = tempfile::tempdir().unwrap();
-    let mut db = local_graph(&dir).await;
+        const ACTOR: &str = "act-cost-gate-served";
+        let dir = tempfile::tempdir().unwrap();
+        let mut db = local_graph(&dir).await;
 
-    let mut curve: Vec<(u64, IoCounts)> = Vec::new();
-    let mut current = 0u64;
-    for d in [10u64, 100] {
-        if d > current {
-            commit_many_as(&mut db, (d - current) as usize, ACTOR).await;
-            current = d;
+        let mut curve: Vec<(u64, IoCounts)> = Vec::new();
+        let mut current = 0u64;
+        for d in [10u64, 100] {
+            if d > current {
+                commit_many_as(&mut db, (d - current) as usize, ACTOR).await;
+                current = d;
+            }
+            // NO `db.optimize()` here — that omission is the whole point. The flat gate
+            // above compacts before measuring and so never exercises this served regime.
+            let io = measure_insert_as(&mut db, &format!("served_{d}"), ACTOR).await;
+            current += 1; // the measured write advanced depth by one
+            eprintln!(
+                "depth~{d} (uncompacted): data={} __manifest={}",
+                io.data_reads, io.manifest_reads
+            );
+            curve.push((d, io));
         }
-        // NO `db.optimize()` here — that omission is the whole point. The flat gate
-        // above compacts before measuring and so never exercises this served regime.
-        let io = measure_insert_as(&mut db, &format!("served_{d}"), ACTOR).await;
-        current += 1; // the measured write advanced depth by one
-        eprintln!(
-            "depth~{d} (uncompacted): data={} __manifest={}",
-            io.data_reads, io.manifest_reads
-        );
-        curve.push((d, io));
-    }
 
-    // Green TODAY (the bug): the per-write `__manifest` scan is O(fragments) and grows
-    // by far more than the flat gate's slack of 4 across a 10→100 depth sweep. The `20`
-    // floor mirrors the proven-safe `assert_grows` sibling (data-table scan) and sits
-    // comfortably below the real growth (~+3 `__manifest` reads/depth × ~90 depth × the
-    // 3–4 publish-path scans) while unambiguously distinguishing "grows" from "flat".
-    assert_grows(&curve, |c| c.manifest_reads, 20, "__manifest scan (uncompacted/served)");
+        // Green TODAY (the bug): the per-write `__manifest` scan is O(fragments) and grows
+        // by far more than the flat gate's slack of 4 across a 10→100 depth sweep. The `20`
+        // floor mirrors the proven-safe `assert_grows` sibling (data-table scan) and sits
+        // comfortably below the real growth (~+3 `__manifest` reads/depth × ~90 depth × the
+        // 3–4 publish-path scans) while unambiguously distinguishing "grows" from "flat".
+        assert_grows(
+            &curve,
+            |c| c.manifest_reads,
+            20,
+            "__manifest scan (uncompacted/served)",
+        );
     })
     .await;
 }
@@ -262,11 +267,21 @@ async fn data_table_reads_split_into_flat_opener_and_scan_flat_with_session() {
         "opener reads must be > 0 — the classifier missed version-resolution reads, \
          so a flat opener assertion would be vacuous"
     );
-    assert_flat(&curve, |c| c.data_opener_reads, 4, "local data-table opener");
+    assert_flat(
+        &curve,
+        |c| c.data_opener_reads,
+        4,
+        "local data-table opener",
+    );
     // Pre-session this term GREW with fragment count (the merge-insert/RI scan
     // re-reading O(depth) fragment metadata per write); the shared session
     // makes repeat reads of immutable metadata cache hits, so it is now flat.
-    assert_flat(&curve, |c| c.data_scan_reads, 4, "local data-table scan (session-cached)");
+    assert_flat(
+        &curve,
+        |c| c.data_scan_reads,
+        4,
+        "local data-table scan (session-cached)",
+    );
 }
 
 // ── (B) Green-today regression guards — run on every PR ──
@@ -280,7 +295,11 @@ async fn single_insert_data_write_is_bounded() {
     commit_many(&mut db, 5).await;
     let io = measure_insert(&mut db, "w").await;
     eprintln!("single insert: data_writes={}", io.data_writes);
-    assert!(io.data_writes <= 4, "data-table write_iops should be a small constant, got {}", io.data_writes);
+    assert!(
+        io.data_writes <= 4,
+        "data-table write_iops should be a small constant, got {}",
+        io.data_writes
+    );
 }
 
 /// At a fixed shallow depth, the per-write object-store read count is below a
@@ -298,34 +317,36 @@ async fn single_insert_data_write_is_bounded() {
 #[tokio::test]
 async fn write_op_count_ceiling_at_shallow_depth() {
     cost_harness(async {
-    let dir = tempfile::tempdir().unwrap();
-    let mut db = local_graph(&dir).await;
-    commit_many(&mut db, 5).await;
-    let io = measure_insert(&mut db, "ceil").await;
-    eprintln!(
-        "depth~5: data={} __manifest={} total_reads={}",
-        io.data_reads, io.manifest_reads, io.total_reads()
-    );
-    // Sub-ceiling on ground-truth `__manifest` reads. ~18 measured at this depth =
-    // ~15 publish-path scans (one fold, not four — RFC-013 P2) + ~3 from the
-    // warm-coordinator freshness probe, which ground truth now counts (the
-    // `version_probes=1` call is 3 object-store RPCs). A re-added publish scan trips
-    // this; `last_manifest_reads()` dumps the read log (method + path) so a breach
-    // names the offending objects. (Deterministic on local FS.)
-    const MANIFEST_CEILING: u64 = 24;
-    assert!(
-        io.manifest_reads <= MANIFEST_CEILING,
-        "per-write __manifest reads {} exceeded ceiling {MANIFEST_CEILING} — a publish-path \
+        let dir = tempfile::tempdir().unwrap();
+        let mut db = local_graph(&dir).await;
+        commit_many(&mut db, 5).await;
+        let io = measure_insert(&mut db, "ceil").await;
+        eprintln!(
+            "depth~5: data={} __manifest={} total_reads={}",
+            io.data_reads,
+            io.manifest_reads,
+            io.total_reads()
+        );
+        // Sub-ceiling on ground-truth `__manifest` reads. ~18 measured at this depth =
+        // ~15 publish-path scans (one fold, not four — RFC-013 P2) + ~3 from the
+        // warm-coordinator freshness probe, which ground truth now counts (the
+        // `version_probes=1` call is 3 object-store RPCs). A re-added publish scan trips
+        // this; `last_manifest_reads()` dumps the read log (method + path) so a breach
+        // names the offending objects. (Deterministic on local FS.)
+        const MANIFEST_CEILING: u64 = 24;
+        assert!(
+            io.manifest_reads <= MANIFEST_CEILING,
+            "per-write __manifest reads {} exceeded ceiling {MANIFEST_CEILING} — a publish-path \
          scan was re-added (RFC-013 P2 folds them into one). Reads: {:#?}",
-        io.manifest_reads,
-        last_manifest_reads(),
-    );
-    const CEILING: u64 = 80;
-    assert!(
-        io.total_reads() <= CEILING,
-        "per-write read ops {} exceeded ceiling {CEILING} — a new round-trip was added",
-        io.total_reads()
-    );
+            io.manifest_reads,
+            last_manifest_reads(),
+        );
+        const CEILING: u64 = 80;
+        assert!(
+            io.total_reads() <= CEILING,
+            "per-write read ops {} exceeded ceiling {CEILING} — a new round-trip was added",
+            io.total_reads()
+        );
     })
     .await;
 }
@@ -348,8 +369,14 @@ async fn keyed_insert_routes_through_fenced_adapter_only() {
     ))
     .await;
     res.unwrap();
-    assert_eq!(staged.stage_merge_insert, 1, "keyed Person insert stages one exact-id fenced merge");
-    assert_eq!(staged.stage_append, 0, "keyed insert must not use bare stage_append");
+    assert_eq!(
+        staged.stage_merge_insert, 1,
+        "keyed Person insert stages one exact-id fenced merge"
+    );
+    assert_eq!(
+        staged.stage_append, 0,
+        "keyed insert must not use bare stage_append"
+    );
     assert_eq!(
         staged.stage_vector_index, 0,
         "no vector-index artifact build on a plain insert"
@@ -396,7 +423,9 @@ async fn write_schema_io_is_bounded_to_capture_fence_and_effect_gate() {
     let exists_delta = counts.exists() - before_exists;
     let write_text_delta = counts.write_text() - before_write_text;
     let delete_delta = counts.delete() - before_delete;
-    eprintln!("schema-contract reads on one write: read_text={read_text_delta} exists={exists_delta}");
+    eprintln!(
+        "schema-contract reads on one write: read_text={read_text_delta} exists={exists_delta}"
+    );
     assert_eq!(
         read_text_delta, 7,
         "a write must do capture validation + trailing identity fence + pre-effect validation (7 reads), not per table",

--- a/crates/omnigraph/tests/write_cost_s3.rs
+++ b/crates/omnigraph/tests/write_cost_s3.rs
@@ -31,8 +31,8 @@
 
 mod helpers;
 
-use helpers::cost::{IoCounts, assert_flat, measure_insert, s3_graph};
 use helpers::commit_many;
+use helpers::cost::{IoCounts, assert_flat, measure_insert, s3_graph};
 
 /// After step 3a the data-table opener term is flat across depth on a real object
 /// store (the measured win). RED on the pre-3a namespace-builder opener (O(depth)
@@ -58,10 +58,7 @@ async fn data_table_opener_is_flat_in_history_on_s3() {
         current += 1;
         eprintln!(
             "depth~{d}: opener={} scan={} data_total={} __manifest={}",
-            io.data_opener_reads,
-            io.data_scan_reads,
-            io.data_reads,
-            io.manifest_reads
+            io.data_opener_reads, io.data_scan_reads, io.data_reads, io.manifest_reads
         );
         curve.push((d, io));
     }

--- a/crates/omnigraph/tests/writes.rs
+++ b/crates/omnigraph/tests/writes.rs
@@ -1882,10 +1882,7 @@ async fn first_write_self_heals_manifest_unreferenced_fork_on_live_branch() {
     db.branch_create("feature").await.unwrap();
 
     // Forge the manifest-unreferenced fork directly at the Lance layer.
-    let main = db
-        .snapshot_of(ReadTarget::branch("main"))
-        .await
-        .unwrap();
+    let main = db.snapshot_of(ReadTarget::branch("main")).await.unwrap();
     let person_path = &main.entry("node:Person").unwrap().table_path;
     let person_uri = format!(
         "{}/{}",


### PR DESCRIPTION
## What & why

Mechanical output of `cargo fmt --all`, no semantic changes: 70 files, +6,963/−6,446 lines (largest single file: `crates/omnigraph-cluster/src/tests.rs`). The tree had accumulated format drift since fmt is not currently gated. This is part 1 of 3 introducing a PR-time lint gate (fmt + clippy); landing the reformat alone keeps the review trivial and confines the blame noise to one commit. The gate itself lands in part 3, after the clippy cleanup in part 2.

## Local verification

- `cargo fmt --all` — applied; this diff is its verbatim output
- `cargo fmt --all --check` — exit 0 after the sweep
- `cargo clippy --workspace --all-targets --locked` — compiles clean on the formatted tree (exit 0; pre-existing warnings unchanged, addressed in part 2)
- `cargo test` — not run: formatting is semantics-preserving by construction; the post-merge workspace run covers it

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies workspace-wide `rustfmt` output without changing intended behavior.
- Reformats production code across the API, CLI, cluster, compiler, server, and core storage/query crates.
- Reformats unit, integration, system, benchmark, and example code consistently.
- Does not change dependencies, public interfaces, authorization boundaries, or persisted data contracts.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/omnigraph-cli/src/client.rs | Reformats imports, signatures, expressions, and tests without changing client behavior. |
| crates/omnigraph-cluster/src/tests.rs | Applies mechanical formatting to the largest changed test file without altering test logic. |
| crates/omnigraph-server/src/handlers.rs | Reformats server handler code without changing request handling or authorization behavior. |
| crates/omnigraph/src/db/omnigraph.rs | Reformats core database implementation code without changing control flow or storage behavior. |
| crates/omnigraph/src/db/write_queue.rs | Reformats write-path code without changing queueing, synchronization, or persistence semantics. |
| crates/omnigraph/src/exec/query.rs | Reformats query execution code without changing query evaluation semantics. |

</details>

<sub>Reviews (2): Last reviewed commit: ["implement"](https://github.com/modernrelay/omnigraph/commit/e969aa81520276cef133e2103d9203cf4d224054) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50915227)</sub>

<!-- /greptile_comment -->