### PR TITLE
docs: remove the crates.io badge from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@
 
 <p align="center">
   <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-1b1b1f?style=flat-square&labelColor=1b1b1f"></a>
-  <a href="https://crates.io/crates/omnigraph-cli"><img alt="crates.io" src="https://img.shields.io/crates/v/omnigraph-cli?style=flat-square&color=d71921&labelColor=1b1b1f"></a>
   <a href="rust-toolchain.toml"><img alt="Rust" src="https://img.shields.io/badge/rust-stable-1b1b1f?style=flat-square&labelColor=1b1b1f"></a>
 </p>
 


### PR DESCRIPTION
The badge points at the frozen `omnigraph-cli` 0.8.0 crate, which no current release feeds. Registry publication is paused while access to the crates.io account is being recovered (the single-crate restructure in #461 was closed as the wrong shape); binaries ship via the installer, Homebrew, Docker, and GitHub Releases.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the crates.io version badge from the README because it points to a frozen crate that is no longer part of the current release flow.

- Preserves the existing license and Rust badges.
- Makes no runtime, API, dependency, or installation changes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable issues identified.

The change only removes an obsolete external badge and leaves runtime behavior, public interfaces, and the remaining README structure unchanged.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Removes one obsolete crates.io badge without affecting the surrounding README markup or documented installation options. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: remove the crates.io badge from th..."](https://github.com/modernrelay/omnigraph/commit/21cb785720f3c50824d4d18933a71c2dab3a2525) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51439982)</sub>

<!-- /greptile_comment -->