### PR TITLE
Push standalone filter clauses down to the Lance scanner

### DIFF
--- a/crates/omnigraph/src/exec/query.rs
+++ b/crates/omnigraph/src/exec/query.rs
@@ -658,6 +658,62 @@ fn search_filter_variable(filter: &IRFilter) -> Option<&str> {
     }
 }
 
+/// Collect every binding variable referenced by an expression into `vars`.
+fn collect_expr_variables(expr: &IRExpr, vars: &mut HashSet<String>) {
+    match expr {
+        IRExpr::PropAccess { variable, .. } => {
+            vars.insert(variable.clone());
+        }
+        IRExpr::Nearest {
+            variable, query, ..
+        } => {
+            vars.insert(variable.clone());
+            collect_expr_variables(query, vars);
+        }
+        IRExpr::Search { field, query }
+        | IRExpr::MatchText { field, query }
+        | IRExpr::Bm25 { field, query } => {
+            collect_expr_variables(field, vars);
+            collect_expr_variables(query, vars);
+        }
+        IRExpr::Fuzzy {
+            field,
+            query,
+            max_edits,
+        } => {
+            collect_expr_variables(field, vars);
+            collect_expr_variables(query, vars);
+            if let Some(e) = max_edits {
+                collect_expr_variables(e, vars);
+            }
+        }
+        IRExpr::Rrf {
+            primary,
+            secondary,
+            k,
+        } => {
+            collect_expr_variables(primary, vars);
+            collect_expr_variables(secondary, vars);
+            if let Some(e) = k {
+                collect_expr_variables(e, vars);
+            }
+        }
+        IRExpr::Variable(v) => {
+            vars.insert(v.clone());
+        }
+        IRExpr::Aggregate { arg, .. } => collect_expr_variables(arg, vars),
+        IRExpr::Param(_) | IRExpr::Literal(_) | IRExpr::AliasRef(_) => {}
+    }
+}
+
+/// The set of binding variables a filter references, across both operands.
+fn filter_variables(filter: &IRFilter) -> HashSet<String> {
+    let mut vars = HashSet::new();
+    collect_expr_variables(&filter.left, &mut vars);
+    collect_expr_variables(&filter.right, &mut vars);
+    vars
+}
+
 fn execute_pipeline<'a>(
     pipeline: &'a [IROp],
     params: &'a ParamMap,
@@ -668,21 +724,67 @@ fn execute_pipeline<'a>(
     search_mode: &'a SearchMode,
 ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<()>> + Send + 'a>> {
     Box::pin(async move {
-        // Pre-pass: collect search filters that need to be hoisted to NodeScan
+        // Pre-pass: hoist filters onto the op that introduces their binding.
+        // Search filters always move to the binding's NodeScan (applied via
+        // `scanner.full_text_search`). Scalar filters referencing exactly one
+        // binding move to that binding's NodeScan (`filter_expr`, which also
+        // arms `prefilter(true)` so a `nearest`/`bm25` on the same scanner is
+        // filtered BEFORE top-k instead of starved after it) or into the
+        // introducing Expand's `dst_filters` (applied during hydration).
+        // Multi-binding filters (e.g. the cycle-closing `temp.id = dst.id`)
+        // and filters on a variable not introduced here (an outer binding
+        // inside an anti-join pipeline) keep their end-of-pipeline placement.
+        let mut scan_vars: HashSet<&str> = HashSet::new();
+        let mut expand_dst_vars: HashSet<&str> = HashSet::new();
+        for op in pipeline {
+            match op {
+                IROp::NodeScan { variable, .. } => {
+                    scan_vars.insert(variable.as_str());
+                }
+                IROp::Expand { dst_var, .. } => {
+                    expand_dst_vars.insert(dst_var.as_str());
+                }
+                IROp::Filter(_) | IROp::AntiJoin { .. } => {}
+            }
+        }
+
         let mut hoisted_search_filters: HashMap<String, Vec<IRFilter>> = HashMap::new();
+        let mut hoisted_scan_filters: HashMap<String, Vec<IRFilter>> = HashMap::new();
+        let mut hoisted_dst_filters: HashMap<String, Vec<IRFilter>> = HashMap::new();
         let mut hoisted_indices: HashSet<usize> = HashSet::new();
         for (i, op) in pipeline.iter().enumerate() {
-            if let IROp::Filter(filter) = op {
-                if is_search_filter(filter) {
-                    if let Some(var) = search_filter_variable(filter) {
-                        hoisted_search_filters
-                            .entry(var.to_string())
-                            .or_default()
-                            .push(filter.clone());
-                        hoisted_indices.insert(i);
-                    }
+            let IROp::Filter(filter) = op else { continue };
+            if is_search_filter(filter) {
+                if let Some(var) = search_filter_variable(filter) {
+                    hoisted_search_filters
+                        .entry(var.to_string())
+                        .or_default()
+                        .push(filter.clone());
+                    hoisted_indices.insert(i);
                 }
+                continue;
             }
+            let mut vars = filter_variables(filter).into_iter();
+            let (Some(var), None) = (vars.next(), vars.next()) else {
+                continue;
+            };
+            // Only pushable filters may leave their in-memory position:
+            // `execute_node_scan` silently ignores filters `ir_filter_to_expr`
+            // cannot lower (no post-scan fallback there). The schema arg only
+            // affects a literal's type, never Some-vs-None, so `None` here
+            // gives the same verdict as the scan site.
+            if ir_filter_to_expr(filter, params, None).is_none() {
+                continue;
+            }
+            let target = if scan_vars.contains(var.as_str()) {
+                &mut hoisted_scan_filters
+            } else if expand_dst_vars.contains(var.as_str()) {
+                &mut hoisted_dst_filters
+            } else {
+                continue;
+            };
+            target.entry(var).or_default().push(filter.clone());
+            hoisted_indices.insert(i);
         }
 
         for (i, op) in pipeline.iter().enumerate() {
@@ -696,9 +798,12 @@ fn execute_pipeline<'a>(
                     type_name,
                     filters,
                 } => {
-                    // Merge inline filters with hoisted search filters
+                    // Merge inline filters with hoisted search + scalar filters
                     let mut all_filters: Vec<IRFilter> = filters.clone();
                     if let Some(extra) = hoisted_search_filters.get(variable) {
+                        all_filters.extend(extra.iter().cloned());
+                    }
+                    if let Some(extra) = hoisted_scan_filters.get(variable) {
                         all_filters.extend(extra.iter().cloned());
                     }
                     let batch = execute_node_scan(
@@ -732,6 +837,11 @@ fn execute_pipeline<'a>(
                     max_hops,
                     dst_filters,
                 } => {
+                    // Merge lowered destination filters with hoisted ones
+                    let mut all_dst_filters: Vec<IRFilter> = dst_filters.clone();
+                    if let Some(extra) = hoisted_dst_filters.get(dst_var) {
+                        all_dst_filters.extend(extra.iter().cloned());
+                    }
                     if let Some(batch) = wide.as_mut() {
                         execute_expand(
                             batch,
@@ -745,7 +855,7 @@ fn execute_pipeline<'a>(
                             dst_type,
                             *min_hops,
                             *max_hops,
-                            dst_filters,
+                            &all_dst_filters,
                             params,
                         )
                         .await?;

--- a/crates/omnigraph/tests/end_to_end.rs
+++ b/crates/omnigraph/tests/end_to_end.rs
@@ -922,6 +922,12 @@ query get_doc($title: String) {
     match { $d: Document { title: $title } }
     return { $d.title, $d.content }
 }
+
+query get_doc_clause($title: String) {
+    match { $d: Document
+        $d.title = $title }
+    return { $d.title, $d.content }
+}
 "#;
 
 const BLOB_MUTATIONS: &str = r#"
@@ -978,26 +984,31 @@ async fn blob_query_returns_metadata() {
         .await
         .unwrap();
 
-    let result = query_main(
-        &mut db,
-        BLOB_QUERIES,
-        "get_doc",
-        &params(&[("$title", "readme")]),
-    )
-    .await
-    .unwrap();
+    // Both filter spellings must survive a blob-bearing scan: inline props and
+    // the standalone clause (hoisted onto the scan) ride the same filter path,
+    // which excludes blob columns before Lance sees the filter.
+    for query_name in ["get_doc", "get_doc_clause"] {
+        let result = query_main(
+            &mut db,
+            BLOB_QUERIES,
+            query_name,
+            &params(&[("$title", "readme")]),
+        )
+        .await
+        .unwrap();
 
-    assert_eq!(result.num_rows(), 1);
+        assert_eq!(result.num_rows(), 1, "{query_name}");
 
-    let json = result.to_sdk_json();
-    let row = json.as_array().unwrap().first().unwrap();
-    assert_eq!(row["d.title"], "readme");
-    // Blob columns return null in query projections — data is accessed via take_blobs API.
-    // (Lance bug: BlobsDescriptions + filter triggers assertion, so blobs are excluded from scan)
-    assert!(
-        row["d.content"].is_null(),
-        "blob column should return null in query projection"
-    );
+        let json = result.to_sdk_json();
+        let row = json.as_array().unwrap().first().unwrap();
+        assert_eq!(row["d.title"], "readme", "{query_name}");
+        // Blob columns return null in query projections — data is accessed via take_blobs API.
+        // (Lance bug: BlobsDescriptions + filter triggers assertion, so blobs are excluded from scan)
+        assert!(
+            row["d.content"].is_null(),
+            "{query_name}: blob column should return null in query projection"
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/omnigraph/tests/search.rs
+++ b/crates/omnigraph/tests/search.rs
@@ -423,49 +423,61 @@ async fn phrase_search_is_documented_fts_fallback() {
 
 // ─── Vector search (nearest) ────────────────────────────────────────────────
 
-/// iss-nearest-postfilter-starves-results: a scalar `match` predicate combined
-/// with `nearest` must return the top-k of the MATCHING rows. Lance's default
-/// is post-filtering (filter applied AFTER the ANN top-k), under which this
-/// fixture — where every filter-matching doc sits far from the query vector,
-/// so the global top-k is entirely non-matching — returns 0 rows despite 3
-/// matches existing. The engine must set prefilter(true) whenever a filter
-/// rides the same scanner as a search.
-#[tokio::test]
-#[serial]
-async fn filtered_nearest_returns_matching_rows_not_postfiltered_topk() {
-    const SCHEMA: &str = r#"
+/// Fixture for the filtered-nearest pair below. The query vector is +e1. The
+/// three status="miss" docs cluster around +e1 (the global top-3); the three
+/// status="hit" docs cluster around -e1, so a post-filtered top-k contains no
+/// matching row and returns 0 rows despite 3 matches existing.
+const FILTERED_NEAREST_SCHEMA: &str = r#"
 node Doc {
     slug: String @key
     status: String
     embedding: Vector(4)
 }
 "#;
-    // Query vector is +e1. The three status="miss" docs cluster around +e1
-    // (global top-3); the three status="hit" docs cluster around -e1.
-    const DATA: &str = r#"{"type":"Doc","data":{"slug":"miss-1","status":"miss","embedding":[1.0,0.01,0.0,0.0]}}
+const FILTERED_NEAREST_DATA: &str = r#"{"type":"Doc","data":{"slug":"miss-1","status":"miss","embedding":[1.0,0.01,0.0,0.0]}}
 {"type":"Doc","data":{"slug":"miss-2","status":"miss","embedding":[1.0,0.0,0.02,0.0]}}
 {"type":"Doc","data":{"slug":"miss-3","status":"miss","embedding":[1.0,0.0,0.0,0.03]}}
 {"type":"Doc","data":{"slug":"hit-1","status":"hit","embedding":[-1.0,0.01,0.0,0.0]}}
 {"type":"Doc","data":{"slug":"hit-2","status":"hit","embedding":[-1.0,0.0,0.02,0.0]}}
 {"type":"Doc","data":{"slug":"hit-3","status":"hit","embedding":[-1.0,0.0,0.0,0.03]}}
 "#;
-    const QUERIES: &str = r#"
+const FILTERED_NEAREST_QUERIES: &str = r#"
 query filtered_nearest($q: Vector(4)) {
     match { $d: Doc { status: "hit" } }
     return { $d.slug }
     order { nearest($d.embedding, $q) }
     limit 3
 }
+
+query filtered_nearest_clause_eq($q: Vector(4)) {
+    match { $d: Doc
+        $d.status = "hit" }
+    return { $d.slug }
+    order { nearest($d.embedding, $q) }
+    limit 3
+}
+
+query filtered_nearest_clause_range($q: Vector(4)) {
+    match { $d: Doc
+        $d.status <= "hit" }
+    return { $d.slug }
+    order { nearest($d.embedding, $q) }
+    limit 3
+}
 "#;
+
+async fn assert_filtered_nearest_returns_hits(query_name: &str) {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, SCHEMA).await.unwrap();
-    load_jsonl(&mut db, DATA, LoadMode::Overwrite).await.unwrap();
+    let mut db = Omnigraph::init(uri, FILTERED_NEAREST_SCHEMA).await.unwrap();
+    load_jsonl(&mut db, FILTERED_NEAREST_DATA, LoadMode::Overwrite)
+        .await
+        .unwrap();
 
     let result = query_main(
         &mut db,
-        QUERIES,
-        "filtered_nearest",
+        FILTERED_NEAREST_QUERIES,
+        query_name,
         &vector_param("$q", &[1.0, 0.0, 0.0, 0.0]),
     )
     .await
@@ -474,8 +486,8 @@ query filtered_nearest($q: Vector(4)) {
     assert_eq!(
         result.num_rows(),
         3,
-        "filtered nearest must return the top-k of MATCHING rows (3 hits exist), \
-         not the post-filtered remainder of the global top-k"
+        "{query_name}: filtered nearest must return the top-k of MATCHING rows \
+         (3 hits exist), not the post-filtered remainder of the global top-k"
     );
     let batch = result.concat_batches().unwrap();
     let slugs = batch
@@ -486,10 +498,33 @@ query filtered_nearest($q: Vector(4)) {
     for i in 0..slugs.len() {
         assert!(
             slugs.value(i).starts_with("hit-"),
-            "only matching docs may appear, got {}",
+            "{query_name}: only matching docs may appear, got {}",
             slugs.value(i)
         );
     }
+}
+
+/// iss-nearest-postfilter-starves-results: a scalar `match` predicate combined
+/// with `nearest` must return the top-k of the MATCHING rows. Lance's default
+/// is post-filtering (filter applied AFTER the ANN top-k), under which this
+/// fixture returns 0 rows. The engine must set prefilter(true) whenever a
+/// filter rides the same scanner as a search.
+#[tokio::test]
+#[serial]
+async fn filtered_nearest_returns_matching_rows_not_postfiltered_topk() {
+    assert_filtered_nearest_returns_hits("filtered_nearest").await;
+}
+
+/// iss-filter-clause-no-pushdown: the same predicate written as a standalone
+/// filter clause is a match filter per docs/user/queries/index.md, so it must
+/// reach the scanner and prefilter the search exactly like the inline-props
+/// spelling above. Covers equality plus a range predicate, which has no
+/// inline-props spelling at all.
+#[tokio::test]
+#[serial]
+async fn filtered_nearest_clause_spelling_prefilters_like_inline() {
+    assert_filtered_nearest_returns_hits("filtered_nearest_clause_eq").await;
+    assert_filtered_nearest_returns_hits("filtered_nearest_clause_range").await;
 }
 
 #[tokio::test]

--- a/docs/dev/execution.md
+++ b/docs/dev/execution.md
@@ -44,13 +44,14 @@ sequenceDiagram
 
 **Code paths:**
 
-- Entry: `Omnigraph::query` at `crates/omnigraph/src/exec/query.rs:7`
-- Search-mode extraction: `extract_search_mode` at `crates/omnigraph/src/exec/query.rs:110`
-- Pipeline runner: `execute_query` at `crates/omnigraph/src/exec/query.rs:347`
-- RRF fan-out: `execute_rrf_query` at `crates/omnigraph/src/exec/query.rs:393`
-- Per-source-row BFS: `execute_expand` at `crates/omnigraph/src/exec/query.rs:675`
-- Lance scan + pushdown: `execute_node_scan` at `crates/omnigraph/src/exec/query.rs:1027`
-- Filter → SQL pushdown: `build_lance_filter` at `crates/omnigraph/src/exec/query.rs:1158`
+- Entry: `Omnigraph::query` at `crates/omnigraph/src/exec/query.rs:31`
+- Search-mode extraction: `extract_search_mode` at `crates/omnigraph/src/exec/query.rs:149`
+- Pipeline runner: `execute_query` at `crates/omnigraph/src/exec/query.rs:419`
+- RRF fan-out: `execute_rrf_query` at `crates/omnigraph/src/exec/query.rs:478`
+- Per-source-row BFS: `execute_expand` at `crates/omnigraph/src/exec/query.rs:1263`
+- Filter hoist pre-pass: `execute_pipeline` at `crates/omnigraph/src/exec/query.rs:717` — search filters and single-binding pushable scalar filters move onto the introducing `NodeScan` (arming `prefilter(true)` for any search on the same scanner) or into the introducing `Expand`'s `dst_filters`; multi-binding and non-pushable filters stay in-memory at their lowered position
+- Lance scan + pushdown: `execute_node_scan` at `crates/omnigraph/src/exec/query.rs:2065`
+- Filter → Expr pushdown: `build_lance_filter_expr` at `crates/omnigraph/src/exec/query.rs:2331`
 
 ### Multi-modal search modes (`SearchMode`)
 

--- a/docs/user/search/index.md
+++ b/docs/user/search/index.md
@@ -23,7 +23,9 @@ rank).
 - Match filters apply **before** the search: combining a `match` predicate with
   `nearest()` (or `bm25()`) returns the top-`limit` of the *matching* rows —
   never a post-filtered remainder of the global top-k. A selective filter
-  narrows the candidate set; it cannot starve the result count.
+  narrows the candidate set; it cannot starve the result count. This holds for
+  both predicate forms — inline props (`$d: Doc { status: "open" }`) and
+  standalone filter lines, including range predicates (`$d.priority <= 2`).
 - Scores and ranks propagate as ordinary columns, so you can `return` a score and
   `order` by it.
 


### PR DESCRIPTION
The two spellings of the same `match` predicate executed differently: inline props (`$d: Doc { status: "open" }`) pushed down to the Lance scanner, while a standalone filter clause (`$d.status = "open"`, the only form that can express ranges) ran in memory after the scan. So a filtered `nearest()` searched top-k of the whole table and the late filter starved the result set (fewer than k rows, possibly zero, exit 0), and without a search the clause form materialized every row of the table, all columns included, before dropping the non-matching ones.

The fix generalizes the existing FTS-filter hoist in the executor: a pre-pass moves each filter that references exactly one binding and lowers to a structured scanner expression onto the op introducing that binding, the node scan (arming `prefilter(true)`) or the expand's destination filters. Multi-binding filters, non-pushable shapes, and filters on outer bindings inside `not { }` keep their in-memory position, so the fallback is exactly the prior behavior.

## Benchmark

Release builds, before = main. Docs with a ~216-char text field and a Vector(256) column, 1% matching `status = "open"`, query returns 10 slugs via the clause form. Peak RSS via /usr/bin/time over 5 runs; inline = the same predicate written inline, the target the clause form should match.

| rows | clause, before | clause, after | reduction | inline (reference) |
|------|---------------:|--------------:|----------:|-------------------:|
| 200k | 659.2 MiB | 77.6 MiB | 88.2% | 77.5 MiB |
| 1M | 2680.4 MiB | 155.5 MiB | 94.2% | 155.6 MiB |

2.6 GB held to return 10 rows becomes 156 MiB, identical to inline: the scan now materializes only the 1% that matches, where the old penalty grew linearly with table size.

## Local verification

- New `filtered_nearest_clause_spelling_prefilters_like_inline` in the search suite, red on unfixed code (0 rows instead of 3), covers equality and a range predicate; blob coverage extended to the clause form
- `cargo test -p omnigraph-engine`: search, traversal, traversal_indexed, literal_filters, ordering, aggregation, proptest_equivalence, end_to_end all green
- `cargo test --workspace --locked` (failpoints features): no failures attributable to this change; the 7 failing targets reproduce identically on unmodified main

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR pushes eligible single-binding standalone filters into the scan or destination-expansion operation so filtering occurs before search top-k selection and avoids unnecessary materialization.
- Adds scalar-filter classification and hoisting during pipeline execution.
- Extends vector-search and blob-query coverage for standalone equality and range predicates.
- Documents standalone pre-search filtering in the developer and user search guides.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/omnigraph/src/exec/query.rs | Adds a guarded pre-pass that hoists lowerable single-binding filters to their introducing scan or expansion while preserving existing fallback placement for unsupported shapes. |
| crates/omnigraph/tests/search.rs | Adds equality and range coverage proving standalone filters prefilter nearest-neighbor search like inline predicates. |
| crates/omnigraph/tests/end_to_end.rs | Extends blob-bearing scan coverage to the newly hoisted standalone-clause path. |
| docs/dev/execution.md | Updates execution references and describes the filter-hoisting behavior and fallback boundaries. |
| docs/user/search/index.md | Completes the prior documentation request by explaining pre-search behavior for inline and standalone equality/range filters. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    F[Standalone filter] --> V{References exactly one binding?}
    V -- No --> M[Keep in-memory position]
    V -- Yes --> L{Lowerable to scanner expression?}
    L -- No --> M
    L -- Yes --> I{Binding introduced by}
    I -- NodeScan --> S[Attach scanner filter and enable prefilter]
    I -- Expand destination --> E[Attach destination filter]
    S --> Q[Search top-k over matching rows]
    E --> H[Filter during destination hydration]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["review"](https://github.com/modernrelay/omnigraph/commit/a8279ad5d903dcbe6b2ae19cb02d9156045e55f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50927884)</sub>

**Context used:**

- Knowledge Base — [Query execution engine](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/omnigraph-query-exec.md)

<!-- /greptile_comment -->