### PR TITLE
Vectorize the in-memory string-predicate filter arm with Arrow kernels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5095,6 +5095,7 @@ dependencies = [
  "arrow-ord",
  "arrow-schema",
  "arrow-select",
+ "arrow-string",
  "async-trait",
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ arrow-schema = "58"
 arrow-select = "58"
 arrow-cast = { version = "58", features = ["prettyprint"] }
 arrow-ord = "58"
+arrow-string = "58"
 
 datafusion = { version = "54", default-features = false, features = ["nested_expressions", "string_expressions"] }
 datafusion-physical-plan = "54"

--- a/crates/omnigraph/Cargo.toml
+++ b/crates/omnigraph/Cargo.toml
@@ -33,6 +33,7 @@ arrow-array = { workspace = true }
 arrow-schema = { workspace = true }
 arrow-ord = { workspace = true }
 arrow-select = { workspace = true }
+arrow-string = { workspace = true }
 arrow-cast = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/omnigraph/src/exec/projection.rs
+++ b/crates/omnigraph/src/exec/projection.rs
@@ -143,40 +143,36 @@ fn evaluate_contains_filter(left: &ArrayRef, right: &ArrayRef) -> Result<Boolean
 /// Exact, case-sensitive string predicates (`starts_with` and the String
 /// overload of `contains`). NULL on either side is not a match, matching the
 /// pushdown arm's SQL semantics.
+///
+/// Uses Arrow's vectorized `like`-family kernels rather than a per-row scan:
+/// same O(rows) work, but columnar/SIMD-friendly, and it natively handles
+/// every string layout (`Utf8`/`LargeUtf8`/`Utf8View`) instead of only the
+/// `Utf8` a downcast would accept.
 fn evaluate_string_match_filter(
     op: CompOp,
     left: &ArrayRef,
     right: &ArrayRef,
 ) -> Result<BooleanArray> {
-    let left_str = left
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .ok_or_else(|| OmniError::manifest(format!("{op} requires String operands")))?;
+    // The kernels require both operands to share a string type; the needle is
+    // typically a broadcast literal already matching, so this cast is usually
+    // a no-op.
     let right = if right.data_type() != left.data_type() {
         arrow_cast::cast::cast(right, left.data_type())
             .map_err(|e| OmniError::Lance(e.to_string()))?
     } else {
         Arc::clone(right)
     };
-    let right_str = right
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .ok_or_else(|| OmniError::manifest(format!("{op} requires String operands")))?;
-
-    let mut values = Vec::with_capacity(left_str.len());
-    for row in 0..left_str.len() {
-        if left_str.is_null(row) || right_str.is_null(row) {
-            values.push(Some(false));
-            continue;
-        }
-        let (l, r) = (left_str.value(row), right_str.value(row));
-        let matched = match op {
-            CompOp::StartsWith => l.starts_with(r),
-            _ => l.contains(r),
-        };
-        values.push(Some(matched));
+    let (left_dyn, right_dyn): (&dyn Array, &dyn Array) = (left.as_ref(), right.as_ref());
+    let matches = match op {
+        CompOp::StartsWith => arrow_string::like::starts_with(&left_dyn, &right_dyn),
+        _ => arrow_string::like::contains(&left_dyn, &right_dyn),
     }
-    Ok(BooleanArray::from(values))
+    .map_err(|e| OmniError::manifest(format!("{op} requires String operands: {e}")))?;
+
+    // A NULL operand yields a NULL result; normalize to `false` so the mask
+    // explicitly excludes those rows (NULL is not a match) rather than relying
+    // on the downstream filter's null handling.
+    Ok(arrow_select::filter::prep_null_mask_filter(&matches))
 }
 
 fn array_value_eq(


### PR DESCRIPTION
<!--
  Thanks for contributing! See CONTRIBUTING.md and GOVERNANCE.md.
-->

## What & why

Follow-up to #358 (based on that branch, not `main`, because it refines code introduced there). Replaces the in-memory `starts_with` / string-`contains` filter arm's per-row scalar loop with Arrow's vectorized `arrow_string::like::{starts_with, contains}` kernels plus `prep_null_mask_filter`. Same O(rows) complexity but columnar/SIMD-friendly, fewer lines, and a correctness bonus: it natively handles `Utf8`/`LargeUtf8`/`Utf8View` instead of only the `Utf8` the previous downcast accepted.

## Backing issue / RFC

- [x] **Trivial fast-lane** (performance/quality refinement, no behavior change) — no issue/RFC required

Maintainer change — internal tracking applies.

## Checklist

- [x] Change is focused (one logical change)
- [x] Tests added/updated for behavior changes (or N/A — behavior identical, `literal_filters` unchanged and green 13/13)
- [x] Public docs updated if user-facing surface changed (or N/A — no surface change)
- [x] Reviewed against [docs/dev/invariants.md](../blob/main/docs/dev/invariants.md) — no Hard Invariant weakened, no deny-list item hit

## Notes for reviewers

- This arm runs **only** for the non-index-accelerated path — cross-variable string predicates and predicates on traversal-materialized batches. The BTREE (`starts_with` → `LikePrefix`) and NGRAM (`contains` → `StringContains`) pushdown paths are untouched; those remain the accelerated, asymptotically-optimal routes.
- NULL semantics preserved exactly: a NULL operand yields a NULL kernel result, normalized to `false` via `prep_null_mask_filter`, so NULL is not a match (same as before and as the pushdown arm).
- Adds a direct `arrow-string` dependency; it was already resolved transitively (arrow 58.3.0), so no new external code enters the tree.
- **Stacked on #358** — base branch is `investigate-ngram-prefix-search`; merge #358 first. Every kernel/`Datum`/null-semantics assumption was validated against the arrow-58.3.0 source.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized execution-path refactor in non-pushdown filtering with preserved null semantics and no API changes; minor risk only if Arrow kernel edge cases differ from the old scalar loop on non-Utf8 layouts.
> 
> **Overview**
> **Replaces** the fallback in-memory `starts_with` / string-`contains` filter path with Arrow’s vectorized `arrow_string::like::{starts_with, contains}` kernels instead of a per-row `StringArray` loop.
> 
> That path still runs only when predicates are not index-pushdown accelerated (e.g. cross-variable or traversal-materialized batches); BTREE/NGRAM pushdown is unchanged. **NULL semantics stay the same**: kernel NULLs are turned into explicit non-matches via `prep_null_mask_filter`. **Operand coverage widens** to `Utf8` / `LargeUtf8` / `Utf8View` without requiring a `Utf8` downcast.
> 
> **Adds** `arrow-string` as an explicit workspace/engine dependency (already transitively present at Arrow 58).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d09b585f5d63ba3ef06f25484fb9c971014ed0f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces scalar in-memory string predicate evaluation with Arrow’s vectorized string kernels while preserving null-as-non-match behavior.

- Adds `arrow-string` to the workspace and engine dependencies.
- Uses vectorized `starts_with` and `contains` kernels for compatible Arrow string layouts.
- Normalizes null kernel results before applying the filter.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/omnigraph/src/exec/projection.rs | Replaces the scalar string-matching loop with Arrow kernels and explicit null-mask normalization; no eligible follow-up defect was established. |
| crates/omnigraph/Cargo.toml | Adds the workspace-managed `arrow-string` dependency required by the new kernel calls. |
| Cargo.toml | Declares Arrow String version 58 consistently with the other Arrow workspace dependencies. |
| Cargo.lock | Records `arrow-string` as an engine dependency without changing the versions or paths of the investigated advisory-bearing dependencies. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Vectorize the in-memory string-predicate..."](https://github.com/modernrelay/omnigraph/commit/d09b585f5d63ba3ef06f25484fb9c971014ed0f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51495498)</sub>

**Context used:**

- Knowledge Base — [Query execution engine](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/omnigraph-query-exec.md)

<!-- /greptile_comment -->