### PR TITLE
refactor(query): replace the binding kind field with a sum type

### DIFF
--- a/crates/omnigraph-compiler/src/ir/lower.rs
+++ b/crates/omnigraph-compiler/src/ir/lower.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use crate::catalog::Catalog;
 use crate::error::Result;
 use crate::query::ast::*;
-use crate::query::typecheck::TypeContext;
+use crate::query::typecheck::{BoundVariable, TypeContext};
 use crate::types::{Direction, PropType, ScalarType};
 
 use super::*;
@@ -403,31 +403,44 @@ fn lower_clauses(
     // resolve variables introduced inside `not { }`. Bindings declare their
     // type; traversal endpoints take the edge's declared endpoint types
     // (bindings win when both name a variable).
-    let mut local_var_types: HashMap<&str, &str> = HashMap::new();
+    let mut local_bindings: HashMap<&str, BoundVariable> = HashMap::new();
     for t in &traversals {
         if let Some(edge) = catalog.lookup_edge_by_name(&t.edge_name) {
-            local_var_types
+            local_bindings
                 .entry(t.src.as_str())
-                .or_insert(&edge.from_type);
-            local_var_types
+                .or_insert_with(|| BoundVariable::Node {
+                    type_name: edge.from_type.clone(),
+                });
+            local_bindings
                 .entry(t.dst.as_str())
-                .or_insert(&edge.to_type);
+                .or_insert_with(|| BoundVariable::Node {
+                    type_name: edge.to_type.clone(),
+                });
             // An edge binding (`$p $w:knows $f`) names the edge type, whose
             // String properties are addressable in filters (`$w.note contains …`).
             if let Some(eb) = &t.edge_binding {
-                local_var_types.entry(eb.as_str()).or_insert(&edge.name);
+                local_bindings
+                    .entry(eb.as_str())
+                    .or_insert_with(|| BoundVariable::Edge {
+                        type_name: edge.name.clone(),
+                    });
             }
         }
     }
     for b in &bindings {
-        local_var_types.insert(b.variable.as_str(), b.type_name.as_str());
+        local_bindings.insert(
+            b.variable.as_str(),
+            BoundVariable::Node {
+                type_name: b.type_name.clone(),
+            },
+        );
     }
 
     // Lower explicit filters
     for filter in &filters {
         pipeline.push(IROp::Filter(IRFilter {
             left: lower_expr(&filter.left, param_names),
-            op: resolve_filter_op(catalog, type_ctx, param_types, &local_var_types, filter),
+            op: resolve_filter_op(catalog, type_ctx, param_types, &local_bindings, filter),
             right: lower_expr(&filter.right, param_names),
         }));
     }
@@ -458,28 +471,27 @@ fn lower_clauses(
     Ok(())
 }
 
-/// Whether `type_name.property` is a non-list scalar String, resolving the
-/// type through node types first and then edge types (an edge-bound variable
-/// like `$w` in `$p $w:knows $f` names an edge type, whose properties are
-/// addressable in filters).
-fn is_scalar_string_property(catalog: &Catalog, type_name: &str, property: &str) -> bool {
-    catalog
-        .node_types
-        .get(type_name)
-        .and_then(|nt| nt.properties.get(property))
-        .or_else(|| {
-            catalog
-                .lookup_edge_by_name(type_name)
-                .and_then(|et| et.properties.get(property))
-        })
-        .is_some_and(|p| !p.list && matches!(p.scalar, ScalarType::String))
+/// Whether `binding.property` is a non-list scalar String. Node and edge type
+/// namespaces are independent, so the binding discriminant selects the one
+/// catalog namespace that may define the property.
+fn is_scalar_string_property(catalog: &Catalog, binding: &BoundVariable, property: &str) -> bool {
+    match binding {
+        BoundVariable::Node { type_name } => catalog
+            .node_types
+            .get(type_name)
+            .and_then(|nt| nt.properties.get(property)),
+        BoundVariable::Edge { type_name } => catalog
+            .lookup_edge_by_name(type_name)
+            .and_then(|et| et.properties.get(property)),
+    }
+    .is_some_and(|p| !p.list && matches!(p.scalar, ScalarType::String))
 }
 
 /// Resolve the overloaded `contains` keyword to its String-substring form
 /// (`StringContains`) when the left operand is a scalar String, so execution
 /// dispatches on the IR op alone and never re-derives operand types.
 ///
-/// Variable types come from `local_var_types` (this clause list's node and
+/// Variable bindings come from `local_bindings` (this clause list's node and
 /// edge bindings + traversal endpoints) first, then the outer `TypeContext`
 /// — negation inners never reach the outer context, while outer variables
 /// referenced inside a negation only exist there.
@@ -487,23 +499,17 @@ fn resolve_filter_op(
     catalog: &Catalog,
     type_ctx: &TypeContext,
     param_types: &HashMap<String, PropType>,
-    local_var_types: &HashMap<&str, &str>,
+    local_bindings: &HashMap<&str, BoundVariable>,
     filter: &Filter,
 ) -> CompOp {
     if filter.op != CompOp::Contains {
         return filter.op;
     }
     let left_is_scalar_string = match &filter.left {
-        Expr::PropAccess { variable, property } => local_var_types
+        Expr::PropAccess { variable, property } => local_bindings
             .get(variable.as_str())
-            .copied()
-            .or_else(|| {
-                type_ctx
-                    .bindings
-                    .get(variable)
-                    .map(|bv| bv.type_name.as_str())
-            })
-            .is_some_and(|type_name| is_scalar_string_property(catalog, type_name, property)),
+            .or_else(|| type_ctx.bindings.get(variable))
+            .is_some_and(|binding| is_scalar_string_property(catalog, binding, property)),
         Expr::Literal(Literal::String(_)) => true,
         Expr::Variable(v) => param_types
             .get(v)

--- a/crates/omnigraph-compiler/src/ir/lower_tests.rs
+++ b/crates/omnigraph-compiler/src/ir/lower_tests.rs
@@ -78,12 +78,11 @@ return { $p.name }
 
 #[test]
 fn test_lower_resolves_contains_overload_on_edge_bound_property() {
-    // `contains` on an edge-bound String property (`$w.note`, where `$w` binds
-    // the matched edge row) must lower to StringContains — the edge-binding
-    // feature makes edge properties addressable in filters, and resolution
-    // must consult edge types, not only node types.
+    // Node and edge type namespaces are independent. These deliberately share
+    // a type and property name but give that property different shapes, so
+    // lowering must retain the binding kind instead of searching by name.
     let schema = parse_schema(
-        "node Person { name: String }\nedge Knows: Person -> Person { note: String  tags: [String]? }",
+        "node Shared { text: [String]? }\nedge Shared: Shared -> Shared { text: String  tags: [String]? }",
     )
     .unwrap();
     let catalog = build_catalog(&schema).unwrap();
@@ -91,12 +90,14 @@ fn test_lower_resolves_contains_overload_on_edge_bound_property() {
         r#"
 query q() {
 match {
-    $p: Person
-    $p $w:knows $f
-    $w.note contains "sub"
+    $a: Shared
+    $a $w:shared $b
+    $a.text contains "node member"
+    $w.text contains "sub"
     $w.tags contains "member"
+    not { $w.text contains "outer sub" }
 }
-return { $f.name }
+return { $b.text }
 }
 "#,
     )
@@ -115,9 +116,25 @@ return { $f.name }
     // Edge String property -> substring; edge list property -> membership.
     assert_eq!(
         filter_ops,
-        vec![CompOp::StringContains, CompOp::Contains],
-        "edge-bound String `contains` must resolve to StringContains, list stays Contains"
+        vec![CompOp::Contains, CompOp::StringContains, CompOp::Contains],
+        "same-named node and edge bindings must resolve through separate namespaces"
     );
+
+    let anti_join_inner = ir
+        .pipeline
+        .iter()
+        .find_map(|op| match op {
+            IROp::AntiJoin { inner, .. } => Some(inner),
+            _ => None,
+        })
+        .expect("expected anti-join for negation");
+    assert!(matches!(
+        anti_join_inner.as_slice(),
+        [IROp::Filter(IRFilter {
+            op: CompOp::StringContains,
+            ..
+        })]
+    ));
 }
 
 #[test]

--- a/crates/omnigraph-compiler/src/query/typecheck.rs
+++ b/crates/omnigraph-compiler/src/query/typecheck.rs
@@ -9,17 +9,32 @@ use crate::types::{Direction, PropType, ScalarType};
 
 use super::ast::*;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BindingKind {
-    Node,
-    Edge,
+/// A variable in the query's single namespace, tagged by what it binds.
+///
+/// Node and edge bindings share one symbol table (GQ has one variable
+/// namespace) but live in *separate type namespaces* — a node type and an edge
+/// type may share a name. A type name therefore only means something once the
+/// kind is known, so the kind is the discriminant: every consumer must match,
+/// and a new kind is a compile error at each site.
+#[derive(Debug, Clone)]
+pub enum BoundVariable {
+    Node { type_name: String },
+    Edge { type_name: String },
 }
 
-#[derive(Debug, Clone)]
-pub struct BoundVariable {
-    pub var_name: String,
-    pub type_name: String,
-    pub kind: BindingKind,
+impl BoundVariable {
+    /// Node type name of a traversal endpoint, or T23 if `self` is an edge
+    /// binding. The type name is only reachable through this check, so no
+    /// caller can compare endpoint types without having ruled the edge case
+    /// out. `var` names the variable for the error message only.
+    fn require_traversal_endpoint(&self, var: &str) -> Result<&str> {
+        match self {
+            Self::Node { type_name } => Ok(type_name),
+            Self::Edge { .. } => Err(CompilerError::Type(format!(
+                "T23: edge binding `${var}` cannot be used as a traversal endpoint; traversal endpoints must be node bindings"
+            ))),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -658,26 +673,28 @@ fn typecheck_binding(
     // same node var is OK). Node and edge namespaces are independent, so a
     // matching type name does not make a cross-kind rebind valid.
     if let Some(existing) = ctx.bindings.get(&binding.variable) {
-        if matches!(existing.kind, BindingKind::Edge) {
-            return Err(CompilerError::Type(format!(
-                "T23: variable `${}` is bound to edge type `{}` and cannot be rebound as node type `{}`",
-                binding.variable, existing.type_name, binding.type_name
-            )));
-        }
-        if existing.type_name != binding.type_name {
-            return Err(CompilerError::Type(format!(
-                "variable `${}` already bound to type `{}`, cannot rebind to `{}`",
-                binding.variable, existing.type_name, binding.type_name
-            )));
+        match existing {
+            BoundVariable::Edge { type_name } => {
+                return Err(CompilerError::Type(format!(
+                    "T23: variable `${}` is bound to edge type `{}` and cannot be rebound as node type `{}`",
+                    binding.variable, type_name, binding.type_name
+                )));
+            }
+            BoundVariable::Node { type_name } => {
+                if *type_name != binding.type_name {
+                    return Err(CompilerError::Type(format!(
+                        "variable `${}` already bound to type `{}`, cannot rebind to `{}`",
+                        binding.variable, type_name, binding.type_name
+                    )));
+                }
+            }
         }
     }
 
     ctx.bindings.insert(
         binding.variable.clone(),
-        BoundVariable {
-            var_name: binding.variable.clone(),
+        BoundVariable::Node {
             type_name: binding.type_name.clone(),
-            kind: BindingKind::Node,
         },
     );
 
@@ -815,10 +832,8 @@ fn typecheck_traversal(
         }
         ctx.bindings.insert(
             binding.clone(),
-            BoundVariable {
-                var_name: binding.clone(),
+            BoundVariable::Edge {
                 type_name: edge.name.clone(),
-                kind: BindingKind::Edge,
             },
         );
     }
@@ -830,35 +845,35 @@ fn typecheck_traversal(
     let mut direction;
 
     if let Some(src_bv) = src_bound {
-        require_node_traversal_endpoint(&traversal.src, src_bv)?;
+        let src_type = src_bv.require_traversal_endpoint(&traversal.src)?;
         // T5: src type must match one endpoint of the edge
-        if src_bv.type_name == edge.from_type {
+        if src_type == edge.from_type {
             direction = Direction::Out;
             // dst should be edge.to_type
             bind_traversal_endpoint(ctx, &traversal.dst, &edge.to_type, edge)?;
-        } else if src_bv.type_name == edge.to_type {
+        } else if src_type == edge.to_type {
             direction = Direction::In;
             // dst should be edge.from_type
             bind_traversal_endpoint(ctx, &traversal.dst, &edge.from_type, edge)?;
         } else {
             return Err(CompilerError::Type(format!(
                 "T5: variable `${}` has type `{}`, which is not an endpoint of edge `{}: {} -> {}`",
-                traversal.src, src_bv.type_name, edge.name, edge.from_type, edge.to_type
+                traversal.src, src_type, edge.name, edge.from_type, edge.to_type
             )));
         }
     } else if let Some(dst_bv) = dst_bound {
-        require_node_traversal_endpoint(&traversal.dst, dst_bv)?;
+        let dst_type = dst_bv.require_traversal_endpoint(&traversal.dst)?;
         // dst is bound, infer direction from it
-        if dst_bv.type_name == edge.to_type {
+        if dst_type == edge.to_type {
             direction = Direction::Out;
             bind_traversal_endpoint(ctx, &traversal.src, &edge.from_type, edge)?;
-        } else if dst_bv.type_name == edge.from_type {
+        } else if dst_type == edge.from_type {
             direction = Direction::In;
             bind_traversal_endpoint(ctx, &traversal.src, &edge.to_type, edge)?;
         } else {
             return Err(CompilerError::Type(format!(
                 "T5: variable `${}` has type `{}`, which is not an endpoint of edge `{}: {} -> {}`",
-                traversal.dst, dst_bv.type_name, edge.name, edge.from_type, edge.to_type
+                traversal.dst, dst_type, edge.name, edge.from_type, edge.to_type
             )));
         }
     } else {
@@ -887,15 +902,6 @@ fn typecheck_traversal(
     Ok(())
 }
 
-fn require_node_traversal_endpoint(var: &str, binding: &BoundVariable) -> Result<()> {
-    if matches!(binding.kind, BindingKind::Edge) {
-        return Err(CompilerError::Type(format!(
-            "T23: edge binding `${var}` cannot be used as a traversal endpoint; traversal endpoints must be node bindings"
-        )));
-    }
-    Ok(())
-}
-
 fn bind_traversal_endpoint(
     ctx: &mut TypeContext,
     var: &str,
@@ -906,20 +912,18 @@ fn bind_traversal_endpoint(
         return Ok(()); // anonymous variable
     }
     if let Some(existing) = ctx.bindings.get(var) {
-        require_node_traversal_endpoint(var, existing)?;
-        if existing.type_name != expected_type {
+        let existing_type = existing.require_traversal_endpoint(var)?;
+        if existing_type != expected_type {
             return Err(CompilerError::Type(format!(
                 "T5: variable `${}` has type `{}` but edge `{}` expects `{}`",
-                var, existing.type_name, edge.name, expected_type
+                var, existing_type, edge.name, expected_type
             )));
         }
     } else {
         ctx.bindings.insert(
             var.to_string(),
-            BoundVariable {
-                var_name: var.to_string(),
+            BoundVariable::Node {
                 type_name: expected_type.to_string(),
-                kind: BindingKind::Node,
             },
         );
     }
@@ -1041,12 +1045,16 @@ fn typecheck_filter(
 fn reject_edge_binding_search_field(ctx: &TypeContext, field: &Expr, func: &str) -> Result<()> {
     if let Expr::PropAccess { variable, property } = field
         && let Some(bv) = ctx.bindings.get(variable)
-        && matches!(bv.kind, BindingKind::Edge)
     {
-        return Err(CompilerError::Type(format!(
-            "T23: {} cannot target edge property `${}.{}`; text/rank search runs on node columns — edge properties support comparison filters and projection",
-            func, variable, property
-        )));
+        match bv {
+            BoundVariable::Node { .. } => {}
+            BoundVariable::Edge { .. } => {
+                return Err(CompilerError::Type(format!(
+                    "T23: {} cannot target edge property `${}.{}`; text/rank search runs on node columns — edge properties support comparison filters and projection",
+                    func, variable, property
+                )));
+            }
+        }
     }
     Ok(())
 }
@@ -1068,29 +1076,28 @@ fn resolve_expr_type(
                 CompilerError::Type(format!("T6: variable `${}` is not bound", variable))
             })?;
 
-            let prop = match bv.kind {
-                BindingKind::Node => {
-                    let node_type = catalog.node_types.get(&bv.type_name).ok_or_else(|| {
+            let prop = match bv {
+                BoundVariable::Node { type_name } => {
+                    let node_type = catalog.node_types.get(type_name).ok_or_else(|| {
                         CompilerError::Type(format!(
                             "T6: type `{}` not found in catalog",
-                            bv.type_name
+                            type_name
                         ))
                     })?;
                     node_type.properties.get(property).ok_or_else(|| {
                         CompilerError::Type(format!(
                             "T6: type `{}` has no property `{}`",
-                            bv.type_name, property
+                            type_name, property
                         ))
                     })?
                 }
-                BindingKind::Edge => {
-                    let edge_type =
-                        catalog.lookup_edge_by_name(&bv.type_name).ok_or_else(|| {
-                            CompilerError::Type(format!(
-                                "T6: edge type `{}` not found in catalog",
-                                bv.type_name
-                            ))
-                        })?;
+                BoundVariable::Edge { type_name } => {
+                    let edge_type = catalog.lookup_edge_by_name(type_name).ok_or_else(|| {
+                        CompilerError::Type(format!(
+                            "T6: edge type `{}` not found in catalog",
+                            type_name
+                        ))
+                    })?;
                     if edge_type.blob_properties.contains(property) {
                         return Err(CompilerError::Type(format!(
                             "T23: blob edge property `${}.{}` is not projectable; the bound edge scan excludes blob columns",
@@ -1100,7 +1107,7 @@ fn resolve_expr_type(
                     edge_type.properties.get(property).ok_or_else(|| {
                         CompilerError::Type(format!(
                             "T6: edge `{}` has no property `{}`",
-                            bv.type_name, property
+                            type_name, property
                         ))
                     })?
                 }
@@ -1113,28 +1120,31 @@ fn resolve_expr_type(
             property,
             query,
         } => {
-            let node_binding = ctx.bindings.get(variable).ok_or_else(|| {
-                CompilerError::Type(format!("T15: variable `${}` is not bound", variable))
+            let node_type_name = match ctx.bindings.get(variable) {
+                Some(BoundVariable::Node { type_name }) => type_name,
+                Some(BoundVariable::Edge { .. }) => {
+                    return Err(CompilerError::Type(format!(
+                        "T23: nearest cannot target edge binding `${}`; vector search runs on node columns",
+                        variable
+                    )));
+                }
+                None => {
+                    return Err(CompilerError::Type(format!(
+                        "T15: variable `${}` is not bound",
+                        variable
+                    )));
+                }
+            };
+            let node_type = catalog.node_types.get(node_type_name).ok_or_else(|| {
+                CompilerError::Type(format!(
+                    "T15: type `{}` not found in catalog",
+                    node_type_name
+                ))
             })?;
-            if matches!(node_binding.kind, BindingKind::Edge) {
-                return Err(CompilerError::Type(format!(
-                    "T23: nearest cannot target edge binding `${}`; vector search runs on node columns",
-                    variable
-                )));
-            }
-            let node_type = catalog
-                .node_types
-                .get(&node_binding.type_name)
-                .ok_or_else(|| {
-                    CompilerError::Type(format!(
-                        "T15: type `{}` not found in catalog",
-                        node_binding.type_name
-                    ))
-                })?;
             let prop_type = node_type.properties.get(property).ok_or_else(|| {
                 CompilerError::Type(format!(
                     "T15: type `{}` has no property `{}`",
-                    node_binding.type_name, property
+                    node_type_name, property
                 ))
             })?;
             let vector_dim = match prop_type.scalar {
@@ -1142,7 +1152,7 @@ fn resolve_expr_type(
                 _ => {
                     return Err(CompilerError::Type(format!(
                         "T15: nearest requires a Vector property, got {}.{}: {}",
-                        node_binding.type_name,
+                        node_type_name,
                         property,
                         prop_type.display_name()
                     )));
@@ -1471,9 +1481,9 @@ fn resolve_expr_type(
             if let Some(prop_type) = params.get(name) {
                 Ok(ResolvedType::Scalar(prop_type.clone()))
             } else if let Some(bv) = ctx.bindings.get(name) {
-                match bv.kind {
-                    BindingKind::Node => Ok(ResolvedType::Node(bv.type_name.clone())),
-                    BindingKind::Edge => Err(CompilerError::Type(format!(
+                match bv {
+                    BoundVariable::Node { type_name } => Ok(ResolvedType::Node(type_name.clone())),
+                    BoundVariable::Edge { .. } => Err(CompilerError::Type(format!(
                         "T23: edge binding `${}` cannot be used bare; access one of its properties (`${}.{{prop}}`)",
                         name, name
                     ))),

--- a/crates/omnigraph-compiler/src/query/typecheck_tests.rs
+++ b/crates/omnigraph-compiler/src/query/typecheck_tests.rs
@@ -3,6 +3,28 @@ use crate::catalog::build_catalog;
 use crate::query::parser::parse_query;
 use crate::schema::parser::parse_schema;
 
+/// Node type name of a binding, panicking if it is an edge binding — the two
+/// namespaces can share a type name (see `setup_same_named_node_and_edge`).
+/// Indexing `ctx.bindings` covers the unbound case with its own panic.
+fn node_type_of(binding: &BoundVariable) -> &str {
+    match binding {
+        BoundVariable::Node { type_name } => type_name,
+        BoundVariable::Edge { type_name } => {
+            panic!("expected a node binding, found edge type `{type_name}`")
+        }
+    }
+}
+
+/// Edge type name of a binding — the dual of `node_type_of`.
+fn edge_type_of(binding: &BoundVariable) -> &str {
+    match binding {
+        BoundVariable::Edge { type_name } => type_name,
+        BoundVariable::Node { type_name } => {
+            panic!("expected an edge binding, found node type `{type_name}`")
+        }
+    }
+}
+
 fn setup() -> Catalog {
     let schema = parse_schema(
         r#"
@@ -863,7 +885,7 @@ return { $f.name }
     .unwrap();
     let ctx = typecheck_query(&catalog, &qf.queries[0]).unwrap();
     assert_eq!(ctx.traversals[0].direction, Direction::Both);
-    assert_eq!(ctx.bindings["f"].type_name, "Person");
+    assert_eq!(node_type_of(&ctx.bindings["f"]), "Person");
 }
 
 #[test]
@@ -904,7 +926,7 @@ return { $f.name }
     .unwrap();
     let ctx = typecheck_query(&catalog, &qf.queries[0]).unwrap();
     assert_eq!(ctx.traversals[0].direction, Direction::Out);
-    assert_eq!(ctx.bindings["f"].type_name, "Person");
+    assert_eq!(node_type_of(&ctx.bindings["f"]), "Person");
 }
 
 #[test]
@@ -1334,9 +1356,7 @@ return { $f.name, $w.since }
     )
     .unwrap();
     let ctx = typecheck_query(&catalog, &qf.queries[0]).unwrap();
-    let w = &ctx.bindings["w"];
-    assert!(matches!(w.kind, BindingKind::Edge));
-    assert_eq!(w.type_name, "Knows");
+    assert_eq!(edge_type_of(&ctx.bindings["w"]), "Knows");
     assert_eq!(
         ctx.traversals[0].edge_binding.as_deref(),
         Some("w"),
@@ -1552,7 +1572,7 @@ return { $f.name, count($w.since) }
     )
     .unwrap();
     let ctx = typecheck_query(&catalog, &qf.queries[0]).unwrap();
-    assert!(matches!(ctx.bindings["w"].kind, BindingKind::Edge));
+    assert!(matches!(&ctx.bindings["w"], BoundVariable::Edge { .. }));
 }
 
 #[test]


### PR DESCRIPTION
## What & why

Follow-up to #447: makes the binding table's node/edge discriminant structural instead of a skippable struct field.

- The `kind` field let a consumer read a binding's type name without checking it, which is how the three #447 edge-binding gaps happened (a node type and an edge type can share a name).
- `BoundVariable` is now an enum with the type name inside each variant: the read requires a match, and a future binding kind is a compile error at every consumer. No wildcard arms.
- Error messages byte-identical, no behavior change; drops a write-only field.

## Local verification

- `cargo test -p omnigraph-compiler`: 292 passed, 0 failed; the #447 same-named node/edge catalog unchanged
- Workspace build, fmt, clippy clean (9 clippy warnings pre-existing, none in the diff)
- `cargo test --workspace --locked`: engine `warm_read_cost` failures pre-existing (pool contention, pass in isolation; engine crate untouched)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces the binding-kind field with structural `BoundVariable::Node` and `BoundVariable::Edge` variants, ensuring consumers select the correct node or edge type namespace.
- Updates typechecking to exhaustively match binding variants.
- Preserves binding kind while lowering overloaded `contains` expressions.
- Adds same-named node/edge regression coverage, including outer edge bindings referenced from negations.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/omnigraph-compiler/src/query/typecheck.rs | Replaces the separate kind field with exhaustive node and edge enum variants while preserving validation and diagnostic branches. |
| crates/omnigraph-compiler/src/ir/lower.rs | Carries structural binding variants into lowering so overloaded property operations use the correct catalog namespace. |
| crates/omnigraph-compiler/src/query/typecheck_tests.rs | Updates binding assertions to distinguish node and edge enum variants. |
| crates/omnigraph-compiler/src/ir/lower_tests.rs | Adds coverage for same-named node and edge types and edge bindings referenced within negation. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  AST[Parsed query clauses] --> TC[Typecheck bindings]
  TC --> N[BoundVariable::Node]
  TC --> E[BoundVariable::Edge]
  N --> NC[Node catalog namespace]
  E --> EC[Edge catalog namespace]
  NC --> IR[Lower typed expressions to IR]
  EC --> IR
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(query): preserve binding kind during..."](https://github.com/modernrelay/omnigraph/commit/2f2def9d6ce353cdb05818787151fa7052d5ede9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51427976)</sub>

**Context used:**

- Knowledge Base — [Query language pipeline (parse → lint → typecheck → lower)](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/compiler-query-language.md)

<!-- /greptile_comment -->