### PR TITLE
test(cluster): remove orphaned WAL failpoint wrapper

### DIFF
--- a/crates/omnigraph-cluster/src/tests.rs
+++ b/crates/omnigraph-cluster/src/tests.rs
@@ -4,17 +4,9 @@
 #![allow(clippy::all)]
 
 use std::fs;
-#[cfg(feature = "failpoints")]
-use std::future::Future;
 use std::path::Path;
-#[cfg(feature = "failpoints")]
-use std::sync::Arc;
 
 use omnigraph::db::Omnigraph;
-#[cfg(feature = "failpoints")]
-use omnigraph_compiler::ir::ParamMap;
-#[cfg(feature = "failpoints")]
-use omnigraph_compiler::query::ast::Literal;
 use serde_json::json;
 use tempfile::tempdir;
 
@@ -62,28 +54,6 @@ policies:
     )
     .unwrap();
     dir
-}
-
-/// Run a composed lifecycle scenario outside libtest's 2-MiB
-/// thread. Individual operations run on ordinary stacks elsewhere; this
-/// only bounds the large debug future assembled by an end-to-end test.
-#[cfg(feature = "failpoints")]
-fn on_big_stack<F>(body: impl FnOnce() -> F + Send + 'static)
-where
-    F: Future<Output = ()>,
-{
-    std::thread::Builder::new()
-        .stack_size(64 * 1024 * 1024)
-        .spawn(move || {
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .unwrap()
-                .block_on(body());
-        })
-        .unwrap()
-        .join()
-        .unwrap();
 }
 
 fn write_mock_embedding_cluster(config_dir: &Path, model: &str) {
@@ -3911,11 +3881,4 @@ async fn plan_annotates_apply_dispositions() {
         by_resource["policy.base"].disposition,
         Some(ApplyDisposition::Applied)
     );
-}
-
-#[cfg(feature = "failpoints")]
-#[test]
-#[serial_test::serial]
-fn blocked_disable_persists_exact_disabling_correction_authority() {
-    on_big_stack(blocked_disable_persists_exact_disabling_correction_authority_body);
 }


### PR DESCRIPTION
## Summary
- remove the WAL-era cluster test wrapper whose body was deleted with RFC-026
- remove its now-unused stack helper and feature-only imports

## Why
The post-merge workspace/failpoint gate on `main` fails to compile because the wrapper still calls the deleted body.

## Validation
- `cargo fmt --all -- --check`
- `cargo test --locked -p omnigraph-cluster --features failpoints --no-run`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR repairs the failpoints-enabled cluster test build by removing an orphaned test wrapper that called a deleted body.
- Removes the wrapper and its now-unused large-stack executor.
- Removes imports used only by the deleted test code.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it removes only orphaned test code and its unused dependencies.

The deleted wrapper referenced a test body already absent from the base revision, while targeted reference checks found no remaining users of the removed helper or imports.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/omnigraph-cluster/src/tests.rs | Safely removes an uncompilable orphaned failpoint test wrapper and the helper and imports that became unused with it. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(cluster): remove orphaned WAL failp..."](https://github.com/modernrelay/omnigraph/commit/5cc71d56f0782945c821c7f2d0b3590f12c21408) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51258950)</sub>

<!-- /greptile_comment -->