### PR TITLE
docs(release): correct the v0.9.0 crates.io channel note

### DIFF
--- a/docs/releases/v0.9.0.md
+++ b/docs/releases/v0.9.0.md
@@ -1,16 +1,20 @@
 # Omnigraph v0.9.0
 
-A substrate and durability release. Lance reaches **9.0.0 stable**, restoring
-crates.io publication; the write path gains rename-stable schema identity,
-key-conflict fencing, and crash recovery for every writer; the query language
-reaches edge properties and pushes filters down to the scanner.
+A substrate and durability release. Lance reaches **9.0.0 stable**; the write
+path gains rename-stable schema identity, key-conflict fencing, and crash
+recovery for every writer; the query language reaches edge properties and
+pushes filters down to the scanner.
 
 **This release changes the on-disk format** — v0.8.x graphs must be rebuilt
 via export/import (see [Upgrade notes](#upgrade-notes) and
 [docs/user/operations/upgrade.md](../user/operations/upgrade.md)).
 
-**Channel note:** `cargo install omnigraph-cli` works again, alongside the
-binaries, Homebrew, installer, and container channels.
+**Channel note:** binaries ship via the installer, Homebrew, Docker, and
+GitHub Releases. Registry publication did not resume in this release: access
+to the crates.io account owning the historical `omnigraph-*` crate names was
+lost, so those names are frozen at their 0.8.0 versions and should not be
+used. OmniGraph returns to crates.io in **0.9.1** as a single crate,
+[`omnigraph-db`](https://crates.io/crates/omnigraph-db).
 
 ## Highlights
 


### PR DESCRIPTION
The 0.9.0 notes claimed registry publication resumed (`cargo install omnigraph-cli`). That claim is no longer true: access to the crates.io account owning the historical `omnigraph-*` names was lost, so those names are frozen at 0.8.0 and 0.9.0 was never published to the registry. This corrects the channel note to say so plainly and points at the 0.9.1 return as the single [`omnigraph-db`](https://crates.io/crates/omnigraph-db) crate (name reserved today at 0.0.1). The GitHub Release body will be synced after merge.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Corrects the v0.9.0 release notes to remove the inaccurate claim that crates.io publication resumed.
- Clarifies that the historical `omnigraph-*` packages remain frozen at 0.8.0.
- Lists the supported binary distribution channels.
- Documents the planned crates.io return under the single `omnigraph-db` package in v0.9.1.

<h3>Confidence Score: 5/5</h3>

The documentation-only correction appears safe to merge.

The updated release note removes misleading crates.io installation guidance and clearly distinguishes the available v0.9.0 channels from the planned v0.9.1 registry return.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/releases/v0.9.0.md | The revised channel note consistently corrects the obsolete registry-installation guidance without introducing an actionable defect. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(release): correct the v0.9.0 crates..."](https://github.com/modernrelay/omnigraph/commit/40cfbed55db3245d29136610c8b63a7c753c08c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51426951)</sub>

<!-- /greptile_comment -->