### PR TITLE
chore: make the workspace clippy-clean under default lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,13 @@ cedar-policy = "4.9"
 sha2 = "0.10"
 subtle = "2"
 
+[workspace.lints.clippy]
+# Nested guards often read clearer than one merged condition (Polars allows this too).
+collapsible_if = "allow"
+# Streaming/recovery internals thread identity + authority + payload explicitly;
+# a params-struct refactor is not earned yet.
+too_many_arguments = "allow"
+
 [profile.dev]
 debug = 0
 

--- a/crates/omnigraph-api-types/Cargo.toml
+++ b/crates/omnigraph-api-types/Cargo.toml
@@ -14,3 +14,6 @@ omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.9.0" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 utoipa = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/omnigraph-cli/Cargo.toml
+++ b/crates/omnigraph-cli/Cargo.toml
@@ -35,3 +35,6 @@ serde_json = { workspace = true }
 tempfile = { workspace = true }
 lance = { workspace = true }
 lance-index = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/omnigraph-cli/src/planes.rs
+++ b/crates/omnigraph-cli/src/planes.rs
@@ -339,6 +339,7 @@ fn accepts_graph_selector(cmd: &Command) -> bool {
 /// - `--server` → served-graph scopes (`any`/`served`);
 /// - `--cluster` → cluster-scoped direct/control verbs;
 /// - `--graph` → any multi-graph scope: a served scope *or* a cluster one.
+///
 /// RFC-010 Slice 1, generalized for RFC-011 cluster addressing.
 pub(crate) fn guard_addressing(cli: &Cli) -> Result<()> {
     if let Command::Alias { .. } = &cli.command {
@@ -413,7 +414,6 @@ mod tests {
     use clap::Parser;
 
     use super::*;
-    use crate::cli::PolicyCommand;
 
     #[test]
     fn scope_flag_matrix_matches_capabilities() {

--- a/crates/omnigraph-cluster/Cargo.toml
+++ b/crates/omnigraph-cluster/Cargo.toml
@@ -35,3 +35,6 @@ ulid = { workspace = true }
 serial_test = "3"
 tempfile = { workspace = true }
 tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/omnigraph-cluster/src/failpoints.rs
+++ b/crates/omnigraph-cluster/src/failpoints.rs
@@ -16,11 +16,11 @@ pub(crate) fn maybe_fail(_name: &str) -> Result<(), Diagnostic> {
     {
         let name = _name;
         fail::fail_point!(name, |_| {
-            return Err(Diagnostic::error(
+            Err(Diagnostic::error(
                 "injected_failpoint",
                 name,
                 format!("injected failpoint triggered: {name}"),
-            ));
+            ))
         });
     }
     Ok(())

--- a/crates/omnigraph-cluster/src/lib.rs
+++ b/crates/omnigraph-cluster/src/lib.rs
@@ -1,7 +1,7 @@
-// The failpoint-only cluster state-machine tests compose several large async
-// futures. Linux rustc needs the wider layout-query budget while building the
-// lib-test harness; production and ordinary test builds keep the default.
-#![cfg_attr(all(test, feature = "failpoints"), recursion_limit = "256")]
+// The cluster state-machine tests compose several large async futures; rustc
+// needs the wider layout-query budget while building the lib-test harness
+// (with or without failpoints). Production builds keep the default.
+#![cfg_attr(test, recursion_limit = "256")]
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self};
@@ -1059,10 +1059,10 @@ pub async fn apply_config_dir_with_options(
                     new_state.resource_statuses.remove(&change.resource);
                 }
             },
-            Some(ApplyDisposition::Blocked) => {
+            Some(ApplyDisposition::Blocked)
                 // The sweep owns recovery statuses (Drifted/Error with their
                 // conditions); a generic Blocked must not clobber them.
-                if change.reason.as_deref() != Some("cluster_recovery_pending") {
+                if change.reason.as_deref() != Some("cluster_recovery_pending") => {
                     set_resource_status(
                         &mut new_state,
                         &change.resource,
@@ -1071,7 +1071,6 @@ pub async fn apply_config_dir_with_options(
                         "waiting on an unapplied or missing dependency",
                     );
                 }
-            }
             _ => {}
         }
     }

--- a/crates/omnigraph-cluster/tests/failpoints.rs
+++ b/crates/omnigraph-cluster/tests/failpoints.rs
@@ -19,8 +19,8 @@ use omnigraph::error::OmniError;
 // it is registry-only (error-type agnostic) and lives in the lowest crate.
 use omnigraph::failpoints::ScopedFailPoint;
 use omnigraph_cluster::{
-    ApplyDisposition, ApplyOptions, apply_config_dir, apply_config_dir_with_options,
-    approve_config_dir, validate_config_dir,
+    ApplyOptions, apply_config_dir, apply_config_dir_with_options, approve_config_dir,
+    validate_config_dir,
 };
 use serial_test::serial;
 use tempfile::tempdir;

--- a/crates/omnigraph-compiler/Cargo.toml
+++ b/crates/omnigraph-compiler/Cargo.toml
@@ -23,3 +23,6 @@ serde_json = { workspace = true }
 ahash = { workspace = true }
 sha2 = { workspace = true }
 ulid = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/omnigraph-compiler/src/catalog/schema_ir.rs
+++ b/crates/omnigraph-compiler/src/catalog/schema_ir.rs
@@ -712,7 +712,7 @@ fn shape_types(shape: &SchemaShape) -> Vec<(TypeKind, String, Option<&str>)> {
         .collect()
 }
 
-fn shape_properties<'a>(shape: &'a SchemaShape) -> Vec<(TypeKind, &'a str, &'a [PropertyShape])> {
+fn shape_properties(shape: &SchemaShape) -> Vec<(TypeKind, &str, &[PropertyShape])> {
     shape
         .interfaces
         .iter()

--- a/crates/omnigraph-compiler/src/catalog/schema_plan.rs
+++ b/crates/omnigraph-compiler/src/catalog/schema_plan.rs
@@ -282,9 +282,9 @@ fn validate_evolution_identity(accepted: &SchemaIR, desired: &SchemaIR) -> Resul
             .into());
         }
         if let Some(incarnation) = incarnation
-            && !accepted_types
+            && accepted_types
                 .get(&type_id)
-                .is_some_and(|(_, previous)| *previous == Some(incarnation))
+                .is_none_or(|(_, previous)| *previous != Some(incarnation))
             && incarnation.get() < accepted.next_identity_id
         {
             return Err(SchemaIdentityError::Resolution(format!(

--- a/crates/omnigraph-compiler/src/catalog/schema_shape.rs
+++ b/crates/omnigraph-compiler/src/catalog/schema_shape.rs
@@ -128,7 +128,7 @@ pub fn compile_schema_shape(schema: &SchemaFile) -> Result<SchemaShape> {
                 let mut properties = Vec::with_capacity(node.properties.len());
                 for effective in &node.properties {
                     let origin = node.property_origins.get(&effective.name);
-                    let declared_directly = origin.map_or(true, |origin| origin.declared_directly);
+                    let declared_directly = origin.is_none_or(|origin| origin.declared_directly);
                     let mut contributions = origin
                         .map(|origin| origin.interface_properties.clone())
                         .unwrap_or_default();

--- a/crates/omnigraph-compiler/src/ir/lower.rs
+++ b/crates/omnigraph-compiler/src/ir/lower.rs
@@ -483,10 +483,8 @@ fn find_outer_var(clauses: &[Clause], outer_bound: &HashSet<String>) -> Option<S
                     return Some(v);
                 }
             }
-            Clause::Binding(b) => {
-                if outer_bound.contains(&b.variable) {
-                    return Some(b.variable.clone());
-                }
+            Clause::Binding(b) if outer_bound.contains(&b.variable) => {
+                return Some(b.variable.clone());
             }
             _ => {}
         }

--- a/crates/omnigraph-compiler/src/query/lint_tests.rs
+++ b/crates/omnigraph-compiler/src/query/lint_tests.rs
@@ -227,7 +227,7 @@ a_field: String?
 }
 "#,
         ),
-        &r#"
+        r#"
 query update_b($slug: String) {
 update Policy set { a_field: "x" } where slug = $slug
 }

--- a/crates/omnigraph-compiler/src/query/typecheck.rs
+++ b/crates/omnigraph-compiler/src/query/typecheck.rs
@@ -579,17 +579,16 @@ fn typecheck_clauses(
                 let mut has_outer = false;
                 for clause in inner {
                     match clause {
-                        Clause::Traversal(t) => {
-                            if outer_vars.contains(&t.src) || outer_vars.contains(&t.dst) {
-                                has_outer = true;
-                            }
+                        Clause::Traversal(t)
+                            if outer_vars.contains(&t.src) || outer_vars.contains(&t.dst) =>
+                        {
+                            has_outer = true;
                         }
-                        Clause::Filter(f) => {
+                        Clause::Filter(f)
                             if expr_references_any(&f.left, &outer_vars)
-                                || expr_references_any(&f.right, &outer_vars)
-                            {
-                                has_outer = true;
-                            }
+                                || expr_references_any(&f.right, &outer_vars) =>
+                        {
+                            has_outer = true;
                         }
                         Clause::Binding(b) if outer_vars.contains(&b.variable) => {
                             has_outer = true;
@@ -1640,15 +1639,13 @@ fn check_literal_type(lit: &Literal, expected: &PropType, prop_name: &str) -> Re
     if expected.is_enum() {
         let allowed = expected.enum_values.as_ref().cloned().unwrap_or_default();
         match lit {
-            Literal::String(v) => {
-                if !allowed.contains(v) {
-                    return Err(CompilerError::Type(format!(
-                        "T3: property `{}` expects one of [{}], got '{}'",
-                        prop_name,
-                        allowed.join(", "),
-                        v
-                    )));
-                }
+            Literal::String(v) if !allowed.contains(v) => {
+                return Err(CompilerError::Type(format!(
+                    "T3: property `{}` expects one of [{}], got '{}'",
+                    prop_name,
+                    allowed.join(", "),
+                    v
+                )));
             }
             Literal::List(items) if expected.list => {
                 for item in items {

--- a/crates/omnigraph-compiler/src/query/typecheck.rs
+++ b/crates/omnigraph-compiler/src/query/typecheck.rs
@@ -591,10 +591,8 @@ fn typecheck_clauses(
                                 has_outer = true;
                             }
                         }
-                        Clause::Binding(b) => {
-                            if outer_vars.contains(&b.variable) {
-                                has_outer = true;
-                            }
+                        Clause::Binding(b) if outer_vars.contains(&b.variable) => {
+                            has_outer = true;
                         }
                         _ => {}
                     }

--- a/crates/omnigraph-compiler/src/schema/ast.rs
+++ b/crates/omnigraph-compiler/src/schema/ast.rs
@@ -149,16 +149,10 @@ pub enum ConstraintBound {
 }
 
 /// Edge cardinality: `@card(min..max)`. Default is `0..*`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct Cardinality {
     pub min: u32,
     pub max: Option<u32>,
-}
-
-impl Default for Cardinality {
-    fn default() -> Self {
-        Self { min: 0, max: None }
-    }
 }
 
 impl Cardinality {

--- a/crates/omnigraph-policy/Cargo.toml
+++ b/crates/omnigraph-policy/Cargo.toml
@@ -18,3 +18,6 @@ serde_yaml = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/omnigraph-policy/src/lib.rs
+++ b/crates/omnigraph-policy/src/lib.rs
@@ -347,7 +347,7 @@ impl PolicyConfig {
                     rule.id
                 );
             }
-            if let Some(_) = rule.allow.branch_scope {
+            if rule.allow.branch_scope.is_some() {
                 for action in &rule.allow.actions {
                     if !action.uses_branch_scope() {
                         bail!(
@@ -358,7 +358,7 @@ impl PolicyConfig {
                     }
                 }
             }
-            if let Some(_) = rule.allow.target_branch_scope {
+            if rule.allow.target_branch_scope.is_some() {
                 for action in &rule.allow.actions {
                     if !action.uses_target_branch_scope() {
                         bail!(

--- a/crates/omnigraph-server/Cargo.toml
+++ b/crates/omnigraph-server/Cargo.toml
@@ -52,3 +52,6 @@ tower = { workspace = true }
 serial_test = "3"
 lance = { workspace = true }
 lance-index = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/omnigraph-server/src/lib.rs
+++ b/crates/omnigraph-server/src/lib.rs
@@ -277,17 +277,21 @@ struct OpenedGraph {
     handle: Arc<GraphHandle>,
 }
 
+/// The structured-detail payloads are boxed to keep `Result<_, ApiError>` cheap
+/// to move: every handler returns one, and at most one detail is ever `Some`.
+/// The boxing is an in-memory representation only; [`api::ErrorOutput`] is what
+/// serializes.
 #[derive(Debug)]
 pub struct ApiError {
     status: StatusCode,
     code: Option<ErrorCode>,
     message: String,
     merge_conflicts: Vec<api::MergeConflictOutput>,
-    manifest_conflict: Option<api::ManifestConflictOutput>,
-    read_set_conflict: Option<api::ReadSetConflictOutput>,
-    key_conflict: Option<api::KeyConflictOutput>,
-    resource_limit: Option<api::ResourceLimitOutput>,
-    recovery_required: Option<api::RecoveryRequiredOutput>,
+    manifest_conflict: Option<Box<api::ManifestConflictOutput>>,
+    read_set_conflict: Option<Box<api::ReadSetConflictOutput>>,
+    key_conflict: Option<Box<api::KeyConflictOutput>>,
+    resource_limit: Option<Box<api::ResourceLimitOutput>>,
+    recovery_required: Option<Box<api::RecoveryRequiredOutput>>,
 }
 
 impl AppState {
@@ -779,7 +783,7 @@ impl ApiError {
             code: Some(ErrorCode::Conflict),
             message,
             merge_conflicts: Vec::new(),
-            manifest_conflict: Some(details),
+            manifest_conflict: Some(Box::new(details)),
             read_set_conflict: None,
             key_conflict: None,
             resource_limit: None,
@@ -794,7 +798,7 @@ impl ApiError {
             message,
             merge_conflicts: Vec::new(),
             manifest_conflict: None,
-            read_set_conflict: Some(details),
+            read_set_conflict: Some(Box::new(details)),
             key_conflict: None,
             resource_limit: None,
             recovery_required: None,
@@ -809,7 +813,7 @@ impl ApiError {
             merge_conflicts: Vec::new(),
             manifest_conflict: None,
             read_set_conflict: None,
-            key_conflict: Some(details),
+            key_conflict: Some(Box::new(details)),
             resource_limit: None,
             recovery_required: None,
         }
@@ -824,7 +828,7 @@ impl ApiError {
             manifest_conflict: None,
             read_set_conflict: None,
             key_conflict: None,
-            resource_limit: Some(details),
+            resource_limit: Some(Box::new(details)),
             recovery_required: None,
         }
     }
@@ -842,7 +846,7 @@ impl ApiError {
             read_set_conflict: None,
             key_conflict: None,
             resource_limit: None,
-            recovery_required: Some(api::RecoveryRequiredOutput { operation_id }),
+            recovery_required: Some(Box::new(api::RecoveryRequiredOutput { operation_id })),
         }
     }
 
@@ -981,11 +985,11 @@ impl IntoResponse for ApiError {
                 error: self.message,
                 code: self.code,
                 merge_conflicts: self.merge_conflicts,
-                manifest_conflict: self.manifest_conflict,
-                read_set_conflict: self.read_set_conflict,
-                key_conflict: self.key_conflict,
-                resource_limit: self.resource_limit,
-                recovery_required: self.recovery_required,
+                manifest_conflict: self.manifest_conflict.map(|d| *d),
+                read_set_conflict: self.read_set_conflict.map(|d| *d),
+                key_conflict: self.key_conflict.map(|d| *d),
+                resource_limit: self.resource_limit.map(|d| *d),
+                recovery_required: self.recovery_required.map(|d| *d),
             }),
         )
             .into_response()
@@ -1323,7 +1327,7 @@ pub async fn open_multi_graph_state(
     };
 
     let configured_graphs = graphs.len();
-    let results = futures::stream::iter(graphs.into_iter())
+    let results = futures::stream::iter(graphs)
         .map(|cfg| async move {
             let graph_id = cfg.graph_id.clone();
             open_single_graph(cfg).await.map_err(|err| (graph_id, err))

--- a/crates/omnigraph-server/tests/auth_policy.rs
+++ b/crates/omnigraph-server/tests/auth_policy.rs
@@ -4,9 +4,8 @@
 use std::env;
 use std::fs;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 
-use axum::body::{Body, Bytes};
+use axum::body::Body;
 use axum::http::header::AUTHORIZATION;
 use axum::http::{Method, Request, StatusCode};
 use omnigraph::db::{Omnigraph, ReadTarget};

--- a/crates/omnigraph-server/tests/multi_graph.rs
+++ b/crates/omnigraph-server/tests/multi_graph.rs
@@ -2,17 +2,12 @@
 //! Moved verbatim from tests/server.rs in the modularization.
 
 use std::fs;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
 
-use axum::body::{Body, Bytes, to_bytes};
-use axum::http::header::{CACHE_CONTROL, ETAG, HeaderValue, IF_MATCH};
+use axum::body::{Body, to_bytes};
 use axum::http::{Method, Request, StatusCode};
-use futures::StreamExt;
 use omnigraph::db::Omnigraph;
 use omnigraph::loader::{LoadMode, load_jsonl};
-use omnigraph_server::api::{ChangeRequest, ErrorOutput, ExportRequest, QueryRequest, ReadRequest};
+use omnigraph_server::api::{ErrorOutput, ExportRequest, ReadRequest};
 use omnigraph_server::{AppState, build_app};
 use serde_json::Value;
 use serial_test::serial;
@@ -409,10 +404,7 @@ async fn cluster_boot_serves_applied_state() {
         graphs,
         config_path,
         server_policy,
-    } = settings.mode
-    else {
-        panic!("cluster boot must select multi-graph routing");
-    };
+    } = settings.mode;
     assert_eq!(graphs.len(), 1);
     assert_eq!(graphs[0].graph_id, "knowledge");
     assert!(server_policy.is_none());
@@ -724,10 +716,8 @@ graphs:
         .join("graphs/knowledge.omni")
         .to_string_lossy()
         .to_string();
-    let mut db = Omnigraph::open(&graph_uri).await.unwrap();
-    load_jsonl(&mut db, &data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    let db = Omnigraph::open(&graph_uri).await.unwrap();
+    load_jsonl(&db, &data, LoadMode::Overwrite).await.unwrap();
 
     let _guard = EnvGuard::set(&[
         ("OMNIGRAPH_EMBEDDINGS_MOCK", None),
@@ -743,10 +733,7 @@ graphs:
         graphs,
         config_path,
         server_policy,
-    } = settings.mode
-    else {
-        panic!("cluster boot must select multi-graph routing");
-    };
+    } = settings.mode;
     let state = omnigraph_server::open_multi_graph_state(
         graphs,
         Vec::new(),
@@ -902,10 +889,7 @@ graphs:
         graphs,
         server_policy,
         ..
-    } = settings.mode
-    else {
-        panic!("cluster boot must select multi-graph routing");
-    };
+    } = settings.mode;
     // Cluster boots carry policy CONTENT (digest-verified catalog blobs),
     // not paths — the catalog may live on object storage.
     let omnigraph_server::PolicySource::Inline(graph_policy) =

--- a/crates/omnigraph-server/tests/openapi.rs
+++ b/crates/omnigraph-server/tests/openapi.rs
@@ -31,10 +31,8 @@ async fn init_loaded_graph() -> tempfile::TempDir {
     Omnigraph::init(graph.to_str().unwrap(), &schema)
         .await
         .unwrap();
-    let mut db = Omnigraph::open(graph.to_str().unwrap()).await.unwrap();
-    load_jsonl(&mut db, &data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    let db = Omnigraph::open(graph.to_str().unwrap()).await.unwrap();
+    load_jsonl(&db, &data, LoadMode::Overwrite).await.unwrap();
     temp
 }
 
@@ -1112,9 +1110,8 @@ fn invoke_stored_query_request_body_is_optional() {
         request_body.is_object(),
         "POST /queries/{{name}} should document its optional request body"
     );
-    assert_eq!(
-        request_body["required"].as_bool().unwrap_or(false),
-        false,
+    assert!(
+        !request_body["required"].as_bool().unwrap_or(false),
         "stored-query invocation body should be optional"
     );
     let schema = &request_body["content"]["application/json"]["schema"];

--- a/crates/omnigraph-server/tests/s3.rs
+++ b/crates/omnigraph-server/tests/s3.rs
@@ -24,9 +24,9 @@ async fn server_opens_s3_graph_directly_and_serves_snapshot_and_read() {
     Omnigraph::init(&uri, &fs::read_to_string(fixture("test.pg")).unwrap())
         .await
         .unwrap();
-    let mut db = Omnigraph::open(&uri).await.unwrap();
+    let db = Omnigraph::open(&uri).await.unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         &fs::read_to_string(fixture("test.jsonl")).unwrap(),
         LoadMode::Overwrite,
     )
@@ -122,9 +122,9 @@ async fn server_boots_cluster_from_bare_storage_uri_and_serves_query() {
         assert!(apply.ok && apply.converged, "{:?}", apply.diagnostics);
 
         let graph_uri = format!("{root}/graphs/knowledge.omni");
-        let mut db = Omnigraph::open(&graph_uri).await.unwrap();
+        let db = Omnigraph::open(&graph_uri).await.unwrap();
         load_jsonl(
-            &mut db,
+            &db,
             "{\"type\":\"Person\",\"data\":{\"name\":\"Ada\"}}\n",
             LoadMode::Overwrite,
         )
@@ -144,10 +144,7 @@ async fn server_boots_cluster_from_bare_storage_uri_and_serves_query() {
         graphs,
         config_path,
         server_policy,
-    } = settings.mode
-    else {
-        panic!("cluster boot must select multi-graph routing");
-    };
+    } = settings.mode;
     let state = omnigraph_server::open_multi_graph_state(
         graphs,
         Vec::new(),

--- a/crates/omnigraph-server/tests/support/mod.rs
+++ b/crates/omnigraph-server/tests/support/mod.rs
@@ -120,10 +120,8 @@ pub async fn init_graph_with_schema_and_data(schema: &str, data: &str) -> tempfi
     Omnigraph::init(graph.to_str().unwrap(), schema)
         .await
         .unwrap();
-    let mut db = Omnigraph::open(graph.to_str().unwrap()).await.unwrap();
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    let db = Omnigraph::open(graph.to_str().unwrap()).await.unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
     temp
 }
 

--- a/crates/omnigraph-storage/Cargo.toml
+++ b/crates/omnigraph-storage/Cargo.toml
@@ -19,3 +19,6 @@ url = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/omnigraph/Cargo.toml
+++ b/crates/omnigraph/Cargo.toml
@@ -73,3 +73,6 @@ libc = "0.2"
 # "Examples & benches". `harness = false`: the file provides its own main.
 name = "scenarios"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/omnigraph/benches/scenarios.rs
+++ b/crates/omnigraph/benches/scenarios.rs
@@ -329,7 +329,7 @@ fn git_worktree_dirty() -> Option<bool> {
         .current_dir(env!("CARGO_MANIFEST_DIR"))
         .output()
         .ok()?;
-    out.status.success().then(|| !out.stdout.is_empty())
+    out.status.success().then_some(!out.stdout.is_empty())
 }
 
 #[cfg(unix)]
@@ -367,6 +367,9 @@ const CHILD_PROTOCOL_EXIT_STATUS: i64 = 70;
 fn run_child_process(args: &Args) -> ChildRun {
     let exe = std::env::current_exe().expect("current_exe");
     let wall_start = Instant::now();
+    // Reaped by `wait4_rusage(pid)` below, which is used instead of
+    // `Child::wait` because only `wait4` reports the child's peak RSS.
+    #[allow(clippy::zombie_processes)]
     let mut child = std::process::Command::new(exe)
         .args(args.to_child_argv())
         .stdout(std::process::Stdio::piped())

--- a/crates/omnigraph/benches/scenarios/rfc023.rs
+++ b/crates/omnigraph/benches/scenarios/rfc023.rs
@@ -1252,7 +1252,7 @@ async fn verify_id_content(
         canonical.update(format!("prefix={prefix};seed={seed}\n").as_bytes());
         for ordinal in 0..rows_per_prefix {
             canonical_id.clear();
-            write!(&mut canonical_id, "{prefix}-{ordinal:010}\n")
+            writeln!(&mut canonical_id, "{prefix}-{ordinal:010}")
                 .expect("format canonical verified ID");
             canonical.update(canonical_id.as_bytes());
         }
@@ -1473,8 +1473,7 @@ fn general_merge_batch_rows(dims: usize) -> usize {
         .saturating_div(per_row);
     usize::try_from(by_bytes)
         .unwrap_or(rfc023_limits::KEYED_WRITE_MAX_ROWS)
-        .min(rfc023_limits::KEYED_WRITE_MAX_ROWS)
-        .max(1)
+        .clamp(1, rfc023_limits::KEYED_WRITE_MAX_ROWS)
 }
 
 fn general_merge_fixture_root(args: &Args) -> &std::path::Path {

--- a/crates/omnigraph/benches/scenarios/rfc023_limits.rs
+++ b/crates/omnigraph/benches/scenarios/rfc023_limits.rs
@@ -113,7 +113,7 @@ pub(crate) fn derive_chunk_plan(
     let batch_rows_u64 = max_rows_by_bytes.min(KEYED_WRITE_MAX_ROWS as u64);
     let batch_rows = usize::try_from(batch_rows_u64)
         .map_err(|_| "derived RFC-023 batch row count exceeds usize".to_string())?;
-    let transaction_count = rows / batch_rows + usize::from(rows % batch_rows != 0);
+    let transaction_count = rows / batch_rows + usize::from(!rows.is_multiple_of(batch_rows));
     let estimated_full_batch_bytes = row_bytes
         .checked_mul(batch_rows as u64)
         .and_then(|value| value.checked_add(BATCH_FIXED_OVERHEAD_BYTES))

--- a/crates/omnigraph/examples/bench_expand.rs
+++ b/crates/omnigraph/examples/bench_expand.rs
@@ -251,10 +251,8 @@ query sel($name: String) {
             // Fresh db per measurement so the query is cold (CSR pays its build).
             let dir = tempfile::tempdir().unwrap();
             let uri = dir.path().to_str().unwrap();
-            let mut db = Omnigraph::init(uri, SCHEMA).await.unwrap();
-            load_jsonl(&mut db, &jsonl, LoadMode::Overwrite)
-                .await
-                .unwrap();
+            let db = Omnigraph::init(uri, SCHEMA).await.unwrap();
+            load_jsonl(&db, &jsonl, LoadMode::Overwrite).await.unwrap();
             // SAFE: example main drives queries sequentially; no concurrent env reader.
             unsafe { std::env::set_var("OMNIGRAPH_TRAVERSAL_MODE", mode) };
 
@@ -295,14 +293,12 @@ async fn main() {
         let uri = dir.path().to_str().unwrap();
 
         let t = Instant::now();
-        let mut db = Omnigraph::init(uri, SCHEMA).await.unwrap();
+        let db = Omnigraph::init(uri, SCHEMA).await.unwrap();
         let init_elapsed = t.elapsed();
 
         let jsonl = generate_jsonl(n, avg_deg, 42);
         let t = Instant::now();
-        load_jsonl(&mut db, &jsonl, LoadMode::Overwrite)
-            .await
-            .unwrap();
+        load_jsonl(&db, &jsonl, LoadMode::Overwrite).await.unwrap();
         let load_elapsed = t.elapsed();
 
         println!(

--- a/crates/omnigraph/src/branch_control.rs
+++ b/crates/omnigraph/src/branch_control.rs
@@ -18,7 +18,8 @@ use crate::error::{OmniError, Result};
 /// Result of a recoverable native create attempt.
 pub(crate) enum BranchCreateOutcome {
     /// The requested branch is durably authoritative and its dataset opens.
-    Created(Dataset),
+    /// Boxed: `Dataset` is ~336 bytes and `RefAlreadyExists` carries none.
+    Created(Box<Dataset>),
     /// The target ref existed before this invocation. Callers classify its
     /// ownership at their own logical layer; this helper never deletes it.
     /// A ref that appears after target absence was captured is instead a typed
@@ -212,7 +213,7 @@ pub(crate) async fn create_branch_recoverably(
             Ok(created) => match crate::failpoints::maybe_fail(
                 crate::failpoints::names::BRANCH_CREATE_POST_NATIVE,
             ) {
-                Ok(()) => return Ok(BranchCreateOutcome::Created(created)),
+                Ok(()) => return Ok(BranchCreateOutcome::Created(Box::new(created))),
                 Err(error) => error,
             },
             Err(error) => error,
@@ -244,7 +245,7 @@ pub(crate) async fn create_branch_recoverably(
                     branch, error, native_error
                 ))
             })?;
-            return Ok(BranchCreateOutcome::Created(created));
+            return Ok(BranchCreateOutcome::Created(Box::new(created)));
         }
 
         match reclaim_ref_absent_tree(source, branch).await {

--- a/crates/omnigraph/src/changes/mod.rs
+++ b/crates/omnigraph/src/changes/mod.rs
@@ -198,32 +198,21 @@ pub(crate) async fn diff_snapshots(
         let (kind, type_name) = parse_table_key(table_key);
         let is_edge = kind == EntityKind::Edge;
 
-        let table_changes = if from_entry.is_none() {
+        let table_changes = match (from_entry, to_entry) {
             // Table added — all rows are inserts
-            diff_table_added(table_store, to_entry.unwrap(), is_edge, filter).await?
-        } else if to_entry.is_none() {
+            (None, Some(to)) => diff_table_added(table_store, to, is_edge, filter).await?,
             // Table removed — all rows are deletes
-            diff_table_removed(table_store, from_entry.unwrap(), is_edge, filter).await?
-        } else if same_lineage(from_entry, to_entry) {
+            (Some(from), None) => diff_table_removed(table_store, from, is_edge, filter).await?,
             // Fast path: version-column diff
-            diff_table_same_lineage(
-                table_store,
-                from_entry.unwrap(),
-                to_entry.unwrap(),
-                is_edge,
-                filter,
-            )
-            .await?
-        } else {
+            (Some(from), Some(to)) if same_lineage(from_entry, to_entry) => {
+                diff_table_same_lineage(table_store, from, to, is_edge, filter).await?
+            }
             // Cross-branch path: streaming ID-based diff
-            diff_table_cross_branch(
-                table_store,
-                from_entry.unwrap(),
-                to_entry.unwrap(),
-                is_edge,
-                filter,
-            )
-            .await?
+            (Some(from), Some(to)) => {
+                diff_table_cross_branch(table_store, from, to, is_edge, filter).await?
+            }
+            // Unreachable: `same_state` above already skipped absent-on-both-sides tables.
+            (None, None) => continue,
         };
 
         for mut c in table_changes {

--- a/crates/omnigraph/src/db/commit_graph.rs
+++ b/crates/omnigraph/src/db/commit_graph.rs
@@ -243,7 +243,7 @@ impl CommitGraph {
         let source_distances = ancestor_distances(source_commit_id, &commits);
         let target_distances = ancestor_distances(target_commit_id, &commits);
 
-        let best = source_distances
+        source_distances
             .iter()
             .filter_map(|(id, source_distance)| {
                 target_distances.get(id).and_then(|target_distance| {
@@ -259,9 +259,7 @@ impl CommitGraph {
                 })
             })
             .min_by_key(|(score, _)| *score)
-            .map(|(_, commit)| commit);
-
-        best
+            .map(|(_, commit)| commit)
     }
 }
 

--- a/crates/omnigraph/src/db/manifest/metadata.rs
+++ b/crates/omnigraph/src/db/manifest/metadata.rs
@@ -83,7 +83,7 @@ impl TableVersionMetadata {
             manifest_path: full_manifest_object_store_path(
                 root_uri,
                 table_path,
-                &dataset.manifest_location().path.to_string(),
+                dataset.manifest_location().path.as_ref(),
             )?,
             manifest_size: dataset.manifest_location().size,
             e_tag: dataset.manifest_location().e_tag.clone(),

--- a/crates/omnigraph/src/db/manifest/namespace.rs
+++ b/crates/omnigraph/src/db/manifest/namespace.rs
@@ -262,9 +262,9 @@ impl LanceNamespace for BranchManifestNamespace {
             .collect();
 
         if request.descending.unwrap_or(false) {
-            versions.sort_by(|a, b| b.version.cmp(&a.version));
+            versions.sort_by_key(|v| std::cmp::Reverse(v.version));
         } else {
-            versions.sort_by(|a, b| a.version.cmp(&b.version));
+            versions.sort_by_key(|v| v.version);
         }
         if let Some(limit) = request.limit {
             versions.truncate(limit as usize);
@@ -412,9 +412,9 @@ impl LanceNamespace for StagedTableNamespace {
             );
         }
         if request.descending.unwrap_or(false) {
-            versions.sort_by(|a, b| b.version.cmp(&a.version));
+            versions.sort_by_key(|v| std::cmp::Reverse(v.version));
         } else {
-            versions.sort_by(|a, b| a.version.cmp(&b.version));
+            versions.sort_by_key(|v| v.version);
         }
         if let Some(limit) = request.limit {
             versions.truncate(limit as usize);
@@ -466,7 +466,7 @@ impl LanceNamespace for StagedTableNamespace {
             _ => ManifestNamingScheme::V2,
         };
         let control_session = crate::lance_access::control_session();
-        let (object_store, base_path, _) = DatasetBuilder::from_uri(&self.table_uri())
+        let (object_store, base_path, _) = DatasetBuilder::from_uri(self.table_uri())
             .with_session(control_session)
             .build_object_store()
             .await

--- a/crates/omnigraph/src/db/manifest/publisher.rs
+++ b/crates/omnigraph/src/db/manifest/publisher.rs
@@ -203,6 +203,15 @@ struct LoadedPublishState {
     graph_heads: HashMap<String, String>,
 }
 
+/// What `fold_inputs` folds a publish batch down to: the alias/path
+/// registrations after the batch, the surviving version entries, and the
+/// `(identity, version)` pairs the batch tombstoned.
+type FoldedPublishInputs = (
+    HashMap<TableIdentity, TableRegistration>,
+    Vec<SubTableEntry>,
+    Vec<(TableIdentity, u64)>,
+);
+
 impl GraphNamespacePublisher {
     #[cfg(test)]
     pub(super) fn new(root_uri: &str, branch: Option<&str>) -> Self {
@@ -696,11 +705,7 @@ impl GraphNamespacePublisher {
         existing_tombstones: &HashMap<(TableIdentity, u64), ()>,
         rows: &[PendingVersionRow],
         registered_tables: &HashMap<TableIdentity, TableRegistration>,
-    ) -> Result<(
-        HashMap<TableIdentity, TableRegistration>,
-        Vec<SubTableEntry>,
-        Vec<(TableIdentity, u64)>,
-    )> {
+    ) -> Result<FoldedPublishInputs> {
         let mut registrations = registered_tables.clone();
         for row in rows {
             if row.object_type == OBJECT_TYPE_TABLE {
@@ -951,10 +956,9 @@ impl GraphNamespacePublisher {
         let registrations = self.load_publish_state().await?.registered_tables;
         let changes = requests
             .iter()
-            .cloned()
             .map(|request| {
                 let (table_key, table_version, row_count, table_branch, version_metadata) =
-                    parse_namespace_version_request(&request)
+                    parse_namespace_version_request(request)
                         .map_err(|e| OmniError::Lance(e.to_string()))?;
                 let identity = registrations
                     .values()

--- a/crates/omnigraph/src/db/manifest/recovery.rs
+++ b/crates/omnigraph/src/db/manifest/recovery.rs
@@ -6099,10 +6099,10 @@ fn has_fixed_rollback_identity(sidecar: &RecoverySidecar) -> bool {
     has_exact_protocol(sidecar) || sidecar.ensure_indices_rollback_v6.is_some()
 }
 
-fn v4_effect_for<'a>(
-    sidecar: &'a RecoverySidecar,
+fn v4_effect_for(
+    sidecar: &RecoverySidecar,
     identity: TableIdentity,
-) -> Option<&'a RecoveryBranchMergeEffect> {
+) -> Option<&RecoveryBranchMergeEffect> {
     sidecar
         .protocol_v4
         .as_ref()?
@@ -10432,7 +10432,7 @@ mod tests {
         };
         let proof = prove_branch_merge_multi_commit_effect(
             &observation,
-            &[planned.clone()],
+            std::slice::from_ref(&planned),
             1,
             "node:Person",
         )

--- a/crates/omnigraph/src/db/manifest/tests.rs
+++ b/crates/omnigraph/src/db/manifest/tests.rs
@@ -1457,7 +1457,7 @@ async fn test_commit_with_expected_accepts_matching_versions() {
         },
     );
 
-    mc.commit_with_expected(&[update.clone()], &expected)
+    mc.commit_with_expected(std::slice::from_ref(&update), &expected)
         .await
         .expect("matching expected versions should publish cleanly");
 
@@ -1918,8 +1918,8 @@ async fn sub_current_graph_is_refused_then_rebuilt_via_export_import() {
     // before upgrading.
     let dir_old = tempfile::tempdir().unwrap();
     let uri_old = dir_old.path().to_str().unwrap();
-    let mut db_old = Omnigraph::init(uri_old, schema).await.unwrap();
-    load_jsonl(&mut db_old, seed, LoadMode::Overwrite)
+    let db_old = Omnigraph::init(uri_old, schema).await.unwrap();
+    load_jsonl(&db_old, seed, LoadMode::Overwrite)
         .await
         .unwrap();
     let exported = db_old.export_jsonl("main", &[], &[]).await.unwrap();
@@ -1954,8 +1954,8 @@ async fn sub_current_graph_is_refused_then_rebuilt_via_export_import() {
     // Rebuild with this binary: fresh init + load the export.
     let dir_new = tempfile::tempdir().unwrap();
     let uri_new = dir_new.path().to_str().unwrap();
-    let mut db_new = Omnigraph::init(uri_new, schema).await.unwrap();
-    load_jsonl(&mut db_new, &exported, LoadMode::Overwrite)
+    let db_new = Omnigraph::init(uri_new, schema).await.unwrap();
+    load_jsonl(&db_new, &exported, LoadMode::Overwrite)
         .await
         .unwrap();
 
@@ -2126,12 +2126,11 @@ async fn exact_publish_rejects_named_branch_delete_recreate_aba() {
     let old_branch = open_manifest_dataset(uri, Some("feature")).await.unwrap();
     let old_identifier = old_branch.branch_identifier().await.unwrap();
     assert!(
-        read_publish_scan(&old_branch)
+        !read_publish_scan(&old_branch)
             .await
             .unwrap()
             .graph_heads
-            .get("feature")
-            .is_none(),
+            .contains_key("feature"),
         "fresh named branch starts without its own graph_head row"
     );
 

--- a/crates/omnigraph/src/db/omnigraph.rs
+++ b/crates/omnigraph/src/db/omnigraph.rs
@@ -4017,10 +4017,10 @@ edge WorksAt: Person -> Company
         // no `__run__` branch behind, so schema apply proceeds.
         let dir = tempfile::tempdir().unwrap();
         let uri = dir.path().to_str().unwrap();
-        let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+        let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
 
         crate::loader::load_jsonl(
-            &mut db,
+            &db,
             r#"{"type": "Person", "data": {"name": "Alice", "age": 30}}"#,
             crate::loader::LoadMode::Overwrite,
         )

--- a/crates/omnigraph/src/db/omnigraph/optimize.rs
+++ b/crates/omnigraph/src/db/omnigraph/optimize.rs
@@ -285,15 +285,14 @@ pub async fn optimize_all_tables(db: &Omnigraph) -> Result<Vec<TableOptimizeStat
     // node/edge types) — the internal system tables below must still be compacted.
     let concurrency = maint_concurrency().min(table_tasks.len()).max(1);
 
-    let preparations: Vec<Result<OptimizePreparation>> =
-        futures::stream::iter(table_tasks.into_iter())
-            .map(|task| {
-                let catalog = std::sync::Arc::clone(&catalog);
-                async move { prepare_optimize_table(db, catalog.as_ref(), task).await }
-            })
-            .buffer_unordered(concurrency)
-            .collect()
-            .await;
+    let preparations: Vec<Result<OptimizePreparation>> = futures::stream::iter(table_tasks)
+        .map(|task| {
+            let catalog = std::sync::Arc::clone(&catalog);
+            async move { prepare_optimize_table(db, catalog.as_ref(), task).await }
+        })
+        .buffer_unordered(concurrency)
+        .collect()
+        .await;
 
     let mut prepared = Vec::new();
     let mut stats = Vec::new();
@@ -332,15 +331,14 @@ pub async fn optimize_all_tables(db: &Omnigraph) -> Result<Vec<TableOptimizeStat
         // siblings: after the shared sidecar is armed, recovery needs the most
         // knowable completed effect set possible.
         let effect_concurrency = maint_concurrency().min(prepared.len()).max(1);
-        let effect_results: Vec<Result<OptimizeEffectOutcome>> =
-            futures::stream::iter(prepared.into_iter())
-                .map(|work| {
-                    let catalog = std::sync::Arc::clone(&catalog);
-                    async move { apply_optimize_table_effects(db, catalog.as_ref(), work).await }
-                })
-                .buffer_unordered(effect_concurrency)
-                .collect()
-                .await;
+        let effect_results: Vec<Result<OptimizeEffectOutcome>> = futures::stream::iter(prepared)
+            .map(|work| {
+                let catalog = std::sync::Arc::clone(&catalog);
+                async move { apply_optimize_table_effects(db, catalog.as_ref(), work).await }
+            })
+            .buffer_unordered(effect_concurrency)
+            .collect()
+            .await;
 
         let mut outcomes = Vec::new();
         let mut first_error = None;
@@ -1184,7 +1182,7 @@ pub async fn cleanup_all_tables(
     // stats row (`error: Some`) and logged, never aborting the healthy tables.
     // cleanup is the convergence backstop, so it must do as much as it can and
     // converge on re-run rather than fail wholesale (invariant 13).
-    let results: Vec<TableCleanupStats> = futures::stream::iter(table_tasks.into_iter())
+    let results: Vec<TableCleanupStats> = futures::stream::iter(table_tasks)
         .map(|(table_key, full_path, live_main_floor)| async move {
             let outcome: Result<RemovalStats> = async {
                 crate::failpoints::maybe_fail(crate::failpoints::names::CLEANUP_TABLE_GC)?;
@@ -1548,9 +1546,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let uri = dir.path().to_str().unwrap();
         let schema = "node Person { name: String @key }\nnode Company { name: String @key }\n";
-        let mut db = Omnigraph::init(uri, schema).await.unwrap();
+        let db = Omnigraph::init(uri, schema).await.unwrap();
         load_jsonl(
-            &mut db,
+            &db,
             "{\"type\":\"Person\",\"data\":{\"name\":\"Alice\"}}\n\
              {\"type\":\"Company\",\"data\":{\"name\":\"Acme\"}}",
             LoadMode::Merge,

--- a/crates/omnigraph/src/db/omnigraph/schema_apply.rs
+++ b/crates/omnigraph/src/db/omnigraph/schema_apply.rs
@@ -1383,11 +1383,11 @@ async fn rebuild_blob_column(
     let mut non_null_row_ids = Vec::new();
     let mut row_has_blob = Vec::with_capacity(row_ids.len());
 
-    for row in 0..row_ids.len() {
+    for (row, row_id) in row_ids.iter().enumerate() {
         let is_null = blob_description_is_null(descriptions, row)?;
         row_has_blob.push(!is_null);
         if !is_null {
-            non_null_row_ids.push(row_ids[row]);
+            non_null_row_ids.push(*row_id);
         }
     }
 

--- a/crates/omnigraph/src/db/omnigraph/table_ops.rs
+++ b/crates/omnigraph/src/db/omnigraph/table_ops.rs
@@ -725,14 +725,14 @@ async fn plan_index_work_node(
                     }
                 }
             }
-            Some(NodePropIndexKind::Btree) => {
-                if !db.storage().has_btree_index(ds, prop_name).await? {
-                    work.push_spec(crate::storage_layer::IndexBuildSpec::BTree {
-                        column: prop_name.clone(),
-                    });
-                }
+            Some(NodePropIndexKind::Btree)
+                if !db.storage().has_btree_index(ds, prop_name).await? =>
+            {
+                work.push_spec(crate::storage_layer::IndexBuildSpec::BTree {
+                    column: prop_name.clone(),
+                });
             }
-            None => {}
+            Some(NodePropIndexKind::Btree) | None => {}
         }
     }
     Ok(work)
@@ -765,7 +765,7 @@ async fn plan_index_work_edge_on_dataset(
     db: &Omnigraph,
     ds: &SnapshotHandle,
 ) -> Result<PlannedIndexWork> {
-    if db.storage().count_rows(&ds, None).await? == 0 {
+    if db.storage().count_rows(ds, None).await? == 0 {
         return Ok(PlannedIndexWork::default());
     }
     let mut work = PlannedIndexWork::default();

--- a/crates/omnigraph/src/exec/query.rs
+++ b/crates/omnigraph/src/exec/query.rs
@@ -1541,7 +1541,7 @@ async fn execute_expand_bound(
             edge_def
                 .arrow_schema
                 .field_with_name(name)
-                .map(Clone::clone)
+                .cloned()
                 .map_err(|e| OmniError::manifest(e.to_string()))
         })
         .collect::<Result<_>>()?;
@@ -2872,7 +2872,7 @@ fn cross_join_batches(left: &RecordBatch, right: &RecordBatch) -> Result<RecordB
         return Ok(RecordBatch::new_empty(Arc::new(Schema::new(fields))));
     }
     let left_indices: Vec<u32> = (0..n as u32)
-        .flat_map(|i| std::iter::repeat(i).take(m))
+        .flat_map(|i| std::iter::repeat_n(i, m))
         .collect();
     let right_indices: Vec<u32> = (0..n).flat_map(|_| 0..m as u32).collect();
     let left_expanded = take_batch(left, &UInt32Array::from(left_indices))?;

--- a/crates/omnigraph/src/failpoints.rs
+++ b/crates/omnigraph/src/failpoints.rs
@@ -5,10 +5,10 @@ pub(crate) fn maybe_fail(_name: &str) -> Result<()> {
     {
         let name = _name;
         fail::fail_point!(name, |_| {
-            return Err(crate::error::OmniError::manifest(format!(
+            Err(crate::error::OmniError::manifest(format!(
                 "injected failpoint triggered: {}",
                 name
-            )));
+            )))
         });
     }
     Ok(())
@@ -25,9 +25,9 @@ pub(crate) fn maybe_fail_retryable_contention(name: &str) -> Result<()> {
     #[cfg(feature = "failpoints")]
     {
         fail::fail_point!(name, |_| {
-            return Err(crate::error::OmniError::manifest_row_level_cas_contention(
+            Err(crate::error::OmniError::manifest_row_level_cas_contention(
                 format!("injected retryable contention failpoint: {name}"),
-            ));
+            ))
         });
     }
     Ok(())

--- a/crates/omnigraph/src/graph_index/mod.rs
+++ b/crates/omnigraph/src/graph_index/mod.rs
@@ -40,6 +40,9 @@ impl TypeIndex {
         self.dense_to_id.get(dense as usize).map(|s| s.as_str())
     }
 
+    // The size of the dense id space, consumed as a CSR row width; emptiness is
+    // not a meaningful question for it.
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.dense_to_id.len()
     }

--- a/crates/omnigraph/src/instrumentation.rs
+++ b/crates/omnigraph/src/instrumentation.rs
@@ -583,6 +583,9 @@ pub struct CountingStorageAdapter {
 
 impl CountingStorageAdapter {
     /// Wrap `inner`, returning the adapter and a shared handle to its counts.
+    // Returns the erased `Arc<dyn StorageAdapter>` the engine consumes plus the
+    // counts handle; a bare `Self` would leave the caller unable to read them.
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(
         inner: Arc<dyn StorageAdapter>,
     ) -> (Arc<dyn StorageAdapter>, Arc<StorageReadCounts>) {

--- a/crates/omnigraph/src/loader/mod.rs
+++ b/crates/omnigraph/src/loader/mod.rs
@@ -918,7 +918,7 @@ fn validate_graph_batch_json_structure(raw_json: &[u8]) -> Result<()> {
             continue;
         }
         if matches!(byte, b'{' | b'}' | b'[' | b']' | b',' | b':') {
-            slots = slots.checked_add(1).unwrap_or(u64::MAX);
+            slots = slots.saturating_add(1);
             if slots > GRAPH_BATCH_JSON_MAX_STRUCTURAL_SLOTS {
                 return Err(OmniError::resource_limit(
                     "graph_batch_json_structural_slots",
@@ -1770,7 +1770,10 @@ fn validate_required_row_string<'a>(
     }
 }
 
+// Single-row test shim over `preflight_strict_row_arrow_bytes_with_limit`,
+// kept next to the strict-row staged-write preflight helpers.
 #[cfg(test)]
+#[allow(dead_code)]
 fn preflight_strict_row_arrow_bytes(
     schema: &arrow_schema::Schema,
     object: &serde_json::Map<String, JsonValue>,
@@ -1787,9 +1790,8 @@ fn preflight_strict_row_arrow_bytes_with_limit(
     let mut projected = 0_u64;
     for field in schema.fields() {
         let value = object.get(field.name()).unwrap_or(&JsonValue::Null);
-        projected = projected
-            .checked_add(projected_strict_column_bytes(field.data_type(), value)?)
-            .unwrap_or(u64::MAX);
+        projected =
+            projected.saturating_add(projected_strict_column_bytes(field.data_type(), value)?);
         if projected > limit {
             return Err(OmniError::resource_limit(
                 "strict_input_arrow_bytes",
@@ -1816,7 +1818,7 @@ fn preflight_strict_rows_arrow_bytes(
             } else {
                 projected_strict_column_bytes(field.data_type(), value)?
             };
-            projected = projected.checked_add(field_bytes).unwrap_or(u64::MAX);
+            projected = projected.saturating_add(field_bytes);
             if projected > limit {
                 return Err(OmniError::resource_limit(
                     "strict_input_arrow_bytes",
@@ -1849,8 +1851,7 @@ fn projected_strict_column_bytes(data_type: &DataType, value: &JsonValue) -> Res
             if let Some(items) = value.as_array() {
                 for item in items {
                     bytes = bytes
-                        .checked_add(projected_strict_list_item_bytes(child.data_type(), item)?)
-                        .unwrap_or(u64::MAX);
+                        .saturating_add(projected_strict_list_item_bytes(child.data_type(), item)?);
                 }
             }
             bytes
@@ -1862,9 +1863,7 @@ fn projected_strict_column_bytes(data_type: &DataType, value: &JsonValue) -> Res
                 ))
             })?;
             let child_width = projected_strict_fixed_width(child.data_type())?;
-            ARRAY_BUFFER_OVERHEAD
-                .checked_add(dimension.checked_mul(child_width + 1).unwrap_or(u64::MAX))
-                .unwrap_or(u64::MAX)
+            ARRAY_BUFFER_OVERHEAD.saturating_add(dimension.saturating_mul(child_width + 1))
         }
         other => {
             return Err(OmniError::manifest(format!(
@@ -3403,9 +3402,9 @@ node Doc {
     async fn test_load_creates_data() {
         let dir = tempfile::tempdir().unwrap();
         let uri = dir.path().to_str().unwrap();
-        let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+        let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
 
-        let result = load_jsonl(&mut db, TEST_DATA, LoadMode::Overwrite)
+        let result = load_jsonl(&db, TEST_DATA, LoadMode::Overwrite)
             .await
             .unwrap();
 
@@ -3419,8 +3418,8 @@ node Doc {
     async fn test_load_data_readable_via_lance() {
         let dir = tempfile::tempdir().unwrap();
         let uri = dir.path().to_str().unwrap();
-        let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
-        load_jsonl(&mut db, TEST_DATA, LoadMode::Overwrite)
+        let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+        load_jsonl(&db, TEST_DATA, LoadMode::Overwrite)
             .await
             .unwrap();
 
@@ -3457,8 +3456,8 @@ node Doc {
     async fn test_load_edges_reference_node_keys() {
         let dir = tempfile::tempdir().unwrap();
         let uri = dir.path().to_str().unwrap();
-        let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
-        load_jsonl(&mut db, TEST_DATA, LoadMode::Overwrite)
+        let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+        load_jsonl(&db, TEST_DATA, LoadMode::Overwrite)
             .await
             .unwrap();
 
@@ -3496,10 +3495,10 @@ node Doc {
     async fn test_load_manifest_version_advances() {
         let dir = tempfile::tempdir().unwrap();
         let uri = dir.path().to_str().unwrap();
-        let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+        let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
         let v1 = db.version().await;
 
-        load_jsonl(&mut db, TEST_DATA, LoadMode::Overwrite)
+        load_jsonl(&db, TEST_DATA, LoadMode::Overwrite)
             .await
             .unwrap();
 
@@ -3510,15 +3509,13 @@ node Doc {
     async fn test_load_append_adds_rows() {
         let dir = tempfile::tempdir().unwrap();
         let uri = dir.path().to_str().unwrap();
-        let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+        let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
 
         let batch1 = r#"{"type": "Person", "data": {"name": "Alice", "age": 30}}"#;
         let batch2 = r#"{"type": "Person", "data": {"name": "Bob", "age": 25}}"#;
 
-        load_jsonl(&mut db, batch1, LoadMode::Overwrite)
-            .await
-            .unwrap();
-        load_jsonl(&mut db, batch2, LoadMode::Append).await.unwrap();
+        load_jsonl(&db, batch1, LoadMode::Overwrite).await.unwrap();
+        load_jsonl(&db, batch2, LoadMode::Append).await.unwrap();
 
         let snap = db.snapshot().await;
         let person_ds = snap.open("node:Person").await.unwrap();
@@ -3529,10 +3526,10 @@ node Doc {
     async fn test_load_unknown_type_rejected() {
         let dir = tempfile::tempdir().unwrap();
         let uri = dir.path().to_str().unwrap();
-        let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+        let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
 
         let bad = r#"{"type": "FakeType", "data": {"name": "x"}}"#;
-        let result = load_jsonl(&mut db, bad, LoadMode::Overwrite).await;
+        let result = load_jsonl(&db, bad, LoadMode::Overwrite).await;
         assert!(result.is_err());
     }
 
@@ -3586,8 +3583,8 @@ node Doc {
     async fn test_ingest_existing_branch_ignores_from_and_merges_data() {
         let dir = tempfile::tempdir().unwrap();
         let uri = dir.path().to_str().unwrap();
-        let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
-        load_jsonl(&mut db, TEST_DATA, LoadMode::Overwrite)
+        let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+        load_jsonl(&db, TEST_DATA, LoadMode::Overwrite)
             .await
             .unwrap();
         db.branch_create_from(crate::db::ReadTarget::branch("main"), "feature")

--- a/crates/omnigraph/src/storage_layer.rs
+++ b/crates/omnigraph/src/storage_layer.rs
@@ -353,6 +353,9 @@ impl ExactCommitOutcome {
 /// pay a clone cost per element. `StagedWrite::clone` is cheap because
 /// `Transaction`, commit metadata, and `Vec<Fragment>` are shallow-clone
 /// friendly.
+// Staged-write helper retained alongside the sealed storage surface (it
+// adapts `StagedHandle`s for `stage_append`'s `prior_stages`).
+#[allow(dead_code)]
 pub(crate) fn staged_handles_as_writes(handles: &[StagedHandle]) -> Vec<StagedWrite> {
     handles.iter().map(|h| h.inner.clone()).collect()
 }
@@ -385,6 +388,10 @@ pub enum ForkOutcome<D> {
 /// `TableStore` is the only `impl`. The trait is sealed; the inline
 /// Lance APIs are not reachable through trait dispatch. New writers that
 /// might advance Lance HEAD MUST add a staged-shape method here.
+// Sealed storage surface: the trait defines the full staged-write
+// vocabulary, so not every method has a caller. Pinned by name in
+// tests/forbidden_apis.rs — deleting one shrinks the audited gateway.
+#[allow(dead_code)]
 #[async_trait]
 pub trait TableStorage: sealed::Sealed + Send + Sync + Debug {
     // ── Snapshot opens (no HEAD advance) ────────────────────────────────

--- a/crates/omnigraph/src/table_store.rs
+++ b/crates/omnigraph/src/table_store.rs
@@ -175,6 +175,9 @@ impl From<&Transaction> for StagedTransactionIdentity {
 /// Without `removed_fragment_ids`, a `stage_merge_insert` that rewrites
 /// existing fragments would yield duplicate rows (the original fragment
 /// stays in the committed manifest while its rewrite shows up in `new_fragments`).
+// Sealed storage surface: `new_fragments`/`removed_fragment_ids` record the
+// read-your-writes fragment delta of a staged effect.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct StagedWrite {
     transaction: Transaction,
@@ -210,6 +213,9 @@ impl StagedCommitMetadata {
     }
 }
 
+// Sealed storage surface: the `new_fragments`/`removed_fragment_ids`
+// accessors complete the staged-effect vocabulary.
+#[allow(dead_code)]
 impl StagedWrite {
     fn new(
         transaction: Transaction,
@@ -299,6 +305,8 @@ impl TableStore {
         }
     }
 
+    // Sealed storage surface, pinned by name in tests/forbidden_apis.rs; no
+    #[allow(dead_code)]
     pub fn root_uri(&self) -> &str {
         &self.root_uri
     }
@@ -471,7 +479,7 @@ impl TableStore {
         )
         .await?
         {
-            crate::branch_control::BranchCreateOutcome::Created(dataset) => dataset,
+            crate::branch_control::BranchCreateOutcome::Created(dataset) => *dataset,
             crate::branch_control::BranchCreateOutcome::RefAlreadyExists => {
                 return Ok(ForkOutcome::RefAlreadyExists);
             }
@@ -497,6 +505,8 @@ impl TableStore {
         self.scan(ds, None, None, None).await
     }
 
+    // Sealed storage surface, pinned by name in tests/forbidden_apis.rs; no
+    #[allow(dead_code)]
     pub async fn scan_batches_for_rewrite(&self, ds: &Dataset) -> Result<Vec<RecordBatch>> {
         let has_blob_columns = ds.schema().fields_pre_order().any(|field| field.is_blob());
         if !has_blob_columns {
@@ -520,6 +530,8 @@ impl TableStore {
     /// downstream writer never materializes the whole table in memory. Blob
     /// columns are rebuilt asynchronously one scanner batch at a time; ordinary
     /// columns pass through the native lazy scan.
+    // Sealed storage surface, pinned by name in tests/forbidden_apis.rs; no
+    #[allow(dead_code)]
     pub async fn scan_stream_for_rewrite(&self, ds: &Dataset) -> Result<SendableRecordBatchStream> {
         let has_blob_columns = ds.schema().fields_pre_order().any(|field| field.is_blob());
         if has_blob_columns {
@@ -643,6 +655,9 @@ impl TableStore {
         Box::pin(RecordBatchStreamAdapter::new(schema, materialized))
     }
 
+    // Sealed storage surface, pinned by name in tests/forbidden_apis.rs; its
+    // only caller is the equally-unused `scan_batches_for_rewrite`.
+    #[allow(dead_code)]
     pub(crate) async fn materialize_blob_batch(
         ds: &Dataset,
         batch: RecordBatch,
@@ -758,11 +773,11 @@ impl TableStore {
         let mut non_null_row_ids = Vec::new();
         let mut row_has_blob = Vec::with_capacity(row_ids.len());
 
-        for row in 0..row_ids.len() {
+        for (row, row_id) in row_ids.iter().enumerate() {
             let is_null = Self::blob_description_is_null(descriptions, row)?;
             row_has_blob.push(!is_null);
             if !is_null {
-                non_null_row_ids.push(row_ids[row]);
+                non_null_row_ids.push(*row_id);
             }
         }
 
@@ -1152,7 +1167,6 @@ impl TableStore {
     pub async fn count_rows(&self, ds: &Dataset, filter: Option<String>) -> Result<usize> {
         ds.count_rows(filter)
             .await
-            .map(|count| count as usize)
             .map_err(|e| OmniError::Lance(e.to_string()))
     }
 
@@ -1170,12 +1184,13 @@ impl TableStore {
 
     /// Legacy inline-commit append: writes fragments AND commits in one
     /// call, advancing Lance HEAD as a side effect. Not on the
-    /// `TableStorage` trait surface — the staged primitive `stage_append`
-    /// + `commit_staged` is the engine write path. This inherent method
-    /// survives only for in-source recovery test setup, so it is
-    /// `#[cfg(test)]`-gated: engine code physically cannot call it (which
-    /// enforces "no new call sites" by construction and silences the
-    /// dead-code warning the non-test lib build would otherwise emit).
+    /// `TableStorage` trait surface — the staged primitive
+    /// `stage_append` + `commit_staged` is the engine write path. This
+    /// inherent method survives only for in-source recovery test setup,
+    /// so it is `#[cfg(test)]`-gated: engine code physically cannot call
+    /// it (which enforces "no new call sites" by construction and
+    /// silences the dead-code warning the non-test lib build would
+    /// otherwise emit).
     #[cfg(test)]
     pub(crate) async fn append_batch(
         &self,
@@ -2596,6 +2611,8 @@ impl TableStore {
     /// the committed scan via DataFusion `MemTable` for read-your-writes
     /// (see `scan_with_pending`), and no production caller passes a filter
     /// here. This method remains on the surface for primitive-level testing.
+    // Sealed storage surface, pinned by name in tests/forbidden_apis.rs; no
+    #[allow(dead_code)]
     pub async fn scan_with_staged(
         &self,
         ds: &Dataset,
@@ -2687,7 +2704,7 @@ impl TableStore {
         // either (a) include the key in projection or (b) drop
         // `key_column` if union is what they wanted.
         if let (Some(key_col), Some(cols)) = (key_column, projection) {
-            if !cols.iter().any(|c| *c == key_col) {
+            if !cols.contains(&key_col) {
                 return Err(OmniError::Lance(format!(
                     "scan_with_pending: key_column '{}' must appear in projection \
                      when merge-shadow semantics are requested (got projection = {:?})",
@@ -2927,6 +2944,8 @@ impl TableStore {
     /// edge-cardinality validation that needs to see staged edges before
     /// commit. Same `committed - removed + new` composition as
     /// `scan_with_staged`.
+    // Sealed storage surface, pinned by name in tests/forbidden_apis.rs; no
+    #[allow(dead_code)]
     pub async fn count_rows_with_staged(
         &self,
         ds: &Dataset,
@@ -3033,7 +3052,7 @@ impl TableStore {
             batch
                 .column_by_name("_rowid")
                 .and_then(|col| col.as_any().downcast_ref::<UInt64Array>())
-                .and_then(|arr| (arr.len() > 0).then(|| arr.value(0)))
+                .and_then(|arr| (!arr.is_empty()).then(|| arr.value(0)))
         }))
     }
 
@@ -3099,6 +3118,8 @@ fn map_lance_commit_error(error: lance::Error) -> OmniError {
 /// `stage_append`'s D₂′ contract. For `stage_merge_insert` results the
 /// `new_fragments` include rewrites that don't add new rows, so this
 /// would over-count.
+// Staged-write helper retained alongside the sealed storage surface; no
+#[allow(dead_code)]
 fn prior_stages_fragment_count(prior_stages: &[StagedWrite]) -> u64 {
     prior_stages
         .iter()
@@ -3121,6 +3142,8 @@ fn assign_fragment_ids(fragments: &mut [Fragment], start_id: u64) {
     }
 }
 
+// Staged-write helper retained alongside the sealed storage surface; no
+#[allow(dead_code)]
 fn prior_stages_row_count(prior_stages: &[StagedWrite]) -> Result<u64> {
     let mut total: u64 = 0;
     for stage in prior_stages {
@@ -3440,6 +3463,9 @@ async fn scan_pending_batches(
         .map_err(|e| OmniError::Lance(e.to_string()))
 }
 
+// Staged-write helper retained alongside the sealed storage surface; its
+// only callers are the equally-unused `*_with_staged` methods.
+#[allow(dead_code)]
 fn combine_committed_with_staged(ds: &Dataset, staged: &[StagedWrite]) -> Vec<Fragment> {
     let removed: std::collections::HashSet<u64> = staged
         .iter()
@@ -4386,6 +4412,8 @@ fn staged_keyed_merge_result(
 /// (`vec!["id".to_string()]`). The check restricts itself to that shape
 /// and surfaces an internal error if a future caller passes anything
 /// else — keeping the assumption explicit instead of silently degrading.
+// Staged-write helper retained alongside the sealed storage surface; no
+#[allow(dead_code)]
 fn check_batch_unique_by_keys(
     batch: &RecordBatch,
     key_columns: &[String],

--- a/crates/omnigraph/src/table_store.rs
+++ b/crates/omnigraph/src/table_store.rs
@@ -99,9 +99,9 @@ pub(crate) fn certified_insert_absence_rows(
         || fields_for_preserving_frag_bitmap != expected_schema_preorder_ids
         || update_mode != &Some(UpdateMode::RewriteRows)
         || updated_fragment_offsets.is_some()
-        || !inserted_rows_filter
+        || inserted_rows_filter
             .as_ref()
-            .is_some_and(|filter| filter.field_ids == vec![id_field_id])
+            .is_none_or(|filter| filter.field_ids != vec![id_field_id])
     {
         return None;
     }

--- a/crates/omnigraph/src/validate.rs
+++ b/crates/omnigraph/src/validate.rs
@@ -756,6 +756,10 @@ where
     Ok(violation_count)
 }
 
+/// One entry of the coalesced `final_by_id` image: `(id, (key column strings,
+/// typed key values))`.
+type FinalKeyByIdEntry = (String, (Vec<String>, Vec<ScalarValue>));
+
 /// Uniqueness for one `@unique`/`@key` group on `table_key`, evaluated against
 /// the delta's FINAL coalesced image (last-wins per id) — the same image commit
 /// persists. Three checks:
@@ -829,8 +833,7 @@ where
     }
 
     // Deterministic order — no HashMap iteration in violation ordering.
-    let mut entries: Vec<(String, (Vec<String>, Vec<ScalarValue>))> =
-        final_by_id.into_iter().collect();
+    let mut entries: Vec<FinalKeyByIdEntry> = final_by_id.into_iter().collect();
     entries.sort_by(|a, b| a.0.cmp(&b.0));
 
     // Pass 2: two DISTINCT ids holding the same final key.

--- a/crates/omnigraph/tests/aggregation.rs
+++ b/crates/omnigraph/tests/aggregation.rs
@@ -202,9 +202,7 @@ async fn inline_global_count_empty() {
     // Load only nodes, no edges
     let data = r#"{"type": "Person", "data": {"name": "Alice", "age": 30}}
 {"type": "Company", "data": {"name": "Acme"}}"#;
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
 
     // Global count — should return 1 row with count=1
     let queries = r#"

--- a/crates/omnigraph/tests/branching.rs
+++ b/crates/omnigraph/tests/branching.rs
@@ -124,8 +124,8 @@ fn write_sized_external_blob(path: &std::path::Path, bytes: u64) {
 
 async fn init_search_db(dir: &tempfile::TempDir) -> Omnigraph {
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, SEARCH_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, SEARCH_DATA, LoadMode::Overwrite)
+    let db = Omnigraph::init(uri, SEARCH_SCHEMA).await.unwrap();
+    load_jsonl(&db, SEARCH_DATA, LoadMode::Overwrite)
         .await
         .unwrap();
     db.ensure_indices().await.unwrap();
@@ -138,10 +138,8 @@ async fn init_db_from_schema_and_data(
     data: &str,
 ) -> Omnigraph {
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, schema).await.unwrap();
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    let db = Omnigraph::init(uri, schema).await.unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
     db
 }
 
@@ -165,7 +163,7 @@ async fn assert_exact_id_primary_key_on_branch(db: &Omnigraph, branch: &str, tab
 async fn branch_create_open_list_and_lazy_branching_work() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut main = init_and_load(&dir).await;
+    let main = init_and_load(&dir).await;
     let main_person = snapshot_main(&main)
         .await
         .unwrap()
@@ -237,7 +235,7 @@ async fn branch_create_open_list_and_lazy_branching_work() {
 #[tokio::test]
 async fn explicit_target_query_reads_multiple_branches_from_one_handle() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
 
     db.branch_create("feature").await.unwrap();
     db.mutate(
@@ -313,7 +311,7 @@ async fn resolved_snapshot_stays_pinned_after_branch_advances() {
 #[tokio::test]
 async fn explicit_target_load_writes_to_named_branch() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
 
     db.branch_create("feature").await.unwrap();
     db.load(
@@ -406,7 +404,7 @@ async fn branch_merge_with_blob_columns_preserves_blob_data() {
     let uri = dir.path().to_str().unwrap();
     let mut main = Omnigraph::init(uri, BLOB_SCHEMA).await.unwrap();
     load_jsonl(
-        &mut main,
+        &main,
         concat!(
             "{\"type\":\"Document\",\"data\":{\"title\":\"seed\",\"content\":\"base64:U2VlZA==\",\"note\":\"original\"}}\n",
             "{\"type\":\"Document\",\"data\":{\"title\":\"main-doc\",\"content\":\"base64:TWFpbg==\",\"note\":\"main\"}}",
@@ -498,15 +496,13 @@ async fn branch_merge_with_external_blob_uri_materializes_payload() {
     fs::write(&external_path, b"External").unwrap();
     let external_uri = format!("file://{}", external_path.display());
 
-    let mut main = Omnigraph::init(uri, BLOB_SCHEMA).await.unwrap();
-    load_jsonl(&mut main, "", LoadMode::Overwrite)
-        .await
-        .unwrap();
+    let main = Omnigraph::init(uri, BLOB_SCHEMA).await.unwrap();
+    load_jsonl(&main, "", LoadMode::Overwrite).await.unwrap();
     main.branch_create("feature").await.unwrap();
 
-    let mut feature = Omnigraph::open(uri).await.unwrap();
+    let feature = Omnigraph::open(uri).await.unwrap();
     load_jsonl(
-        &mut main,
+        &main,
         "{\"type\":\"Document\",\"data\":{\"title\":\"main-doc\",\"content\":\"base64:TWFpbg==\",\"note\":\"main\"}}",
         LoadMode::Append,
     )
@@ -577,11 +573,9 @@ async fn branch_merge_rejects_oversized_blob_payloads_pre_effect() {
         })
         .to_string();
 
-        let mut db = Omnigraph::init(graph_uri, WIDE_BLOB_SCHEMA).await.unwrap();
+        let db = Omnigraph::init(graph_uri, WIDE_BLOB_SCHEMA).await.unwrap();
         let base = r#"{"type":"Document","data":{"title":"base"}}"#;
-        load_jsonl(&mut db, base, LoadMode::Overwrite)
-            .await
-            .unwrap();
+        load_jsonl(&db, base, LoadMode::Overwrite).await.unwrap();
         db.branch_create("feature").await.unwrap();
         db.load(
             "feature",
@@ -646,7 +640,7 @@ async fn branch_merge_rejects_oversized_blob_payloads_pre_effect() {
 async fn branch_merge_applies_node_insert_to_main() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut main = init_and_load(&dir).await;
+    let main = init_and_load(&dir).await;
     main.branch_create("feature").await.unwrap();
 
     let mut feature = Omnigraph::open(uri).await.unwrap();
@@ -679,7 +673,7 @@ async fn branch_merge_applies_node_insert_to_main() {
 async fn branch_merge_records_single_latest_commit_with_two_parents() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut main = init_and_load(&dir).await;
+    let main = init_and_load(&dir).await;
     main.branch_create("feature").await.unwrap();
 
     let mut feature = Omnigraph::open(uri).await.unwrap();
@@ -913,7 +907,7 @@ async fn same_branch_update_after_external_commit_and_read_is_linear() {
 async fn branch_merge_records_actor_on_latest_commit() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut main = init_and_load(&dir).await;
+    let main = init_and_load(&dir).await;
     main.branch_create("feature").await.unwrap();
 
     let mut feature = Omnigraph::open(uri).await.unwrap();
@@ -947,7 +941,7 @@ async fn branch_merge_records_actor_on_latest_commit() {
 async fn already_up_to_date_branch_merge_returns_without_new_commit() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut main = init_and_load(&dir).await;
+    let main = init_and_load(&dir).await;
     main.branch_create("feature").await.unwrap();
 
     let source_head_before = CommitGraph::open_at_branch(uri, "feature")
@@ -1152,7 +1146,7 @@ async fn merged_rewritten_indexed_table_is_searchable_immediately() {
 async fn explicit_target_reads_see_branch_local_writes_without_refresh() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut main = init_and_load(&dir).await;
+    let main = init_and_load(&dir).await;
     main.branch_create("feature").await.unwrap();
 
     let mut writer = Omnigraph::open(uri).await.unwrap();
@@ -1195,7 +1189,7 @@ async fn explicit_target_reads_see_branch_local_writes_without_refresh() {
 async fn branch_created_from_non_main_inherits_branch_state() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut main = init_and_load(&dir).await;
+    let main = init_and_load(&dir).await;
     main.branch_create("feature").await.unwrap();
 
     let mut feature = Omnigraph::open(uri).await.unwrap();
@@ -1258,7 +1252,7 @@ async fn branch_created_from_non_main_inherits_branch_state() {
 async fn ensure_indices_on_child_branch_keeps_inherited_table_when_no_work_is_needed() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut main = init_and_load(&dir).await;
+    let main = init_and_load(&dir).await;
     main.branch_create("feature").await.unwrap();
 
     let mut feature = Omnigraph::open(uri).await.unwrap();
@@ -1276,7 +1270,7 @@ async fn ensure_indices_on_child_branch_keeps_inherited_table_when_no_work_is_ne
         .await
         .unwrap();
 
-    let mut experiment = Omnigraph::open(uri).await.unwrap();
+    let experiment = Omnigraph::open(uri).await.unwrap();
     let experiment_inherited = snapshot_branch(&experiment, "experiment").await.unwrap();
     assert_eq!(
         experiment_inherited
@@ -1350,7 +1344,7 @@ async fn ensure_indices_on_child_branch_keeps_inherited_table_when_no_work_is_ne
 async fn branch_edge_only_write_only_branches_edge_table() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut main = init_and_load(&dir).await;
+    let main = init_and_load(&dir).await;
     main.branch_create("feature").await.unwrap();
 
     let mut feature = Omnigraph::open(uri).await.unwrap();
@@ -1405,7 +1399,7 @@ async fn branch_edge_only_write_only_branches_edge_table() {
 async fn branch_merge_into_non_main_target_works() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut main = init_and_load(&dir).await;
+    let main = init_and_load(&dir).await;
     main.branch_create("feature").await.unwrap();
 
     let mut feature = Omnigraph::open(uri).await.unwrap();
@@ -1722,7 +1716,7 @@ query delete_person($name: String) {
 #[tokio::test]
 async fn branch_api_rejects_reserved_main_and_same_source_target_merge() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
 
     let err = db.branch_create("main").await.unwrap_err();
     assert!(err.to_string().contains("cannot create branch 'main'"));
@@ -1788,7 +1782,7 @@ async fn branch_delete_removes_owned_table_branches_and_allows_recreate() {
 #[tokio::test]
 async fn branch_namespace_rejects_live_physical_path_prefix_collisions() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
 
     db.branch_create("feature").await.unwrap();
     let err = db.branch_create("feature/child").await.unwrap_err();
@@ -1831,7 +1825,7 @@ async fn branch_namespace_rejects_live_physical_path_prefix_collisions() {
 async fn branch_delete_refuses_legacy_physical_path_children() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
     db.branch_create("feature/child").await.unwrap();
 
     // Forge a graph written before the prefix-disjoint namespace invariant.
@@ -1874,7 +1868,7 @@ async fn branch_delete_refuses_legacy_physical_path_children() {
 async fn branch_delete_rejects_branches_still_referenced_by_descendants() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut main = init_and_load(&dir).await;
+    let main = init_and_load(&dir).await;
 
     main.branch_create("feature").await.unwrap();
     let mut feature = Omnigraph::open(uri).await.unwrap();
@@ -1984,7 +1978,7 @@ async fn merged_table_preserves_row_version_for_unchanged_rows() {
 #[tokio::test]
 async fn edge_tables_have_id_btree_after_ensure_indices() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
     db.ensure_indices().await.unwrap();
 
     let snap = snapshot_main(&db).await.unwrap();

--- a/crates/omnigraph/tests/changes.rs
+++ b/crates/omnigraph/tests/changes.rs
@@ -494,7 +494,7 @@ async fn diff_after_merge_reports_actual_changes() {
 
     // Bob's update should be detected
     assert!(
-        !person_updates.is_empty() || person_inserts.len() > 0,
+        !person_updates.is_empty() || !person_inserts.is_empty(),
         "Should detect Bob's age update or Eve's insert"
     );
 }
@@ -503,7 +503,7 @@ async fn diff_after_merge_reports_actual_changes() {
 async fn diff_commits_resolves_feature_commit_from_main_handle() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut main = init_and_load(&dir).await;
+    let main = init_and_load(&dir).await;
     main.branch_create("feature").await.unwrap();
 
     let mut feature = Omnigraph::open(uri).await.unwrap();
@@ -550,7 +550,7 @@ async fn diff_commits_resolves_feature_commit_from_main_handle() {
 async fn cross_branch_diff_honors_insert_only_filter() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut main = init_and_load(&dir).await;
+    let main = init_and_load(&dir).await;
     main.branch_create("feature").await.unwrap();
 
     let mut feature = Omnigraph::open(uri).await.unwrap();
@@ -601,7 +601,7 @@ async fn cross_branch_diff_honors_insert_only_filter() {
 async fn diff_commits_resolves_commits_across_branches_from_any_handle() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut main = init_and_load(&dir).await;
+    let main = init_and_load(&dir).await;
     let base_commit = head_commit_id(uri, None).await;
 
     main.branch_create("feature").await.unwrap();
@@ -636,7 +636,7 @@ async fn diff_commits_resolves_commits_across_branches_from_any_handle() {
 async fn cross_lineage_diff_honors_delete_only_filter() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut main = init_and_load(&dir).await;
+    let main = init_and_load(&dir).await;
     main.branch_create("feature").await.unwrap();
     let mut feature = Omnigraph::open(uri).await.unwrap();
     let before = snapshot_id(&feature, "feature").await.unwrap();
@@ -684,7 +684,7 @@ async fn cross_lineage_diff_honors_delete_only_filter() {
 async fn same_branch_diff_across_first_lazy_fork_detects_update() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut main = init_and_load(&dir).await;
+    let main = init_and_load(&dir).await;
     main.branch_create("feature").await.unwrap();
     let mut feature = Omnigraph::open(uri).await.unwrap();
     let before = snapshot_id(&feature, "feature").await.unwrap();
@@ -711,7 +711,7 @@ async fn same_branch_diff_across_first_lazy_fork_detects_update() {
 async fn diff_commits_cross_branch_reports_property_only_updates() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut main = init_and_load(&dir).await;
+    let main = init_and_load(&dir).await;
     let base_commit = head_commit_id(uri, None).await;
 
     main.branch_create("feature").await.unwrap();

--- a/crates/omnigraph/tests/composite_flow.rs
+++ b/crates/omnigraph/tests/composite_flow.rs
@@ -70,9 +70,7 @@ async fn composite_flow_canonical_lifecycle() {
     // Step 2: load JSONL seed data (Person + Company nodes,
     // Knows + WorksAt edges).
     // ─────────────────────────────────────────────────────────────────
-    load_jsonl(&mut db, TEST_DATA, LoadMode::Append)
-        .await
-        .unwrap();
+    load_jsonl(&db, TEST_DATA, LoadMode::Append).await.unwrap();
     let v_after_load = version_branch(&db, "main").await.unwrap();
     assert!(
         v_after_load > v_init,
@@ -450,8 +448,8 @@ async fn composite_flow_schema_apply_then_branch_ops_no_deadlock_in_refresh() {
     let uri = dir.path().to_str().unwrap();
 
     // Step 1: init + load on handle A.
-    let mut db_a = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
-    load_jsonl(&mut db_a, TEST_DATA, LoadMode::Append)
+    let db_a = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    load_jsonl(&db_a, TEST_DATA, LoadMode::Append)
         .await
         .unwrap();
     assert_eq!(count_rows(&db_a, "node:Person").await, 4);
@@ -583,9 +581,7 @@ async fn composite_flow_multi_branch_sequential_merges() {
     // edges from test.jsonl).
     // ─────────────────────────────────────────────────────────────────
     let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, TEST_DATA, LoadMode::Append)
-        .await
-        .unwrap();
+    load_jsonl(&db, TEST_DATA, LoadMode::Append).await.unwrap();
     assert_eq!(count_rows(&db, "node:Person").await, 4);
     assert_eq!(count_rows(&db, "edge:Knows").await, 3);
 

--- a/crates/omnigraph/tests/consistency.rs
+++ b/crates/omnigraph/tests/consistency.rs
@@ -80,10 +80,10 @@ async fn snapshot_returns_stale_data_after_write() {
 async fn load_append_rejects_existing_id_without_update() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
 
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Person","data":{"name":"Alice","age":30}}"#,
         LoadMode::Overwrite,
     )
@@ -98,7 +98,7 @@ async fn load_append_rejects_existing_id_without_update() {
         .table_version;
 
     let err = load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Person","data":{"name":"Alice","age":99}}"#,
         LoadMode::Append,
     )
@@ -169,16 +169,16 @@ async fn load_keyed_write_row_cap_excludes_strict_overwrite() {
     };
 
     let exact_dir = tempfile::tempdir().unwrap();
-    let mut exact = Omnigraph::init(exact_dir.path().to_str().unwrap(), SCHEMA)
+    let exact = Omnigraph::init(exact_dir.path().to_str().unwrap(), SCHEMA)
         .await
         .unwrap();
-    load_jsonl(&mut exact, &jsonl(LIMIT), LoadMode::Append)
+    load_jsonl(&exact, &jsonl(LIMIT), LoadMode::Append)
         .await
         .expect("the exact keyed row limit is inclusive");
     assert_eq!(count_rows(&exact, "node:Thing").await, LIMIT);
 
     let over_dir = tempfile::tempdir().unwrap();
-    let mut over = Omnigraph::init(over_dir.path().to_str().unwrap(), SCHEMA)
+    let over = Omnigraph::init(over_dir.path().to_str().unwrap(), SCHEMA)
         .await
         .unwrap();
     let before = snapshot_main(&over).await.unwrap();
@@ -191,7 +191,7 @@ async fn load_keyed_write_row_cap_excludes_strict_overwrite() {
         entry.table_path.trim_start_matches('/')
     );
     let before_head = Dataset::open(&table_uri).await.unwrap().version().version;
-    let error = load_jsonl(&mut over, &jsonl(LIMIT + 1), LoadMode::Append)
+    let error = load_jsonl(&over, &jsonl(LIMIT + 1), LoadMode::Append)
         .await
         .unwrap_err();
     assert!(
@@ -243,7 +243,7 @@ node Thing {
 "#;
 
     let dir = tempfile::tempdir().unwrap();
-    let mut db = Omnigraph::init(dir.path().to_str().unwrap(), SCHEMA)
+    let db = Omnigraph::init(dir.path().to_str().unwrap(), SCHEMA)
         .await
         .unwrap();
     let before = snapshot_main(&db).await.unwrap();
@@ -260,9 +260,7 @@ node Thing {
     let wide = "x".repeat(LIMIT as usize + 1024);
     let input =
         format!("{{\"type\":\"Thing\",\"data\":{{\"key\":\"wide\",\"payload\":\"{wide}\"}}}}");
-    let error = load_jsonl(&mut db, &input, LoadMode::Append)
-        .await
-        .unwrap_err();
+    let error = load_jsonl(&db, &input, LoadMode::Append).await.unwrap_err();
     assert!(
         matches!(
             error,
@@ -476,13 +474,13 @@ node Thing {
         .collect::<Result<Vec<_>, _>>()
         .unwrap();
     let start = Arc::new(Barrier::new(SAME_KEY_WRITERS));
-    let same_results = join_all(writers.into_iter().enumerate().map(|(writer, mut db)| {
+    let same_results = join_all(writers.into_iter().enumerate().map(|(writer, db)| {
         let start = Arc::clone(&start);
         async move {
             start.wait().await;
             let row =
                 format!(r#"{{"type":"Thing","data":{{"key":"SAME","value":"writer-{writer}"}}}}"#);
-            (writer, load_jsonl(&mut db, &row, LoadMode::Append).await)
+            (writer, load_jsonl(&db, &row, LoadMode::Append).await)
         }
     }))
     .await;
@@ -525,16 +523,16 @@ node Thing {
         "the persisted row must belong to the sole successful writer"
     );
 
-    let mut left = Omnigraph::open(uri).await.unwrap();
-    let mut right = Omnigraph::open(uri).await.unwrap();
+    let left = Omnigraph::open(uri).await.unwrap();
+    let right = Omnigraph::open(uri).await.unwrap();
     let (left, right) = tokio::join!(
         load_jsonl(
-            &mut left,
+            &left,
             r#"{"type":"Thing","data":{"key":"LEFT","value":"l"}}"#,
             LoadMode::Append,
         ),
         load_jsonl(
-            &mut right,
+            &right,
             r#"{"type":"Thing","data":{"key":"RIGHT","value":"r"}}"#,
             LoadMode::Append,
         ),
@@ -555,23 +553,19 @@ node Thing {
 async fn load_merge_upserts_existing_and_inserts_new() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
 
     // Load Alice(30) and Bob(25) via Overwrite
     let initial = r#"{"type": "Person", "data": {"name": "Alice", "age": 30}}
 {"type": "Person", "data": {"name": "Bob", "age": 25}}"#;
-    load_jsonl(&mut db, initial, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, initial, LoadMode::Overwrite).await.unwrap();
 
     assert_eq!(count_rows(&db, "node:Person").await, 2);
 
     // Merge: Alice updated to age=31, Charlie is new
     let merge_data = r#"{"type": "Person", "data": {"name": "Alice", "age": 31}}
 {"type": "Person", "data": {"name": "Charlie", "age": 35}}"#;
-    load_jsonl(&mut db, merge_data, LoadMode::Merge)
-        .await
-        .unwrap();
+    load_jsonl(&db, merge_data, LoadMode::Merge).await.unwrap();
 
     // Should have 3 persons total (not 4)
     assert_eq!(count_rows(&db, "node:Person").await, 3);
@@ -627,7 +621,7 @@ node Thing {
     optional_val: String?
 }
 "#;
-    let mut db = Omnigraph::init(uri, schema).await.unwrap();
+    let db = Omnigraph::init(uri, schema).await.unwrap();
 
     // Seed with 50 fully-populated rows (id + required + optional).
     let mut seed = String::new();
@@ -637,9 +631,7 @@ node Thing {
 "#,
         ));
     }
-    load_jsonl(&mut db, &seed, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, &seed, LoadMode::Overwrite).await.unwrap();
 
     // Partial-schema delta — mirrors the bug report exactly: omits
     // `optional_val`. 25 existing keys + 5 new keys, one row per key.
@@ -651,12 +643,12 @@ node Thing {
         ));
     }
 
-    load_jsonl(&mut db, &delta, LoadMode::Merge)
+    load_jsonl(&db, &delta, LoadMode::Merge)
         .await
         .expect("first merge must succeed");
     assert_eq!(count_rows(&db, "node:Thing").await, 55);
 
-    load_jsonl(&mut db, &delta, LoadMode::Merge)
+    load_jsonl(&db, &delta, LoadMode::Merge)
         .await
         .expect("second merge against same keys must succeed");
     assert_eq!(count_rows(&db, "node:Thing").await, 55);
@@ -691,14 +683,14 @@ node Thing {
     value: String
 }
 "#;
-    let mut db = Omnigraph::init(uri, schema).await.unwrap();
+    let db = Omnigraph::init(uri, schema).await.unwrap();
 
     let dupes = r#"{"type":"Thing","data":{"key":"DUP","value":"first"}}
 {"type":"Thing","data":{"key":"DUP","value":"second"}}
 "#;
 
     for mode in [LoadMode::Overwrite, LoadMode::Append, LoadMode::Merge] {
-        let err = load_jsonl(&mut db, dupes, mode).await.unwrap_err();
+        let err = load_jsonl(&db, dupes, mode).await.unwrap_err();
         let msg = err.to_string();
         assert!(
             msg.contains("@unique violation") && msg.contains("DUP"),
@@ -826,14 +818,14 @@ node ExternalID {
     @unique(source, external_id)
 }
 "#;
-    let mut db = Omnigraph::init(uri, schema).await.unwrap();
+    let db = Omnigraph::init(uri, schema).await.unwrap();
 
     // Same `source`, different `external_id` → unique on the composite key.
     // This is the exact repro from MR-983 and must be accepted.
     let composite_ok = r#"{"type":"ExternalID","data":{"slug":"a","source":"whatsapp","external_id":"+E.164"}}
 {"type":"ExternalID","data":{"slug":"b","source":"whatsapp","external_id":"pn:12345"}}
 "#;
-    load_jsonl(&mut db, composite_ok, LoadMode::Overwrite)
+    load_jsonl(&db, composite_ok, LoadMode::Overwrite)
         .await
         .expect("rows unique on the composite (source, external_id) must be accepted");
     assert_eq!(count_rows(&db, "node:ExternalID").await, 2);
@@ -843,7 +835,7 @@ node ExternalID {
     let composite_dupe = r#"{"type":"ExternalID","data":{"slug":"c","source":"whatsapp","external_id":"dup"}}
 {"type":"ExternalID","data":{"slug":"d","source":"whatsapp","external_id":"dup"}}
 "#;
-    let err = load_jsonl(&mut db, composite_dupe, LoadMode::Overwrite)
+    let err = load_jsonl(&db, composite_dupe, LoadMode::Overwrite)
         .await
         .unwrap_err();
     let msg = err.to_string();
@@ -949,7 +941,7 @@ node Thing {
     optional_val: String?
 }
 "#;
-    let mut db = Omnigraph::init(uri, schema).await.unwrap();
+    let db = Omnigraph::init(uri, schema).await.unwrap();
 
     let mut seed = String::new();
     for i in 1..=50 {
@@ -958,9 +950,7 @@ node Thing {
 "#,
         ));
     }
-    load_jsonl(&mut db, &seed, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, &seed, LoadMode::Overwrite).await.unwrap();
 
     // Explicit ensure_indices between seed and the merges — the Window
     // 2 trigger. The eager-build behavior (MR-583) means the BTREE on
@@ -980,11 +970,11 @@ node Thing {
     // Both merges must succeed under the FirstSeen workaround.
     // `processed_row_ids` re-processes the same target row_id under
     // the default `SourceDedupeBehavior::Fail`; FirstSeen tolerates it.
-    load_jsonl(&mut db, &delta, LoadMode::Merge)
+    load_jsonl(&db, &delta, LoadMode::Merge)
         .await
         .expect("first merge after ensure_indices must succeed");
     db.ensure_indices().await.unwrap();
-    load_jsonl(&mut db, &delta, LoadMode::Merge).await.expect(
+    load_jsonl(&db, &delta, LoadMode::Merge).await.expect(
         "second merge after ensure_indices must succeed \
              (Window 2 canary: drop the FirstSeen setter in table_store.rs \
              only when this stays green WITHOUT it)",
@@ -1016,9 +1006,7 @@ query company($name: String) {
 "#;
 
     let mut db = Omnigraph::init(uri, schema).await.unwrap();
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
 
     let result = query_main(&mut db, query, "company", &params(&[("$name", "Alice")]))
         .await
@@ -1128,9 +1116,7 @@ async fn null_values_in_filter_and_projection() {
     let data = r#"{"type": "Person", "data": {"name": "Alice", "age": 30}}
 {"type": "Person", "data": {"name": "Bob"}}
 {"type": "Person", "data": {"name": "Charlie", "age": 35}}"#;
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
 
     // Filter: age > 30 should exclude Bob (null) and Alice (30), keep Charlie (35)
     let queries = r#"
@@ -1358,9 +1344,7 @@ node Item {
         ));
     }
     let data = lines.join("\n");
-    load_jsonl(&mut db, &data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, &data, LoadMode::Overwrite).await.unwrap();
 
     assert_eq!(count_rows(&db, "node:Item").await, 500);
 

--- a/crates/omnigraph/tests/end_to_end.rs
+++ b/crates/omnigraph/tests/end_to_end.rs
@@ -116,10 +116,8 @@ node Flagged {
 "#;
     let data = r#"{"type":"Flagged","data":{"slug":"alpha","active":true,"rating":42}}"#;
 
-    let mut db = Omnigraph::init(uri, schema).await.unwrap();
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    let db = Omnigraph::init(uri, schema).await.unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
 
     let entity = db
         .entity_at_target(ReadTarget::branch("main"), "node:Flagged", "alpha")
@@ -144,10 +142,8 @@ node Doc {
     let data = r#"{"type":"Doc","data":{"slug":"a"}}
 {"type":"Doc","data":{"slug":"b","embedding":[1.0,2.0]}}"#;
 
-    let mut db = Omnigraph::init(uri, schema).await.unwrap();
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    let db = Omnigraph::init(uri, schema).await.unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
 
     let missing = db
         .entity_at_target(ReadTarget::branch("main"), "node:Doc", "a")
@@ -226,10 +222,10 @@ async fn edge_ids_are_unique_strings() {
 async fn overwrite_replaces_data() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
 
     // Load full data
-    load_jsonl(&mut db, TEST_DATA, LoadMode::Overwrite)
+    load_jsonl(&db, TEST_DATA, LoadMode::Overwrite)
         .await
         .unwrap();
 
@@ -242,9 +238,7 @@ async fn overwrite_replaces_data() {
     let small = r#"{"type": "Person", "data": {"name": "Zara", "age": 40}}
 {"edge": "Knows", "from": "Zara", "to": "Zara"}
 {"edge": "WorksAt", "from": "Zara", "to": "Acme"}"#;
-    load_jsonl(&mut db, small, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, small, LoadMode::Overwrite).await.unwrap();
 
     let batches = read_table(&db, "node:Person").await;
     let batch = &batches[0];
@@ -262,15 +256,13 @@ async fn overwrite_replaces_data() {
 async fn append_adds_rows() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
 
     let batch1 = r#"{"type": "Person", "data": {"name": "Alice", "age": 30}}"#;
     let batch2 = r#"{"type": "Person", "data": {"name": "Bob", "age": 25}}"#;
 
-    load_jsonl(&mut db, batch1, LoadMode::Overwrite)
-        .await
-        .unwrap();
-    load_jsonl(&mut db, batch2, LoadMode::Append).await.unwrap();
+    load_jsonl(&db, batch1, LoadMode::Overwrite).await.unwrap();
+    load_jsonl(&db, batch2, LoadMode::Append).await.unwrap();
 
     let snap = snapshot_main(&db).await.unwrap();
     let ds = snap.open("node:Person").await.unwrap();
@@ -283,10 +275,10 @@ async fn append_adds_rows() {
 async fn load_from_file_works() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
 
     let fixture_path = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/test.jsonl");
-    load_jsonl_file(&mut db, fixture_path, LoadMode::Overwrite)
+    load_jsonl_file(&db, fixture_path, LoadMode::Overwrite)
         .await
         .unwrap();
 
@@ -304,10 +296,8 @@ async fn signals_fixture_loads_correctly() {
 
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, schema).await.unwrap();
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    let db = Omnigraph::init(uri, schema).await.unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
 
     let snap = snapshot_main(&db).await.unwrap();
 
@@ -554,9 +544,7 @@ query unemployed() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
     let mut db = Omnigraph::init(uri, schema).await.unwrap();
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
 
     let result = query_main(&mut db, queries, "unemployed", &ParamMap::new())
         .await
@@ -958,15 +946,13 @@ async fn blob_schema_parses_and_init_succeeds() {
 async fn blob_load_base64_inline() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, BLOB_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, BLOB_SCHEMA).await.unwrap();
 
     // "Hello World" = "SGVsbG8gV29ybGQ="
     let data = r#"{"type": "Document", "data": {"title": "readme", "content": "base64:SGVsbG8gV29ybGQ="}}
 {"type": "Document", "data": {"title": "empty"}}
 "#;
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
 
     let snap = snapshot_main(&db).await.unwrap();
     let ds = snap.open("node:Document").await.unwrap();
@@ -980,9 +966,7 @@ async fn blob_query_returns_metadata() {
     let mut db = Omnigraph::init(uri, BLOB_SCHEMA).await.unwrap();
 
     let data = r#"{"type": "Document", "data": {"title": "readme", "content": "base64:SGVsbG8gV29ybGQ="}}"#;
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
 
     // Both filter spellings must survive a blob-bearing scan: inline props and
     // the standalone clause (hoisted onto the scan) ride the same filter path,
@@ -1018,9 +1002,7 @@ async fn blob_null_returns_null_in_query() {
     let mut db = Omnigraph::init(uri, BLOB_SCHEMA).await.unwrap();
 
     let data = r#"{"type": "Document", "data": {"title": "empty"}}"#;
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
 
     let result = query_main(
         &mut db,
@@ -1122,13 +1104,11 @@ async fn blob_update_mutation() {
 async fn blob_read_returns_bytes() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, BLOB_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, BLOB_SCHEMA).await.unwrap();
 
     // "Hello World" = base64 "SGVsbG8gV29ybGQ="
     let data = r#"{"type": "Document", "data": {"title": "readme", "content": "base64:SGVsbG8gV29ybGQ="}}"#;
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
 
     let blob = db.read_blob("Document", "readme", "content").await.unwrap();
     assert_eq!(blob.size(), 11); // "Hello World" = 11 bytes
@@ -1141,12 +1121,10 @@ async fn blob_read_returns_bytes() {
 async fn blob_read_not_found_errors() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, BLOB_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, BLOB_SCHEMA).await.unwrap();
 
     let data = r#"{"type": "Document", "data": {"title": "readme", "content": "base64:SGVsbG8="}}"#;
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
 
     // Non-existent ID
     let err = db.read_blob("Document", "nonexistent", "content").await;
@@ -1193,12 +1171,10 @@ async fn blob_scan_with_descriptions_on_nonempty_dataset() {
 
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, BLOB_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, BLOB_SCHEMA).await.unwrap();
 
     let data = r#"{"type": "Document", "data": {"title": "readme", "content": "base64:SGVsbG8gV29ybGQ="}}"#;
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
 
     // Open the dataset directly and try BlobsDescriptions
     let snap = snapshot_main(&db).await.unwrap();
@@ -1235,11 +1211,11 @@ node Person {
 "#;
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, schema).await.unwrap();
+    let db = Omnigraph::init(uri, schema).await.unwrap();
 
     // age = 300 exceeds max of 200
     let data = r#"{"type": "Person", "data": {"name": "Old", "age": 300}}"#;
-    let result = load_jsonl(&mut db, data, LoadMode::Overwrite).await;
+    let result = load_jsonl(&db, data, LoadMode::Overwrite).await;
     assert!(result.is_err(), "expected range violation");
     let err = result.unwrap_err().to_string();
     assert!(err.contains("@range violation"), "error: {}", err);
@@ -1256,12 +1232,10 @@ node Person {
 "#;
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, schema).await.unwrap();
+    let db = Omnigraph::init(uri, schema).await.unwrap();
 
     let data = r#"{"type": "Person", "data": {"name": "Alice", "age": 30}}"#;
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
 
     let snap = snapshot_main(&db).await.unwrap();
     let ds = snap.open("node:Person").await.unwrap();
@@ -1279,10 +1253,10 @@ node Measurement {
 "#;
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, schema).await.unwrap();
+    let db = Omnigraph::init(uri, schema).await.unwrap();
 
     let data = r#"{"type": "Measurement", "data": {"name": "hot", "temperature": 150.5}}"#;
-    let result = load_jsonl(&mut db, data, LoadMode::Overwrite).await;
+    let result = load_jsonl(&db, data, LoadMode::Overwrite).await;
     assert!(result.is_err(), "expected range violation for float");
     let err = result.unwrap_err().to_string();
     assert!(err.contains("@range violation"), "error: {}", err);
@@ -1299,12 +1273,10 @@ node Measurement {
 "#;
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, schema).await.unwrap();
+    let db = Omnigraph::init(uri, schema).await.unwrap();
 
     let data = r#"{"type": "Measurement", "data": {"name": "warm", "temperature": 37.5}}"#;
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
 
     let snap = snapshot_main(&db).await.unwrap();
     let ds = snap.open("node:Measurement").await.unwrap();
@@ -1322,17 +1294,15 @@ node Measurement {
 "#;
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, schema).await.unwrap();
+    let db = Omnigraph::init(uri, schema).await.unwrap();
 
     // Within bounds — should succeed
     let data = r#"{"type": "Measurement", "data": {"name": "cold", "temperature": -20.0}}"#;
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
 
     // Below minimum — should fail
     let data = r#"{"type": "Measurement", "data": {"name": "arctic", "temperature": -50.0}}"#;
-    let result = load_jsonl(&mut db, data, LoadMode::Overwrite).await;
+    let result = load_jsonl(&db, data, LoadMode::Overwrite).await;
     assert!(result.is_err(), "expected range violation for -50.0");
     let err = result.unwrap_err().to_string();
     assert!(err.contains("@range violation"), "error: {}", err);
@@ -1348,10 +1318,10 @@ node Order {
 "#;
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, schema).await.unwrap();
+    let db = Omnigraph::init(uri, schema).await.unwrap();
 
     let data = r#"{"type": "Order", "data": {"code": "invalid"}}"#;
-    let result = load_jsonl(&mut db, data, LoadMode::Overwrite).await;
+    let result = load_jsonl(&db, data, LoadMode::Overwrite).await;
     assert!(result.is_err(), "expected check violation");
     let err = result.unwrap_err().to_string();
     assert!(err.contains("@check violation"), "error: {}", err);
@@ -1367,12 +1337,10 @@ node Order {
 "#;
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, schema).await.unwrap();
+    let db = Omnigraph::init(uri, schema).await.unwrap();
 
     let data = r#"{"type": "Order", "data": {"code": "ABC-123"}}"#;
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
 
     let snap = snapshot_main(&db).await.unwrap();
     let ds = snap.open("node:Order").await.unwrap();
@@ -1433,7 +1401,7 @@ query set_age($name: String, $age: I32) {
     let uri = dir.path().to_str().unwrap();
     let mut db = Omnigraph::init(uri, schema).await.unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type": "Person", "data": {"name": "Alice", "age": 30}}"#,
         LoadMode::Overwrite,
     )
@@ -1507,7 +1475,7 @@ query set_label($code: String, $label: String) {
     let uri = dir.path().to_str().unwrap();
     let mut db = Omnigraph::init(uri, schema).await.unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type": "Order", "data": {"code": "ABC-123", "label": "VALID"}}"#,
         LoadMode::Overwrite,
     )
@@ -1541,7 +1509,7 @@ edge WorksAt: Person -> Company @card(0..1)
 "#;
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, schema).await.unwrap();
+    let db = Omnigraph::init(uri, schema).await.unwrap();
 
     // Alice works at two companies — violates @card(0..1)
     let data = r#"{"type": "Person", "data": {"name": "Alice"}}
@@ -1550,7 +1518,7 @@ edge WorksAt: Person -> Company @card(0..1)
 {"edge": "WorksAt", "from": "Alice", "to": "Acme"}
 {"edge": "WorksAt", "from": "Alice", "to": "Globex"}
 "#;
-    let result = load_jsonl(&mut db, data, LoadMode::Overwrite).await;
+    let result = load_jsonl(&db, data, LoadMode::Overwrite).await;
     assert!(result.is_err(), "expected cardinality violation");
     let err = result.unwrap_err().to_string();
     assert!(err.contains("@card violation"), "error: {}", err);
@@ -1565,15 +1533,13 @@ edge WorksAt: Person -> Company @card(0..1)
 "#;
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, schema).await.unwrap();
+    let db = Omnigraph::init(uri, schema).await.unwrap();
 
     let data = r#"{"type": "Person", "data": {"name": "Alice"}}
 {"type": "Company", "data": {"name": "Acme"}}
 {"edge": "WorksAt", "from": "Alice", "to": "Acme"}
 "#;
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
 
     let snap = snapshot_main(&db).await.unwrap();
     let ds = snap.open("edge:WorksAt").await.unwrap();
@@ -1660,9 +1626,7 @@ async fn blob_update_null_to_non_null() {
 
     // Load a row with blob = null (no blob data in dataset)
     let data = r#"{"type": "Document", "data": {"title": "kid-a"}}"#;
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
 
     // Update: null → non-null blob. Previously panicked with assertion
     // `left: 0, right: 1` in lance-table stream.rs.
@@ -1697,16 +1661,14 @@ async fn blob_load_external_file_uri() {
     std::fs::write(&blob_path, b"Hello from file").unwrap();
     let file_uri = format!("file://{}", blob_path.display());
 
-    let mut db = Omnigraph::init(uri, BLOB_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, BLOB_SCHEMA).await.unwrap();
     let data = format!(
         r#"{{"type": "Document", "data": {{"title": "from-file", "content": "{}"}}}}"#,
         file_uri
     );
 
     // Load with external URI
-    load_jsonl(&mut db, &data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, &data, LoadMode::Overwrite).await.unwrap();
 
     // Verify the blob is accessible
     let blob = db
@@ -1772,10 +1734,10 @@ query filter_date($d: String) {
 #[tokio::test]
 async fn append_mode_manifest_row_count_is_total() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await; // Overwrite: 4 persons
+    let db = init_and_load(&dir).await; // Overwrite: 4 persons
 
     let extra = r#"{"type": "Person", "data": {"name": "Eve", "age": 22}}"#;
-    load_jsonl(&mut db, extra, LoadMode::Append).await.unwrap();
+    load_jsonl(&db, extra, LoadMode::Append).await.unwrap();
 
     let snap = snapshot_main(&db).await.unwrap();
     let entry = snap.entry("node:Person").unwrap();
@@ -1798,7 +1760,7 @@ edge WorksAt: Person -> Company @card(0..1)
 "#;
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, schema).await.unwrap();
+    let db = Omnigraph::init(uri, schema).await.unwrap();
 
     // Alice works at two companies — violates @card(0..1) (at most 1)
     let data = r#"
@@ -1810,7 +1772,7 @@ edge WorksAt: Person -> Company @card(0..1)
 "#;
 
     let v_before = version_main(&db).await.unwrap();
-    let result = load_jsonl(&mut db, data, LoadMode::Overwrite).await;
+    let result = load_jsonl(&db, data, LoadMode::Overwrite).await;
     assert!(result.is_err(), "cardinality violation should be rejected");
     assert!(
         result.unwrap_err().to_string().contains("@card violation"),
@@ -1827,14 +1789,14 @@ edge WorksAt: Person -> Company @card(0..1)
 async fn dangling_edge_dst_rejected_on_load() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
 
     let data = r#"
 {"type": "Person", "data": {"name": "Alice", "age": 30}}
 {"type": "Company", "data": {"name": "Acme"}}
 {"edge": "Knows", "from": "Alice", "to": "NonExistent"}
 "#;
-    let result = load_jsonl(&mut db, data, LoadMode::Overwrite).await;
+    let result = load_jsonl(&db, data, LoadMode::Overwrite).await;
     assert!(result.is_err(), "dangling edge dst should be rejected");
     let err = result.unwrap_err().to_string();
     assert!(
@@ -1848,14 +1810,14 @@ async fn dangling_edge_dst_rejected_on_load() {
 async fn dangling_edge_src_rejected_on_load() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
 
     let data = r#"
 {"type": "Person", "data": {"name": "Alice", "age": 30}}
 {"type": "Company", "data": {"name": "Acme"}}
 {"edge": "WorksAt", "from": "Ghost", "to": "Acme"}
 "#;
-    let result = load_jsonl(&mut db, data, LoadMode::Overwrite).await;
+    let result = load_jsonl(&db, data, LoadMode::Overwrite).await;
     assert!(result.is_err(), "dangling edge src should be rejected");
     let err = result.unwrap_err().to_string();
     assert!(
@@ -1870,7 +1832,7 @@ async fn dangling_edge_src_rejected_on_load() {
 #[tokio::test]
 async fn ensure_indices_does_not_error_on_repeated_call() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
     let version_after_load = version_main(&db).await.unwrap();
 
     // load commits now enforce required indices; repeated ensure_indices calls
@@ -1919,9 +1881,7 @@ node Doc {
     let mut db = Omnigraph::init(dir.path().to_str().unwrap(), schema)
         .await
         .unwrap();
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
 
     let queries = r#"
 query docs_with_tag($tag: String) {

--- a/crates/omnigraph/tests/export.rs
+++ b/crates/omnigraph/tests/export.rs
@@ -191,7 +191,7 @@ async fn assert_exact_id_primary_key(db: &Omnigraph, table_key: &str) {
 #[tokio::test]
 async fn export_jsonl_round_trips_branch_snapshot() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
     db.branch_create_from(ReadTarget::branch("main"), "feature")
         .await
         .unwrap();
@@ -233,18 +233,17 @@ async fn export_jsonl_round_trips_branch_snapshot() {
 
     let imported_main_dir = tempfile::tempdir().unwrap();
     let imported_feature_dir = tempfile::tempdir().unwrap();
-    let mut imported_main =
-        Omnigraph::init(imported_main_dir.path().to_str().unwrap(), TEST_SCHEMA)
-            .await
-            .unwrap();
-    let mut imported_feature =
+    let imported_main = Omnigraph::init(imported_main_dir.path().to_str().unwrap(), TEST_SCHEMA)
+        .await
+        .unwrap();
+    let imported_feature =
         Omnigraph::init(imported_feature_dir.path().to_str().unwrap(), TEST_SCHEMA)
             .await
             .unwrap();
-    load_jsonl(&mut imported_main, &main_jsonl, LoadMode::Overwrite)
+    load_jsonl(&imported_main, &main_jsonl, LoadMode::Overwrite)
         .await
         .unwrap();
-    load_jsonl(&mut imported_feature, &feature_jsonl, LoadMode::Overwrite)
+    load_jsonl(&imported_feature, &feature_jsonl, LoadMode::Overwrite)
         .await
         .unwrap();
 
@@ -866,20 +865,20 @@ async fn numeric_narrowing_rejects_out_of_range_loader_and_mutation_values_pre_e
 #[tokio::test]
 async fn export_jsonl_preserves_explicit_ids_for_non_key_graphs() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = Omnigraph::init(dir.path().to_str().unwrap(), NOTE_SCHEMA)
+    let db = Omnigraph::init(dir.path().to_str().unwrap(), NOTE_SCHEMA)
         .await
         .unwrap();
-    load_jsonl(&mut db, NOTE_DATA, LoadMode::Overwrite)
+    load_jsonl(&db, NOTE_DATA, LoadMode::Overwrite)
         .await
         .unwrap();
 
     let exported = db.export_jsonl("main", &[], &[]).await.unwrap();
 
     let imported_dir = tempfile::tempdir().unwrap();
-    let mut imported = Omnigraph::init(imported_dir.path().to_str().unwrap(), NOTE_SCHEMA)
+    let imported = Omnigraph::init(imported_dir.path().to_str().unwrap(), NOTE_SCHEMA)
         .await
         .unwrap();
-    load_jsonl(&mut imported, &exported, LoadMode::Overwrite)
+    load_jsonl(&imported, &exported, LoadMode::Overwrite)
         .await
         .unwrap();
 
@@ -924,14 +923,12 @@ node Document {
 }
 "#;
 
-    let mut db = Omnigraph::init(uri, BLOB_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, BLOB_SCHEMA).await.unwrap();
     let data = concat!(
         "{\"type\": \"Document\", \"data\": {\"title\": \"readme\", \"content\": \"base64:SGVsbG8=\"}}\n",
         "{\"type\": \"Document\", \"data\": {\"title\": \"empty\"}}\n",
     );
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
 
     // Export should succeed
     let exported = db.export_jsonl("main", &[], &[]).await.unwrap();
@@ -949,8 +946,8 @@ node Document {
     // Round-trip: re-import and verify blob data survives
     let imported_dir = tempfile::tempdir().unwrap();
     let imported_uri = imported_dir.path().to_str().unwrap();
-    let mut imported = Omnigraph::init(imported_uri, BLOB_SCHEMA).await.unwrap();
-    load_jsonl(&mut imported, &exported, LoadMode::Overwrite)
+    let imported = Omnigraph::init(imported_uri, BLOB_SCHEMA).await.unwrap();
+    load_jsonl(&imported, &exported, LoadMode::Overwrite)
         .await
         .unwrap();
 
@@ -964,7 +961,7 @@ node Document {
     // A later import into the already-populated v6 table must retain both the
     // physical PK contract and blob-v2 fidelity.
     load_jsonl(
-        &mut imported,
+        &imported,
         r#"{"type":"Document","data":{"title":"later","content":"base64:AAECA/8="}}"#,
         LoadMode::Append,
     )

--- a/crates/omnigraph/tests/failpoints.rs
+++ b/crates/omnigraph/tests/failpoints.rs
@@ -3465,7 +3465,7 @@ async fn recovery_rolls_forward_load_overwrite() {
     let parent_commit_id;
 
     {
-        let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
+        let db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
         // Seed Persons only (no edges): the fault-injected step below overwrites
         // node:Person down to a single row, and a per-table overwrite that drops
         // Persons referenced by seeded Knows/WorksAt edges is now rejected as an
@@ -3473,7 +3473,7 @@ async fn recovery_rolls_forward_load_overwrite() {
         // failpoint this test drives. Keeping the seed edge-free makes the
         // overwrite a clean single-table roll-forward, which is what's under test.
         load_jsonl(
-            &mut db,
+            &db,
             "{\"type\":\"Person\",\"data\":{\"name\":\"Alice\",\"age\":30}}\n\
              {\"type\":\"Person\",\"data\":{\"name\":\"Bob\",\"age\":31}}\n",
             LoadMode::Overwrite,
@@ -3550,12 +3550,10 @@ async fn recovery_rolls_forward_ensure_indices_on_feature_branch_inner() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap().to_string();
     let operation_id;
-    let feature_parent_commit_id;
-    let main_person_pin;
 
     let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Person","data":{"name":"alice","age":30}}
 "#,
         LoadMode::Append,
@@ -3577,7 +3575,7 @@ async fn recovery_rolls_forward_ensure_indices_on_feature_branch_inner() {
     // ensure_indices recovery rather than first materialization.
     db.ensure_indices_on("feature").await.unwrap();
 
-    main_person_pin = db
+    let main_person_pin = db
         .snapshot_of(omnigraph::db::ReadTarget::branch("main"))
         .await
         .unwrap()
@@ -3612,7 +3610,7 @@ async fn recovery_rolls_forward_ensure_indices_on_feature_branch_inner() {
         dropped_index_head,
         "test setup must publish the dropped-index table head before ensure_indices runs",
     );
-    feature_parent_commit_id = branch_head_commit_id(dir.path(), "feature").await.unwrap();
+    let feature_parent_commit_id = branch_head_commit_id(dir.path(), "feature").await.unwrap();
 
     {
         let _failpoint = ScopedFailPoint::new(
@@ -3754,9 +3752,9 @@ async fn ensure_indices_complete_armed_effects_roll_back() {
     let _scenario = FailScenario::setup();
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap().to_string();
-    let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Person","data":{"name":"alice","age":30}}"#,
         LoadMode::Append,
     )
@@ -3819,9 +3817,9 @@ async fn ensure_indices_entry_barrier_refuses_partial_armed_before_staging() {
     let _scenario = FailScenario::setup();
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap().to_string();
-    let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Person","data":{"name":"alice","age":30}}
 {"type":"Company","data":{"name":"acme"}}"#,
         LoadMode::Append,
@@ -4080,9 +4078,9 @@ async fn ensure_indices_first_touch_crash_before_ref_recovers_cleanly() {
     let _scenario = FailScenario::setup();
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap().to_string();
-    let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Person","data":{"name":"alice","age":30}}
 "#,
         LoadMode::Append,
@@ -4414,7 +4412,7 @@ async fn load_after_finalize_publisher_failure_heals_without_reopen() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap().to_string();
 
-    let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
 
     // Failed multi-table load: Person + Company + WorksAt all run
     // commit_staged (Lance HEAD advances on three tables), then the
@@ -4423,7 +4421,7 @@ async fn load_after_finalize_publisher_failure_heals_without_reopen() {
         let _failpoint =
             ScopedFailPoint::new(names::MUTATION_POST_FINALIZE_PRE_PUBLISHER, "return");
         let err = load_jsonl(
-            &mut db,
+            &db,
             r#"{"type":"Person","data":{"name":"Alice","age":30}}
 {"type":"Person","data":{"name":"Bob","age":25}}
 {"type":"Company","data":{"name":"Acme"}}
@@ -4449,7 +4447,7 @@ async fn load_after_finalize_publisher_failure_heals_without_reopen() {
     // Follow-up load on the SAME handle, touching the drifted tables.
     // Must succeed without manual intervention.
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Person","data":{"name":"Carol","age":41}}
 {"type":"Company","data":{"name":"Globex"}}
 "#,
@@ -4492,7 +4490,7 @@ async fn sidecar_write_failure_aborts_load_with_no_head_advance() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap().to_string();
 
-    let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
 
     let person_uri = node_table_uri(&db, "Person").await;
     let pre_head = lance::Dataset::open(&person_uri)
@@ -4504,7 +4502,7 @@ async fn sidecar_write_failure_aborts_load_with_no_head_advance() {
     {
         let _failpoint = ScopedFailPoint::new(names::RECOVERY_SIDECAR_WRITE, "return");
         let err = load_jsonl(
-            &mut db,
+            &db,
             r#"{"type":"Person","data":{"name":"Alice","age":30}}
 {"type":"Company","data":{"name":"Acme"}}
 "#,
@@ -4552,7 +4550,7 @@ async fn sidecar_write_failure_aborts_load_with_no_head_advance() {
     // Fault cleared: the same handle writes normally — no wedge, no
     // recovery required.
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Person","data":{"name":"Alice","age":30}}
 {"type":"Company","data":{"name":"Acme"}}
 "#,
@@ -4583,7 +4581,7 @@ async fn s3_load_recovers_after_publisher_failure_without_reopen() {
     };
 
     let _scenario = FailScenario::setup();
-    let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
 
     // Failed load: commit_staged lands on S3, manifest publish does not;
     // the sidecar PUT went through the S3 adapter.
@@ -4591,15 +4589,14 @@ async fn s3_load_recovers_after_publisher_failure_without_reopen() {
         let _failpoint =
             ScopedFailPoint::new(names::MUTATION_POST_FINALIZE_PRE_PUBLISHER, "return");
         let err = load_jsonl(
-            &mut db,
+            &db,
             r#"{"type":"Person","data":{"name":"Alice","age":30}}
 {"type":"Company","data":{"name":"Acme"}}
 "#,
             LoadMode::Merge,
         )
         .await
-        .err()
-        .expect("finalize failpoint must fail the load");
+        .expect_err("finalize failpoint must fail the load");
         assert!(
             err.to_string()
                 .contains("injected failpoint triggered: mutation.post_finalize_pre_publisher"),
@@ -4610,7 +4607,7 @@ async fn s3_load_recovers_after_publisher_failure_without_reopen() {
     // Same-handle follow-up load: the entry heal LISTs __recovery/ on
     // S3, rolls the sidecar forward, DELETEs it, and the write lands.
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Person","data":{"name":"Bob","age":25}}
 "#,
         LoadMode::Merge,
@@ -4644,21 +4641,20 @@ async fn record_audit_failure_after_roll_forward_converges_on_next_write() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap().to_string();
 
-    let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
 
     // Pending sidecar with real drift.
     {
         let _failpoint =
             ScopedFailPoint::new(names::MUTATION_POST_FINALIZE_PRE_PUBLISHER, "return");
         load_jsonl(
-            &mut db,
+            &db,
             r#"{"type":"Person","data":{"name":"Alice","age":30}}
 "#,
             LoadMode::Merge,
         )
         .await
-        .err()
-        .expect("finalize failpoint must fail the load");
+        .expect_err("finalize failpoint must fail the load");
     }
 
     // The next write's heal rolls forward (manifest publish lands) but
@@ -4667,14 +4663,13 @@ async fn record_audit_failure_after_roll_forward_converges_on_next_write() {
     {
         let _failpoint = ScopedFailPoint::new(names::RECOVERY_RECORD_AUDIT, "return");
         let err = load_jsonl(
-            &mut db,
+            &db,
             r#"{"type":"Person","data":{"name":"Bob","age":25}}
 "#,
             LoadMode::Merge,
         )
         .await
-        .err()
-        .expect("an audit write failure mid-heal must fail the write");
+        .expect_err("an audit write failure mid-heal must fail the write");
         assert!(
             err.to_string()
                 .contains("injected failpoint triggered: recovery.record_audit"),
@@ -4691,7 +4686,7 @@ async fn record_audit_failure_after_roll_forward_converges_on_next_write() {
     // Fault cleared: the next write converges — stale-sidecar audit
     // recovery (manifest already advanced) + the write itself.
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Person","data":{"name":"Carol","age":41}}
 "#,
         LoadMode::Merge,
@@ -4737,14 +4732,14 @@ async fn sidecar_list_failure_fails_write_and_open_loudly_then_clears() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap().to_string();
 
-    let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
 
     // Pending sidecar via the usual finalize → publisher failure.
     {
         let _failpoint =
             ScopedFailPoint::new(names::MUTATION_POST_FINALIZE_PRE_PUBLISHER, "return");
         let err = load_jsonl(
-            &mut db,
+            &db,
             r#"{"type":"Person","data":{"name":"Alice","age":30}}
 "#,
             LoadMode::Merge,
@@ -4765,7 +4760,7 @@ async fn sidecar_list_failure_fails_write_and_open_loudly_then_clears() {
     // Write-entry heal: the list failure surfaces as the write's error —
     // no silent skip that would proceed over the pending sidecar.
     let err = load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Person","data":{"name":"Bob","age":25}}
 "#,
         LoadMode::Merge,
@@ -4819,14 +4814,14 @@ async fn sidecar_delete_failure_keeps_write_success_and_next_write_heals() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap().to_string();
 
-    let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
 
     {
         let _failpoint = ScopedFailPoint::new(names::RECOVERY_SIDECAR_DELETE, "return");
         // The load itself must succeed: commit_staged + manifest publish
         // landed; only the Phase D cleanup failed (swallowed + logged).
         load_jsonl(
-            &mut db,
+            &db,
             r#"{"type":"Person","data":{"name":"Alice","age":30}}
 "#,
             LoadMode::Merge,
@@ -4846,7 +4841,7 @@ async fn sidecar_delete_failure_keeps_write_success_and_next_write_heals() {
     // sidecar (manifest pin already caught up — the stale-sidecar
     // roll-forward audit path) and the write lands.
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Person","data":{"name":"Bob","age":25}}
 "#,
         LoadMode::Merge,
@@ -4880,7 +4875,7 @@ async fn sidecar_write_failure_aborts_branch_merge_with_no_head_advance() {
 
     let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Person","data":{"name":"Alice","age":30}}
 "#,
         LoadMode::Append,
@@ -5034,13 +5029,13 @@ async fn schema_apply_after_finalize_publisher_failure_heals_without_reopen() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap().to_string();
 
-    let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
 
     {
         let _failpoint =
             ScopedFailPoint::new(names::MUTATION_POST_FINALIZE_PRE_PUBLISHER, "return");
         let err = load_jsonl(
-            &mut db,
+            &db,
             r#"{"type":"Person","data":{"name":"Alice","age":30}}
 {"type":"Company","data":{"name":"Acme"}}
 "#,
@@ -5100,7 +5095,7 @@ async fn branch_merge_after_finalize_publisher_failure_heals_without_reopen() {
 
     let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Person","data":{"name":"Alice","age":30}}
 "#,
         LoadMode::Append,
@@ -5126,7 +5121,7 @@ async fn branch_merge_after_finalize_publisher_failure_heals_without_reopen() {
         let _failpoint =
             ScopedFailPoint::new(names::MUTATION_POST_FINALIZE_PRE_PUBLISHER, "return");
         let err = load_jsonl(
-            &mut db,
+            &db,
             r#"{"type":"Person","data":{"name":"Bob","age":25}}
 "#,
             LoadMode::Merge,
@@ -5186,7 +5181,7 @@ async fn orphaned_branch_discard_is_idempotent_across_delete_failure() {
 
     let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         "{\"type\":\"Person\",\"data\":{\"name\":\"Alice\",\"age\":30}}\n",
         LoadMode::Merge,
     )
@@ -5248,13 +5243,12 @@ async fn orphaned_branch_discard_is_idempotent_across_delete_failure() {
     {
         let _failpoint = ScopedFailPoint::new(names::RECOVERY_SIDECAR_DELETE, "return");
         let err = load_jsonl(
-            &mut db,
+            &db,
             "{\"type\":\"Person\",\"data\":{\"name\":\"Bob\",\"age\":25}}\n",
             LoadMode::Merge,
         )
         .await
-        .err()
-        .expect("a sidecar-delete fault mid-discard must fail the write");
+        .expect_err("a sidecar-delete fault mid-discard must fail the write");
         assert!(
             err.to_string()
                 .contains("injected failpoint triggered: recovery.sidecar_delete"),
@@ -5265,7 +5259,7 @@ async fn orphaned_branch_discard_is_idempotent_across_delete_failure() {
 
     // Retry: must finish the delete WITHOUT a second audit row.
     load_jsonl(
-        &mut db,
+        &db,
         "{\"type\":\"Person\",\"data\":{\"name\":\"Bob\",\"age\":25}}\n",
         LoadMode::Merge,
     )
@@ -5296,9 +5290,9 @@ async fn stage_a_barrier_reports_exact_operation_before_drift_guard() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap().to_string();
 
-    let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         "{\"type\":\"Person\",\"data\":{\"name\":\"alice\",\"age\":30}}\n",
         LoadMode::Append,
     )
@@ -5349,13 +5343,12 @@ async fn stage_a_barrier_reports_exact_operation_before_drift_guard() {
     .unwrap();
 
     let err = load_jsonl(
-        &mut db,
+        &db,
         "{\"type\":\"Person\",\"data\":{\"name\":\"bob\",\"age\":25}}\n",
         LoadMode::Merge,
     )
     .await
-    .err()
-    .expect("drift must still fail the write");
+    .expect_err("drift must still fail the write");
     let msg = err.to_string();
     assert!(
         matches!(
@@ -5386,7 +5379,7 @@ async fn orphaned_branch_discard_converges_across_audit_append_failure() {
 
     let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         "{\"type\":\"Person\",\"data\":{\"name\":\"Alice\",\"age\":30}}\n",
         LoadMode::Merge,
     )
@@ -5447,13 +5440,12 @@ async fn orphaned_branch_discard_converges_across_audit_append_failure() {
         let _failpoint =
             ScopedFailPoint::new(names::RECOVERY_ORPHAN_DISCARD_AUDIT_APPEND, "return");
         let err = load_jsonl(
-            &mut db,
+            &db,
             "{\"type\":\"Person\",\"data\":{\"name\":\"Bob\",\"age\":25}}\n",
             LoadMode::Merge,
         )
         .await
-        .err()
-        .expect("an audit-append fault mid-discard must fail the write");
+        .expect_err("an audit-append fault mid-discard must fail the write");
         assert!(
             err.to_string()
                 .contains("injected failpoint triggered: recovery.orphan_discard_audit_append"),
@@ -5474,7 +5466,7 @@ async fn orphaned_branch_discard_converges_across_audit_append_failure() {
 
     // Retry: converges — sidecar consumed, exactly one audit row.
     load_jsonl(
-        &mut db,
+        &db,
         "{\"type\":\"Person\",\"data\":{\"name\":\"Bob\",\"age\":25}}\n",
         LoadMode::Merge,
     )
@@ -5507,9 +5499,9 @@ async fn load_after_schema_apply_phase_b_failure_uses_recovered_catalog() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap().to_string();
 
-    let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         "{\"type\":\"Person\",\"data\":{\"name\":\"alice\",\"age\":30}}\n",
         LoadMode::Append,
     )
@@ -5555,7 +5547,7 @@ edge WorksAt: Person -> Company
     // and the loader must then validate against the RECOVERED catalog,
     // not the stale in-memory one.
     load_jsonl(
-        &mut db,
+        &db,
         "{\"type\":\"Tag\",\"data\":{\"label\":\"t1\"}}\n",
         LoadMode::Merge,
     )
@@ -5673,7 +5665,7 @@ async fn refresh_defers_rollback_eligible_sidecar_to_next_open() {
     // Bootstrap.
     let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Person","data":{"name":"alice","age":30}}
 "#,
         LoadMode::Append,
@@ -5866,7 +5858,7 @@ async fn finalize_publisher_residual_does_not_drift_untouched_tables() {
     // node:Person drifted. node:Company didn't — try a Company write.
     use omnigraph::loader::{LoadMode, load_jsonl};
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type": "Company", "data": {"name": "Acme"}}"#,
         LoadMode::Append,
     )
@@ -6014,9 +6006,9 @@ async fn schema_apply_without_schema_staging_rolls_back_on_next_open() {
     let operation_id;
 
     {
-        let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
+        let db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
         load_jsonl(
-            &mut db,
+            &db,
             r#"{"type":"Person","data":{"name":"alice","age":30}}
 "#,
             LoadMode::Append,
@@ -6546,9 +6538,9 @@ async fn schema_apply_phase_b_failure_recovered_on_next_open() {
     // Seed: a Person table with one row so the schema-apply rewritten_tables
     // loop has actual work to do.
     {
-        let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
+        let db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
         load_jsonl(
-            &mut db,
+            &db,
             r#"{"type":"Person","data":{"name":"alice","age":30}}
 "#,
             LoadMode::Append,
@@ -7231,9 +7223,9 @@ node Embedding {
     let _scenario = FailScenario::setup();
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap().to_string();
-    let mut db = Omnigraph::init(&uri, SCHEMA).await.unwrap();
+    let db = Omnigraph::init(&uri, SCHEMA).await.unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Work","data":{"name":"w0"}}
 {"type":"Embedding","data":{"name":"e0","vector":null}}
 "#,
@@ -7252,7 +7244,7 @@ node Embedding {
     // whose buildable indexes are current and whose vector remains pending-only.
     for name in ["w1", "w2", "w3", "w4"] {
         load_jsonl(
-            &mut db,
+            &db,
             &format!(r#"{{"type":"Work","data":{{"name":"{name}"}}}}"#),
             LoadMode::Merge,
         )
@@ -8035,7 +8027,7 @@ async fn branch_merge_phase_b_failure_recovered_on_next_open() {
     {
         let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
         load_jsonl(
-            &mut db,
+            &db,
             r#"{"type":"Person","data":{"name":"alice","age":30}}
 "#,
             LoadMode::Append,
@@ -9075,9 +9067,9 @@ async fn branch_merge_adopt_with_delta_phase_b_failure_recovered_on_next_open() 
     // merge is a fast-forward and Person classifies `AdoptWithDelta` (forked
     // source, target == base, non-empty delta) — NOT `RewriteMerged`.
     {
-        let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
+        let db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
         load_jsonl(
-            &mut db,
+            &db,
             r#"{"type":"Person","data":{"name":"alice","age":30}}
 "#,
             LoadMode::Append,
@@ -9163,9 +9155,9 @@ async fn setup_branch_merge_multichunk_adopt(dir: &tempfile::TempDir) -> (String
     const CHUNK_ROWS: usize = 8192;
 
     let uri = dir.path().to_str().unwrap().to_string();
-    let mut db = Omnigraph::init(&uri, RFC023_KEY_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(&uri, RFC023_KEY_SCHEMA).await.unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Person","data":{"name":"base","score":0}}"#,
         LoadMode::Append,
     )
@@ -9514,9 +9506,9 @@ async fn assert_partial_merge_rolls_back(scenario: MergeScenario, failpoint: &st
     // (upsert), remove dave (delete). For Rewrite, also move main past base so the
     // table classifies RewriteMerged instead of a fast-forward AdoptWithDelta.
     {
-        let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
+        let db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
         load_jsonl(
-            &mut db,
+            &db,
             "{\"type\":\"Person\",\"data\":{\"name\":\"alice\",\"age\":30}}\n\
              {\"type\":\"Person\",\"data\":{\"name\":\"carol\",\"age\":50}}\n\
              {\"type\":\"Person\",\"data\":{\"name\":\"dave\",\"age\":60}}\n",
@@ -9665,9 +9657,9 @@ async fn pre_upgrade_v1_branch_merge_sidecar_rolls_forward_not_back() {
     // main {alice}; feature adds bob → a fast-forward AdoptWithDelta merge, which
     // writes a recovery sidecar.
     {
-        let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
+        let db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
         load_jsonl(
-            &mut db,
+            &db,
             "{\"type\":\"Person\",\"data\":{\"name\":\"alice\",\"age\":30}}\n",
             LoadMode::Append,
         )
@@ -9745,7 +9737,6 @@ async fn branch_merge_phase_b_failure_recovered_on_non_main_target() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap().to_string();
     let operation_id;
-    let target_parent_commit_id;
 
     // Setup:
     //   main: alice
@@ -9753,9 +9744,9 @@ async fn branch_merge_phase_b_failure_recovered_on_non_main_target() {
     //   source_branch (off main): + carol (source moved past base)
     // Merge: source_branch → target_branch
     {
-        let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
+        let db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
         load_jsonl(
-            &mut db,
+            &db,
             r#"{"type":"Person","data":{"name":"alice","age":30}}
 "#,
             LoadMode::Append,
@@ -9791,7 +9782,7 @@ async fn branch_merge_phase_b_failure_recovered_on_non_main_target() {
             .expect("main must have Person")
             .table_version
     };
-    target_parent_commit_id = branch_head_commit_id(dir.path(), "target_branch")
+    let target_parent_commit_id = branch_head_commit_id(dir.path(), "target_branch")
         .await
         .unwrap();
 
@@ -9874,9 +9865,9 @@ async fn branch_merge_sidecar_pins_table_branch_to_active_branch() {
     let uri = dir.path().to_str().unwrap().to_string();
 
     {
-        let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
+        let db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
         load_jsonl(
-            &mut db,
+            &db,
             r#"{"type":"Person","data":{"name":"alice","age":30}}
 "#,
             LoadMode::Append,
@@ -9977,9 +9968,9 @@ async fn ensure_indices_phase_b_failure_does_not_leak_sidecar_when_no_work_neede
     // Seed, then reconcile the index declaration once. RFC-022 writes publish
     // only their exact data effect; index construction is derived work.
     {
-        let mut db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
+        let db = Omnigraph::init(&uri, helpers::TEST_SCHEMA).await.unwrap();
         load_jsonl(
-            &mut db,
+            &db,
             r#"{"type":"Person","data":{"name":"alice","age":30}}
 {"type":"Person","data":{"name":"bob","age":25}}
 "#,

--- a/crates/omnigraph/tests/forbidden_apis.rs
+++ b/crates/omnigraph/tests/forbidden_apis.rs
@@ -873,7 +873,7 @@ fn walk_into(dir: &Path, out: &mut Vec<PathBuf>) {
     }
 }
 
-fn relative_to_src<'a>(src: &Path, file: &'a Path) -> String {
+fn relative_to_src(src: &Path, file: &Path) -> String {
     file.strip_prefix(src)
         .unwrap_or(file)
         .to_string_lossy()

--- a/crates/omnigraph/tests/helpers/cost.rs
+++ b/crates/omnigraph/tests/helpers/cost.rs
@@ -672,10 +672,10 @@ pub async fn local_graph(dir: &tempfile::TempDir) -> Omnigraph {
 pub async fn s3_graph(name: &str) -> Option<Omnigraph> {
     let bucket = std::env::var("OMNIGRAPH_S3_TEST_BUCKET").ok()?;
     let uri = format!("s3://{bucket}/cost-tests/{name}-{}", std::process::id());
-    let mut db = Omnigraph::init(&uri, TEST_SCHEMA)
+    let db = Omnigraph::init(&uri, TEST_SCHEMA)
         .await
         .expect("OMNIGRAPH_S3_TEST_BUCKET is set but S3 graph init failed");
-    load_jsonl(&mut db, TEST_DATA, LoadMode::Overwrite)
+    load_jsonl(&db, TEST_DATA, LoadMode::Overwrite)
         .await
         .expect("OMNIGRAPH_S3_TEST_BUCKET is set but S3 seed load failed");
     Some(db)

--- a/crates/omnigraph/tests/helpers/mod.rs
+++ b/crates/omnigraph/tests/helpers/mod.rs
@@ -74,8 +74,8 @@ pub async fn open_dataset_head(uri: &str, branch: Option<&str>) -> lance::Datase
 /// Init a graph and load the standard test data.
 pub async fn init_and_load(dir: &tempfile::TempDir) -> Omnigraph {
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, TEST_DATA, LoadMode::Overwrite)
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    load_jsonl(&db, TEST_DATA, LoadMode::Overwrite)
         .await
         .unwrap();
     // Mutation/load publish only exact data effects; physical indexes are

--- a/crates/omnigraph/tests/lifecycle.rs
+++ b/crates/omnigraph/tests/lifecycle.rs
@@ -344,7 +344,7 @@ async fn refresh_rejects_schema_ir_tables_missing_from_manifest() {
 async fn write_capture_rejects_schema_ir_tables_missing_from_manifest() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
     let accepted = db.catalog().bound_schema_ir().unwrap().clone();
     let with_temporary_source =
         format!("{TEST_SCHEMA}\nnode Temporary {{\n    key: String @key\n}}\n");
@@ -355,7 +355,7 @@ async fn write_capture_rejects_schema_ir_tables_missing_from_manifest() {
     persist_schema_contract(dir.path(), &replacement);
 
     let err = omnigraph::loader::load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Person","data":{"name":"blocked"}}"#,
         omnigraph::loader::LoadMode::Merge,
     )
@@ -527,13 +527,13 @@ async fn snapshot_version_is_pinned() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
 
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
 
     let snap1 = snapshot_main(&db).await.unwrap();
     let v1 = snap1.version();
 
     omnigraph::loader::load_jsonl(
-        &mut db,
+        &db,
         r#"{"type": "Person", "data": {"name": "Alice", "age": 30}}"#,
         omnigraph::loader::LoadMode::Overwrite,
     )

--- a/crates/omnigraph/tests/literal_filters.rs
+++ b/crates/omnigraph/tests/literal_filters.rs
@@ -34,10 +34,8 @@ const DATA: &str = r#"{"type":"Metric","data":{"name":"m1","score":2.5,"ratio":0
 
 async fn metric_db(dir: &tempfile::TempDir) -> Omnigraph {
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, SCHEMA).await.unwrap();
-    load_jsonl(&mut db, DATA, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    let db = Omnigraph::init(uri, SCHEMA).await.unwrap();
+    load_jsonl(&db, DATA, LoadMode::Overwrite).await.unwrap();
     db
 }
 
@@ -194,9 +192,7 @@ async fn camelcase_property_filter_executes() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
     let mut db = Omnigraph::init(uri, CC_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, CC_DATA, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, CC_DATA, LoadMode::Overwrite).await.unwrap();
 
     let q =
         r#"query by_repo($r: String) { match { $d: Doc { repoName: $r } } return { $d.slug } }"#;

--- a/crates/omnigraph/tests/maintenance.rs
+++ b/crates/omnigraph/tests/maintenance.rs
@@ -399,12 +399,12 @@ node Doc {
 "#;
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, SCHEMA).await.unwrap();
 
     // Loads publish only data effects; establish the initial id + rank BTREEs
     // explicitly through the reconciler before creating partial coverage.
     load_jsonl(
-        &mut db,
+        &db,
         "{\"type\":\"Doc\",\"data\":{\"slug\":\"d1\",\"rank\":1}}\n\
          {\"type\":\"Doc\",\"data\":{\"slug\":\"d2\",\"rank\":2}}",
         LoadMode::Merge,
@@ -416,7 +416,7 @@ node Doc {
     // A second load with NEW keys appends a fragment the existing BTREEs do not
     // cover (the existence gate skips re-building an index that already exists).
     load_jsonl(
-        &mut db,
+        &db,
         "{\"type\":\"Doc\",\"data\":{\"slug\":\"d3\",\"rank\":3}}\n\
          {\"type\":\"Doc\",\"data\":{\"slug\":\"d4\",\"rank\":4}}",
         LoadMode::Merge,
@@ -472,28 +472,28 @@ async fn optimize_compacts_blob_table_alongside_plain_table() {
     let schema = "\
 node Doc {\n    slug: String @key\n    content: Blob\n}\n\
 node Tag {\n    slug: String @key\n}\n";
-    let mut db = Omnigraph::init(uri, schema).await.unwrap();
+    let db = Omnigraph::init(uri, schema).await.unwrap();
 
     // Multi-fragment blob table: Overwrite creates fragment 1; each Merge of
     // new keys appends another. A >=2-fragment blob table exercises the rewrite
     // path that exposed the historical Lance regression (a single fragment
     // would be a no-op).
     load_jsonl(
-        &mut db,
+        &db,
         "{\"type\":\"Doc\",\"data\":{\"slug\":\"d1\",\"content\":\"base64:aGVsbG8x\"}}\n{\"type\":\"Doc\",\"data\":{\"slug\":\"d2\",\"content\":\"base64:aGVsbG8y\"}}",
         LoadMode::Overwrite,
     )
     .await
     .unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         "{\"type\":\"Doc\",\"data\":{\"slug\":\"d3\",\"content\":\"base64:aGVsbG8z\"}}",
         LoadMode::Merge,
     )
     .await
     .unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         "{\"type\":\"Doc\",\"data\":{\"slug\":\"d4\",\"content\":\"base64:aGVsbG80\"}}",
         LoadMode::Merge,
     )
@@ -501,14 +501,14 @@ node Tag {\n    slug: String @key\n}\n";
     .unwrap();
     // Plain table, also multi-fragment so it has something to compact.
     load_jsonl(
-        &mut db,
+        &db,
         "{\"type\":\"Tag\",\"data\":{\"slug\":\"t1\"}}\n{\"type\":\"Tag\",\"data\":{\"slug\":\"t2\"}}",
         LoadMode::Merge,
     )
     .await
     .unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         "{\"type\":\"Tag\",\"data\":{\"slug\":\"t3\"}}",
         LoadMode::Merge,
     )
@@ -863,7 +863,7 @@ async fn non_strict_load_refuses_uncovered_drift_before_folding_it() {
     let (manifest_before, head_before, _) = forge_person_compaction_drift(&mut db, &root).await;
 
     let err = load_jsonl(
-        &mut db,
+        &db,
         "{\"type\":\"Person\",\"data\":{\"name\":\"Ivan\",\"age\":44}}",
         LoadMode::Merge,
     )
@@ -970,8 +970,8 @@ async fn ensure_indices_refuses_uncovered_drift_before_arming_recovery() {
         .trim_end_matches('/')
         .to_string();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, TEST_DATA, LoadMode::Overwrite)
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    load_jsonl(&db, TEST_DATA, LoadMode::Overwrite)
         .await
         .unwrap();
     let (manifest_before, head_before, _) = forge_person_delete_drift(&db, &root).await;
@@ -1209,9 +1209,7 @@ async fn cleanup_older_than_zero_preserves_head() {
 
     // Smoke test: after aggressive cleanup, we can still read and write the
     // graph — head wasn't pruned.
-    load_jsonl(&mut db, TEST_DATA, LoadMode::Merge)
-        .await
-        .unwrap();
+    load_jsonl(&db, TEST_DATA, LoadMode::Merge).await.unwrap();
 }
 
 #[tokio::test]
@@ -1460,9 +1458,7 @@ async fn cleanup_then_optimize_preserves_rows_and_table_remains_writable() {
     assert_eq!(count_rows(&db, "node:Company").await, companies_before);
 
     // Table is still writable after the cleanup+optimize sequence.
-    load_jsonl(&mut db, TEST_DATA, LoadMode::Merge)
-        .await
-        .unwrap();
+    load_jsonl(&db, TEST_DATA, LoadMode::Merge).await.unwrap();
     assert_eq!(count_rows(&db, "node:Person").await, people_before);
 }
 
@@ -1606,10 +1602,10 @@ async fn index_build_tolerates_null_vector_rows() {
         n: I64 @index\n    \
         embedding: Vector(8)? @index\n\
         }\n";
-    let mut db = Omnigraph::init(uri, schema).await.unwrap();
+    let db = Omnigraph::init(uri, schema).await.unwrap();
     // Rows present, embeddings null (loaded but not yet embedded).
     load_jsonl(
-        &mut db,
+        &db,
         "{\"type\":\"Doc\",\"data\":{\"slug\":\"d1\",\"n\":1}}\n\
          {\"type\":\"Doc\",\"data\":{\"slug\":\"d2\",\"n\":2}}",
         LoadMode::Merge,
@@ -1664,9 +1660,9 @@ async fn optimize_materializes_index_declared_but_unbuilt() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
     let v1 = "node Doc {\n    slug: String @key\n    rank: I32\n}\n";
-    let mut db = Omnigraph::init(uri, v1).await.unwrap();
+    let db = Omnigraph::init(uri, v1).await.unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         "{\"type\":\"Doc\",\"data\":{\"slug\":\"d1\",\"rank\":1}}\n\
          {\"type\":\"Doc\",\"data\":{\"slug\":\"d2\",\"rank\":2}}",
         LoadMode::Merge,
@@ -1716,9 +1712,9 @@ async fn optimize_materializes_index_after_type_rename() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
     let v1 = "node Doc {\n    slug: String @key\n    rank: I32 @index\n}\n";
-    let mut db = Omnigraph::init(uri, v1).await.unwrap();
+    let db = Omnigraph::init(uri, v1).await.unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         "{\"type\":\"Doc\",\"data\":{\"slug\":\"d1\",\"rank\":1}}\n\
          {\"type\":\"Doc\",\"data\":{\"slug\":\"d2\",\"rank\":2}}",
         LoadMode::Merge,

--- a/crates/omnigraph/tests/merge_fast_forward.rs
+++ b/crates/omnigraph/tests/merge_fast_forward.rs
@@ -745,9 +745,9 @@ async fn fast_forward_merge_streams_blob_columns() {
 
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut main = Omnigraph::init(uri, BLOB_SCHEMA).await.unwrap();
+    let main = Omnigraph::init(uri, BLOB_SCHEMA).await.unwrap();
     load_jsonl(
-        &mut main,
+        &main,
         "{\"type\":\"Document\",\"data\":{\"title\":\"seed\",\"content\":\"base64:U2VlZA==\",\"note\":\"base\"}}",
         LoadMode::Overwrite,
     )

--- a/crates/omnigraph/tests/merge_truth_table.rs
+++ b/crates/omnigraph/tests/merge_truth_table.rs
@@ -98,8 +98,8 @@ query get_person($name: String) {
 
 async fn bootstrap(dir: &tempfile::TempDir) -> Omnigraph {
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, TRUTH_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, TRUTH_DATA, LoadMode::Overwrite)
+    let db = Omnigraph::init(uri, TRUTH_SCHEMA).await.unwrap();
+    load_jsonl(&db, TRUTH_DATA, LoadMode::Overwrite)
         .await
         .unwrap();
     db

--- a/crates/omnigraph/tests/ordering.rs
+++ b/crates/omnigraph/tests/ordering.rs
@@ -37,10 +37,8 @@ fn names_in_order(result: &QueryResult) -> Vec<String> {
 /// Init the standard schema and load a custom Person-only dataset.
 async fn init_people(dir: &tempfile::TempDir, jsonl: &str) -> Omnigraph {
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, jsonl, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    load_jsonl(&db, jsonl, LoadMode::Overwrite).await.unwrap();
     db
 }
 
@@ -117,7 +115,7 @@ async fn ordering_parallel_edge_tie_breaks_by_physical_edge_id() {
     // order is deliberately the reverse of physical edge-id order. The two
     // rows are otherwise tied: same user sort key and same endpoint ids.
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Person","data":{"name":"Alice","age":30}}
 {"type":"Person","data":{"name":"Bob","age":25}}
 {"edge":"Knows","from":"Alice","to":"Bob","data":{"id":"edge-b","label":"loaded-first"}}"#,
@@ -126,7 +124,7 @@ async fn ordering_parallel_edge_tie_breaks_by_physical_edge_id() {
     .await
     .unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"edge":"Knows","from":"Alice","to":"Bob","data":{"id":"edge-a","label":"id-first"}}"#,
         LoadMode::Merge,
     )

--- a/crates/omnigraph/tests/proptest_equivalence.rs
+++ b/crates/omnigraph/tests/proptest_equivalence.rs
@@ -152,8 +152,8 @@ fn config() -> Config {
 async fn load_graph(graph: &GenGraph) -> (tempfile::TempDir, Omnigraph) {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, &graph.to_jsonl(), LoadMode::Overwrite)
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    load_jsonl(&db, &graph.to_jsonl(), LoadMode::Overwrite)
         .await
         .unwrap();
     (dir, db)

--- a/crates/omnigraph/tests/recovery.rs
+++ b/crates/omnigraph/tests/recovery.rs
@@ -162,7 +162,7 @@ async fn recovery_refuses_corrupt_sidecar_on_open_and_write() {
 
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
 
     // A truncated/garbage sidecar — e.g. a crashed writer or a partial
     // local-FS write (S3 PutObject is atomic; local fs::write is not).
@@ -171,14 +171,13 @@ async fn recovery_refuses_corrupt_sidecar_on_open_and_write() {
     // A live handle's write-entry heal must surface the parse failure
     // loudly instead of proceeding over a sidecar it cannot interpret.
     let err = load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Person","data":{"name":"Alice","age":30}}
 "#,
         LoadMode::Merge,
     )
     .await
-    .err()
-    .expect("expected the write to fail on the corrupt sidecar");
+    .expect_err("expected the write to fail on the corrupt sidecar");
     assert!(
         err.to_string().contains("is not valid JSON"),
         "expected the corrupt-sidecar parse error, got: {}",
@@ -219,9 +218,9 @@ async fn drift_guard_advice_ignores_other_branch_sidecars() {
 
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         "{\"type\":\"Person\",\"data\":{\"name\":\"Alice\",\"age\":30}}\n",
         LoadMode::Merge,
     )
@@ -272,13 +271,12 @@ async fn drift_guard_advice_ignores_other_branch_sidecars() {
     let _ = helpers::lance_delete_inline(&mut ds, "1 = 2").await;
 
     let err = load_jsonl(
-        &mut db,
+        &db,
         "{\"type\":\"Person\",\"data\":{\"name\":\"Bob\",\"age\":25}}\n",
         LoadMode::Merge,
     )
     .await
-    .err()
-    .expect("uncovered main drift must fail the write");
+    .expect_err("uncovered main drift must fail the write");
     assert!(
         err.to_string().contains("run `omnigraph repair`"),
         "a feature-branch sidecar must not flip main's uncovered-drift \
@@ -299,9 +297,9 @@ async fn deleted_branch_sidecar_does_not_wedge_writes_or_open() {
 
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap().to_string();
-    let mut db = Omnigraph::init(&uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(&uri, TEST_SCHEMA).await.unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         "{\"type\":\"Person\",\"data\":{\"name\":\"Alice\",\"age\":30}}\n",
         LoadMode::Merge,
     )
@@ -349,7 +347,7 @@ async fn deleted_branch_sidecar_does_not_wedge_writes_or_open() {
     // The next write's heal must classify the orphan and discard it,
     // not fail opening the dead branch.
     load_jsonl(
-        &mut db,
+        &db,
         "{\"type\":\"Person\",\"data\":{\"name\":\"Bob\",\"age\":25}}\n",
         LoadMode::Merge,
     )
@@ -476,13 +474,11 @@ async fn recovery_rolls_back_synthetic_drift_on_open() {
 
     // Bootstrap a real graph with a Person table so we have a Lance dataset
     // to advance synthetically.
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
     let test_data = r#"{"type":"Person","data":{"name":"alice","age":30}}
 {"type":"Person","data":{"name":"bob","age":25}}
 "#;
-    load_jsonl(&mut db, test_data, LoadMode::Append)
-        .await
-        .unwrap();
+    load_jsonl(&db, test_data, LoadMode::Append).await.unwrap();
     let (person_uri, person_identity) = node_table_fixture(&db, "Person").await;
     drop(db);
 
@@ -586,9 +582,9 @@ async fn recovery_rollback_converges_manifest_so_schema_apply_succeeds() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
 
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Person","data":{"name":"alice","age":30}}
 {"type":"Person","data":{"name":"bob","age":25}}
 "#,
@@ -702,7 +698,7 @@ async fn read_latest_recovery_audit(
         .try_collect()
         .await
         .ok()?;
-    let last_batch = batches.iter().filter(|b| b.num_rows() > 0).last()?;
+    let last_batch = batches.iter().rfind(|b| b.num_rows() > 0)?;
     let row = last_batch.num_rows() - 1;
     let kinds = last_batch
         .column_by_name("recovery_kind")?
@@ -795,13 +791,11 @@ async fn recovery_rolls_forward_after_phase_b_completes() {
 
     // Bootstrap: init + load 2 rows. Manifest pin and Lance HEAD both
     // advance via the legitimate publisher path.
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
     let test_data = r#"{"type":"Person","data":{"name":"alice","age":30}}
 {"type":"Person","data":{"name":"bob","age":25}}
 "#;
-    load_jsonl(&mut db, test_data, LoadMode::Append)
-        .await
-        .unwrap();
+    load_jsonl(&db, test_data, LoadMode::Append).await.unwrap();
     let (person_uri, person_identity) = node_table_fixture(&db, "Person").await;
     drop(db);
 
@@ -883,13 +877,11 @@ async fn recovery_records_rolled_forward_for_stale_sidecar_after_successful_roll
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
 
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
     let test_data = r#"{"type":"Person","data":{"name":"alice","age":30}}
 {"type":"Person","data":{"name":"bob","age":25}}
 "#;
-    load_jsonl(&mut db, test_data, LoadMode::Append)
-        .await
-        .unwrap();
+    load_jsonl(&db, test_data, LoadMode::Append).await.unwrap();
 
     // Capture the current manifest pin and Lance HEAD — these match
     // because the load went through the publisher.
@@ -975,7 +967,7 @@ async fn recovery_records_rolled_forward_for_stale_sidecar_after_successful_roll
         .try_collect()
         .await
         .unwrap();
-    let last = batches.iter().filter(|b| b.num_rows() > 0).last().unwrap();
+    let last = batches.iter().rfind(|b| b.num_rows() > 0).unwrap();
     let row = last.num_rows() - 1;
     let outcomes_json = last
         .column_by_name("per_table_outcomes_json")
@@ -1000,12 +992,10 @@ async fn recovery_rolls_back_records_audit_row_with_recovery_actor() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
 
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
     let test_data = r#"{"type":"Person","data":{"name":"alice","age":30}}
 "#;
-    load_jsonl(&mut db, test_data, LoadMode::Append)
-        .await
-        .unwrap();
+    load_jsonl(&db, test_data, LoadMode::Append).await.unwrap();
     let (person_uri, person_identity) = node_table_fixture(&db, "Person").await;
     drop(db);
 
@@ -1063,12 +1053,10 @@ async fn recovery_rolls_forward_with_null_actor() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
 
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
     let test_data = r#"{"type":"Person","data":{"name":"alice","age":30}}
 "#;
-    load_jsonl(&mut db, test_data, LoadMode::Append)
-        .await
-        .unwrap();
+    load_jsonl(&db, test_data, LoadMode::Append).await.unwrap();
     let (person_uri, person_identity) = node_table_fixture(&db, "Person").await;
     drop(db);
 
@@ -1136,13 +1124,11 @@ async fn recovery_processes_multiple_sidecars_with_fresh_snapshot_per_iter() {
     let uri = dir.path().to_str().unwrap();
 
     // Bootstrap: load Person and Company so both have committed datasets.
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
     let test_data = r#"{"type":"Person","data":{"name":"alice","age":30}}
 {"type":"Company","data":{"name":"acme"}}
 "#;
-    load_jsonl(&mut db, test_data, LoadMode::Append)
-        .await
-        .unwrap();
+    load_jsonl(&db, test_data, LoadMode::Append).await.unwrap();
     let (person_uri, person_identity) = node_table_fixture(&db, "Person").await;
     let (company_uri, company_identity) = node_table_fixture(&db, "Company").await;
     drop(db);
@@ -1226,13 +1212,11 @@ async fn recovery_ensure_indices_steady_state_no_sidecar() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
 
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
     let test_data = r#"{"type":"Person","data":{"name":"alice","age":30}}
 {"type":"Company","data":{"name":"acme"}}
 "#;
-    load_jsonl(&mut db, test_data, LoadMode::Append)
-        .await
-        .unwrap();
+    load_jsonl(&db, test_data, LoadMode::Append).await.unwrap();
     db.ensure_indices().await.unwrap();
     drop(db);
 
@@ -1366,9 +1350,9 @@ async fn recovery_multi_sidecar_requires_fresh_snapshot_for_correctness() {
 
     // Bootstrap: load Person rows; manifest pin and Lance HEAD == some
     // baseline N.
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Person","data":{"name":"alice","age":30}}
 "#,
         LoadMode::Append,
@@ -1510,9 +1494,9 @@ async fn recovery_classifies_feature_branch_sidecar_against_feature_branch() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
 
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Person","data":{"name":"alice","age":30}}
 "#,
         LoadMode::Append,
@@ -1621,9 +1605,9 @@ async fn recovery_rolls_back_feature_branch_sidecar_against_feature_branch() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
 
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Person","data":{"name":"alice","age":30}}
 "#,
         LoadMode::Append,

--- a/crates/omnigraph/tests/s3_storage.rs
+++ b/crates/omnigraph/tests/s3_storage.rs
@@ -17,8 +17,8 @@ async fn s3_compatible_graph_lifecycle_works() {
         return;
     };
 
-    let mut db = Omnigraph::init(&uri, TEST_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, TEST_DATA, LoadMode::Overwrite)
+    let db = Omnigraph::init(&uri, TEST_SCHEMA).await.unwrap();
+    load_jsonl(&db, TEST_DATA, LoadMode::Overwrite)
         .await
         .unwrap();
 
@@ -91,12 +91,12 @@ async fn s3_branch_change_merge_flow_works() {
     };
 
     let mut main = Omnigraph::init(&uri, TEST_SCHEMA).await.unwrap();
-    load_jsonl(&mut main, TEST_DATA, LoadMode::Overwrite)
+    load_jsonl(&main, TEST_DATA, LoadMode::Overwrite)
         .await
         .unwrap();
     main.branch_create("feature").await.unwrap();
 
-    let mut feature = Omnigraph::open(&uri).await.unwrap();
+    let feature = Omnigraph::open(&uri).await.unwrap();
     feature
         .mutate(
             "feature",
@@ -144,8 +144,8 @@ async fn s3_public_load_uses_hidden_run_and_publishes() {
         return;
     };
 
-    let mut db = Omnigraph::init(&uri, TEST_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, TEST_DATA, LoadMode::Overwrite)
+    let db = Omnigraph::init(&uri, TEST_SCHEMA).await.unwrap();
+    load_jsonl(&db, TEST_DATA, LoadMode::Overwrite)
         .await
         .unwrap();
 
@@ -249,8 +249,8 @@ async fn s3_schema_apply_migrates_live_graph() {
         eprintln!("skipping s3 schema apply test: OMNIGRAPH_S3_TEST_BUCKET is not set");
         return;
     };
-    let mut db = Omnigraph::init(&uri, TEST_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, TEST_DATA, LoadMode::Overwrite)
+    let db = Omnigraph::init(&uri, TEST_SCHEMA).await.unwrap();
+    load_jsonl(&db, TEST_DATA, LoadMode::Overwrite)
         .await
         .unwrap();
 
@@ -279,9 +279,9 @@ async fn s3_fresh_branch_traversal_reuses_main_graph_index_with_etags() {
         return;
     };
 
-    let mut writer = Omnigraph::init(&uri, TEST_SCHEMA).await.unwrap();
+    let writer = Omnigraph::init(&uri, TEST_SCHEMA).await.unwrap();
     // TEST_DATA seeds Alice->Bob and Alice->Charlie Knows edges.
-    load_jsonl(&mut writer, TEST_DATA, LoadMode::Overwrite)
+    load_jsonl(&writer, TEST_DATA, LoadMode::Overwrite)
         .await
         .unwrap();
 

--- a/crates/omnigraph/tests/scalar_indexes.rs
+++ b/crates/omnigraph/tests/scalar_indexes.rs
@@ -39,10 +39,8 @@ const DATA: &str = r#"{"type":"Item","data":{"slug":"a","status":"active","publi
 async fn node_scalar_and_enum_index_columns_get_btree() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, SCHEMA).await.unwrap();
-    load_jsonl(&mut db, DATA, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    let db = Omnigraph::init(uri, SCHEMA).await.unwrap();
+    load_jsonl(&db, DATA, LoadMode::Overwrite).await.unwrap();
     db.ensure_indices().await.unwrap();
 
     let snap = snapshot_main(&db).await.unwrap();

--- a/crates/omnigraph/tests/schema_apply.rs
+++ b/crates/omnigraph/tests/schema_apply.rs
@@ -513,7 +513,7 @@ async fn plan_schema_rejects_when_schema_contract_has_drifted() {
 async fn apply_schema_noop_returns_not_applied() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
 
     let result = db.apply_schema(TEST_SCHEMA).await.unwrap();
     assert!(result.supported);
@@ -526,7 +526,7 @@ async fn apply_schema_noop_returns_not_applied() {
 async fn apply_schema_rejects_when_non_main_branch_exists() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
     db.branch_create("feature").await.unwrap();
 
     let desired = TEST_SCHEMA.replace(
@@ -545,7 +545,7 @@ async fn apply_schema_rejects_when_non_main_branch_exists() {
 async fn apply_schema_unsupported_plan_does_not_advance_manifest() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
     let before_version = db
         .snapshot_of(ReadTarget::branch("main"))
         .await
@@ -583,7 +583,7 @@ async fn apply_schema_unsupported_plan_does_not_advance_manifest() {
 #[cfg_attr(feature = "failpoints", serial_test::parallel)]
 async fn apply_schema_drops_a_nullable_property_softly_preserves_prior_version() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
 
     let people_before = count_rows(&db, "node:Person").await;
     let before_version = db
@@ -690,7 +690,7 @@ async fn apply_schema_drops_a_nullable_property_softly_preserves_prior_version()
 #[cfg_attr(feature = "failpoints", serial_test::parallel)]
 async fn apply_schema_drops_node_and_referencing_edge_softly() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
     let before_version = db
         .snapshot_of(ReadTarget::branch("main"))
         .await
@@ -804,7 +804,7 @@ edge Knows: Person -> Person {
 #[cfg_attr(feature = "failpoints", serial_test::parallel)]
 async fn apply_schema_drops_an_edge_type_softly() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
     let before_version = db
         .snapshot_of(ReadTarget::branch("main"))
         .await
@@ -862,7 +862,7 @@ async fn apply_schema_drops_an_edge_type_softly() {
 #[cfg_attr(feature = "failpoints", serial_test::parallel)]
 async fn apply_schema_rejects_adding_a_required_property_without_backfill() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
     let before_version = db
         .snapshot_of(ReadTarget::branch("main"))
         .await
@@ -898,8 +898,8 @@ async fn plan_schema_for_property_type_narrowing_is_not_supported() {
     let uri = dir.path().to_str().unwrap();
 
     let initial = TEST_SCHEMA.replace("age: I32?", "age: I64?");
-    let mut db = Omnigraph::init(uri, &initial).await.unwrap();
-    load_jsonl(&mut db, TEST_DATA, LoadMode::Overwrite)
+    let db = Omnigraph::init(uri, &initial).await.unwrap();
+    load_jsonl(&db, TEST_DATA, LoadMode::Overwrite)
         .await
         .unwrap();
 
@@ -919,7 +919,7 @@ async fn plan_schema_for_property_type_narrowing_is_not_supported() {
 #[cfg_attr(feature = "failpoints", serial_test::parallel)]
 async fn apply_schema_pure_type_rename_preserves_identity_path_and_version() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
     db.ensure_indices().await.unwrap();
     let before_snapshot = db.snapshot_of(ReadTarget::branch("main")).await.unwrap();
     let before_version = before_snapshot.version();
@@ -1059,7 +1059,7 @@ async fn apply_schema_renames_node_type_via_rename_from_and_preserves_rows() {
     // "supported" half of the destructive-vs-supported boundary that the
     // rejections above cover.
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
     let before = db
         .snapshot_of(ReadTarget::branch("main"))
         .await
@@ -1231,7 +1231,7 @@ query put_pair($aaaa: String, $zzzz: String, $label: String) {
 async fn apply_schema_drop_then_same_name_readd_mints_new_identity_and_path() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(
+    let db = Omnigraph::init(
         uri,
         r#"
 node Person { name: String @key }
@@ -1295,7 +1295,7 @@ node Anchor { name: String @key }
 #[cfg_attr(feature = "failpoints", serial_test::parallel)]
 async fn apply_schema_with_allow_data_loss_promotes_drops_to_hard() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
 
     let desired = TEST_SCHEMA.replace("    age: I32?\n", "");
 
@@ -1362,7 +1362,7 @@ async fn apply_schema_with_allow_data_loss_promotes_drops_to_hard() {
 #[cfg_attr(feature = "failpoints", serial_test::parallel)]
 async fn apply_schema_hard_drops_property_makes_prior_version_unreachable() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
     let before_version = db
         .snapshot_of(ReadTarget::branch("main"))
         .await
@@ -1415,7 +1415,7 @@ async fn apply_schema_hard_drops_property_makes_prior_version_unreachable() {
 #[cfg_attr(feature = "failpoints", serial_test::parallel)]
 async fn apply_schema_hard_drops_node_and_edge_with_flag_succeeds() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
     let before_version = db
         .snapshot_of(ReadTarget::branch("main"))
         .await
@@ -1519,7 +1519,7 @@ async fn apply_schema_defers_vector_index_on_empty_table() {
         body: String?\n    \
         embedding: Vector(8) @index\n\
         }\n";
-    let mut db = Omnigraph::init(uri, v1).await.unwrap();
+    let db = Omnigraph::init(uri, v1).await.unwrap();
 
     // Add an unrelated scalar @index on `body`. Schema apply must record both
     // declarations without trying to build either one or train the empty vector.
@@ -1537,7 +1537,7 @@ async fn apply_schema_defers_vector_index_on_empty_table() {
     // The deferred declarations are not dropped: after data arrives, the
     // explicit reconciler materializes every buildable index without error.
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Doc","data":{"slug":"d1","body":"hello","embedding":[0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8]}}"#,
         LoadMode::Merge,
     )
@@ -1560,9 +1560,9 @@ async fn index_only_constraint_apply_touches_no_table_data() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
     let v1 = "node Doc {\n    slug: String @key\n    n: I64\n}\n";
-    let mut db = Omnigraph::init(uri, v1).await.unwrap();
+    let db = Omnigraph::init(uri, v1).await.unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Doc","data":{"slug":"d1","n":1}}"#,
         LoadMode::Merge,
     )
@@ -1615,9 +1615,9 @@ async fn enum_widening_apply_is_metadata_only_and_accepts_new_variant() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
     let v1 = "node Ticket {\n    slug: String @key\n    status: enum(todo, doing, done)\n}\n";
-    let mut db = Omnigraph::init(uri, v1).await.unwrap();
+    let db = Omnigraph::init(uri, v1).await.unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Ticket","data":{"slug":"t1","status":"todo"}}"#,
         LoadMode::Merge,
     )
@@ -1659,7 +1659,7 @@ async fn enum_widening_apply_is_metadata_only_and_accepts_new_variant() {
 
     // The NEW variant is accepted on the write path...
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Ticket","data":{"slug":"t2","status":"blocked"}}"#,
         LoadMode::Merge,
     )
@@ -1667,7 +1667,7 @@ async fn enum_widening_apply_is_metadata_only_and_accepts_new_variant() {
     .expect("new variant must be accepted after widening");
     // ...an original variant still is...
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Ticket","data":{"slug":"t3","status":"done"}}"#,
         LoadMode::Merge,
     )
@@ -1676,7 +1676,7 @@ async fn enum_widening_apply_is_metadata_only_and_accepts_new_variant() {
     // ...and an out-of-set value is still rejected (the fence didn't widen to
     // free text).
     let err = load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Ticket","data":{"slug":"t4","status":"bogus"}}"#,
         LoadMode::Merge,
     )
@@ -1690,7 +1690,7 @@ async fn enum_narrowing_apply_is_refused() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
     let v1 = "node Ticket {\n    slug: String @key\n    status: enum(todo, doing, done)\n}\n";
-    let mut db = Omnigraph::init(uri, v1).await.unwrap();
+    let db = Omnigraph::init(uri, v1).await.unwrap();
 
     let narrowed = "node Ticket {\n    slug: String @key\n    status: enum(todo, done)\n}\n";
     let err = db.apply_schema(narrowed).await;
@@ -1703,7 +1703,7 @@ async fn enum_narrowing_apply_is_refused() {
 
     // The graph stays healthy and writable on the original schema.
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Ticket","data":{"slug":"t1","status":"doing"}}"#,
         LoadMode::Merge,
     )

--- a/crates/omnigraph/tests/search.rs
+++ b/crates/omnigraph/tests/search.rs
@@ -127,8 +127,8 @@ query rrf_edges($q1: Vector(4), $q2: Vector(4)) {
 
 async fn init_search_db(dir: &tempfile::TempDir) -> Omnigraph {
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, SEARCH_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, SEARCH_DATA, LoadMode::Overwrite)
+    let db = Omnigraph::init(uri, SEARCH_SCHEMA).await.unwrap();
+    load_jsonl(&db, SEARCH_DATA, LoadMode::Overwrite)
         .await
         .unwrap();
     db.ensure_indices().await.unwrap();
@@ -137,8 +137,8 @@ async fn init_search_db(dir: &tempfile::TempDir) -> Omnigraph {
 
 async fn init_ranked_edge_db(dir: &tempfile::TempDir) -> Omnigraph {
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, RANKED_EDGE_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, RANKED_EDGE_DATA, LoadMode::Overwrite)
+    let db = Omnigraph::init(uri, RANKED_EDGE_SCHEMA).await.unwrap();
+    load_jsonl(&db, RANKED_EDGE_DATA, LoadMode::Overwrite)
         .await
         .unwrap();
     db
@@ -146,8 +146,8 @@ async fn init_ranked_edge_db(dir: &tempfile::TempDir) -> Omnigraph {
 
 async fn init_mock_embedding_search_db(dir: &tempfile::TempDir) -> Omnigraph {
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, MOCK_SEARCH_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, &mock_embedding_seed_data(), LoadMode::Overwrite)
+    let db = Omnigraph::init(uri, MOCK_SEARCH_SCHEMA).await.unwrap();
+    load_jsonl(&db, &mock_embedding_seed_data(), LoadMode::Overwrite)
         .await
         .unwrap();
     db.ensure_indices().await.unwrap();
@@ -156,8 +156,8 @@ async fn init_mock_embedding_search_db(dir: &tempfile::TempDir) -> Omnigraph {
 
 async fn init_model_recorded_search_db(dir: &tempfile::TempDir) -> Omnigraph {
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, MODEL_RECORDED_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, &mock_embedding_seed_data(), LoadMode::Overwrite)
+    let db = Omnigraph::init(uri, MODEL_RECORDED_SCHEMA).await.unwrap();
+    load_jsonl(&db, &mock_embedding_seed_data(), LoadMode::Overwrite)
         .await
         .unwrap();
     db.ensure_indices().await.unwrap();
@@ -286,7 +286,7 @@ async fn deferred_indexes_do_not_block_hybrid_reads() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
     let mut db = Omnigraph::init(uri, MOCK_SEARCH_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, &mock_embedding_seed_data(), LoadMode::Overwrite)
+    load_jsonl(&db, &mock_embedding_seed_data(), LoadMode::Overwrite)
         .await
         .unwrap();
 
@@ -538,7 +538,7 @@ async fn assert_filtered_nearest_returns_hits(query_name: &str) {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
     let mut db = Omnigraph::init(uri, FILTERED_NEAREST_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, FILTERED_NEAREST_DATA, LoadMode::Overwrite)
+    load_jsonl(&db, FILTERED_NEAREST_DATA, LoadMode::Overwrite)
         .await
         .unwrap();
 
@@ -1147,10 +1147,8 @@ node Doc {
 
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, schema).await.unwrap();
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    let db = Omnigraph::init(uri, schema).await.unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
     assert_eq!(
         doc_user_index_count(&db).await,
         0,

--- a/crates/omnigraph/tests/traversal.rs
+++ b/crates/omnigraph/tests/traversal.rs
@@ -64,7 +64,7 @@ query connected_directional($name: String) {
     // Dedup: add the reverse edge Diana->Bob so (Bob, Diana) exists both
     // ways; Diana must still appear exactly once.
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"edge": "Knows", "from": "Diana", "to": "Bob"}"#,
         LoadMode::Merge,
     )
@@ -305,9 +305,7 @@ async fn nested_anti_join_with_fanout_correlates_correctly() {
 {"edge":"WorksAt","from":"p2","to":"Globex"}
 {"edge":"WorksAt","from":"p3","to":"Acme"}"#;
     let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
 
     let queries = r#"
 query no_nonacme_employer() {
@@ -357,9 +355,7 @@ async fn anti_join_respects_multi_hop_bounds() {
 {"edge":"Knows","from":"c","to":"d"}
 {"edge":"Knows","from":"d","to":"e"}"#;
     let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
 
     let queries = r#"
 query no_two_hop() {
@@ -404,8 +400,8 @@ const CHAIN_DATA: &str = r#"{"type": "Person", "data": {"name": "A"}}
 
 async fn init_chain(dir: &tempfile::TempDir) -> Omnigraph {
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, CHAIN_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, CHAIN_DATA, LoadMode::Overwrite)
+    let db = Omnigraph::init(uri, CHAIN_SCHEMA).await.unwrap();
+    load_jsonl(&db, CHAIN_DATA, LoadMode::Overwrite)
         .await
         .unwrap();
     db
@@ -559,9 +555,7 @@ async fn traversal_no_edges_returns_empty() {
     let data = r#"{"type": "Person", "data": {"name": "Alice", "age": 30}}
 {"type": "Person", "data": {"name": "Bob", "age": 25}}
 {"type": "Company", "data": {"name": "Acme"}}"#;
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
 
     // Traversal should return empty, not crash
     let result = query_main(
@@ -1097,7 +1091,7 @@ async fn edge_binding_filters_and_projects_edge_properties() {
     // Fixture Knows edges (Alice->Bob, Alice->Charlie, Bob->Diana) carry no
     // `since`; give Alice two dated friendships on either side of the cutoff.
     load_jsonl(
-        &mut db,
+        &db,
         concat!(
             r#"{"edge": "Knows", "from": "Alice", "to": "Bob", "data": {"since": "2020-05-01"}}"#,
             "\n",

--- a/crates/omnigraph/tests/traversal_indexed.rs
+++ b/crates/omnigraph/tests/traversal_indexed.rs
@@ -324,9 +324,7 @@ query reach($name: String) {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
     let mut db = Omnigraph::init(uri, SCHEMA).await.unwrap();
-    load_jsonl(&mut db, DATA, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, DATA, LoadMode::Overwrite).await.unwrap();
 
     let got = both_modes(&mut db, QUERY, "reach", &params(&[("$name", "alice")])).await;
     assert_eq!(
@@ -363,9 +361,7 @@ async fn variable_hops_terminate_and_dedup_on_cycle() {
 {"edge":"Knows","from":"b","to":"c"}
 {"edge":"Knows","from":"c","to":"a"}"#;
     let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
 
     let got = both_modes(&mut db, REACH_5, "reach", &params(&[("$name", "a")])).await;
     // From a: b (1 hop), c (2 hops); the c->a back-edge hits the seeded source
@@ -384,9 +380,7 @@ async fn variable_hops_handle_self_loop() {
 {"edge":"Knows","from":"a","to":"a"}
 {"edge":"Knows","from":"a","to":"b"}"#;
     let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
 
     let got = both_modes(&mut db, REACH_5, "reach", &params(&[("$name", "a")])).await;
     // a->a hits the seeded source (pruned); only b is reached.

--- a/crates/omnigraph/tests/validators.rs
+++ b/crates/omnigraph/tests/validators.rs
@@ -103,11 +103,9 @@ query drop_employment($person: String) {
 async fn init_with(schema: &str, data: &str) -> (tempfile::TempDir, Omnigraph) {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, schema).await.unwrap();
+    let db = Omnigraph::init(uri, schema).await.unwrap();
     if !data.is_empty() {
-        load_jsonl(&mut db, data, LoadMode::Overwrite)
-            .await
-            .unwrap();
+        load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
     }
     (dir, db)
 }
@@ -128,11 +126,11 @@ node Doc {
 /// direction while passing every dimension check.
 #[tokio::test]
 async fn non_numeric_vector_element_rejected_on_jsonl_load() {
-    let (_dir, mut db) = init_with(VECTOR_SCHEMA, "").await;
+    let (_dir, db) = init_with(VECTOR_SCHEMA, "").await;
 
     // A null element (what json! produces for a non-finite float).
     let bad_null = r#"{"type":"Doc","data":{"slug":"d1","embedding":[0.1,null,0.3]}}"#;
-    let err = load_jsonl(&mut db, bad_null, LoadMode::Overwrite)
+    let err = load_jsonl(&db, bad_null, LoadMode::Overwrite)
         .await
         .unwrap_err();
     assert!(
@@ -143,7 +141,7 @@ async fn non_numeric_vector_element_rejected_on_jsonl_load() {
 
     // A string element.
     let bad_str = r#"{"type":"Doc","data":{"slug":"d2","embedding":[0.1,"0.2",0.3]}}"#;
-    let err = load_jsonl(&mut db, bad_str, LoadMode::Overwrite)
+    let err = load_jsonl(&db, bad_str, LoadMode::Overwrite)
         .await
         .unwrap_err();
     assert!(
@@ -155,7 +153,7 @@ async fn non_numeric_vector_element_rejected_on_jsonl_load() {
     // Pin the adjacent (existing) dimension check while we are here — no
     // loader vector validation had any coverage before this test.
     let bad_dim = r#"{"type":"Doc","data":{"slug":"d3","embedding":[0.1,0.2]}}"#;
-    let err = load_jsonl(&mut db, bad_dim, LoadMode::Overwrite)
+    let err = load_jsonl(&db, bad_dim, LoadMode::Overwrite)
         .await
         .unwrap_err();
     assert!(
@@ -166,20 +164,16 @@ async fn non_numeric_vector_element_rejected_on_jsonl_load() {
 
     // A valid row still loads.
     let good = r#"{"type":"Doc","data":{"slug":"d4","embedding":[0.1,0.2,0.3]}}"#;
-    load_jsonl(&mut db, good, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, good, LoadMode::Overwrite).await.unwrap();
 }
 
 // ─── Enum validation ─────────────────────────────────────────────────────────
 
 #[tokio::test]
 async fn enum_rejected_on_jsonl_load() {
-    let (_dir, mut db) = init_with(ENUM_SCHEMA, "").await;
+    let (_dir, db) = init_with(ENUM_SCHEMA, "").await;
     let bad = r#"{"type":"Person","data":{"name":"Alice","role":"superadmin"}}"#;
-    let err = load_jsonl(&mut db, bad, LoadMode::Overwrite)
-        .await
-        .unwrap_err();
+    let err = load_jsonl(&db, bad, LoadMode::Overwrite).await.unwrap_err();
     assert!(
         err.to_string().contains("invalid enum value 'superadmin'"),
         "got: {}",
@@ -227,11 +221,9 @@ async fn enum_rejected_on_mutation_update() {
 
 #[tokio::test]
 async fn range_rejected_on_jsonl_load() {
-    let (_dir, mut db) = init_with(RANGE_SCHEMA, "").await;
+    let (_dir, db) = init_with(RANGE_SCHEMA, "").await;
     let bad = r#"{"type":"Person","data":{"name":"Alice","age":250}}"#;
-    let err = load_jsonl(&mut db, bad, LoadMode::Overwrite)
-        .await
-        .unwrap_err();
+    let err = load_jsonl(&db, bad, LoadMode::Overwrite).await.unwrap_err();
     assert!(err.to_string().contains("@range violation"), "got: {}", err);
 }
 
@@ -275,12 +267,10 @@ async fn range_rejected_on_mutation_update() {
 
 #[tokio::test]
 async fn intra_batch_unique_rejected_on_jsonl_load() {
-    let (_dir, mut db) = init_with(UNIQUE_SCHEMA, "").await;
+    let (_dir, db) = init_with(UNIQUE_SCHEMA, "").await;
     let bad = r#"{"type":"User","data":{"name":"Alice","email":"dup@example.com"}}
 {"type":"User","data":{"name":"Bob","email":"dup@example.com"}}"#;
-    let err = load_jsonl(&mut db, bad, LoadMode::Overwrite)
-        .await
-        .unwrap_err();
+    let err = load_jsonl(&db, bad, LoadMode::Overwrite).await.unwrap_err();
     assert!(
         err.to_string().contains("@unique violation on User.email"),
         "got: {}",
@@ -362,16 +352,16 @@ edge Knows: Person -> Person
 /// must not survive the rejected load).
 #[tokio::test]
 async fn cross_version_unique_rejected_on_append_load() {
-    let (_dir, mut db) = init_with(UNIQUE_SCHEMA, "").await;
+    let (_dir, db) = init_with(UNIQUE_SCHEMA, "").await;
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"User","data":{"name":"Bob","email":"dup@example.com"}}"#,
         LoadMode::Append,
     )
     .await
     .unwrap();
     let err = load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"User","data":{"name":"Carol","email":"dup@example.com"}}
 {"type":"User","data":{"name":"Dave","email":"dave@example.com"}}"#,
         LoadMode::Append,
@@ -397,16 +387,16 @@ async fn cross_version_unique_rejected_on_append_load() {
 /// coercion error (the red symptom before the fix).
 #[tokio::test]
 async fn cross_version_unique_rejected_on_date_column() {
-    let (_dir, mut db) = init_with(DATE_UNIQUE_SCHEMA, "").await;
+    let (_dir, db) = init_with(DATE_UNIQUE_SCHEMA, "").await;
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Task","data":{"name":"T1","due":"2026-06-29"}}"#,
         LoadMode::Append,
     )
     .await
     .unwrap();
     let err = load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Task","data":{"name":"T2","due":"2026-06-29"}}"#,
         LoadMode::Append,
     )
@@ -425,16 +415,16 @@ async fn cross_version_unique_rejected_on_date_column() {
 /// match), so this happy path failed too.
 #[tokio::test]
 async fn noncolliding_write_to_date_unique_column_succeeds() {
-    let (_dir, mut db) = init_with(DATE_UNIQUE_SCHEMA, "").await;
+    let (_dir, db) = init_with(DATE_UNIQUE_SCHEMA, "").await;
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Task","data":{"name":"T1","due":"2026-06-29"}}"#,
         LoadMode::Append,
     )
     .await
     .unwrap();
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Task","data":{"name":"T2","due":"2026-07-01"}}"#,
         LoadMode::Append,
     )
@@ -453,10 +443,10 @@ async fn merge_load_edge_src_move_rechecks_vacated_src_cardinality() {
 {"type":"Person","data":{"name":"Bob"}}
 {"type":"Company","data":{"name":"Acme"}}
 {"edge":"WorksAt","from":"Alice","to":"Acme","data":{"id":"E1"}}"#;
-    let (_dir, mut db) = init_with(CARD_MIN_SCHEMA, seed).await;
+    let (_dir, db) = init_with(CARD_MIN_SCHEMA, seed).await;
 
     let err = load_jsonl(
-        &mut db,
+        &db,
         r#"{"edge":"WorksAt","from":"Bob","to":"Acme","data":{"id":"E1"}}"#,
         LoadMode::Merge,
     )
@@ -481,13 +471,13 @@ async fn merge_load_duplicate_edge_id_counts_once_per_card() {
 {"type":"Company","data":{"name":"Acme"}}
 {"type":"Company","data":{"name":"Beta"}}
 {"edge":"WorksAt","from":"Alice","to":"Acme","data":{"id":"E0"}}"#;
-    let (_dir, mut db) = init_with(CARDINALITY_SCHEMA, seed).await;
+    let (_dir, db) = init_with(CARDINALITY_SCHEMA, seed).await;
 
     // Same edge id E1 under two srcs in one batch: commit keeps the last
     // (Bob->Beta). Alice stays at her one committed edge (E0).
     let batch = r#"{"edge":"WorksAt","from":"Alice","to":"Beta","data":{"id":"E1"}}
 {"edge":"WorksAt","from":"Bob","to":"Beta","data":{"id":"E1"}}"#;
-    load_jsonl(&mut db, batch, LoadMode::Merge)
+    load_jsonl(&db, batch, LoadMode::Merge)
         .await
         .expect("a deduped edge id must not double-count Alice into a @card(0..1) violation");
     assert_eq!(count_rows(&db, "edge:WorksAt").await, 2);
@@ -529,10 +519,10 @@ async fn mutation_delete_edge_below_card_min_rejected() {
 /// an update, not a duplicate — it must NOT false-trigger the cross-version check.
 #[tokio::test]
 async fn merge_load_reupsert_existing_key_is_not_unique_violation() {
-    let (_dir, mut db) = init_with(UNIQUE_SCHEMA, "").await;
+    let (_dir, db) = init_with(UNIQUE_SCHEMA, "").await;
     let row = r#"{"type":"User","data":{"name":"Alice","email":"alice@example.com"}}"#;
-    load_jsonl(&mut db, row, LoadMode::Merge).await.unwrap();
-    load_jsonl(&mut db, row, LoadMode::Merge)
+    load_jsonl(&db, row, LoadMode::Merge).await.unwrap();
+    load_jsonl(&db, row, LoadMode::Merge)
         .await
         .expect("merge-load re-upserting an existing @key is not a unique violation");
 }
@@ -542,10 +532,10 @@ async fn merge_load_reupsert_existing_key_is_not_unique_violation() {
 /// only in the new batch loads cleanly (regression against using the old image).
 #[tokio::test]
 async fn overwrite_load_validates_ri_against_new_image() {
-    let (_dir, mut db) = init_with(RI_SCHEMA, r#"{"type":"Person","data":{"name":"Alice"}}"#).await;
+    let (_dir, db) = init_with(RI_SCHEMA, r#"{"type":"Person","data":{"name":"Alice"}}"#).await;
     let batch = r#"{"type":"Person","data":{"name":"Carol"}}
 {"edge":"Knows","from":"Carol","to":"Carol"}"#;
-    load_jsonl(&mut db, batch, LoadMode::Overwrite)
+    load_jsonl(&db, batch, LoadMode::Overwrite)
         .await
         .expect("Overwrite RI validates against the new batch image, not the replaced committed");
 }
@@ -554,9 +544,9 @@ async fn overwrite_load_validates_ri_against_new_image() {
 /// (edge-RI enforced via the evaluator).
 #[tokio::test]
 async fn append_load_rejects_orphan_edge() {
-    let (_dir, mut db) = init_with(RI_SCHEMA, r#"{"type":"Person","data":{"name":"Alice"}}"#).await;
+    let (_dir, db) = init_with(RI_SCHEMA, r#"{"type":"Person","data":{"name":"Alice"}}"#).await;
     let err = load_jsonl(
-        &mut db,
+        &db,
         r#"{"edge":"Knows","from":"Alice","to":"Ghost"}"#,
         LoadMode::Append,
     )
@@ -579,10 +569,10 @@ async fn overwrite_node_removal_rejects_retained_orphan_edge() {
     let seed = r#"{"type":"Person","data":{"name":"Alice"}}
 {"type":"Person","data":{"name":"Bob"}}
 {"edge":"Knows","from":"Alice","to":"Bob"}"#;
-    let (_dir, mut db) = init_with(RI_SCHEMA, seed).await;
+    let (_dir, db) = init_with(RI_SCHEMA, seed).await;
 
     let err = load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Person","data":{"name":"Alice"}}"#,
         LoadMode::Overwrite,
     )
@@ -710,12 +700,10 @@ async fn cardinality_rejected_on_jsonl_load() {
     // Already covered by existing loader Phase 3 logic but assert the
     // same error surface as the mutation path so a regression is caught
     // even if only one path changes.
-    let (_dir, mut db) = init_with(CARDINALITY_SCHEMA, CARDINALITY_SEED).await;
+    let (_dir, db) = init_with(CARDINALITY_SCHEMA, CARDINALITY_SEED).await;
     let bad = r#"{"edge":"WorksAt","from":"Alice","to":"Acme"}
 {"edge":"WorksAt","from":"Alice","to":"Beta"}"#;
-    let err = load_jsonl(&mut db, bad, LoadMode::Append)
-        .await
-        .unwrap_err();
+    let err = load_jsonl(&db, bad, LoadMode::Append).await.unwrap_err();
     assert!(
         err.to_string().to_lowercase().contains("cardinality")
             || err.to_string().to_lowercase().contains("@card"),

--- a/crates/omnigraph/tests/write_cost.rs
+++ b/crates/omnigraph/tests/write_cost.rs
@@ -360,7 +360,7 @@ async fn write_op_count_ceiling_at_shallow_depth() {
 #[tokio::test]
 async fn keyed_insert_routes_through_fenced_adapter_only() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = local_graph(&dir).await;
+    let db = local_graph(&dir).await;
     let (res, _io, staged) = measure_with_staged(db.mutate(
         "main",
         MUTATION_QUERIES,
@@ -459,7 +459,7 @@ async fn write_schema_io_is_bounded_to_capture_fence_and_effect_gate() {
 #[tokio::test]
 async fn keyed_insert_opens_table_at_most_once() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = local_graph(&dir).await;
+    let db = local_graph(&dir).await;
     let io = {
         let (res, io) = measure(db.mutate(
             "main",
@@ -564,20 +564,20 @@ node User {
     for rows in [4u64, 64] {
         let dir = tempfile::tempdir().unwrap();
         let uri = dir.path().to_str().unwrap();
-        let mut db = omnigraph::db::Omnigraph::init(uri, UNIQUE_COST_SCHEMA)
+        let db = omnigraph::db::Omnigraph::init(uri, UNIQUE_COST_SCHEMA)
             .await
             .unwrap();
         // Committed baseline so the cross-version `@unique` probe has a
         // non-empty committed view (an empty view skips the probe entirely).
         omnigraph::loader::load_jsonl(
-            &mut db,
+            &db,
             &users_jsonl("seed", 4),
             omnigraph::loader::LoadMode::Append,
         )
         .await
         .unwrap();
         let (res, io) = measure(omnigraph::loader::load_jsonl(
-            &mut db,
+            &db,
             &users_jsonl(&format!("delta{rows}"), rows),
             omnigraph::loader::LoadMode::Append,
         ))

--- a/crates/omnigraph/tests/writes.rs
+++ b/crates/omnigraph/tests/writes.rs
@@ -33,9 +33,9 @@ use helpers::*;
 async fn load_does_not_create_run_branch() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
 
-    load_jsonl(&mut db, TEST_DATA, LoadMode::Overwrite)
+    load_jsonl(&db, TEST_DATA, LoadMode::Overwrite)
         .await
         .unwrap();
 
@@ -63,7 +63,7 @@ async fn load_does_not_create_run_branch() {
 async fn mutation_does_not_create_run_branch() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
 
     let result = db
         .mutate(
@@ -88,7 +88,7 @@ async fn mutation_does_not_create_run_branch() {
 #[tokio::test]
 async fn failed_mutation_leaves_target_unchanged() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
 
     let err = db
         .mutate(
@@ -125,7 +125,7 @@ async fn failed_mutation_leaves_target_unchanged() {
 #[tokio::test]
 async fn multi_statement_mutation_is_atomic_with_read_your_writes() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
 
     let result = db
         .mutate(
@@ -179,7 +179,7 @@ async fn multi_statement_mutation_is_atomic_with_read_your_writes() {
 #[tokio::test]
 async fn partial_failure_leaves_target_queryable_and_unblocks_next_mutation() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
 
     // Op-1 stages a Person 'Eve' insert. Op-2 attempts an edge to
     // 'Missing' — fails at validate_edge_insert_endpoints because
@@ -256,8 +256,8 @@ async fn stale_non_strict_insert_reprepares_from_live_branch_state() {
     let uri = dir.path().to_string_lossy().into_owned();
 
     {
-        let mut db = Omnigraph::init(&uri, TEST_SCHEMA).await.unwrap();
-        load_jsonl(&mut db, TEST_DATA, LoadMode::Overwrite)
+        let db = Omnigraph::init(&uri, TEST_SCHEMA).await.unwrap();
+        load_jsonl(&db, TEST_DATA, LoadMode::Overwrite)
             .await
             .unwrap();
     }
@@ -269,7 +269,7 @@ async fn stale_non_strict_insert_reprepares_from_live_branch_state() {
 
     // Writer A advances the manifest by inserting a new Person.
     {
-        let mut db_a = Omnigraph::open(&uri).await.unwrap();
+        let db_a = Omnigraph::open(&uri).await.unwrap();
         db_a.mutate(
             "main",
             MUTATION_QUERIES,
@@ -327,8 +327,8 @@ async fn cancelled_mutation_future_leaves_no_state() {
     let uri = dir.path().to_string_lossy().into_owned();
 
     {
-        let mut db = Omnigraph::init(&uri, TEST_SCHEMA).await.unwrap();
-        load_jsonl(&mut db, TEST_DATA, LoadMode::Overwrite)
+        let db = Omnigraph::init(&uri, TEST_SCHEMA).await.unwrap();
+        load_jsonl(&db, TEST_DATA, LoadMode::Overwrite)
             .await
             .unwrap();
     }
@@ -340,7 +340,7 @@ async fn cancelled_mutation_future_leaves_no_state() {
 
     let uri_handle = uri.clone();
     let handle = tokio::spawn(async move {
-        let mut db = Omnigraph::open(&uri_handle).await.unwrap();
+        let db = Omnigraph::open(&uri_handle).await.unwrap();
         db.mutate(
             "main",
             MUTATION_QUERIES,
@@ -387,7 +387,7 @@ async fn cancelled_mutation_future_leaves_no_state() {
 async fn mutation_actor_id_lands_in_commit_graph() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
 
     db.mutate_as(
         "main",
@@ -416,16 +416,14 @@ async fn mutation_actor_id_lands_in_commit_graph() {
 async fn repeated_loads_do_not_accumulate_branches() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
 
     for i in 0..10 {
         let payload = format!(
             r#"{{"type":"Person","data":{{"name":"p{}","age":{}}}}}"#,
             i, i
         );
-        load_jsonl(&mut db, &payload, LoadMode::Append)
-            .await
-            .unwrap();
+        load_jsonl(&db, &payload, LoadMode::Append).await.unwrap();
     }
 
     assert_eq!(db.branch_list().await.unwrap(), vec!["main".to_string()]);
@@ -438,7 +436,7 @@ async fn repeated_loads_do_not_accumulate_branches() {
 #[tokio::test]
 async fn public_branch_apis_reject_internal_system_refs() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
 
     // `__run__*` is no longer reserved — creating it now succeeds.
     db.branch_create("__run__formerly_reserved")
@@ -633,10 +631,10 @@ query update_all() {
 "#;
 
     let exact_dir = tempfile::tempdir().unwrap();
-    let mut exact = Omnigraph::init(exact_dir.path().to_str().unwrap(), SCHEMA)
+    let exact = Omnigraph::init(exact_dir.path().to_str().unwrap(), SCHEMA)
         .await
         .unwrap();
-    load_jsonl(&mut exact, &bulk_update_fixture(LIMIT), LoadMode::Overwrite)
+    load_jsonl(&exact, &bulk_update_fixture(LIMIT), LoadMode::Overwrite)
         .await
         .unwrap();
     let exact_result = exact
@@ -647,16 +645,12 @@ query update_all() {
     assert_eq!(count_rows(&exact, "node:Thing").await, LIMIT);
 
     let over_dir = tempfile::tempdir().unwrap();
-    let mut over = Omnigraph::init(over_dir.path().to_str().unwrap(), SCHEMA)
+    let over = Omnigraph::init(over_dir.path().to_str().unwrap(), SCHEMA)
         .await
         .unwrap();
-    load_jsonl(
-        &mut over,
-        &bulk_update_fixture(LIMIT + 1),
-        LoadMode::Overwrite,
-    )
-    .await
-    .unwrap();
+    load_jsonl(&over, &bulk_update_fixture(LIMIT + 1), LoadMode::Overwrite)
+        .await
+        .unwrap();
     let before = snapshot_main(&over).await.unwrap();
     let before_manifest = before.version();
     let entry = before.entry("node:Thing").unwrap();
@@ -730,7 +724,7 @@ query update_note($note: String) {
     let external_uri = format!("file://{}", external_path.display());
 
     let graph_path = dir.path().join("graph");
-    let mut db = Omnigraph::init(graph_path.to_str().unwrap(), SCHEMA)
+    let db = Omnigraph::init(graph_path.to_str().unwrap(), SCHEMA)
         .await
         .unwrap();
     let row = serde_json::json!({
@@ -741,9 +735,7 @@ query update_note($note: String) {
         }
     })
     .to_string();
-    load_jsonl(&mut db, &row, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, &row, LoadMode::Overwrite).await.unwrap();
     let before = snapshot_main(&db).await.unwrap();
     let before_manifest = before.version();
     let entry = before.entry("node:Document").unwrap();
@@ -807,7 +799,7 @@ query update_note($note: String) {
 #[tokio::test]
 async fn mutation_rejects_mixed_insert_and_delete_at_parse_time() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
 
     // Capture pre-mutation state on touched tables to confirm no I/O.
     let persons_before = count_rows(&db, "node:Person").await;
@@ -862,7 +854,7 @@ async fn mutation_rejects_mixed_insert_and_delete_at_parse_time() {
 #[tokio::test]
 async fn overlapping_delete_predicates_do_not_double_count_affected() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
 
     let r = db
         .mutate(
@@ -926,10 +918,8 @@ edge Knows: Person -> Person
     let data = r#"{"type":"Person","data":{"name":"Charlie","age":35}}
 {"type":"Person","data":{"name":"Zoe"}}
 {"edge":"Knows","from":"Zoe","to":"Charlie"}"#;
-    let mut db = Omnigraph::init(uri, schema).await.unwrap();
-    load_jsonl(&mut db, data, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    let db = Omnigraph::init(uri, schema).await.unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
 
     let q = r#"
 query del_age_then_name($threshold: I32, $name: String) {
@@ -969,7 +959,7 @@ query del_age_then_name($threshold: I32, $name: String) {
 #[tokio::test]
 async fn mixed_insert_and_update_on_same_person_coalesces_to_one_merge() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
 
     let pre_version = version_main(&db).await.unwrap();
 
@@ -1039,7 +1029,7 @@ async fn mixed_insert_and_update_on_same_person_coalesces_to_one_merge() {
 #[tokio::test]
 async fn multiple_edge_inserts_coalesce_to_one_fenced_write() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
 
     // Add Eve so the second edge has a valid endpoint.
     db.mutate(
@@ -1086,7 +1076,7 @@ async fn multiple_edge_inserts_coalesce_to_one_fenced_write() {
 #[tokio::test]
 async fn multi_statement_inserts_publish_exactly_once() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
 
     let pre_version = version_main(&db).await.unwrap();
 
@@ -1142,10 +1132,10 @@ async fn multi_statement_inserts_publish_exactly_once() {
 async fn load_with_bad_edge_reference_unblocks_next_load() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
     // Seed with the standard fixture so we're working from a non-empty
     // baseline.
-    load_jsonl(&mut db, TEST_DATA, LoadMode::Overwrite)
+    load_jsonl(&db, TEST_DATA, LoadMode::Overwrite)
         .await
         .unwrap();
 
@@ -1158,7 +1148,7 @@ async fn load_with_bad_edge_reference_unblocks_next_load() {
     let bad = r#"{"type": "Person", "data": {"name": "Mallory", "age": 5}}
 {"edge": "Knows", "from": "Mallory", "to": "Ghost"}
 "#;
-    let err = load_jsonl(&mut db, bad, LoadMode::Append)
+    let err = load_jsonl(&db, bad, LoadMode::Append)
         .await
         .expect_err("RI violation must fail the load");
     let OmniError::Manifest(manifest_err) = err else {
@@ -1184,7 +1174,7 @@ async fn load_with_bad_edge_reference_unblocks_next_load() {
 
     // Second load against the same tables — succeeds (no HEAD drift).
     let good = r#"{"type": "Person", "data": {"name": "Pat", "age": 55}}"#;
-    load_jsonl(&mut db, good, LoadMode::Append).await.unwrap();
+    load_jsonl(&db, good, LoadMode::Append).await.unwrap();
     assert_eq!(
         count_rows(&db, "node:Person").await,
         pre_persons + 1,
@@ -1196,8 +1186,8 @@ async fn load_with_bad_edge_reference_unblocks_next_load() {
 async fn load_overwrite_with_bad_edge_reference_unblocks_next_load() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, TEST_DATA, LoadMode::Overwrite)
+    let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    load_jsonl(&db, TEST_DATA, LoadMode::Overwrite)
         .await
         .unwrap();
 
@@ -1207,7 +1197,7 @@ async fn load_overwrite_with_bad_edge_reference_unblocks_next_load() {
     let bad = r#"{"type": "Person", "data": {"name": "Mallory", "age": 5}}
 {"edge": "Knows", "from": "Mallory", "to": "Ghost"}
 "#;
-    let err = load_jsonl(&mut db, bad, LoadMode::Overwrite)
+    let err = load_jsonl(&db, bad, LoadMode::Overwrite)
         .await
         .expect_err("RI violation must fail overwrite before commit_staged");
     let OmniError::Manifest(manifest_err) = err else {
@@ -1231,9 +1221,7 @@ async fn load_overwrite_with_bad_edge_reference_unblocks_next_load() {
 {"edge": "Knows", "from": "Pat", "to": "Quinn"}
 {"edge": "WorksAt", "from": "Pat", "to": "Acme"}
 "#;
-    load_jsonl(&mut db, good, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, good, LoadMode::Overwrite).await.unwrap();
     assert_eq!(count_rows(&db, "node:Person").await, 2);
     assert_eq!(count_rows(&db, "edge:Knows").await, 1);
 }
@@ -1261,15 +1249,13 @@ edge WorksAt: Person -> Company @card(0..1)
 
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, CARD_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, CARD_SCHEMA).await.unwrap();
 
     let seed = r#"{"type": "Person", "data": {"name": "Alice", "age": 30}}
 {"type": "Company", "data": {"name": "Acme"}}
 {"type": "Company", "data": {"name": "Bigco"}}
 "#;
-    load_jsonl(&mut db, seed, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, seed, LoadMode::Overwrite).await.unwrap();
 
     let pre_works = count_rows(&db, "edge:WorksAt").await;
 
@@ -1277,7 +1263,7 @@ edge WorksAt: Person -> Company @card(0..1)
     let bad = r#"{"edge": "WorksAt", "from": "Alice", "to": "Acme"}
 {"edge": "WorksAt", "from": "Alice", "to": "Bigco"}
 "#;
-    let err = load_jsonl(&mut db, bad, LoadMode::Append)
+    let err = load_jsonl(&db, bad, LoadMode::Append)
         .await
         .expect_err("cardinality violation must fail the load");
     let OmniError::Manifest(manifest_err) = err else {
@@ -1294,7 +1280,7 @@ edge WorksAt: Person -> Company @card(0..1)
     assert_eq!(mid_works, pre_works);
 
     let good = r#"{"edge": "WorksAt", "from": "Alice", "to": "Acme"}"#;
-    load_jsonl(&mut db, good, LoadMode::Append).await.unwrap();
+    load_jsonl(&db, good, LoadMode::Append).await.unwrap();
     assert_eq!(
         count_rows(&db, "edge:WorksAt").await,
         pre_works + 1,
@@ -1317,22 +1303,20 @@ edge WorksAt: Person -> Company @card(0..1)
 
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, CARD_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, CARD_SCHEMA).await.unwrap();
 
     let seed = r#"{"type": "Person", "data": {"name": "Alice", "age": 30}}
 {"type": "Company", "data": {"name": "Acme"}}
 {"type": "Company", "data": {"name": "Bigco"}}
 "#;
-    load_jsonl(&mut db, seed, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, seed, LoadMode::Overwrite).await.unwrap();
 
     let pre_works = count_rows(&db, "edge:WorksAt").await;
 
     let bad = r#"{"edge": "WorksAt", "from": "Alice", "to": "Acme"}
 {"edge": "WorksAt", "from": "Alice", "to": "Bigco"}
 "#;
-    let err = load_jsonl(&mut db, bad, LoadMode::Overwrite)
+    let err = load_jsonl(&db, bad, LoadMode::Overwrite)
         .await
         .expect_err("cardinality violation must fail overwrite before commit_staged");
     let OmniError::Manifest(manifest_err) = err else {
@@ -1346,9 +1330,7 @@ edge WorksAt: Person -> Company @card(0..1)
     assert_eq!(count_rows(&db, "edge:WorksAt").await, pre_works);
 
     let good = r#"{"edge": "WorksAt", "from": "Alice", "to": "Acme"}"#;
-    load_jsonl(&mut db, good, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, good, LoadMode::Overwrite).await.unwrap();
     assert_eq!(count_rows(&db, "edge:WorksAt").await, 1);
 }
 
@@ -1375,7 +1357,7 @@ edge WorksAt: Person -> Company @card(0..1)
 #[tokio::test]
 async fn chained_updates_with_overlapping_predicate_respects_intermediate_value() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
 
     let pre_version = version_main(&db).await.unwrap();
 
@@ -1445,7 +1427,7 @@ async fn chained_updates_with_overlapping_predicate_respects_intermediate_value(
 #[tokio::test]
 async fn multi_statement_delete_on_same_node_table() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
 
     let pre_persons = count_rows(&db, "node:Person").await;
     let pre_version = version_main(&db).await.unwrap();
@@ -1504,7 +1486,7 @@ query cascade_then_explicit($name: String, $other: String) {
 "#;
 
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
 
     // TEST_DATA seeds three Knows edges:
     //   Alice → Bob, Alice → Charlie (cascade target — should be deleted by op-1)
@@ -1564,14 +1546,12 @@ query add_friend($from: String, $to: String) {
 
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, MIN_CARD_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, MIN_CARD_SCHEMA).await.unwrap();
 
     let seed = r#"{"type": "Person", "data": {"name": "Alice"}}
 {"type": "Person", "data": {"name": "Bob"}}
 "#;
-    load_jsonl(&mut db, seed, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, seed, LoadMode::Overwrite).await.unwrap();
 
     // Single insert: count=1 < min=2 → reject with clear message.
     let err = db
@@ -1615,7 +1595,7 @@ edge WorksAt: Person -> Company @card(0..1)
 
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, CARD_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, CARD_SCHEMA).await.unwrap();
 
     // Seed: Alice + Acme + Bigco + WorksAt(id=w1, Alice→Acme). Note the
     // loader reads edge ids from the `data.id` field (not top-level), so
@@ -1625,16 +1605,14 @@ edge WorksAt: Person -> Company @card(0..1)
 {"type": "Company", "data": {"name": "Bigco"}}
 {"edge": "WorksAt", "from": "Alice", "to": "Acme", "data": {"id": "w1"}}
 "#;
-    load_jsonl(&mut db, seed, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, seed, LoadMode::Overwrite).await.unwrap();
 
     // Merge-update the same edge id w1 to point at Bigco. Counted naively
     // as union, Alice has 2 WorksAt (committed Acme + pending Bigco) which
     // would trip @card(0..1). With merge dedupe, Alice has 1 WorksAt.
     let merge_data = r#"{"edge": "WorksAt", "from": "Alice", "to": "Bigco", "data": {"id": "w1"}}
 "#;
-    load_jsonl(&mut db, merge_data, LoadMode::Merge)
+    load_jsonl(&db, merge_data, LoadMode::Merge)
         .await
         .expect("Merge update must dedupe the committed edge by id");
 
@@ -1667,15 +1645,13 @@ edge WorksAt: Person -> Company @card(0..1)
 
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, CARD_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, CARD_SCHEMA).await.unwrap();
 
     let seed = r#"{"type": "Person", "data": {"name": "Alice"}}
 {"type": "Company", "data": {"name": "Acme"}}
 {"type": "Company", "data": {"name": "Bigco"}}
 "#;
-    load_jsonl(&mut db, seed, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    load_jsonl(&db, seed, LoadMode::Overwrite).await.unwrap();
 
     // Merge load with the SAME edge id twice — the second row supersedes
     // the first in the end-of-query dedupe. If pending-counting doesn't
@@ -1684,7 +1660,7 @@ edge WorksAt: Person -> Company @card(0..1)
     let dup_data = r#"{"edge": "WorksAt", "from": "Alice", "to": "Acme", "data": {"id": "w1"}}
 {"edge": "WorksAt", "from": "Alice", "to": "Bigco", "data": {"id": "w1"}}
 "#;
-    load_jsonl(&mut db, dup_data, LoadMode::Merge)
+    load_jsonl(&db, dup_data, LoadMode::Merge)
         .await
         .expect("Merge load with within-input dup ids must dedupe pending count");
 
@@ -1720,13 +1696,13 @@ query insert_then_update_note(
 
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, BLOB_SCHEMA).await.unwrap();
+    let db = Omnigraph::init(uri, BLOB_SCHEMA).await.unwrap();
 
     // Keep one committed blob row as well as the just-inserted pending row so
     // the table has the real blob-v2 physical representation while this query
     // exercises the pending union.
     load_jsonl(
-        &mut db,
+        &db,
         r#"{"type":"Document","data":{"title":"seed","content":"base64:AQID"}}"#,
         LoadMode::Overwrite,
     )
@@ -1794,7 +1770,7 @@ query insert_then_update_note(
 #[tokio::test]
 async fn second_sequential_update_on_same_row_succeeds() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
 
     db.mutate(
         "main",
@@ -1991,10 +1967,8 @@ const CC_DATA: &str = r#"{"type":"Doc","data":{"slug":"d1","repoName":"acme","st
 async fn camelcase_mutation_predicate_updates_and_deletes() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, CC_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, CC_DATA, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    let db = Omnigraph::init(uri, CC_SCHEMA).await.unwrap();
+    load_jsonl(&db, CC_DATA, LoadMode::Overwrite).await.unwrap();
 
     let m = r#"
 query set_status($repo: String, $st: String) { update Doc set { status: $st } where repoName = $repo }
@@ -2036,10 +2010,8 @@ query del($repo: String) { delete Doc where repoName = $repo }
 async fn camelcase_chained_mutation_reads_pending_by_camelcase() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = Omnigraph::init(uri, CC_SCHEMA).await.unwrap();
-    load_jsonl(&mut db, CC_DATA, LoadMode::Overwrite)
-        .await
-        .unwrap();
+    let db = Omnigraph::init(uri, CC_SCHEMA).await.unwrap();
+    load_jsonl(&db, CC_DATA, LoadMode::Overwrite).await.unwrap();
 
     // op-1 stages a status change to the acme Doc; op-2 re-filters the same
     // camelCase column, so it must match op-1's pending row.
@@ -2132,7 +2104,7 @@ async fn node_delete_with_no_incident_edges_leaves_no_edge_table_drift() {
 async fn post_publish_fold_matches_fresh_reopen() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
-    let mut db = init_and_load(&dir).await;
+    let db = init_and_load(&dir).await;
 
     db.mutate(
         "main",
@@ -2199,7 +2171,7 @@ async fn filtered_read_after_merge_update_and_delete_keeps_row_ids_consistent() 
     let seed: String = (1..=40)
         .map(|i| format!("{{\"type\":\"Person\",\"data\":{{\"name\":\"p{i}\",\"age\":{i}}}}}\n"))
         .collect();
-    load_jsonl(&mut db, &seed, LoadMode::Merge).await.unwrap();
+    load_jsonl(&db, &seed, LoadMode::Merge).await.unwrap();
 
     // Same-key updates: Lance Operation::Update rewrites these 15 rows into
     // new fragments that keep their original stable row ids (the overlap).
@@ -2211,9 +2183,7 @@ async fn filtered_read_after_merge_update_and_delete_keeps_row_ids_consistent() 
             )
         })
         .collect();
-    load_jsonl(&mut db, &updates, LoadMode::Merge)
-        .await
-        .unwrap();
+    load_jsonl(&db, &updates, LoadMode::Merge).await.unwrap();
 
     // The delete adds a deletion vector, so the overlapping region no longer
     // densely tiles its id range — the shape lance#7444 choked on.
@@ -2256,13 +2226,13 @@ async fn filtered_read_after_append_and_delete_is_consistent() {
     let seed: String = (1..=40)
         .map(|i| format!("{{\"type\":\"Person\",\"data\":{{\"name\":\"p{i}\",\"age\":{i}}}}}\n"))
         .collect();
-    load_jsonl(&mut db, &seed, LoadMode::Merge).await.unwrap();
+    load_jsonl(&db, &seed, LoadMode::Merge).await.unwrap();
 
     // Disjoint keys: plain inserts, no fragment rewrite, no id reuse.
     let more: String = (41..=55)
         .map(|i| format!("{{\"type\":\"Person\",\"data\":{{\"name\":\"p{i}\",\"age\":{i}}}}}\n"))
         .collect();
-    load_jsonl(&mut db, &more, LoadMode::Merge).await.unwrap();
+    load_jsonl(&db, &more, LoadMode::Merge).await.unwrap();
 
     mutate_main(
         &mut db,


### PR DESCRIPTION
## What & why

First of two PRs enabling lint gating: makes the workspace clippy-clean at the default lint set (617 emissions to 0), so the follow-up can gate PRs on `cargo clippy -- -D warnings` plus `cargo fmt --check` without landing red.

- Mostly mechanical `cargo clippy --fix` output
- Boxes the large error detail payloads; JSON wire shape unchanged
- Remaining warnings become allows, each with a justifying comment
- Adds the minimal `[workspace.lints]` table
- Widens the cluster crate's `recursion_limit` to all test builds, fixing a pre-existing compile failure under `--all-targets`

## Local verification

- `cargo clippy --workspace --all-targets --locked -- -D warnings -W clippy::dbg_macro`: exit 0, zero emissions, at default features and with `--features omnigraph-engine/failpoints,omnigraph-cluster/failpoints`
- `cargo fmt --all --check`: clean
- `cargo test -p omnigraph-engine --lib` 266 passed; `omnigraph-server --lib` 95 passed, 1 ignored; `forbidden_apis` 17 passed; server `openapi` 86 passed (wire-compat evidence for the error boxing)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes the Rust workspace clean under the default Clippy lint set while preserving existing behavior and wire representations.
- Adds workspace lint configuration and enables inheritance across member crates.
- Applies mechanical lint-driven rewrites throughout production code, tests, examples, and benchmarks.
- Boxes large internal error and branch-creation payloads while unboxing server error details at the existing DTO boundary.
- Broadens the cluster library test recursion limit to cover all test builds.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Adds narrowly documented workspace-level Clippy allowances inherited by all member crates. |
| crates/omnigraph-server/src/lib.rs | Boxes large internal API error details and explicitly unboxes them when constructing unchanged response DTOs. |
| crates/omnigraph/src/branch_control.rs | Boxes the internal branch-created dataset payload, with affected consumers updated to move out the dataset. |
| crates/omnigraph-compiler/src/catalog/schema_plan.rs | Rewrites a negated Option predicate using a logically equivalent `is_none_or` expression. |
| crates/omnigraph-compiler/src/query/typecheck.rs | Converts nested conditional match arms into equivalent guarded arms. |
| crates/omnigraph-cluster/src/lib.rs | Extends the recursion limit to every cluster library test build and applies equivalent lint-driven control-flow cleanup. |

</details>

<sub>Reviews (4): Last reviewed commit: ["chore: fix clippy 1.95 diagnostics"](https://github.com/modernrelay/omnigraph/commit/a7a5bd7c2d906c324f067df8760f45fc56d16b38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51423420)</sub>

<!-- /greptile_comment -->