### PR TITLE
Make `init` crash-safe: stamp `__manifest` in its Create commit

### DIFF
--- a/crates/omnigraph/src/db/manifest.rs
+++ b/crates/omnigraph/src/db/manifest.rs
@@ -84,7 +84,6 @@ const OBJECT_TYPE_GRAPH_COMMIT: &str = "graph_commit";
 /// Mutable per-branch head pointer for the graph lineage (RFC-013 Phase 7).
 /// `object_id` is `graph_head:<branch>` (`graph_head:main` for the main branch).
 const OBJECT_TYPE_GRAPH_HEAD: &str = "graph_head";
-const TABLE_VERSION_MANAGEMENT_KEY: &str = "table_version_management";
 
 /// Stable head-key segment for the main branch in `graph_head:<branch>` rows.
 /// `table_branch`/`manifest_branch` encode main as null, but `object_id` must be
@@ -105,9 +104,14 @@ pub(crate) struct CommitOutcome {
 }
 
 /// The on-disk internal-schema stamp of `__manifest` at `branch` (main when
-/// `None`). Used by the open-path refusal guard and to surface the storage
-/// version to operators (`omnigraph snapshot`).
-pub(crate) async fn internal_schema_stamp_at(root_uri: &str, branch: Option<&str>) -> Result<u32> {
+/// `None`), or `None` when no parseable stamp exists (a torn init by an
+/// older binary, a genuine pre-stamp store, or corrupt metadata — see
+/// `migrations::guard_stamp`, which the open paths use instead). Surfaces
+/// the storage version to operators (`omnigraph snapshot`).
+pub(crate) async fn internal_schema_stamp_at(
+    root_uri: &str,
+    branch: Option<&str>,
+) -> Result<Option<u32>> {
     let control_session = crate::lance_access::control_session();
     let dataset = open_manifest_dataset_with_session(root_uri, branch, &control_session).await?;
     Ok(migrations::read_stamp(&dataset))
@@ -129,8 +133,9 @@ pub(crate) async fn internal_schema_stamp_at(root_uri: &str, branch: Option<&str
 /// (writes are refused per-branch by the publisher; a newer binary advancing
 /// main is refused here). See the matching known gap in `docs/dev/invariants.md`.
 pub(crate) async fn refuse_if_internal_schema_unsupported(root_uri: &str) -> Result<()> {
-    let stamp = internal_schema_stamp_at(root_uri, None).await?;
-    migrations::refuse_if_stamp_unsupported(stamp)
+    let control_session = crate::lance_access::control_session();
+    let dataset = open_manifest_dataset_with_session(root_uri, None, &control_session).await?;
+    migrations::guard_stamp(&dataset).map(|_| ())
 }
 
 /// Immutable point-in-time view of the database.

--- a/crates/omnigraph/src/db/manifest/graph.rs
+++ b/crates/omnigraph/src/db/manifest/graph.rs
@@ -11,10 +11,9 @@ use omnigraph_compiler::catalog::Catalog;
 
 use crate::error::{OmniError, Result};
 
-use super::TABLE_VERSION_MANAGEMENT_KEY;
 use super::layout::{manifest_uri, open_manifest_dataset_with_session};
 use super::metadata::TableVersionMetadata;
-use super::migrations::stamp_current_version;
+use super::migrations::current_stamp_entry;
 use super::state::{
     GraphLineageRow, ManifestState, SubTableEntry, entries_to_batch, graph_lineage_row_parts,
     manifest_schema, read_manifest_state, read_manifest_state_and_lineage,
@@ -23,9 +22,9 @@ use super::{TableIdentity, table_path_for_identity};
 
 /// The manifest version the init `Dataset::write` produces (Lance datasets start
 /// at version one). The genesis graph commit pins this version — a snapshot at
-/// it is the empty, freshly-initialized graph. The two config-only commits that
-/// follow (`update_config`, `stamp_current_version`) advance the live manifest
-/// version but add no table data, so genesis correctly stays pinned at one.
+/// it is the empty, freshly-initialized graph, and since the whole manifest
+/// birth is that single Create commit (entries, lineage, and the
+/// internal-schema stamp all ride it), genesis IS the live version at init.
 const GENESIS_MANIFEST_VERSION: u64 = 1;
 
 pub(super) async fn init_manifest_graph(
@@ -51,7 +50,24 @@ pub(super) async fn init_manifest_graph(
     let genesis_lineage = graph_lineage_row_parts(&genesis, None)?;
 
     let manifest_batch = entries_to_batch(&entries, &version_metadata, &genesis_lineage)?;
-    let schema = manifest_schema();
+    // The internal-schema stamp rides the Create write's schema metadata, so
+    // the stamp is atomic with manifest birth: no crash window can leave
+    // `__manifest` durable but unstamped. The Create commit is the manifest's
+    // entire birth — entries, genesis lineage, and the stamp in one commit,
+    // with nothing failable after it. (A `table_version_management` config
+    // key is deliberately not written: nothing in Lance 9 or this crate
+    // reads it.)
+    let (stamp_key, stamp_value) = current_stamp_entry();
+    let schema: SchemaRef = Arc::new(
+        manifest_schema()
+            .as_ref()
+            .clone()
+            .with_metadata([(stamp_key, stamp_value)].into_iter().collect()),
+    );
+    let manifest_batch = RecordBatch::try_new(schema.clone(), manifest_batch.columns().to_vec())
+        .map_err(|e| {
+            OmniError::manifest_internal(format!("attach stamp metadata to init batch: {e}"))
+        })?;
     let reader = RecordBatchIterator::new(vec![Ok(manifest_batch)], schema);
     let params = WriteParams {
         mode: WriteMode::Create,
@@ -63,14 +79,10 @@ pub(super) async fn init_manifest_graph(
         ..Default::default()
     };
     let manifest_path = manifest_uri(root);
-    let mut dataset = Dataset::write(reader, &manifest_path, Some(params))
+    let dataset = Dataset::write(reader, &manifest_path, Some(params))
         .await
         .map_err(|e| OmniError::Lance(e.to_string()))?;
-    dataset
-        .update_config([(TABLE_VERSION_MANAGEMENT_KEY, Some("true"))])
-        .await
-        .map_err(|e| OmniError::Lance(e.to_string()))?;
-    stamp_current_version(&mut dataset).await?;
+    crate::failpoints::maybe_fail(crate::failpoints::names::INIT_POST_MANIFEST_CREATE)?;
 
     let (known_state, lineage_rows) = read_manifest_state_and_lineage(&dataset).await?;
     Ok((dataset, known_state, lineage_rows))

--- a/crates/omnigraph/src/db/manifest/graph.rs
+++ b/crates/omnigraph/src/db/manifest/graph.rs
@@ -55,8 +55,8 @@ pub(super) async fn init_manifest_graph(
     // `__manifest` durable but unstamped. The Create commit is the manifest's
     // entire birth — entries, genesis lineage, and the stamp in one commit,
     // with nothing failable after it. (A `table_version_management` config
-    // key is deliberately not written: nothing in Lance 9 or this crate
-    // reads it.)
+    // key is deliberately not written: neither the pinned Lance substrate nor
+    // this crate reads it.)
     let (stamp_key, stamp_value) = current_stamp_entry();
     let schema: SchemaRef = Arc::new(
         manifest_schema()

--- a/crates/omnigraph/src/db/manifest/migrations.rs
+++ b/crates/omnigraph/src/db/manifest/migrations.rs
@@ -139,14 +139,15 @@ pub(crate) fn read_stamp(dataset: &Dataset) -> Option<u32> {
 /// - A stamp key whose value is not a version number — refused naming the
 ///   raw value. Never classified as absent: a corrupt stamp must not flow
 ///   into the delete-and-re-init advice below.
-/// - No stamp key on a manifest with the modern layout — a torn init: the
-///   RFC-028 identity columns arrived at v5, after stamping began, so no
-///   genuine pre-stamp (v1) manifest can carry them. The only writer of
-///   unstamped-modern manifests is a pre-atomic-stamp binary whose init died
-///   between the `__manifest` Create commit and the stamp commit. Refused
-///   with the real remedy (delete and re-init), not the "ancient store"
-///   export advice, which is impossible to follow for a store no binary
-///   opens.
+/// - No stamp key on a manifest with the modern layout — not a genuine
+///   pre-stamp (v1) manifest, because the RFC-028 identity columns arrived at
+///   v5, after stamping began. This can be an older binary's init interrupted
+///   between the `__manifest` Create commit and its separate stamp commit, or
+///   damaged/externally modified metadata on a graph that progressed further.
+///   Those cases are indistinguishable from the remaining metadata, so the
+///   guard fails closed. Delete-and-re-init is advised only when the operator
+///   independently knows initialization never completed; otherwise the root
+///   must be preserved for investigation or recovery.
 /// - No stamp key on a pre-modern layout — the genuine pre-stamp world:
 ///   treated as v1 and refused through the ordinary sub-floor message naming
 ///   the 0.3.1 export path.
@@ -164,11 +165,14 @@ pub(crate) fn guard_stamp(dataset: &Dataset) -> Result<u32> {
             ))),
         },
         None if manifest_layout_is_modern(dataset) => Err(OmniError::manifest(
-            "__manifest has the current manifest layout but no internal-schema stamp: \
-             an `omnigraph init` on this root crashed before completing (older \
-             omnigraph binaries stamped `__manifest` in a separate commit after \
-             creating it). The graph was never fully initialized and holds no \
-             committed data. Delete the graph root and run `omnigraph init` again.",
+            "__manifest has the current manifest layout but no internal-schema stamp. \
+             This may be an interrupted `omnigraph init` from an older binary, which \
+             stamped `__manifest` in a separate commit, or damaged or externally \
+             modified metadata. OmniGraph cannot safely distinguish those cases and \
+             will not open the graph. If you know initialization never completed, \
+             delete the graph root and run `omnigraph init` again. Otherwise preserve \
+             the root and investigate or restore from a known-good backup; do not \
+             reinitialize it in place.",
         )),
         None => {
             refuse_if_stamp_unsupported(1)?;
@@ -178,9 +182,9 @@ pub(crate) fn guard_stamp(dataset: &Dataset) -> Result<u32> {
 }
 
 /// Whether `__manifest`'s schema carries the RFC-028 stable-identity columns
-/// (v5+). Distinguishes a torn init (unstamped but modern) from a genuine
-/// pre-stamp v1 store — free, since the schema is already in memory when the
-/// stamp is read.
+/// (v5+). Distinguishes an unstamped modern manifest (possible interrupted init
+/// or metadata damage) from a genuine pre-stamp v1 store — free, since the
+/// schema is already in memory when the stamp is read.
 fn manifest_layout_is_modern(dataset: &Dataset) -> bool {
     dataset.schema().field("stable_table_id").is_some()
         && dataset.schema().field("table_incarnation_id").is_some()

--- a/crates/omnigraph/src/db/manifest/migrations.rs
+++ b/crates/omnigraph/src/db/manifest/migrations.rs
@@ -21,8 +21,10 @@
 //! message, not silently upgraded. This is the deliberate pre-release contract —
 //! storage-format changes are a cutover, not a rolling in-place migration (see
 //! `docs/user/operations/upgrade.md` and the versioning policy in `docs/dev`).
-//! `stamp_current_version` stamps fresh graphs at CURRENT, so newly initialized
-//! graphs always pass.
+//! Fresh graphs are stamped at CURRENT *inside* the init `Dataset::write`
+//! Create commit (`current_stamp_entry` rides the write's schema metadata), so
+//! the stamp is atomic with manifest birth: no crash can leave `__manifest`
+//! durable but unstamped.
 //!
 //! ## If an in-place migration is ever needed
 //!
@@ -105,21 +107,83 @@ pub(crate) fn release_for_internal_schema_version(stamp: u32) -> &'static str {
 
 const INTERNAL_SCHEMA_VERSION_KEY: &str = "omnigraph:internal_schema_version";
 
-/// Read the on-disk stamp from `__manifest`'s schema-level metadata.
-/// Absent ⇒ v1 (pre-stamp world), which is below `MIN_SUPPORTED` and so refused.
-pub(crate) fn read_stamp(dataset: &Dataset) -> u32 {
+/// The schema-metadata entry stamping a fresh manifest at CURRENT. Folded into
+/// the Arrow schema of init's `Dataset::write` so the stamp lands in the same
+/// Lance commit that creates `__manifest` — the atomic-birth half of the
+/// torn-init fix (the other half is `guard_stamp`'s absent arm).
+pub(super) fn current_stamp_entry() -> (String, String) {
+    (
+        INTERNAL_SCHEMA_VERSION_KEY.to_string(),
+        INTERNAL_MANIFEST_SCHEMA_VERSION.to_string(),
+    )
+}
+
+/// Read the on-disk stamp from `__manifest`'s schema-level metadata for
+/// display surfaces (`omnigraph snapshot`). `None` covers both an absent key
+/// and an unparseable value; the open paths never use this — they go through
+/// `guard_stamp`, which distinguishes those shapes and refuses each with its
+/// own diagnosis instead of flooring to a version.
+pub(crate) fn read_stamp(dataset: &Dataset) -> Option<u32> {
     dataset
         .schema()
         .metadata
         .get(INTERNAL_SCHEMA_VERSION_KEY)
         .and_then(|s| s.parse().ok())
-        .unwrap_or(1)
 }
 
-/// Stamp a freshly-initialized manifest with the current internal schema
-/// version. Idempotent — safe to call on an already-stamped dataset.
-pub(super) async fn stamp_current_version(dataset: &mut Dataset) -> Result<()> {
-    set_stamp(dataset, INTERNAL_MANIFEST_SCHEMA_VERSION).await
+/// The single stamp gate for every open path: read the stamp and refuse
+/// anything this binary cannot serve, with an honest diagnosis for each shape.
+///
+/// - A parseable stamp — the ordinary floor/ceiling refusal
+///   (`refuse_if_stamp_unsupported`).
+/// - A stamp key whose value is not a version number — refused naming the
+///   raw value. Never classified as absent: a corrupt stamp must not flow
+///   into the delete-and-re-init advice below.
+/// - No stamp key on a manifest with the modern layout — a torn init: the
+///   RFC-028 identity columns arrived at v5, after stamping began, so no
+///   genuine pre-stamp (v1) manifest can carry them. The only writer of
+///   unstamped-modern manifests is a pre-atomic-stamp binary whose init died
+///   between the `__manifest` Create commit and the stamp commit. Refused
+///   with the real remedy (delete and re-init), not the "ancient store"
+///   export advice, which is impossible to follow for a store no binary
+///   opens.
+/// - No stamp key on a pre-modern layout — the genuine pre-stamp world:
+///   treated as v1 and refused through the ordinary sub-floor message naming
+///   the 0.3.1 export path.
+pub(crate) fn guard_stamp(dataset: &Dataset) -> Result<u32> {
+    match dataset.schema().metadata.get(INTERNAL_SCHEMA_VERSION_KEY) {
+        Some(value) => match value.parse::<u32>() {
+            Ok(stamp) => {
+                refuse_if_stamp_unsupported(stamp)?;
+                Ok(stamp)
+            }
+            Err(_) => Err(OmniError::manifest(format!(
+                "__manifest carries an internal-schema stamp that is not a version \
+                 number ('{value}'). The stamp metadata may be corrupt; refusing to \
+                 open rather than guess the storage format.",
+            ))),
+        },
+        None if manifest_layout_is_modern(dataset) => Err(OmniError::manifest(
+            "__manifest has the current manifest layout but no internal-schema stamp: \
+             an `omnigraph init` on this root crashed before completing (older \
+             omnigraph binaries stamped `__manifest` in a separate commit after \
+             creating it). The graph was never fully initialized and holds no \
+             committed data. Delete the graph root and run `omnigraph init` again.",
+        )),
+        None => {
+            refuse_if_stamp_unsupported(1)?;
+            Ok(1)
+        }
+    }
+}
+
+/// Whether `__manifest`'s schema carries the RFC-028 stable-identity columns
+/// (v5+). Distinguishes a torn init (unstamped but modern) from a genuine
+/// pre-stamp v1 store — free, since the schema is already in memory when the
+/// stamp is read.
+fn manifest_layout_is_modern(dataset: &Dataset) -> bool {
+    dataset.schema().field("stable_table_id").is_some()
+        && dataset.schema().field("table_incarnation_id").is_some()
 }
 
 /// Refuse to open a manifest whose stamp this binary cannot serve — in either
@@ -155,6 +219,7 @@ pub(crate) fn refuse_if_stamp_unsupported(stamp: u32) -> Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
 async fn set_stamp(dataset: &mut Dataset, version: u32) -> Result<()> {
     dataset
         .update_schema_metadata([(INTERNAL_SCHEMA_VERSION_KEY.to_string(), version.to_string())])
@@ -169,6 +234,37 @@ async fn set_stamp(dataset: &mut Dataset, version: u32) -> Result<()> {
 #[cfg(test)]
 pub(crate) async fn set_stamp_for_test(dataset: &mut Dataset, version: u32) -> Result<()> {
     set_stamp(dataset, version).await
+}
+
+/// Test-only: overwrite the internal-schema stamp with a raw (possibly
+/// non-numeric) value. Used to pin `guard_stamp`'s unreadable-stamp arm.
+#[cfg(test)]
+pub(crate) async fn set_raw_stamp_for_test(dataset: &mut Dataset, value: &str) -> Result<()> {
+    dataset
+        .update_schema_metadata([(INTERNAL_SCHEMA_VERSION_KEY.to_string(), value.to_string())])
+        .await
+        .map_err(|e| OmniError::Lance(e.to_string()))?;
+    Ok(())
+}
+
+/// Test-only: strip the internal-schema stamp entirely, synthesizing the torn
+/// state a pre-atomic-stamp binary left when init died between the `__manifest`
+/// Create commit and the stamp commit. Used to pin `guard_stamp`'s absent arm.
+#[cfg(test)]
+pub(crate) async fn remove_stamp_for_test(dataset: &mut Dataset) -> Result<()> {
+    let remaining: Vec<(String, String)> = dataset
+        .schema()
+        .metadata
+        .iter()
+        .filter(|(k, _)| k.as_str() != INTERNAL_SCHEMA_VERSION_KEY)
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    dataset
+        .update_schema_metadata(remaining)
+        .replace()
+        .await
+        .map_err(|e| OmniError::Lance(e.to_string()))?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/omnigraph/src/db/manifest/publisher.rs
+++ b/crates/omnigraph/src/db/manifest/publisher.rs
@@ -35,7 +35,7 @@ use super::layout::{
     open_manifest_dataset_with_session, table_object_id, tombstone_object_id, version_object_id,
 };
 use super::metadata::{TableVersionMetadata, parse_namespace_version_request};
-use super::migrations::{read_stamp, refuse_if_stamp_unsupported};
+use super::migrations::guard_stamp;
 use super::state::{
     GraphLineageRow, GraphLineageRowPart, ManifestState, assemble_manifest_state,
     graph_head_object_id, graph_lineage_row_parts, head_lineage_row, manifest_rows_batch,
@@ -254,7 +254,7 @@ impl GraphNamespacePublisher {
         // format) is refused with the rebuild-via-export/import message. There is
         // no in-place migration — storage-format changes are a cutover. See
         // `db/manifest/migrations.rs`.
-        refuse_if_stamp_unsupported(read_stamp(&dataset))?;
+        guard_stamp(&dataset)?;
         // ONE `__manifest` scan for everything the publish needs: table
         // locations, version entries, tombstones, `graph_commit` lineage rows
         // for parent resolution, AND exact `graph_head` rows for OCC (RFC-013

--- a/crates/omnigraph/src/db/manifest/tests.rs
+++ b/crates/omnigraph/src/db/manifest/tests.rs
@@ -1716,6 +1716,11 @@ async fn test_init_stamps_internal_schema_version() {
 
     let ds = open_manifest_dataset(uri, None).await.unwrap();
     assert_eq!(
+        ds.version().version,
+        1,
+        "fresh __manifest HEAD must be its Create commit; init must not append config or stamp commits",
+    );
+    assert_eq!(
         super::migrations::read_stamp(&ds),
         Some(super::migrations::INTERNAL_MANIFEST_SCHEMA_VERSION),
         "init should stamp the manifest at the current internal schema version",
@@ -1734,13 +1739,13 @@ async fn test_init_stamps_internal_schema_version() {
 }
 
 // The absent-stamp arm of the open guard. An unstamped manifest that carries
-// the modern (v5+) identity columns cannot be a genuine pre-stamp v1 store —
-// only an init torn by a pre-atomic-stamp binary produces that shape — so the
-// guard must name the torn init and its real remedy, never the "created by
-// omnigraph 0.3.1 or earlier, rebuild via export" misdiagnosis (whose remedy
-// is impossible: no binary opens the store to export it).
+// the modern (v5+) identity columns cannot be a genuine pre-stamp v1 store,
+// but the remaining metadata cannot distinguish an init interrupted under a
+// pre-atomic-stamp binary from later metadata damage. The guard must name both
+// possibilities, fail closed, and make delete-and-re-init conditional on the
+// operator independently knowing that initialization never completed.
 #[tokio::test]
-async fn unstamped_modern_manifest_is_diagnosed_as_torn_init() {
+async fn unstamped_modern_manifest_is_refused_as_interrupted_init_or_corruption() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
     let catalog = build_test_catalog();
@@ -1757,23 +1762,26 @@ async fn unstamped_modern_manifest_is_diagnosed_as_torn_init() {
         .expect_err("an unstamped manifest must be refused")
         .to_string();
     assert!(
-        err.contains("crashed before completing"),
-        "the refusal must name the torn init: {err}"
+        err.contains("interrupted `omnigraph init`")
+            && err.contains("damaged or externally modified metadata"),
+        "the refusal must name both possible causes: {err}"
     );
     assert!(
-        err.contains("Delete the graph root"),
-        "the refusal must carry the real remedy: {err}"
+        err.contains("cannot safely distinguish those cases")
+            && err.contains("If you know initialization never completed")
+            && err.contains("Otherwise preserve the root"),
+        "the refusal must fail closed and make deletion conditional: {err}"
     );
     assert!(
-        !err.contains("0.3.1"),
-        "an unstamped-modern manifest must not be misdiagnosed as ancient: {err}"
+        !err.contains("holds no committed data") && !err.contains("0.3.1"),
+        "the refusal must neither assume an empty graph nor misdiagnose it as ancient: {err}"
     );
 }
 
 // The unreadable-stamp arm: a stamp key that is present but not a version
 // number must be refused naming the raw value — never classified as absent,
-// because the absent-modern arm advises deleting the root, and corrupt
-// metadata must not flow into destructive advice.
+// because an explicitly corrupt value should not flow even into the modern
+// absent-stamp arm's conditional delete advice.
 #[tokio::test]
 async fn unreadable_stamp_is_refused_without_delete_advice() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/omnigraph/src/db/manifest/tests.rs
+++ b/crates/omnigraph/src/db/manifest/tests.rs
@@ -1717,8 +1717,86 @@ async fn test_init_stamps_internal_schema_version() {
     let ds = open_manifest_dataset(uri, None).await.unwrap();
     assert_eq!(
         super::migrations::read_stamp(&ds),
-        super::migrations::INTERNAL_MANIFEST_SCHEMA_VERSION,
+        Some(super::migrations::INTERNAL_MANIFEST_SCHEMA_VERSION),
         "init should stamp the manifest at the current internal schema version",
+    );
+
+    // The stamp must ride the Create commit itself — checking out manifest
+    // version one (the genesis Create write) must already show it. This is the
+    // torn-init guarantee: there is no on-disk moment where `__manifest`
+    // exists unstamped.
+    let genesis = ds.checkout_version(1).await.unwrap();
+    assert_eq!(
+        super::migrations::read_stamp(&genesis),
+        Some(super::migrations::INTERNAL_MANIFEST_SCHEMA_VERSION),
+        "the stamp must land in the same Lance commit that creates __manifest",
+    );
+}
+
+// The absent-stamp arm of the open guard. An unstamped manifest that carries
+// the modern (v5+) identity columns cannot be a genuine pre-stamp v1 store —
+// only an init torn by a pre-atomic-stamp binary produces that shape — so the
+// guard must name the torn init and its real remedy, never the "created by
+// omnigraph 0.3.1 or earlier, rebuild via export" misdiagnosis (whose remedy
+// is impossible: no binary opens the store to export it).
+#[tokio::test]
+async fn unstamped_modern_manifest_is_diagnosed_as_torn_init() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = dir.path().to_str().unwrap();
+    let catalog = build_test_catalog();
+    ManifestCoordinator::init(uri, &catalog).await.unwrap();
+
+    let mut ds = open_manifest_dataset(uri, None).await.unwrap();
+    super::migrations::remove_stamp_for_test(&mut ds)
+        .await
+        .unwrap();
+
+    let ds = open_manifest_dataset(uri, None).await.unwrap();
+    assert_eq!(super::migrations::read_stamp(&ds), None);
+    let err = super::migrations::guard_stamp(&ds)
+        .expect_err("an unstamped manifest must be refused")
+        .to_string();
+    assert!(
+        err.contains("crashed before completing"),
+        "the refusal must name the torn init: {err}"
+    );
+    assert!(
+        err.contains("Delete the graph root"),
+        "the refusal must carry the real remedy: {err}"
+    );
+    assert!(
+        !err.contains("0.3.1"),
+        "an unstamped-modern manifest must not be misdiagnosed as ancient: {err}"
+    );
+}
+
+// The unreadable-stamp arm: a stamp key that is present but not a version
+// number must be refused naming the raw value — never classified as absent,
+// because the absent-modern arm advises deleting the root, and corrupt
+// metadata must not flow into destructive advice.
+#[tokio::test]
+async fn unreadable_stamp_is_refused_without_delete_advice() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = dir.path().to_str().unwrap();
+    let catalog = build_test_catalog();
+    ManifestCoordinator::init(uri, &catalog).await.unwrap();
+
+    let mut ds = open_manifest_dataset(uri, None).await.unwrap();
+    super::migrations::set_raw_stamp_for_test(&mut ds, "not-a-number")
+        .await
+        .unwrap();
+
+    let ds = open_manifest_dataset(uri, None).await.unwrap();
+    let err = super::migrations::guard_stamp(&ds)
+        .expect_err("an unreadable stamp must be refused")
+        .to_string();
+    assert!(
+        err.contains("not-a-number"),
+        "the refusal must name the raw value: {err}"
+    );
+    assert!(
+        !err.contains("Delete the graph root") && !err.contains("0.3.1"),
+        "corrupt metadata must not trigger delete advice or the ancient misdiagnosis: {err}"
     );
 }
 
@@ -1742,7 +1820,7 @@ async fn branch_inherits_main_internal_schema_stamp() {
     let feature_ds = open_manifest_dataset(uri, Some("feature")).await.unwrap();
     assert_eq!(
         super::migrations::read_stamp(&main_ds),
-        super::migrations::INTERNAL_MANIFEST_SCHEMA_VERSION,
+        Some(super::migrations::INTERNAL_MANIFEST_SCHEMA_VERSION),
         "fresh graph stamps main at CURRENT",
     );
     assert_eq!(

--- a/crates/omnigraph/src/db/omnigraph.rs
+++ b/crates/omnigraph/src/db/omnigraph.rs
@@ -1513,7 +1513,13 @@ impl Omnigraph {
     /// version this graph is stamped at). Surfaced via `omnigraph snapshot`.
     pub async fn internal_schema_version_of(&self, target: impl Into<ReadTarget>) -> Result<u32> {
         let branch = self.resolved_branch_of(target).await?;
-        crate::db::manifest::internal_schema_stamp_at(self.uri(), branch.as_deref()).await
+        crate::db::manifest::internal_schema_stamp_at(self.uri(), branch.as_deref())
+            .await?
+            .ok_or_else(|| {
+                // Unreachable through this handle: every open path runs the
+                // stamp guard, which refuses unstamped manifests.
+                OmniError::manifest_internal("opened graph has no internal-schema stamp")
+            })
     }
 
     pub async fn resolved_branch_of(

--- a/crates/omnigraph/src/failpoints.rs
+++ b/crates/omnigraph/src/failpoints.rs
@@ -116,6 +116,11 @@ pub mod names {
     pub const INIT_AFTER_COORDINATOR_INIT: &str = "init.after_coordinator_init";
     pub const INIT_AFTER_SCHEMA_CONTRACT_WRITTEN: &str = "init.after_schema_contract_written";
     pub const INIT_AFTER_SCHEMA_PG_WRITTEN: &str = "init.after_schema_pg_written";
+    /// Inside `init_manifest_graph`, immediately after the `__manifest`
+    /// Create commit — the manifest's entire birth (entries, genesis lineage,
+    /// and the internal-schema stamp all ride that one commit). A crash here
+    /// must leave an openable store.
+    pub const INIT_POST_MANIFEST_CREATE: &str = "init.post_manifest_create";
     /// A read-write bind of a local graph root, before the create-if-absent
     /// probe writes its probe object. Injecting here simulates a filesystem
     /// without hard-link support (issue #453) for both `init` and

--- a/crates/omnigraph/tests/failpoints.rs
+++ b/crates/omnigraph/tests/failpoints.rs
@@ -10159,6 +10159,53 @@ async fn init_failpoint_after_coordinator_init_cleans_up_schema_files() {
     // root is fully empty.
 }
 
+// The torn-init regression: the `__manifest` Create commit is the manifest's
+// entire birth (entries, genesis lineage, and the internal-schema stamp ride
+// the one commit), so a crash immediately after it — previously the
+// create-to-stamp gap, which left a durable-but-unstamped manifest that every
+// later open misdiagnosed as "created by omnigraph 0.3.1 or earlier" and no
+// re-init could recover — must now leave a store that opens cleanly and
+// serves reads and writes. The crash is a panic (not an error return) so
+// init's best-effort cleanup does not run, modeling a process death.
+#[tokio::test]
+#[serial]
+async fn init_crash_after_manifest_create_leaves_openable_store() {
+    let _scenario = FailScenario::setup();
+    let dir = tempfile::tempdir().unwrap();
+    let uri = dir.path().to_str().unwrap().to_string();
+
+    let crash = ScopedFailPoint::new(names::INIT_POST_MANIFEST_CREATE, "panic");
+    let cloned = uri.clone();
+    let died = tokio::spawn(async move {
+        Omnigraph::init(&cloned, helpers::TEST_SCHEMA)
+            .await
+            .map(|_| ())
+    })
+    .await;
+    drop(crash);
+    assert!(
+        died.expect_err("init must die at the injected crash point")
+            .is_panic(),
+        "the injected failpoint action is a panic"
+    );
+
+    // The Create commit carried the stamp, so the store is fully born: it
+    // opens without the ancient-version misdiagnosis and serves a write and
+    // a read.
+    let mut db = Omnigraph::open(&uri)
+        .await
+        .expect("store must open cleanly after a crash in the post-create window");
+    mutate_main(
+        &mut db,
+        MUTATION_QUERIES,
+        "insert_person",
+        &mixed_params(&[("$name", "torn-init-survivor")], &[("$age", 1)]),
+    )
+    .await
+    .expect("store must accept writes after the crash");
+    assert_eq!(count_rows(&db, "node:Person").await, 1);
+}
+
 #[tokio::test]
 #[serial]
 async fn init_failpoint_returns_original_error_not_cleanup_error() {

--- a/crates/omnigraph/tests/forbidden_apis.rs
+++ b/crates/omnigraph/tests/forbidden_apis.rs
@@ -613,14 +613,16 @@ macro_rules! durable_calls {
 // manifest implementations are included; only standalone test-only sources
 // whose parent cfg is invisible to this file walker are excluded.
 durable_calls! {
+    // The `__manifest` Create write is the manifest's entire birth: entries,
+    // genesis lineage, and the internal-schema stamp all ride the one commit,
+    // so the stamp is atomic with birth and no bootstrap write follows it.
+    // (A `table_version_management` config key is deliberately not written:
+    // nothing in Lance 9 or this crate reads it.)
     ("db/manifest/graph.rs", "Dataset::write(", 2, WriteProtocol::Bootstrap),
-    ("db/manifest/graph.rs", ".update_config(", 1, WriteProtocol::Bootstrap),
-    ("db/manifest/graph.rs", "stamp_current_version(", 1, WriteProtocol::Bootstrap),
     ("db/manifest/publisher.rs", ".dataset()", 2, WriteProtocol::ReadOnlyAccess),
     ("db/manifest/publisher.rs", ".publish_with_precondition(", 1, WriteProtocol::Exact("manifest publisher trait forwarding")),
     ("db/manifest/publisher.rs", "MergeInsertBuilder::try_new(", 1, WriteProtocol::Exact("lowest manifest publisher gateway")),
     ("db/manifest/publisher.rs", ".execute_reader(", 1, WriteProtocol::Exact("lowest manifest publisher gateway")),
-    ("db/manifest/migrations.rs", ".update_schema_metadata(", 1, WriteProtocol::Bootstrap),
     ("instrumentation.rs", ".write_text(", 1, WriteProtocol::Composed("instrumented storage forwarding")),
     ("instrumentation.rs", ".write_text_if_absent(", 1, WriteProtocol::Composed("instrumented storage forwarding")),
     ("instrumentation.rs", ".write_text_if_match(", 1, WriteProtocol::Composed("instrumented storage forwarding")),
@@ -787,7 +789,6 @@ const DURABLE_PRIMITIVES: &[&str] = &[
     "cleanup_old_versions(",
     ".update_config(",
     ".update_schema_metadata(",
-    "stamp_current_version(",
     "write_schema_contract_staging(",
     "promote_exact_schema_staging(",
     "discard_exact_schema_staging(",

--- a/crates/omnigraph/tests/forbidden_apis.rs
+++ b/crates/omnigraph/tests/forbidden_apis.rs
@@ -617,7 +617,7 @@ durable_calls! {
     // genesis lineage, and the internal-schema stamp all ride the one commit,
     // so the stamp is atomic with birth and no bootstrap write follows it.
     // (A `table_version_management` config key is deliberately not written:
-    // nothing in Lance 9 or this crate reads it.)
+    // neither the pinned Lance substrate nor this crate reads it.)
     ("db/manifest/graph.rs", "Dataset::write(", 2, WriteProtocol::Bootstrap),
     ("db/manifest/publisher.rs", ".dataset()", 2, WriteProtocol::ReadOnlyAccess),
     ("db/manifest/publisher.rs", ".publish_with_precondition(", 1, WriteProtocol::Exact("manifest publisher trait forwarding")),

--- a/docs/dev/versioning.md
+++ b/docs/dev/versioning.md
@@ -50,14 +50,18 @@ state:
 - a stamp below v6 is refused with rebuild guidance;
 - a stamp above v6 is refused with an upgrade-binary message;
 - an absent stamp on a manifest with the modern (v5+) column layout is refused
-  as a torn init (an `omnigraph init` that crashed between creating
-  `__manifest` and stamping it — older binaries stamped in a separate commit)
-  with delete-and-re-init guidance; an absent stamp on a pre-modern layout is
-  the genuine pre-stamp world, treated as v1; a stamp that is present but not
-  a version number is refused naming the raw value. Current binaries cannot
-  produce the torn state: the `__manifest` Create commit is the manifest's
-  entire birth — entries, genesis lineage, and the stamp ride that single
-  commit, so the stamp is atomic with manifest birth.
+  as either an interrupted older-binary init (those binaries stamped in a
+  separate commit after creating `__manifest`) or damaged/externally modified
+  metadata. The remaining metadata cannot distinguish those cases, so the
+  guard fails closed. It advises deletion and re-init only when the operator
+  independently knows initialization never completed; otherwise it says to
+  preserve the root for investigation or recovery. An absent stamp on a
+  pre-modern layout is the genuine pre-stamp world, treated as v1; a stamp
+  that is present but not a version number is refused naming the raw value.
+  Current binaries cannot produce the interrupted-init state: the `__manifest`
+  Create commit is the manifest's entire birth — entries, genesis lineage, and
+  the stamp ride that single commit, so the stamp is atomic with manifest
+  birth.
 
 There is no in-place migration dispatcher. A released v4 graph is exported with
 its v0.8.x binary, initialized as a fresh v6 graph, and loaded through the

--- a/docs/dev/versioning.md
+++ b/docs/dev/versioning.md
@@ -48,7 +48,16 @@ The rationale and historical links are in
 state:
 
 - a stamp below v6 is refused with rebuild guidance;
-- a stamp above v6 is refused with an upgrade-binary message.
+- a stamp above v6 is refused with an upgrade-binary message;
+- an absent stamp on a manifest with the modern (v5+) column layout is refused
+  as a torn init (an `omnigraph init` that crashed between creating
+  `__manifest` and stamping it — older binaries stamped in a separate commit)
+  with delete-and-re-init guidance; an absent stamp on a pre-modern layout is
+  the genuine pre-stamp world, treated as v1; a stamp that is present but not
+  a version number is refused naming the raw value. Current binaries cannot
+  produce the torn state: the `__manifest` Create commit is the manifest's
+  entire birth — entries, genesis lineage, and the stamp ride that single
+  commit, so the stamp is atomic with manifest birth.
 
 There is no in-place migration dispatcher. A released v4 graph is exported with
 its v0.8.x binary, initialized as a fresh v6 graph, and loaded through the

--- a/docs/releases/v0.10.0.md
+++ b/docs/releases/v0.10.0.md
@@ -10,3 +10,13 @@ graph commit, and acknowledges only after manifest visibility. The decision,
 retained evidence, and compatibility posture are recorded in
 [Streaming ingestion after RFC-026](../dev/wal-removal.md). The rejected design
 itself remains available as [RFC-026](../rfcs/0026-memwal-streaming-ingest.md).
+
+## Follow-on v0.10.0 work
+
+- **Crash-safe manifest initialization.** A fresh `__manifest` now finishes at
+  Lance version 1 instead of version 3. Its entries, genesis lineage, and
+  internal-schema stamp all ride the initial Create commit. The unused
+  `table_version_management` config update and the separate schema-stamp update
+  were removed, closing the crash window in which a manifest could exist with
+  a modern layout but no stamp. This does not change OmniGraph's internal
+  manifest schema version.

--- a/docs/user/operations/upgrade.md
+++ b/docs/user/operations/upgrade.md
@@ -52,11 +52,16 @@ If the graph's stamp is **higher** than the binary's, the binary is too old —
 upgrade omnigraph rather than rebuilding the graph.
 
 If the refusal says `__manifest` has the current manifest layout but **no
-internal-schema stamp at all**, the graph is not old: an `omnigraph init` on
-that root crashed before completing (older binaries wrote the stamp in a
-separate commit after creating `__manifest`). The store was never fully
-initialized and holds no committed data — delete the graph root and run
-`omnigraph init` again. No export or rebuild is involved.
+internal-schema stamp at all**, the graph is not a genuine pre-stamp store. It
+may be an `omnigraph init` from an older binary interrupted between creating
+`__manifest` and writing its separate stamp commit, or the stamp metadata may
+have been damaged or externally modified later. OmniGraph cannot safely tell
+which happened and refuses to open the graph.
+
+Delete the root and run `omnigraph init` again **only if you independently know
+that initialization never completed**. Otherwise preserve the root, do not
+reinitialize it in place, and investigate the metadata or restore from a
+known-good backup.
 
 ## What is preserved (and what is not)
 

--- a/docs/user/operations/upgrade.md
+++ b/docs/user/operations/upgrade.md
@@ -51,6 +51,13 @@ You can also check versions before you hit a refusal:
 If the graph's stamp is **higher** than the binary's, the binary is too old —
 upgrade omnigraph rather than rebuilding the graph.
 
+If the refusal says `__manifest` has the current manifest layout but **no
+internal-schema stamp at all**, the graph is not old: an `omnigraph init` on
+that root crashed before completing (older binaries wrote the stamp in a
+separate commit after creating `__manifest`). The store was never fully
+initialized and holds no committed data — delete the graph root and run
+`omnigraph init` again. No export or rebuild is involved.
+
 ## What is preserved (and what is not)
 
 | Preserved | Not preserved |


### PR DESCRIPTION
## What & why

Closes #483.

init wrote `__manifest` in three unfenced Lance commits (Create, a config write, the internal-schema version stamp), so a crash between the first and third left a durable but unstamped manifest. The open guard floored an absent stamp to v1 and refused the store as "created by omnigraph 0.3.1 or earlier, rebuild via export": a wrong diagnosis with an impossible remedy, and neither plain nor `--force` re-init could recover the root.

- The stamp now rides the Create commit's schema metadata, so it is atomic with manifest birth; the follow-up config commit wrote a `table_version_management` key nothing reads and is removed, making the Create commit the manifest's entire birth. The crash window is gone by construction, pinned by a test that reads the stamp at manifest version 1.
- The open guard no longer floors an absent stamp: a manifest with the current column layout but no stamp is refused as a torn init with the real remedy (delete the root and run init again), a genuinely pre-stamp store still gets the export message, and a stamp that is present but not a version number is refused naming the raw value instead of being classified as absent.
- Observable deltas: a fresh graph's `__manifest` now starts at version 1 instead of 3, and new stores no longer carry the unread config key.

## Future work

An open-time re-stamp heal would recover legacy torn inits automatically, but it cannot distinguish them from corruption-caused stamp loss, and fixed binaries produce no new unstamped stores, so refusal with a clear remedy wins.

## Local verification

- `cargo test -p omnigraph-engine --features failpoints --test failpoints`: green (134 passed, 1 pre-existing ignore), including the new crash regression `init_crash_after_manifest_create_leaves_openable_store` (panic-crash after the Create commit, then the store opens and serves a write; the same crash on unmodified main leaves the store refused as ancient, reproduced with the failpoint plant in the issue)
- `cargo test -p omnigraph-engine`: green, including the new guard pins (stamp readable at manifest version 1, torn-init diagnosis, unreadable-stamp refusal)
- `cargo test --workspace --locked`: 75 binaries green; `cargo clippy --workspace --all-targets` and `cargo fmt --all --check` clean

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes manifest initialization crash-safe by placing the internal-schema stamp in the same Lance Create commit that creates `__manifest`.
- Removes the unused configuration commit and separate schema-stamp commit, leaving fresh manifests at Lance version 1.
- Adds explicit refusal paths for absent and malformed schema stamps.
- Adds unit and failpoint coverage for atomic stamping, torn initialization, and malformed metadata.
- Updates versioning, upgrade, and release documentation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/omnigraph/src/db/manifest/graph.rs | Moves the internal-schema stamp into the manifest Create schema and removes the two post-create metadata commits. |
| crates/omnigraph/src/db/manifest/migrations.rs | Introduces a unified stamp guard that distinguishes supported, absent, and malformed metadata states. |
| crates/omnigraph/src/db/manifest.rs | Routes the graph-level compatibility check through the new dataset-aware stamp guard. |
| crates/omnigraph/src/db/manifest/publisher.rs | Applies the unified stamp guard before loading manifest publish state. |
| crates/omnigraph/src/db/omnigraph.rs | Converts the internal optional stamp representation back into the existing public numeric version contract. |
| crates/omnigraph/tests/failpoints.rs | Verifies that a panic immediately after manifest creation leaves a graph that can reopen and serve writes. |
| crates/omnigraph/src/db/manifest/tests.rs | Pins manifest version 1 stamping and the missing or malformed stamp refusal behavior. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Init as omnigraph init
    participant Lance as Lance __manifest
    participant Guard as Open stamp guard
    Init->>Lance: Create(entries + genesis lineage + schema stamp)
    Lance-->>Init: Durable manifest version 1
    Note over Init,Lance: A crash after Create leaves a stamped manifest
    Guard->>Lance: Read schema metadata
    alt Supported numeric stamp
        Guard-->>Init: Open graph
    else Missing modern-layout stamp
        Guard-->>Init: Refuse as interrupted init or metadata damage
    else Malformed stamp
        Guard-->>Init: Refuse and report raw value
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(manifest): fail closed on missing sc..."](https://github.com/modernrelay/omnigraph/commit/b9331d763d8f7ad5b7f0e71c4d3dffc3a3e7e7a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52396794)</sub>

**Context used:**

- Knowledge Base — [OmniGraph core storage: manifest, table store, and Lance access](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/omnigraph-core-storage.md)

<!-- /greptile_comment -->