### PR TITLE
docs(release): tighten the v0.9.0 notes

### DIFF
--- a/docs/releases/v0.9.0.md
+++ b/docs/releases/v0.9.0.md
@@ -1,189 +1,120 @@
 # Omnigraph v0.9.0
 
-A substrate and durability release. The storage substrate reaches **Lance
-9.0.0 stable**, which restores crates.io publication; the write path gains
-stable schema identity across renames, substrate-native key-conflict fencing,
-and crash recovery for every writer. The query language reaches edge
-properties, and standalone filters now push down to the scanner.
+A substrate and durability release. Lance reaches **9.0.0 stable**, restoring
+crates.io publication; the write path gains rename-stable schema identity,
+key-conflict fencing, and crash recovery for every writer; the query language
+reaches edge properties and pushes filters down to the scanner.
 
-**This release changes the on-disk format.** Internal schema advances from v4
-(0.8.x) to v6, so **v0.8.x graphs must be rebuilt via export/import** — see
-[Upgrade notes](#upgrade-notes) below and
-[docs/user/operations/upgrade.md](../user/operations/upgrade.md).
+**This release changes the on-disk format** — v0.8.x graphs must be rebuilt
+via export/import (see [Upgrade notes](#upgrade-notes) and
+[docs/user/operations/upgrade.md](../user/operations/upgrade.md)).
 
-**Channel note:** registry publication resumes, as promised in the v0.8.1
-notes. `Cargo.lock` now carries zero git sources, so `cargo install
-omnigraph-cli` works again alongside the binaries, Homebrew, and installer
-channels.
+**Channel note:** `cargo install omnigraph-cli` works again, alongside the
+binaries, Homebrew, installer, and container channels.
 
 ## Highlights
 
-- **Storage substrate: Lance 9.0.0 stable.** The 9.x prerelease git-rev pin is
-  retired for ordinary registry versions. This is not a storage-format event on
-  the substrate side — Omnigraph still writes explicit stable V2_2 files, and
-  dependency floors are unchanged (Arrow 58, DataFusion 54, `object_store`
-  0.13.2). The bump was validated against a full review of the 35 upstream
-  commits since the pinned release candidate plus the complete local and CI
-  test matrix.
+- **Lance 9.0.0 stable.** The prerelease git-rev pin is retired for registry
+  versions. File format and dependency floors are unchanged (stable V2_2
+  files; Arrow 58, DataFusion 54); validated against all 35 upstream commits
+  since the pinned release candidate plus the full test matrix.
 
-- **Stable schema identity across renames.** Type and property identity now
-  survives a supported rename: renaming a type is a metadata-only migration
-  that keeps the same dataset, path, Lance version history, and built indexes.
-  Drop-and-re-add remains a new logical lifetime with a fresh identity and an
-  independent version sequence. Identity is never inferred from a name, path,
-  or Lance version.
+- **Schema identity survives renames.** Renaming a type is a metadata-only
+  migration keeping the dataset, path, version history, and indexes.
+  Drop-and-re-add remains a new lifetime. Identity is never inferred from a
+  name, path, or version.
 
-- **Key-conflict fencing on keyed writes.** Every node and edge table declares
-  its exact non-null `id` as the substrate's primary key, and every production
-  insert and upsert is fenced on that field. Strict inserts that collide with
-  an existing key now fail with a typed `KeyConflict` instead of depending on
-  incidental behavior. Merging a branch whose history is provably
-  insert-only also takes a faster path that stages immutable fragments directly
-  rather than joining against the merge target.
+- **Key-conflict fencing.** Every node and edge table declares its `id` as the
+  substrate's primary key; every insert and upsert is fenced on it. A strict
+  insert colliding with an existing key fails with a typed `KeyConflict`.
+  Merging a provably insert-only branch skips the target join entirely.
 
-- **Crash recovery for every writer.** Mutations, loads, schema applies, branch
-  merges, index materialization, and `optimize` each record a durable recovery
-  intent before their first durable effect. An interrupted write is rolled
-  forward or compensated on the next read-write open, all-or-nothing, and
-  ambiguous state fails closed rather than being silently adopted. Interrupted
-  operations surface as a typed `RecoveryRequired` outcome.
+- **Crash recovery for every writer.** Mutations, loads, schema applies,
+  branch merges, index builds, and `optimize` record a durable recovery intent
+  before their first durable effect. An interrupted write rolls forward or
+  compensates on the next read-write open, all-or-nothing; ambiguity fails
+  closed as `RecoveryRequired`.
 
-- **Edge properties are queryable.** An optional binding on the edge word —
-  `$src $w:EDGE_NAME $dst`, or undirected `$a $w:<related> $b` — binds the
-  matched edge *row*, so declared edge properties (role, confidence,
-  provenance, …) work anywhere a node field does: filters
-  (`$w.confidence = "asserted"`), projections (`return { $w.role }`),
-  aggregates, and ordering. A bound traversal emits one row per matching edge
-  row, so parallel edges between the same endpoints stay distinct; unbound
-  traversals keep their existing set-of-pairs semantics. Binding a `{min,max}`
-  multi-hop, rebinding a taken name, or projecting a bare `$w` is rejected at
-  typecheck (`T23`). Bound traversals read the edge table directly — the
-  in-memory adjacency index holds topology only — and pushing edge-property
-  filters into that scan is a planned optimization. See
-  [docs/user/queries/index.md](../user/queries/index.md).
+- **Edge properties are queryable.** `$src $w:EDGE_NAME $dst` (undirected
+  `$a $w:<related> $b`) binds the matched edge row, so edge properties work in
+  filters, projections, aggregates, and ordering — `$w.confidence =
+  "asserted"`, `return { $w.role }`. A bound traversal returns one row per
+  edge, keeping parallel edges distinct; unbound traversals keep set
+  semantics. Invalid bindings are rejected at typecheck (`T23`).
 
-- **Standalone filter clauses push down to the Lance scanner.** v0.8.1 fixed
-  pre-search filtering for the inline-props form (`$d: Doc { status: "open" }`);
-  the standalone clause form — the only spelling that can express ranges
-  (`$d.priority <= 2`) — still ran in memory after the scan, so a filtered
-  `nearest()` could return fewer than `limit` rows and a plain filtered scan
-  materialized every row before dropping non-matches. A filter that references
-  exactly one binding and lowers to a structured scanner expression now moves
-  onto the scan (or traversal step) that introduces the binding, and search
-  runs with the filter as a true prefilter. Selectively filtered searches now
-  return the top-`limit` of the matching rows, and peak memory on a filtered
-  1M-row scan drops from 2,680 MiB to 156 MiB (200k rows: 659 MiB → 78 MiB).
-  Multi-binding filters, non-pushable shapes, and filters on outer bindings
-  inside `not { }` keep their previous in-memory placement, so semantics are
-  unchanged where pushdown does not apply.
+- **Filters push down to the scanner.** Standalone filter clauses — the only
+  form that can express ranges (`$d.priority <= 2`) — now push down like
+  inline props already did: filtered `nearest()` returns the top-`limit` of
+  the *matching* rows, and filtered scans stop materializing every row (peak
+  memory on a filtered 1M-row scan: 2,680 MiB → 156 MiB). Filters that cannot
+  push down keep their previous in-memory behavior.
 
-- **`branch merge --delete-branch`.** Deletes the source branch as part of a
-  successful merge, so the common review-branch workflow no longer needs a
-  second command. Also available as a field on the branch-merge endpoint.
+- **`branch merge --delete-branch`.** Deletes the source branch on a
+  successful merge; also a field on the endpoint.
 
-- **Container images on release.** `omnigraph-server` images are published to
-  both GitHub Container Registry and Docker Hub as part of the release
-  workflow.
+- **Container images on release.** `omnigraph-server` ships to GHCR and
+  Docker Hub.
 
-- **Faster uniqueness checking on bulk writes.** Committed `@unique` constraint
-  probes are batched per constraint group — one filtered scan per chunk of up
-  to 8,192 keys instead of one scan per row. Write-path I/O for uniqueness
-  checks is now flat in the number of rows being written.
+- **Faster uniqueness checks on bulk writes.** Committed `@unique` probes
+  batch per constraint group — one filtered scan per 8,192-key chunk instead
+  of one per row.
 
-- **Bounded graph-batch ingestion.** CLI, HTTP, and SDK bulk ingestion all use
-  the ordinary actor-aware Load path. A request may contain logical node and
-  edge rows, publishes one graph commit across the touched datasets, and is
-  acknowledged only after that manifest commit is visible. The experimental
-  RFC-026 write-ahead path was rejected and is not part of this release.
+- **Bounded graph-batch ingestion.** CLI, HTTP, and SDK bulk ingestion use the
+  ordinary actor-aware Load path: one graph commit per request, acknowledged
+  only after it is visible. The experimental RFC-026 write-ahead path was
+  rejected and is not in this release.
 
-- **Bounded streaming export.** Served export pins one immutable graph cut,
-  scans exact Lance versions incrementally, and emits hard-capped 64 KiB JSONL
-  chunks through a process-wide bounded queue. Authorization and cut validation
-  complete before success headers; client backpressure does not require
-  collecting the complete export in memory.
+- **Bounded streaming export.** Served export pins one immutable graph cut and
+  streams hard-capped 64 KiB JSONL chunks through a bounded queue — no
+  whole-export buffering, authorization before success headers.
 
 ## Behavior changes
 
-- **Commit listings are newest-first.** `omnigraph commit list`, `GET
-  /commits`, and the SDK now return a branch's reachable history most recent
-  first, matching the documented contract (the implementation had shipped
-  ascending). Omitting `branch` lists main's history — the description
-  previously claimed "across all branches", which has been stale since graph
-  lineage moved into the manifest.
+- **Commit listings are newest-first** (`commit list`, `GET /commits`, SDK),
+  matching the documented contract. Omitting `branch` lists main's history.
 
-- **`load --mode append` is strict on existing ids.** An append whose batch
-  contains an id already present in the table is rejected with a key conflict
-  rather than absorbed. Use `--mode merge` for upsert semantics.
+- **`load --mode append` is strict on existing ids** — a duplicate id is a key
+  conflict, not an absorbed upsert. Use `--mode merge` for upserts.
 
-- **Keyed writes are bounded per transaction.** One `mutate` or keyed `load`
-  (`--mode append`/`merge`) stages at most 8,192 rows and 32 MiB of Arrow
-  memory per table per operation; a larger batch is refused with a typed
-  `ResourceLimitExceeded` (HTTP **413**) before any durable effect — split it
-  across multiple operations. `load --mode overwrite` stages a whole-table
-  replacement transaction and is not subject to the keyed ceiling, so bulk
-  reloads keep their full capacity.
+- **Keyed writes are bounded.** One `mutate` or keyed `load` stages at most
+  8,192 rows / 32 MiB per table, refused up front with
+  `ResourceLimitExceeded` (HTTP 413). `--mode overwrite` is a whole-table
+  replacement and is not row-capped.
 
-- **Cluster policy bundles are validated before apply.** `cluster validate`,
-  `plan`, and `apply` reject unsafe policy configuration before taking the
-  cluster lock: unknown fields in policy YAML are errors rather than silently
-  ignored, a bundle carries exactly one runtime kind (server rules or graph
-  scopes, never both), each served graph or cluster scope has exactly one
-  owning bundle, and server-scoped actions cannot carry branch scopes. A
-  configuration that relied on a previously-ignored field will now fail
-  loudly — split mixed bundles and remove stray fields. See
-  [docs/user/clusters/config.md](../user/clusters/config.md).
+- **Cluster policy is validated strictly.** Unknown YAML fields are errors;
+  one runtime kind per bundle; one owning bundle per scope; no branch scopes
+  on server actions. Configs that relied on ignored fields now fail loudly.
 
-- **CLI scope flags are validated per verb.** Flags that a command never reads
-  are now rejected loudly instead of silently ignored: `--profile` on verbs
-  that resolve no scope (`init`, the `cluster` family, local-only verbs),
-  `--store` on `init` (which takes a positional target), and `--as` on
-  read-only control verbs (only `cluster apply` and `cluster approve` attribute
-  an actor). Scripts passing a flag that was previously discarded will now get
-  an error. The ambient `$OMNIGRAPH_PROFILE` default is still ignored by those
-  verbs rather than rejected.
+- **CLI scope flags are validated per verb** — a flag a command never reads is
+  rejected instead of silently ignored.
 
-- **`graphs list` resolves against the server registry.** It no longer routes
-  through graph-addressed resolution, which required `--graph` before the
-  enumeration could run and corrupted the request path when one was supplied.
-  A scope's `default_graph` is deliberately ignored on this path.
+- **`graphs list` resolves against the server registry** and no longer
+  requires `--graph`.
 
-- **`GET /commits` with no `branch` authorizes as `main`.** The handler already
-  executed the omitted form as main's history but authorized it with no branch
-  in scope, so under default-deny a branch-scoped read grant could permit
-  `?branch=main` while denying the equivalent plain request. The omitted form
-  now behaves exactly like the explicit `?branch=main` form.
+- **`GET /commits` without `branch` authorizes as `main`**, exactly like the
+  explicit form.
 
 ## Upgrade notes
 
-- **Storage-format change — rebuild required.** Opening a v0.8.x graph is
-  refused with a message naming the release line that wrote it and the exact
-  commands. The recipe: export with a 0.8.x binary, `init` a **different** root
-  with 0.9.x, then `load --mode overwrite`. Data, vectors, and blobs are
-  preserved; commit history and branches are not. Keep the old root unchanged
-  through the rollback window, and never force-init the old root in place.
-- **Server deployments:** take the graph out of the serving set, rebuild it
-  offline with the CLI, then repoint the cluster with `cluster apply`.
-- **Internal schema v5 was never published.** It was the identity-only
-  development predecessor to v6. The later v7-v19 stamps belonged to the
-  rejected RFC-026 experiment and were also never released. A published binary
-  writes v4 (0.8.x) or v6 (0.9.x), never one of those development formats.
-- Downgrade to 0.8.x is not possible for a v6 graph — a 0.8.x binary refuses it,
-  by design.
+- Opening a v0.8.x graph is refused with a message naming the exact commands.
+  Recipe: export with a 0.8.x binary, `init` a **different** root with 0.9.x,
+  `load --mode overwrite`. Data, vectors, and blobs are preserved; commit
+  history and branches are not. Keep the old root untouched through the
+  rollback window.
+- Server deployments: pull the graph from the serving set, rebuild offline,
+  repoint via `cluster apply`.
+- Downgrade is not possible — a 0.8.x binary refuses a 0.9.x graph by design.
 
 ## Developer-facing
 
-- The workspace builds entirely from registry dependencies again; a Lance
-  source guard fails if a git source returns.
-- The write path is one protocol: every graph-content, schema, and maintenance
-  transition becomes authoritative at a single manifest publish, and writer
-  adapters supply exact pre-minted transaction identities rather than inferring
-  ownership from version movement. See
-  [docs/dev/writes.md](../dev/writes.md).
-- Cross-version rebuild tests run against genuine older binaries rather than
-  simulated stamps, including the immediately preceding format.
-- RFC-030 (graph change feed) is published, and its first internal groundwork
-  landed: identity-keyed changed-table intervals and constant-time first-parent
-  commit classification. No public feed API ships in this release. RFC-031
-  (comparative cost harness) and RFC-032 (adversarial correctness harness) are
-  published as drafts.
+- The workspace builds from registry dependencies only; a source guard fails
+  if a git dependency returns.
+- One write protocol: every graph-content, schema, and maintenance transition
+  becomes authoritative at a single manifest publish, with exact pre-minted
+  transaction identities. See [docs/dev/writes.md](../dev/writes.md).
+- Cross-version rebuild tests run against genuine older binaries, including
+  the immediately preceding format.
+- RFC-030 (graph change feed) is published with its first internal groundwork;
+  no public feed API ships. RFC-031/032 (cost and correctness harnesses) are
+  drafts.
 - The workspace carries a uniform `rustfmt` baseline.


### PR DESCRIPTION
Post-release cleanup of the v0.9.0 notes: roughly half the length, same facts. Removes the internal-stamp bullet (v5/v7–v19 development numbering is invisible to anyone on released binaries; the downgrade bullet already carries the user-facing fact), drops internal stamp numbers from the intro in favor of the release-line names the refusal error actually shows, and trims per-bullet verbosity. The GitHub Release body will be updated to match after merge.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR substantially shortens the v0.9.0 release notes while retaining the release’s storage, query, operational, upgrade, and developer-facing highlights. One resource-limit sentence now describes overwrite’s exemption more narrowly than the implementation and canonical documentation.
- Condenses feature highlights and behavior changes.
- Streamlines cross-version rebuild and downgrade guidance.
- Removes internal development-format details from the public release summary.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with one non-blocking wording ambiguity around overwrite’s exemption from keyed-write limits.

The implementation and canonical documentation exempt overwrite from both keyed-write limits, while the shortened release note explicitly mentions only the row-cap exemption.

**Files Needing Attention:** docs/releases/v0.9.0.md

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/releases/v0.9.0.md | The shortened notes preserve the substantive release claims overall, but the overwrite wording leaves its exemption from the 32 MiB keyed-write cap ambiguous. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Adocs%2Freleases%2Fv0.9.0.md%3A82%0A**Clarify%20overwrite's%20full%20exemption**%0A%0AThe%20preceding%20sentence%20defines%20both%20row%20and%20byte%20limits%2C%20but%20this%20wording%20exempts%20overwrite%20only%20from%20the%20row%20cap.%20Overwrite%20is%20exempt%20from%20the%20entire%20keyed-write%20ceiling%2C%20so%20readers%20can%20otherwise%20infer%20that%20valid%20replacements%20remain%20limited%20to%2032%20MiB.%0A%0A%60%60%60suggestion%0A%20%20replacement%20and%20is%20not%20subject%20to%20either%20cap.%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=modernrelay%2Fomnigraph&pr=457&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(release): tighten the v0.9.0 notes"](https://github.com/modernrelay/omnigraph/commit/f87f55f5fd5a997a4141d89814428ddd82c7490b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51361771)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->