### PR TITLE
Supervise configured graph availability, with typed failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5180,6 +5180,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tower",
  "tower-http",
  "tracing",
@@ -7627,6 +7628,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5161,6 +5161,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "dashmap",
+ "fastrand",
  "futures",
  "lance",
  "lance-index",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ base64 = "0.22"
 ariadne = "0.4"
 regex = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+tokio-util = { version = "0.7", features = ["rt"] }
 object_store = { version = "0.13.2", default-features = false, features = ["aws", "fs"] }
 fail = "0.5"
 time = { version = "0.3", features = ["formatting"] }

--- a/crates/omnigraph-api-types/src/lib.rs
+++ b/crates/omnigraph-api-types/src/lib.rs
@@ -665,7 +665,27 @@ pub struct ResourceLimitOutput {
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct RecoveryRequiredOutput {
+    /// The durable operation that blocked this request. This is not a request
+    /// identifier for the current HTTP call.
     pub operation_id: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum GraphState {
+    Ready,
+    Recovering,
+    Degraded,
+    Opening,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct GraphUnavailableOutput {
+    pub graph_id: String,
+    pub state: GraphState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retry_after_seconds: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -697,6 +717,10 @@ pub struct ErrorOutput {
     /// retry. Its table effects may or may not have started.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub recovery_required: Option<RecoveryRequiredOutput>,
+    /// Present when the graph id is configured but cannot currently serve the
+    /// requested operation. Unknown graph ids remain ordinary 404 responses.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub graph_unavailable: Option<GraphUnavailableOutput>,
 }
 
 pub fn snapshot_payload(
@@ -844,17 +868,25 @@ pub fn read_target_output(target: &ReadTarget) -> ReadTargetOutput {
 
 // ─── MR-668 — management endpoint shapes ──────────────────────────────────
 
-/// One entry in the response from `GET /graphs`. Cluster operators
-/// consume this list to discover which graphs the server is currently
-/// serving. The shape is intentionally minimal — `graph_id` and `uri`
-/// are the only fields a routing client needs.
+/// One configured graph and its current serving state.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct GraphInfo {
     pub graph_id: String,
     pub uri: String,
+    pub state: GraphState,
+    pub read_ready: bool,
+    pub write_ready: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_class: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retry_after_seconds: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blocking_operation_id: Option<String>,
 }
 
-/// Response from `GET /graphs`. Lists every graph registered with the
+/// Response from `GET /graphs`. Lists every graph configured on the
 /// server in alphabetical order by `graph_id` (sorted server-side so
 /// clients get deterministic output across requests).
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/crates/omnigraph-server/Cargo.toml
+++ b/crates/omnigraph-server/Cargo.toml
@@ -41,6 +41,7 @@ subtle = { workspace = true }
 async-trait = { workspace = true }
 arc-swap = { workspace = true }
 dashmap = "6"
+fastrand = "2"
 regex = { workspace = true }
 thiserror = { workspace = true }
 aws-config = { version = "1", optional = true, default-features = false, features = ["rustls", "rt-tokio", "credentials-process", "sso"] }

--- a/crates/omnigraph-server/Cargo.toml
+++ b/crates/omnigraph-server/Cargo.toml
@@ -44,6 +44,8 @@ dashmap = "6"
 fastrand = "2"
 regex = { workspace = true }
 thiserror = { workspace = true }
+# `TaskTracker`: the supervisor owns each attempt past the wait that started it.
+tokio-util = { workspace = true }
 aws-config = { version = "1", optional = true, default-features = false, features = ["rustls", "rt-tokio", "credentials-process", "sso"] }
 aws-sdk-secretsmanager = { version = "1", optional = true, default-features = false, features = ["rustls", "rt-tokio"] }
 

--- a/crates/omnigraph-server/src/handlers.rs
+++ b/crates/omnigraph-server/src/handlers.rs
@@ -79,11 +79,13 @@ pub(crate) async fn server_graphs_list(
             GraphInfo {
                 graph_id: entry.key.graph_id.as_str().to_string(),
                 uri: entry.uri.clone(),
-                state: graph_state_output(availability.state),
+                state: availability.state.into(),
                 read_ready: availability.read_ready,
                 write_ready: availability.write_ready,
-                failure_class: availability.failure_class.map(str::to_string),
-                last_error: availability.last_error,
+                failure_class: availability
+                    .failure_class
+                    .map(|class| class.as_str().to_string()),
+                last_error: availability.summary.map(str::to_string),
                 retry_after_seconds: availability.retry_after_seconds,
                 blocking_operation_id: availability.blocking_operation_id,
             }
@@ -91,16 +93,6 @@ pub(crate) async fn server_graphs_list(
         .collect();
     graphs.sort_by(|a, b| a.graph_id.cmp(&b.graph_id));
     Ok(Json(GraphListResponse { graphs }))
-}
-
-fn graph_state_output(state: &str) -> api::GraphState {
-    match state {
-        "ready" => api::GraphState::Ready,
-        "recovering" => api::GraphState::Recovering,
-        "degraded" => api::GraphState::Degraded,
-        "opening" => api::GraphState::Opening,
-        _ => api::GraphState::Unavailable,
-    }
 }
 
 pub(crate) async fn server_openapi(

--- a/crates/omnigraph-server/src/handlers.rs
+++ b/crates/omnigraph-server/src/handlers.rs
@@ -34,18 +34,17 @@ pub(crate) async fn server_health() -> Json<HealthOutput> {
     tag = "management",
     operation_id = "listGraphs",
     responses(
-        (status = 200, description = "List of registered graphs", body = GraphListResponse),
+        (status = 200, description = "List of configured graphs and runtime status", body = GraphListResponse),
         (status = 401, description = "Unauthorized", body = ErrorOutput),
         (status = 403, description = "Forbidden", body = ErrorOutput),
-        (status = 405, description = "Method not allowed (single-graph mode)", body = ErrorOutput),
     ),
     security(("bearer_token" = [])),
 )]
-/// List every graph currently registered with this server.
+/// List every graph configured for this server, including graphs that have not
+/// opened successfully.
 ///
-/// Multi-graph mode only. In single mode, the route returns 405 — there's
-/// no registry to enumerate. Cedar-gated by the server-level policy via
-/// the `graph_list` action against `Omnigraph::Server::"root"`.
+/// Cedar-gated by the server-level policy via the `graph_list` action against
+/// `Omnigraph::Server::"root"`.
 ///
 /// Order: alphabetical by `graph_id` (server-sorted so clients see
 /// deterministic output across requests).
@@ -75,13 +74,33 @@ pub(crate) async fn server_graphs_list(
     let mut graphs: Vec<GraphInfo> = registry
         .list()
         .into_iter()
-        .map(|handle| GraphInfo {
-            graph_id: handle.key.graph_id.as_str().to_string(),
-            uri: handle.uri.clone(),
+        .map(|entry| {
+            let availability = entry.availability();
+            GraphInfo {
+                graph_id: entry.key.graph_id.as_str().to_string(),
+                uri: entry.uri.clone(),
+                state: graph_state_output(availability.state),
+                read_ready: availability.read_ready,
+                write_ready: availability.write_ready,
+                failure_class: availability.failure_class.map(str::to_string),
+                last_error: availability.last_error,
+                retry_after_seconds: availability.retry_after_seconds,
+                blocking_operation_id: availability.blocking_operation_id,
+            }
         })
         .collect();
     graphs.sort_by(|a, b| a.graph_id.cmp(&b.graph_id));
     Ok(Json(GraphListResponse { graphs }))
+}
+
+fn graph_state_output(state: &str) -> api::GraphState {
+    match state {
+        "ready" => api::GraphState::Ready,
+        "recovering" => api::GraphState::Recovering,
+        "degraded" => api::GraphState::Degraded,
+        "opening" => api::GraphState::Opening,
+        _ => api::GraphState::Unavailable,
+    }
 }
 
 pub(crate) async fn server_openapi(
@@ -280,6 +299,9 @@ pub(crate) async fn resolve_graph_handle(
     let key = GraphKey::cluster(graph_id.clone());
     let handle = match registry.get(&key) {
         RegistryLookup::Ready(handle) => handle,
+        RegistryLookup::Unavailable(availability) => {
+            return Err(ApiError::graph_unavailable(&graph_id, &availability));
+        }
         RegistryLookup::Gone => {
             return Err(ApiError::not_found(format!("graph '{graph_id}' not found")));
         }

--- a/crates/omnigraph-server/src/lib.rs
+++ b/crates/omnigraph-server/src/lib.rs
@@ -542,6 +542,7 @@ impl AppState {
             GraphRegistry::from_handles(vec![handle])
                 .expect("a single handle never collides on graph id"),
         );
+        let supervisors = supervisor::SupervisorSet::start(Arc::clone(&registry));
         Self {
             routing: GraphRouting {
                 registry,
@@ -551,7 +552,7 @@ impl AppState {
             bearer_tokens,
             server_policy: None,
             export_transport: export_transport::ExportTransport::with_defaults(),
-            supervisors: supervisor::SupervisorSet::idle(),
+            supervisors,
         }
     }
 
@@ -570,6 +571,7 @@ impl AppState {
     ) -> std::result::Result<Self, InsertError> {
         let bearer_tokens = hash_bearer_tokens(bearer_tokens);
         let registry = Arc::new(GraphRegistry::from_handles(handles)?);
+        let supervisors = supervisor::SupervisorSet::start(Arc::clone(&registry));
         Ok(Self {
             routing: GraphRouting {
                 registry,
@@ -579,7 +581,7 @@ impl AppState {
             bearer_tokens,
             server_policy: server_policy.map(Arc::new),
             export_transport: export_transport::ExportTransport::with_defaults(),
-            supervisors: supervisor::SupervisorSet::idle(),
+            supervisors,
         })
     }
 

--- a/crates/omnigraph-server/src/lib.rs
+++ b/crates/omnigraph-server/src/lib.rs
@@ -2,6 +2,7 @@ pub mod api;
 mod export_transport;
 mod handlers;
 mod settings;
+mod supervisor;
 use handlers::*;
 use settings::*;
 pub use settings::{ServerRuntimeState, classify_server_runtime_state, load_server_settings};
@@ -15,7 +16,10 @@ pub mod workload;
 
 pub use graph_id::GraphId;
 pub use identity::{AuthSource, GraphKey, ResolvedActor, Scope, TenantId};
-pub use registry::{GraphHandle, GraphRegistry, InsertError, RegistryLookup, RegistrySnapshot};
+pub use registry::{
+    FailureClass, GraphAvailability, GraphEntry, GraphHandle, GraphRegistry, GraphRuntimeState,
+    InsertError, RegistryLookup, RegistrySnapshot, WriteState,
+};
 
 use crate::queries::{QueryRegistry, check, format_check_breakages};
 
@@ -220,6 +224,10 @@ pub struct GraphStartupConfig {
     pub graph_id: String,
     pub uri: String,
     pub policy: Option<PolicySource>,
+    /// Permanent graph-attributed failure discovered while resolving the
+    /// applied cluster snapshot. The graph still enters the configured
+    /// registry so policy and URI ownership cannot disappear.
+    pub startup_error: Option<String>,
     /// Pre-resolved embedding config from an applied cluster provider profile.
     /// Legacy config paths leave this unset and continue to use env resolution.
     pub embedding: Option<omnigraph::embedding::EmbeddingConfig>,
@@ -271,10 +279,9 @@ pub struct AppState {
     /// Bounded process-wide ownership for queued served-export bytes. The
     /// response body and detached producer jointly retain each reservation.
     export_transport: export_transport::ExportTransport,
-}
-
-struct OpenedGraph {
-    handle: Arc<GraphHandle>,
+    /// One coalescing open/recovery supervisor per configured graph.
+    #[allow(dead_code)]
+    supervisors: Arc<supervisor::SupervisorSet>,
 }
 
 /// The structured-detail payloads are boxed to keep `Result<_, ApiError>` cheap
@@ -292,6 +299,7 @@ pub struct ApiError {
     key_conflict: Option<Box<api::KeyConflictOutput>>,
     resource_limit: Option<Box<api::ResourceLimitOutput>>,
     recovery_required: Option<Box<api::RecoveryRequiredOutput>>,
+    graph_unavailable: Option<Box<api::GraphUnavailableOutput>>,
 }
 
 impl AppState {
@@ -543,6 +551,7 @@ impl AppState {
             bearer_tokens,
             server_policy: None,
             export_transport: export_transport::ExportTransport::with_defaults(),
+            supervisors: supervisor::SupervisorSet::idle(),
         }
     }
 
@@ -570,7 +579,28 @@ impl AppState {
             bearer_tokens,
             server_policy: server_policy.map(Arc::new),
             export_transport: export_transport::ExportTransport::with_defaults(),
+            supervisors: supervisor::SupervisorSet::idle(),
         })
+    }
+
+    fn from_configured_registry(
+        registry: Arc<GraphRegistry>,
+        bearer_tokens: Vec<(String, String)>,
+        server_policy: Option<PolicyEngine>,
+        config_path: PathBuf,
+    ) -> Self {
+        let supervisors = supervisor::SupervisorSet::start(Arc::clone(&registry));
+        Self {
+            routing: GraphRouting {
+                registry,
+                config_path: Some(config_path),
+            },
+            workload: Arc::new(workload::WorkloadController::from_env()),
+            bearer_tokens: hash_bearer_tokens(bearer_tokens),
+            server_policy: server_policy.map(Arc::new),
+            export_transport: export_transport::ExportTransport::with_defaults(),
+            supervisors,
+        }
     }
 
     /// Runtime routing accessor. Handlers don't typically inspect this —
@@ -629,6 +659,7 @@ impl ApiError {
             key_conflict: None,
             resource_limit: None,
             recovery_required: None,
+            graph_unavailable: None,
         }
     }
 
@@ -643,6 +674,7 @@ impl ApiError {
             key_conflict: None,
             resource_limit: None,
             recovery_required: None,
+            graph_unavailable: None,
         }
     }
 
@@ -657,6 +689,7 @@ impl ApiError {
             key_conflict: None,
             resource_limit: None,
             recovery_required: None,
+            graph_unavailable: None,
         }
     }
 
@@ -671,6 +704,7 @@ impl ApiError {
             key_conflict: None,
             resource_limit: None,
             recovery_required: None,
+            graph_unavailable: None,
         }
     }
 
@@ -689,6 +723,7 @@ impl ApiError {
             key_conflict: None,
             resource_limit: None,
             recovery_required: None,
+            graph_unavailable: None,
         }
     }
 
@@ -703,6 +738,7 @@ impl ApiError {
             key_conflict: None,
             resource_limit: None,
             recovery_required: None,
+            graph_unavailable: None,
         }
     }
 
@@ -717,6 +753,7 @@ impl ApiError {
             key_conflict: None,
             resource_limit: None,
             recovery_required: None,
+            graph_unavailable: None,
         }
     }
 
@@ -731,6 +768,22 @@ impl ApiError {
             key_conflict: None,
             resource_limit: None,
             recovery_required: None,
+            graph_unavailable: None,
+        }
+    }
+
+    pub fn service_unavailable(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            code: None,
+            message: message.into(),
+            merge_conflicts: Vec::new(),
+            manifest_conflict: None,
+            read_set_conflict: None,
+            key_conflict: None,
+            resource_limit: None,
+            recovery_required: None,
+            graph_unavailable: None,
         }
     }
 
@@ -749,6 +802,7 @@ impl ApiError {
             key_conflict: None,
             resource_limit: None,
             recovery_required: None,
+            graph_unavailable: None,
         }
     }
 
@@ -774,6 +828,7 @@ impl ApiError {
             key_conflict: None,
             resource_limit: None,
             recovery_required: None,
+            graph_unavailable: None,
         }
     }
 
@@ -788,6 +843,7 @@ impl ApiError {
             key_conflict: None,
             resource_limit: None,
             recovery_required: None,
+            graph_unavailable: None,
         }
     }
 
@@ -802,6 +858,7 @@ impl ApiError {
             key_conflict: None,
             resource_limit: None,
             recovery_required: None,
+            graph_unavailable: None,
         }
     }
 
@@ -816,6 +873,7 @@ impl ApiError {
             key_conflict: Some(Box::new(details)),
             resource_limit: None,
             recovery_required: None,
+            graph_unavailable: None,
         }
     }
 
@@ -830,6 +888,7 @@ impl ApiError {
             key_conflict: None,
             resource_limit: Some(Box::new(details)),
             recovery_required: None,
+            graph_unavailable: None,
         }
     }
 
@@ -847,6 +906,42 @@ impl ApiError {
             key_conflict: None,
             resource_limit: None,
             recovery_required: Some(Box::new(api::RecoveryRequiredOutput { operation_id })),
+            graph_unavailable: None,
+        }
+    }
+
+    fn graph_unavailable(graph_id: &GraphId, availability: &registry::GraphAvailability) -> Self {
+        let state = match availability.state {
+            "ready" => api::GraphState::Ready,
+            "recovering" => api::GraphState::Recovering,
+            "degraded" => api::GraphState::Degraded,
+            "opening" => api::GraphState::Opening,
+            _ => api::GraphState::Unavailable,
+        };
+        Self {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            code: None,
+            message: format!(
+                "graph '{}' is {}{}",
+                graph_id,
+                availability.state,
+                availability
+                    .last_error
+                    .as_deref()
+                    .map(|error| format!(": {error}"))
+                    .unwrap_or_default()
+            ),
+            merge_conflicts: Vec::new(),
+            manifest_conflict: None,
+            read_set_conflict: None,
+            key_conflict: None,
+            resource_limit: None,
+            recovery_required: None,
+            graph_unavailable: Some(Box::new(api::GraphUnavailableOutput {
+                graph_id: graph_id.as_str().to_string(),
+                state,
+                retry_after_seconds: availability.retry_after_seconds,
+            })),
         }
     }
 
@@ -982,6 +1077,19 @@ impl IntoResponse for ApiError {
                 axum::http::header::RETRY_AFTER,
                 axum::http::HeaderValue::from_static(RETRY_AFTER_SECONDS),
             );
+        } else if self.recovery_required.is_some() {
+            headers.insert(
+                axum::http::header::RETRY_AFTER,
+                axum::http::HeaderValue::from_static("1"),
+            );
+        } else if let Some(seconds) = self
+            .graph_unavailable
+            .as_ref()
+            .and_then(|detail| detail.retry_after_seconds)
+        {
+            if let Ok(value) = axum::http::HeaderValue::from_str(&seconds.max(1).to_string()) {
+                headers.insert(axum::http::header::RETRY_AFTER, value);
+            }
         }
         (
             self.status,
@@ -995,6 +1103,7 @@ impl IntoResponse for ApiError {
                 key_conflict: self.key_conflict.map(|d| *d),
                 resource_limit: self.resource_limit.map(|d| *d),
                 recovery_required: self.recovery_required.map(|d| *d),
+                graph_unavailable: self.graph_unavailable.map(|d| *d),
             }),
         )
             .into_response()
@@ -1014,6 +1123,7 @@ mod api_error_tests {
         .into_response();
 
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(response.headers()[axum::http::header::RETRY_AFTER], "1");
         let body = axum::body::to_bytes(response.into_body(), usize::MAX)
             .await
             .unwrap();
@@ -1023,6 +1133,31 @@ mod api_error_tests {
             error.recovery_required.unwrap().operation_id,
             "01JTESTRECOVERY"
         );
+    }
+
+    #[tokio::test]
+    async fn configured_opening_graph_is_503_with_detail_and_retry_after() {
+        let graph_id = GraphId::try_from("opening").unwrap();
+        let availability = GraphAvailability {
+            state: "opening",
+            read_ready: false,
+            write_ready: false,
+            failure_class: Some("io"),
+            last_error: Some("temporary object-store failure".to_string()),
+            retry_after_seconds: Some(3),
+            blocking_operation_id: None,
+        };
+        let response = ApiError::graph_unavailable(&graph_id, &availability).into_response();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(response.headers()[axum::http::header::RETRY_AFTER], "3");
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let error: ErrorOutput = serde_json::from_slice(&body).unwrap();
+        let detail = error.graph_unavailable.expect("graph detail");
+        assert_eq!(detail.graph_id, "opening");
+        assert_eq!(detail.state, api::GraphState::Opening);
+        assert_eq!(detail.retry_after_seconds, Some(3));
     }
 
     #[tokio::test]
@@ -1300,14 +1435,10 @@ fn load_graph_policy(source: &PolicySource, graph_id: &str) -> Result<PolicyEngi
     }
 }
 
-/// Parallel open of every graph in the startup config, with bounded
-/// concurrency (`buffer_unordered(4)`). Graph-specific open failures
-/// quarantine that graph; startup succeeds as long as at least one graph
-/// opens.
-///
-/// The bound 4 is a rule-of-thumb for I/O-bound work. At N ≤ 10 this
-/// trades startup latency for a small amount of concurrent S3 / Lance
-/// open pressure.
+/// Validate the complete configured set, make one bounded initial open attempt
+/// per graph, then start one coalescing supervisor per graph. Default boot does
+/// not require a healthy graph; strict boot retains the explicit fail-fast
+/// override.
 pub async fn open_multi_graph_state(
     graphs: Vec<GraphStartupConfig>,
     tokens: Vec<(String, String)>,
@@ -1315,11 +1446,17 @@ pub async fn open_multi_graph_state(
     config_path: PathBuf,
     require_all_graphs: bool,
 ) -> Result<AppState> {
-    use futures::StreamExt;
-
     if graphs.is_empty() {
         bail!("multi-graph mode requires at least one graph in the `graphs:` map");
     }
+
+    // All graph ids and canonical URIs, including duplicate URI ownership, are
+    // validated before the first graph open begins. A configured entry remains
+    // present even if every subsequent open attempt fails.
+    let registry = Arc::new(
+        GraphRegistry::from_configs(graphs)
+            .map_err(|error| color_eyre::eyre::eyre!("multi-graph registry: {error}"))?,
+    );
 
     // Server-level policy (loaded once, applies to management endpoints).
     // The placeholder graph_id `"server"` is the sentinel the Cedar
@@ -1331,95 +1468,27 @@ pub async fn open_multi_graph_state(
         None => None,
     };
 
-    let configured_graphs = graphs.len();
-    let results = futures::stream::iter(graphs)
-        .map(|cfg| async move {
-            let graph_id = cfg.graph_id.clone();
-            open_single_graph(cfg).await.map_err(|err| (graph_id, err))
-        })
-        .buffer_unordered(4)
-        .collect::<Vec<_>>()
-        .await;
-    let mut handles = Vec::new();
-    let mut failed = 0usize;
-    for result in results {
-        match result {
-            Ok(opened) => {
-                handles.push(opened.handle);
-            }
-            Err((graph_id, err)) => {
-                failed += 1;
-                warn!(
-                    graph_id = %graph_id,
-                    error = %err,
-                    "graph quarantined during startup"
-                );
-            }
-        }
-    }
-    if require_all_graphs && failed > 0 {
+    let configured_graphs = registry.len();
+    supervisor::initial_open_all(Arc::clone(&registry)).await;
+    let unavailable = registry
+        .list()
+        .into_iter()
+        .filter(|entry| !entry.availability().write_ready)
+        .count();
+    if require_all_graphs && unavailable > 0 {
         bail!(
             "strict multi-graph startup requires every graph to open ({} configured, {} failed)",
             configured_graphs,
-            failed
-        );
-    }
-    if handles.is_empty() {
-        bail!(
-            "no healthy graphs opened from multi-graph startup config ({} configured, {} failed)",
-            configured_graphs,
-            failed
+            unavailable
         );
     }
 
-    let workload = workload::WorkloadController::from_env();
-    let state = AppState::new_multi(handles, tokens, server_policy, workload, Some(config_path))
-        .map_err(|err| color_eyre::eyre::eyre!("multi-graph registry: {err}"))?;
-    Ok(state)
-}
-
-/// Open one graph and wrap it in a `GraphHandle`. Used at startup by
-/// `open_multi_graph_state`.
-async fn open_single_graph(cfg: GraphStartupConfig) -> Result<OpenedGraph> {
-    let graph_id = GraphId::try_from(cfg.graph_id.clone())
-        .map_err(|err| color_eyre::eyre::eyre!("graph id '{}': {err}", cfg.graph_id))?;
-    let uri = normalize_root_uri(&cfg.uri)
-        .wrap_err_with(|| format!("normalize URI for graph '{}'", cfg.graph_id))?;
-
-    let db = Omnigraph::open(&uri)
-        .await
-        .map_err(|err| color_eyre::eyre::eyre!("open graph '{}' at {}: {err}", graph_id, uri))?;
-    let db = if let Some(embedding) = cfg.embedding {
-        db.with_embedding_config(Arc::new(embedding))
-    } else {
-        db
-    };
-
-    // Validate this graph's stored queries against the live schema and
-    // resolve them to an attachable handle (refuse boot on breakage).
-    // Done before the policy match rebinds `db`; the catalog handle is an
-    // owned `Arc`, so no borrow of `db` survives into the match.
-    let queries = validate_and_attach(cfg.queries, &db.catalog(), graph_id.as_str())?;
-
-    let (policy_arc, db) = match &cfg.policy {
-        Some(source) => {
-            let policy = load_graph_policy(source, graph_id.as_str())?;
-            let policy_arc: Arc<PolicyEngine> = Arc::new(policy);
-            let checker = Arc::clone(&policy_arc) as Arc<dyn omnigraph_policy::PolicyChecker>;
-            (Some(policy_arc), db.with_policy(checker))
-        }
-        None => (None, db),
-    };
-
-    Ok(OpenedGraph {
-        handle: Arc::new(GraphHandle {
-            key: GraphKey::cluster(graph_id),
-            uri,
-            engine: Arc::new(db),
-            policy: policy_arc,
-            queries,
-        }),
-    })
+    Ok(AppState::from_configured_registry(
+        registry,
+        tokens,
+        server_policy,
+        config_path,
+    ))
 }
 
 async fn wait_for_ctrl_c() {

--- a/crates/omnigraph-server/src/lib.rs
+++ b/crates/omnigraph-server/src/lib.rs
@@ -911,25 +911,22 @@ impl ApiError {
     }
 
     fn graph_unavailable(graph_id: &GraphId, availability: &registry::GraphAvailability) -> Self {
-        let state = match availability.state {
-            "ready" => api::GraphState::Ready,
-            "recovering" => api::GraphState::Recovering,
-            "degraded" => api::GraphState::Degraded,
-            "opening" => api::GraphState::Opening,
-            _ => api::GraphState::Unavailable,
-        };
+        let state: api::GraphState = availability.state.into();
         Self {
             status: StatusCode::SERVICE_UNAVAILABLE,
             code: None,
+            // Graph id and typed state only. This runs in middleware, before
+            // any per-graph policy check, so it reaches principals a Cedar
+            // policy would deny — and backend error text carries bucket names
+            // and filesystem paths. The full diagnostic is in the logs, and
+            // `GET /graphs` (which is policy-gated) carries the class summary.
             message: format!(
-                "graph '{}' is {}{}",
+                "graph '{}' is {}",
                 graph_id,
-                availability.state,
-                availability
-                    .last_error
-                    .as_deref()
-                    .map(|error| format!(": {error}"))
-                    .unwrap_or_default()
+                availability.failure_class.map_or_else(
+                    || format!("{:?}", availability.state).to_lowercase(),
+                    |class| class.as_str().to_string()
+                )
             ),
             merge_conflicts: Vec::new(),
             manifest_conflict: None,
@@ -1139,11 +1136,11 @@ mod api_error_tests {
     async fn configured_opening_graph_is_503_with_detail_and_retry_after() {
         let graph_id = GraphId::try_from("opening").unwrap();
         let availability = GraphAvailability {
-            state: "opening",
+            state: registry::GraphState::Opening,
             read_ready: false,
             write_ready: false,
-            failure_class: Some("io"),
-            last_error: Some("temporary object-store failure".to_string()),
+            failure_class: Some(registry::FailureClass::TransientStorage),
+            summary: Some(registry::FailureClass::TransientStorage.summary()),
             retry_after_seconds: Some(3),
             blocking_operation_id: None,
         };
@@ -1158,6 +1155,8 @@ mod api_error_tests {
         assert_eq!(detail.graph_id, "opening");
         assert_eq!(detail.state, api::GraphState::Opening);
         assert_eq!(detail.retry_after_seconds, Some(3));
+        // The public 503 carries the graph id and a class, never backend text.
+        assert_eq!(error.error, "graph 'opening' is transient_storage");
     }
 
     #[tokio::test]

--- a/crates/omnigraph-server/src/registry.rs
+++ b/crates/omnigraph-server/src/registry.rs
@@ -1,32 +1,22 @@
-//! `GraphRegistry` — the multi-graph routing substrate (MR-668).
+//! Configured-graph registry and atomically readable runtime state.
 //!
-//! Holds the open `Arc<GraphHandle>` for every graph the server is currently
-//! serving. Lock-free reads via `ArcSwap<RegistrySnapshot>`; mutations
-//! serialize through `mutate: Mutex<()>` for read-modify-write atomicity.
-//!
-//! **Deletion is deferred** in v0.6.0 (MR-668 scope cut). The registry has
-//! no `tombstones` field, no `RegistryLookup::Tombstoned` variant, no
-//! `tombstone()` / `clear_tombstone()` methods. When `DELETE /graphs/{id}`
-//! lands in a follow-up release, those return without breaking caller
-//! signatures (`Gone` is the closest semantic — the graph is no longer
-//! in the registry).
-//!
-//! Engine instance survival across registry mutations:
-//! a request that grabbed `Arc<GraphHandle>` before a registry swap keeps
-//! the engine alive via its own `Arc` clone (see `server_export` at
-//! `lib.rs:1019-1033` for the spawn-and-clone pattern). The engine drops
-//! when the last `Arc<Omnigraph>` clone drops, regardless of the
-//! registry's current state.
+//! The configured graph set is immutable for the lifetime of a server process;
+//! runtime add/remove and config hot reload are deliberately out of scope. Each
+//! entry owns canonical configuration plus a small state machine that can move
+//! between opening, serving, recovery-blocked, and unavailable without
+//! rebuilding the registry or replacing a live engine handle.
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Instant;
 
 use arc_swap::ArcSwap;
 use omnigraph::db::Omnigraph;
 use omnigraph::storage::normalize_root_uri;
-#[cfg(test)]
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Notify};
 
+use crate::GraphStartupConfig;
+use crate::graph_id::GraphId;
 use crate::identity::GraphKey;
 use crate::policy::PolicyEngine;
 use crate::queries::QueryRegistry;
@@ -55,29 +45,279 @@ pub struct GraphHandle {
     pub queries: Option<Arc<QueryRegistry>>,
 }
 
-/// Immutable snapshot of the registry's current state. Replaced atomically
-/// via `ArcSwap`; readers see a consistent view of all graphs without locking.
-///
-/// Derived state (`any_per_graph_policy`) is computed at snapshot
-/// construction so request-time middleware doesn't have to walk the
-/// graph map every call. Construct only via [`RegistrySnapshot::new`]
-/// (or `Default`) so the field stays in sync with `graphs`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailureClass {
+    Io,
+    Timeout,
+    InvalidConfiguration,
+    UnsupportedFormat,
+    InvariantViolation,
+    Unknown,
+}
+
+impl FailureClass {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Io => "io",
+            Self::Timeout => "timeout",
+            Self::InvalidConfiguration => "invalid_configuration",
+            Self::UnsupportedFormat => "unsupported_format",
+            Self::InvariantViolation => "invariant_violation",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    pub fn retryable(self) -> bool {
+        matches!(self, Self::Io | Self::Timeout)
+    }
+}
+
+#[derive(Clone)]
+pub enum WriteState {
+    Ready,
+    Recovering {
+        attempts: u32,
+        blocking_operation_id: Option<String>,
+    },
+    Blocked {
+        attempts: u32,
+        next_retry: Instant,
+        failure_class: FailureClass,
+        last_error: String,
+        blocking_operation_id: Option<String>,
+    },
+}
+
+#[derive(Clone)]
+pub enum GraphRuntimeState {
+    Serving {
+        handle: Arc<GraphHandle>,
+        writes: WriteState,
+    },
+    Opening {
+        attempts: u32,
+        next_retry: Instant,
+        failure_class: Option<FailureClass>,
+        last_error: Option<String>,
+    },
+    Unavailable {
+        failure_class: FailureClass,
+        last_error: String,
+    },
+}
+
+/// Request- and wire-facing projection of a configured graph's state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GraphAvailability {
+    pub state: &'static str,
+    pub read_ready: bool,
+    pub write_ready: bool,
+    pub failure_class: Option<&'static str>,
+    pub last_error: Option<String>,
+    pub retry_after_seconds: Option<u64>,
+    pub blocking_operation_id: Option<String>,
+}
+
+fn retry_after_seconds(deadline: Instant) -> u64 {
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    remaining
+        .as_secs()
+        .saturating_add(u64::from(remaining.subsec_nanos() > 0))
+        .max(1)
+}
+
+fn sanitize_status_error(message: &str) -> String {
+    message
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .chars()
+        .take(512)
+        .collect()
+}
+
+impl GraphRuntimeState {
+    pub fn availability(&self) -> GraphAvailability {
+        match self {
+            Self::Serving {
+                writes: WriteState::Ready,
+                ..
+            } => GraphAvailability {
+                state: "ready",
+                read_ready: true,
+                write_ready: true,
+                failure_class: None,
+                last_error: None,
+                retry_after_seconds: None,
+                blocking_operation_id: None,
+            },
+            Self::Serving {
+                writes:
+                    WriteState::Recovering {
+                        blocking_operation_id,
+                        ..
+                    },
+                ..
+            } => GraphAvailability {
+                state: "recovering",
+                read_ready: true,
+                write_ready: false,
+                failure_class: None,
+                last_error: None,
+                retry_after_seconds: Some(1),
+                blocking_operation_id: blocking_operation_id.clone(),
+            },
+            Self::Serving {
+                writes:
+                    WriteState::Blocked {
+                        next_retry,
+                        failure_class,
+                        last_error,
+                        blocking_operation_id,
+                        ..
+                    },
+                ..
+            } => GraphAvailability {
+                state: "degraded",
+                read_ready: true,
+                write_ready: false,
+                failure_class: Some(failure_class.as_str()),
+                last_error: Some(last_error.clone()),
+                retry_after_seconds: Some(retry_after_seconds(*next_retry)),
+                blocking_operation_id: blocking_operation_id.clone(),
+            },
+            Self::Opening {
+                next_retry,
+                failure_class,
+                last_error,
+                ..
+            } => GraphAvailability {
+                state: "opening",
+                read_ready: false,
+                write_ready: false,
+                failure_class: failure_class.map(FailureClass::as_str),
+                last_error: last_error.clone(),
+                retry_after_seconds: Some(retry_after_seconds(*next_retry)),
+                blocking_operation_id: None,
+            },
+            Self::Unavailable {
+                failure_class,
+                last_error,
+            } => GraphAvailability {
+                state: "unavailable",
+                read_ready: false,
+                write_ready: false,
+                failure_class: Some(failure_class.as_str()),
+                last_error: Some(last_error.clone()),
+                retry_after_seconds: None,
+                blocking_operation_id: None,
+            },
+        }
+    }
+}
+
+/// One immutable configured graph plus its atomically replaceable runtime
+/// state. `mutation` serializes short state transitions only; no graph I/O is
+/// performed while it is held.
+pub struct GraphEntry {
+    pub key: GraphKey,
+    pub uri: String,
+    pub policy_configured: bool,
+    startup: Option<Arc<GraphStartupConfig>>,
+    runtime: ArcSwap<GraphRuntimeState>,
+    pub(crate) mutation: Mutex<()>,
+    pub(crate) notify: Notify,
+}
+
+impl GraphEntry {
+    fn from_handle(handle: Arc<GraphHandle>) -> Result<Self, InsertError> {
+        let (canonical_uri, handle) = canonicalize_handle_uri(handle)?;
+        Ok(Self {
+            key: handle.key.clone(),
+            uri: canonical_uri,
+            policy_configured: handle.policy.is_some(),
+            startup: None,
+            runtime: ArcSwap::from_pointee(GraphRuntimeState::Serving {
+                handle,
+                writes: WriteState::Ready,
+            }),
+            mutation: Mutex::new(()),
+            notify: Notify::new(),
+        })
+    }
+
+    fn from_config(mut config: GraphStartupConfig) -> Result<Self, InsertError> {
+        let graph_id = GraphId::try_from(config.graph_id.clone()).map_err(|err| {
+            InsertError::InvalidGraphId {
+                graph_id: config.graph_id.clone(),
+                message: err.to_string(),
+            }
+        })?;
+        config.uri = normalize_root_uri(&config.uri).map_err(|err| InsertError::InvalidUri {
+            uri: config.uri.clone(),
+            message: err.to_string(),
+        })?;
+        let policy_configured = config.policy.is_some();
+        let runtime = match config.startup_error.as_deref() {
+            Some(error) => GraphRuntimeState::Unavailable {
+                failure_class: FailureClass::InvalidConfiguration,
+                last_error: sanitize_status_error(error),
+            },
+            None => GraphRuntimeState::Opening {
+                attempts: 0,
+                next_retry: Instant::now(),
+                failure_class: None,
+                last_error: None,
+            },
+        };
+        Ok(Self {
+            key: GraphKey::cluster(graph_id),
+            uri: config.uri.clone(),
+            policy_configured,
+            startup: Some(Arc::new(config)),
+            runtime: ArcSwap::from_pointee(runtime),
+            mutation: Mutex::new(()),
+            notify: Notify::new(),
+        })
+    }
+
+    pub fn startup_config(&self) -> Option<Arc<GraphStartupConfig>> {
+        self.startup.clone()
+    }
+
+    pub fn runtime(&self) -> arc_swap::Guard<Arc<GraphRuntimeState>> {
+        self.runtime.load()
+    }
+
+    pub(crate) fn store_runtime(&self, state: GraphRuntimeState) {
+        self.runtime.store(Arc::new(state));
+    }
+
+    pub fn availability(&self) -> GraphAvailability {
+        self.runtime.load().availability()
+    }
+
+    pub fn serving_handle(&self) -> Option<Arc<GraphHandle>> {
+        match self.runtime.load().as_ref() {
+            GraphRuntimeState::Serving { handle, .. } => Some(Arc::clone(handle)),
+            GraphRuntimeState::Opening { .. } | GraphRuntimeState::Unavailable { .. } => None,
+        }
+    }
+
+    pub fn wake(&self) {
+        self.notify.notify_one();
+    }
+}
+
+/// Immutable configured-set snapshot. Entry runtime changes do not rebuild it.
 pub struct RegistrySnapshot {
-    pub graphs: HashMap<GraphKey, Arc<GraphHandle>>,
-    /// `true` iff any registered graph has a per-graph policy installed.
-    /// Used by `AppState::requires_bearer_auth` to decide whether the
-    /// auth middleware should challenge a request — a per-graph policy
-    /// implies bearer auth is required even when no server-level tokens
-    /// or policy are configured.
+    pub graphs: HashMap<GraphKey, Arc<GraphEntry>>,
     pub any_per_graph_policy: bool,
 }
 
 impl RegistrySnapshot {
-    /// Build a snapshot from a graph map, deriving cached fields.
-    /// The only construction path — direct struct-literal use elsewhere
-    /// would let derived state drift from `graphs`.
-    pub fn new(graphs: HashMap<GraphKey, Arc<GraphHandle>>) -> Self {
-        let any_per_graph_policy = graphs.values().any(|h| h.policy.is_some());
+    pub fn new(graphs: HashMap<GraphKey, Arc<GraphEntry>>) -> Self {
+        let any_per_graph_policy = graphs.values().any(|entry| entry.policy_configured);
         Self {
             graphs,
             any_per_graph_policy,
@@ -91,12 +331,9 @@ impl Default for RegistrySnapshot {
     }
 }
 
-/// Result of a registry lookup. Two-valued — `Tombstoned` deferred with DELETE.
 pub enum RegistryLookup {
-    /// Graph is open and ready to serve.
     Ready(Arc<GraphHandle>),
-    /// Graph is not in the registry (never existed, or was unregistered in a
-    /// future release). Handlers respond with 404.
+    Unavailable(GraphAvailability),
     Gone,
 }
 
@@ -114,14 +351,12 @@ pub enum InsertError {
     /// A handle carried an invalid graph URI. Maps to startup failure.
     #[error("URI '{uri}' is invalid: {message}")]
     InvalidUri { uri: String, message: String },
+    #[error("graph id '{graph_id}' is invalid: {message}")]
+    InvalidGraphId { graph_id: String, message: String },
 }
 
 pub struct GraphRegistry {
     snapshot: ArcSwap<RegistrySnapshot>,
-    /// Serializes runtime mutations through [`GraphRegistry::insert`].
-    /// Gated with `insert` because they share a single contract — if
-    /// the consumer goes away, so does the lock. Re-introducing one
-    /// requires re-introducing the other.
     #[cfg(test)]
     mutate: Mutex<()>,
 }
@@ -136,21 +371,36 @@ impl GraphRegistry {
         }
     }
 
-    /// Build a registry from a startup-time list of open handles.
-    /// Rejects duplicate `GraphKey`s and duplicate URIs.
     pub fn from_handles(handles: Vec<Arc<GraphHandle>>) -> Result<Self, InsertError> {
-        let mut graphs: HashMap<GraphKey, Arc<GraphHandle>> = HashMap::with_capacity(handles.len());
-        let mut seen_uris: HashMap<String, GraphKey> = HashMap::with_capacity(handles.len());
+        let mut entries = Vec::with_capacity(handles.len());
         for handle in handles {
-            let (canonical_uri, handle) = canonicalize_handle_uri(handle)?;
-            if graphs.contains_key(&handle.key) {
-                return Err(InsertError::DuplicateKey(handle.key.clone()));
+            entries.push(Arc::new(GraphEntry::from_handle(handle)?));
+        }
+        Self::from_entries(entries)
+    }
+
+    /// Validate every graph id and canonical URI, including collisions, before
+    /// any open attempt can begin.
+    pub fn from_configs(configs: Vec<GraphStartupConfig>) -> Result<Self, InsertError> {
+        let mut entries = Vec::with_capacity(configs.len());
+        for config in configs {
+            entries.push(Arc::new(GraphEntry::from_config(config)?));
+        }
+        Self::from_entries(entries)
+    }
+
+    fn from_entries(entries: Vec<Arc<GraphEntry>>) -> Result<Self, InsertError> {
+        let mut graphs = HashMap::with_capacity(entries.len());
+        let mut seen_uris = HashMap::with_capacity(entries.len());
+        for entry in entries {
+            if graphs.contains_key(&entry.key) {
+                return Err(InsertError::DuplicateKey(entry.key.clone()));
             }
-            if seen_uris.contains_key(&canonical_uri) {
-                return Err(InsertError::DuplicateUri(handle.uri.clone()));
+            if seen_uris.contains_key(&entry.uri) {
+                return Err(InsertError::DuplicateUri(entry.uri.clone()));
             }
-            seen_uris.insert(canonical_uri, handle.key.clone());
-            graphs.insert(handle.key.clone(), handle);
+            seen_uris.insert(entry.uri.clone(), entry.key.clone());
+            graphs.insert(entry.key.clone(), entry);
         }
         Ok(Self {
             snapshot: ArcSwap::from_pointee(RegistrySnapshot::new(graphs)),
@@ -167,21 +417,71 @@ impl GraphRegistry {
         self.snapshot.load()
     }
 
-    /// Lock-free read. Returns `Ready` if the graph is in the current snapshot,
-    /// `Gone` otherwise.
     pub fn get(&self, key: &GraphKey) -> RegistryLookup {
         let snapshot = self.snapshot.load();
         match snapshot.graphs.get(key) {
-            Some(handle) => RegistryLookup::Ready(Arc::clone(handle)),
+            Some(entry) => match entry.serving_handle() {
+                Some(handle) => RegistryLookup::Ready(handle),
+                None => RegistryLookup::Unavailable(entry.availability()),
+            },
             None => RegistryLookup::Gone,
         }
     }
 
-    /// Snapshot the full set of currently-registered handles. Ordering
-    /// matches the underlying `HashMap` iteration (intentionally
-    /// non-deterministic — callers that need a stable order sort by
-    /// `handle.key.graph_id`).
-    pub fn list(&self) -> Vec<Arc<GraphHandle>> {
+    pub fn entry(&self, key: &GraphKey) -> Option<Arc<GraphEntry>> {
+        self.snapshot.load().graphs.get(key).cloned()
+    }
+
+    /// Block new writes and coalesce a Full-recovery wake-up for a serving
+    /// graph. The prior blocking operation remains the public diagnostic until
+    /// recovery succeeds; later requests are never treated as replays of it.
+    pub async fn mark_recovering(
+        &self,
+        key: &GraphKey,
+        blocking_operation_id: Option<String>,
+    ) -> bool {
+        let Some(entry) = self.entry(key) else {
+            return false;
+        };
+        let _guard = entry.mutation.lock().await;
+        let current = entry.runtime().as_ref().clone();
+        let next = match current {
+            GraphRuntimeState::Serving { handle, writes } => {
+                let existing = match writes {
+                    WriteState::Ready => None,
+                    WriteState::Recovering {
+                        blocking_operation_id,
+                        ..
+                    }
+                    | WriteState::Blocked {
+                        blocking_operation_id,
+                        ..
+                    } => blocking_operation_id,
+                };
+                GraphRuntimeState::Serving {
+                    handle,
+                    writes: WriteState::Recovering {
+                        attempts: 0,
+                        blocking_operation_id: existing.or(blocking_operation_id),
+                    },
+                }
+            }
+            GraphRuntimeState::Opening { .. } | GraphRuntimeState::Unavailable { .. } => {
+                return false;
+            }
+        };
+        entry.store_runtime(next);
+        drop(_guard);
+        entry.wake();
+        true
+    }
+
+    pub fn write_availability(&self, key: &GraphKey) -> Option<GraphAvailability> {
+        self.entry(key).map(|entry| entry.availability())
+    }
+
+    /// Snapshot every configured entry, including graphs that never opened.
+    pub fn list(&self) -> Vec<Arc<GraphEntry>> {
         let snapshot = self.snapshot.load();
         snapshot.graphs.values().cloned().collect()
     }
@@ -195,41 +495,21 @@ impl GraphRegistry {
         self.len() == 0
     }
 
-    /// Add a new handle. Async because the mutex is `tokio::sync::Mutex`
-    /// (a future managed-catalog flow may hold it across `.await` points
-    /// during atomic registry mutations). Rejects duplicate `GraphKey`
-    /// and duplicate `uri`.
-    ///
-    /// **Test-only surface.** No production code reaches this — startup
-    /// uses `from_handles`, and runtime add/remove is deferred. The
-    /// race-contract tests below pin the mutex linearization point so
-    /// that when a real consumer ships (managed cluster catalog), the
-    /// concurrency contract is already proven. Ungate by removing
-    /// `#[cfg(test)]` once that consumer is in scope.
-    ///
-    /// Race semantics (pinned by `concurrent_insert_same_key_exactly_one_succeeds`):
-    /// under N concurrent calls with the same key, exactly one returns
-    /// `Ok(())` and the rest return `Err(InsertError::DuplicateKey(_))`.
     #[cfg(test)]
     pub async fn insert(&self, handle: Arc<GraphHandle>) -> Result<(), InsertError> {
         let _guard = self.mutate.lock().await;
         let current = self.snapshot.load();
-        let (canonical_uri, handle) = canonicalize_handle_uri(handle)?;
-        if current.graphs.contains_key(&handle.key) {
-            return Err(InsertError::DuplicateKey(handle.key.clone()));
+        let entry = Arc::new(GraphEntry::from_handle(handle)?);
+        if current.graphs.contains_key(&entry.key) {
+            return Err(InsertError::DuplicateKey(entry.key.clone()));
         }
         for existing in current.graphs.values() {
-            let existing_uri =
-                normalize_root_uri(&existing.uri).map_err(|err| InsertError::InvalidUri {
-                    uri: existing.uri.clone(),
-                    message: err.to_string(),
-                })?;
-            if existing_uri == canonical_uri {
-                return Err(InsertError::DuplicateUri(handle.uri.clone()));
+            if existing.uri == entry.uri {
+                return Err(InsertError::DuplicateUri(entry.uri.clone()));
             }
         }
         let mut new_graphs = current.graphs.clone();
-        new_graphs.insert(handle.key.clone(), handle);
+        new_graphs.insert(entry.key.clone(), entry);
         self.snapshot
             .store(Arc::new(RegistrySnapshot::new(new_graphs)));
         Ok(())
@@ -273,6 +553,17 @@ mod tests {
 
     const TEST_SCHEMA: &str = "node Person { name: String @key }\n";
 
+    fn startup_config(graph_id: &str, uri: String) -> GraphStartupConfig {
+        GraphStartupConfig {
+            graph_id: graph_id.to_string(),
+            uri,
+            policy: None,
+            startup_error: None,
+            embedding: None,
+            queries: QueryRegistry::default(),
+        }
+    }
+
     async fn build_handle(graph_id: &str, dir: &Path) -> Arc<GraphHandle> {
         let graph_uri = dir.join(graph_id).to_str().unwrap().to_string();
         let engine = Omnigraph::init(&graph_uri, TEST_SCHEMA)
@@ -295,6 +586,45 @@ mod tests {
         assert!(registry.list().is_empty());
     }
 
+    #[test]
+    fn configured_entries_exist_before_open_and_validate_all_collisions() {
+        let dir = TempDir::new().unwrap();
+        let uri = dir.path().join("same").to_string_lossy().to_string();
+        let duplicate = GraphRegistry::from_configs(vec![
+            startup_config("alpha", uri.clone()),
+            startup_config("beta", format!("file://{uri}/")),
+        ]);
+        assert!(matches!(duplicate, Err(InsertError::DuplicateUri(_))));
+
+        let mut configured = startup_config("alpha", uri);
+        configured.policy = Some(crate::PolicySource::Inline(
+            "version: 1\nrules: []\n".into(),
+        ));
+        let registry = GraphRegistry::from_configs(vec![configured]).unwrap();
+        assert_eq!(registry.len(), 1);
+        assert!(registry.snapshot_ref().any_per_graph_policy);
+        let entry = registry.list().pop().unwrap();
+        assert_eq!(entry.availability().state, "opening");
+        assert!(!entry.availability().read_ready);
+        assert!(matches!(
+            registry.get(&entry.key),
+            RegistryLookup::Unavailable(_)
+        ));
+    }
+
+    #[test]
+    fn configured_entries_reject_invalid_ids_before_open() {
+        let dir = TempDir::new().unwrap();
+        let error = match GraphRegistry::from_configs(vec![startup_config(
+            "not/valid",
+            dir.path().join("graph").to_string_lossy().to_string(),
+        )]) {
+            Ok(_) => panic!("invalid graph id must fail preflight"),
+            Err(error) => error,
+        };
+        assert!(matches!(error, InsertError::InvalidGraphId { .. }));
+    }
+
     #[tokio::test]
     async fn insert_then_get_returns_ready() {
         let dir = TempDir::new().unwrap();
@@ -306,6 +636,7 @@ mod tests {
             RegistryLookup::Ready(found) => {
                 assert!(Arc::ptr_eq(&found, &handle));
             }
+            RegistryLookup::Unavailable(_) => panic!("expected Ready, got Unavailable"),
             RegistryLookup::Gone => panic!("expected Ready, got Gone"),
         }
     }
@@ -317,6 +648,7 @@ mod tests {
         match registry.get(&key) {
             RegistryLookup::Gone => {}
             RegistryLookup::Ready(_) => panic!("expected Gone"),
+            RegistryLookup::Unavailable(_) => panic!("expected Gone"),
         }
     }
 
@@ -548,14 +880,19 @@ mod tests {
             for _ in 0..200 {
                 let snap = reader_registry.list();
                 assert!(snap.len() <= N_WRITES);
-                for handle in &snap {
-                    match reader_registry.get(&handle.key) {
+                for entry in &snap {
+                    match reader_registry.get(&entry.key) {
                         RegistryLookup::Ready(found) => {
-                            assert!(Arc::ptr_eq(&found, handle));
+                            let expected = entry.serving_handle().expect("listed entry is serving");
+                            assert!(Arc::ptr_eq(&found, &expected));
                         }
+                        RegistryLookup::Unavailable(_) => panic!(
+                            "snapshot listed key {} but get() returned Unavailable",
+                            entry.key.graph_id
+                        ),
                         RegistryLookup::Gone => panic!(
                             "snapshot listed key {} but get() returned Gone",
-                            handle.key.graph_id
+                            entry.key.graph_id
                         ),
                     }
                 }

--- a/crates/omnigraph-server/src/registry.rs
+++ b/crates/omnigraph-server/src/registry.rs
@@ -8,14 +8,17 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 use arc_swap::ArcSwap;
 use omnigraph::db::Omnigraph;
 use omnigraph::storage::normalize_root_uri;
 use tokio::sync::{Mutex, Notify};
+use tracing::warn;
 
 use crate::GraphStartupConfig;
+use crate::api;
 use crate::graph_id::GraphId;
 use crate::identity::GraphKey;
 use crate::policy::PolicyEngine;
@@ -47,43 +50,83 @@ pub struct GraphHandle {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FailureClass {
+    /// A classified transient storage condition — transport, timeout,
+    /// throttling, or an exhausted object-store retry budget. The engine
+    /// derives this at the substrate boundary; the server never infers it.
+    TransientStorage,
     Io,
     Timeout,
     InvalidConfiguration,
     UnsupportedFormat,
     InvariantViolation,
+    /// A failure the engine did not classify. Not retried: the supervisor has
+    /// no evidence that retrying could help.
     Unknown,
+    /// The cluster quarantined this graph pending a control-plane recovery
+    /// sweep. Distinct from graph recovery — no amount of `refresh()` clears
+    /// it; an operator runs `cluster apply`.
+    RecoveryPending,
 }
 
 impl FailureClass {
     pub fn as_str(self) -> &'static str {
         match self {
+            Self::TransientStorage => "transient_storage",
             Self::Io => "io",
             Self::Timeout => "timeout",
             Self::InvalidConfiguration => "invalid_configuration",
             Self::UnsupportedFormat => "unsupported_format",
             Self::InvariantViolation => "invariant_violation",
             Self::Unknown => "unknown",
+            Self::RecoveryPending => "recovery_pending",
         }
     }
 
     pub fn retryable(self) -> bool {
-        matches!(self, Self::Io | Self::Timeout)
+        matches!(self, Self::TransientStorage | Self::Io | Self::Timeout)
+    }
+
+    /// A bounded, operator-facing summary. The full diagnostic stays in
+    /// structured logs: this string reaches unauthenticated 503 responses and
+    /// backend exception text can carry bucket names and filesystem paths.
+    pub fn summary(self) -> &'static str {
+        match self {
+            Self::TransientStorage => "storage is temporarily unreachable",
+            Self::Io => "an I/O error occurred",
+            Self::Timeout => "the operation timed out",
+            Self::InvalidConfiguration => "the graph configuration is invalid",
+            Self::UnsupportedFormat => "the graph storage format is not supported by this binary",
+            Self::InvariantViolation => "the graph reported an internal consistency failure",
+            Self::Unknown => "the graph failed to open for an unrecognised reason",
+            Self::RecoveryPending => "the cluster has quarantined this graph pending recovery",
+        }
     }
 }
+
+/// Monotonic counter distinguishing one recovery request from the next.
+///
+/// A supervisor attempt reads state, performs I/O without holding the entry
+/// lock, then writes a result derived from that read. Without a generation it
+/// cannot tell "the state I observed" from "a newer request that arrived while
+/// I was working", and would clobber the newer one.
+pub type RecoveryGeneration = u64;
 
 #[derive(Clone)]
 pub enum WriteState {
     Ready,
     Recovering {
+        generation: RecoveryGeneration,
         attempts: u32,
         blocking_operation_id: Option<String>,
     },
     Blocked {
+        generation: RecoveryGeneration,
         attempts: u32,
-        next_retry: Instant,
+        /// `None` means no retry is scheduled: the failure is permanent and
+        /// only a new trigger will start another attempt. Reads keep working
+        /// either way.
+        retry_at: Option<Instant>,
         failure_class: FailureClass,
-        last_error: String,
         blocking_operation_id: Option<String>,
     },
 }
@@ -98,22 +141,55 @@ pub enum GraphRuntimeState {
         attempts: u32,
         next_retry: Instant,
         failure_class: Option<FailureClass>,
-        last_error: Option<String>,
     },
-    Unavailable {
-        failure_class: FailureClass,
-        last_error: String,
-    },
+    /// Never opened. Reachable only from `Opening`, never from `Serving`: a
+    /// graph that is serving reads keeps serving them. See [`WriteState`].
+    Unavailable { failure_class: FailureClass },
+}
+
+/// The states a configured graph can be in, as a type rather than a string.
+///
+/// This is the internal vocabulary; `api::GraphState` is the wire form and the
+/// conversion happens once, at the boundary. It used to be a `&'static str`
+/// re-parsed by two independent `match`es, each with a catch-all that silently
+/// reported "unavailable" for anything it did not recognise.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GraphState {
+    Ready,
+    Recovering,
+    Degraded,
+    Opening,
+    Unavailable,
+}
+
+/// The single internal → wire conversion. Exhaustive, so adding a state is a
+/// compile error here rather than a silent "unavailable" at one call site and
+/// the correct value at another.
+impl From<GraphState> for api::GraphState {
+    fn from(state: GraphState) -> Self {
+        match state {
+            GraphState::Ready => Self::Ready,
+            GraphState::Recovering => Self::Recovering,
+            GraphState::Degraded => Self::Degraded,
+            GraphState::Opening => Self::Opening,
+            GraphState::Unavailable => Self::Unavailable,
+        }
+    }
 }
 
 /// Request- and wire-facing projection of a configured graph's state.
+///
+/// `summary` is a bounded, class-derived phrase — never backend exception
+/// text. This reaches unauthenticated 503 responses, and storage errors carry
+/// bucket names and filesystem paths. The full diagnostic lives in the
+/// structured logs the supervisor emits.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GraphAvailability {
-    pub state: &'static str,
+    pub state: GraphState,
     pub read_ready: bool,
     pub write_ready: bool,
-    pub failure_class: Option<&'static str>,
-    pub last_error: Option<String>,
+    pub failure_class: Option<FailureClass>,
+    pub summary: Option<&'static str>,
     pub retry_after_seconds: Option<u64>,
     pub blocking_operation_id: Option<String>,
 }
@@ -126,16 +202,6 @@ fn retry_after_seconds(deadline: Instant) -> u64 {
         .max(1)
 }
 
-fn sanitize_status_error(message: &str) -> String {
-    message
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
-        .chars()
-        .take(512)
-        .collect()
-}
-
 impl GraphRuntimeState {
     pub fn availability(&self) -> GraphAvailability {
         match self {
@@ -143,11 +209,11 @@ impl GraphRuntimeState {
                 writes: WriteState::Ready,
                 ..
             } => GraphAvailability {
-                state: "ready",
+                state: GraphState::Ready,
                 read_ready: true,
                 write_ready: true,
                 failure_class: None,
-                last_error: None,
+                summary: None,
                 retry_after_seconds: None,
                 blocking_operation_id: None,
             },
@@ -159,56 +225,54 @@ impl GraphRuntimeState {
                     },
                 ..
             } => GraphAvailability {
-                state: "recovering",
+                state: GraphState::Recovering,
                 read_ready: true,
                 write_ready: false,
                 failure_class: None,
-                last_error: None,
+                summary: None,
                 retry_after_seconds: Some(1),
                 blocking_operation_id: blocking_operation_id.clone(),
             },
             Self::Serving {
                 writes:
                     WriteState::Blocked {
-                        next_retry,
+                        retry_at,
                         failure_class,
-                        last_error,
                         blocking_operation_id,
                         ..
                     },
                 ..
             } => GraphAvailability {
-                state: "degraded",
+                state: GraphState::Degraded,
+                // Reads survive every recovery failure: a failed refresh leaves
+                // the live view exactly as it was.
                 read_ready: true,
                 write_ready: false,
-                failure_class: Some(failure_class.as_str()),
-                last_error: Some(last_error.clone()),
-                retry_after_seconds: Some(retry_after_seconds(*next_retry)),
+                failure_class: Some(*failure_class),
+                summary: Some(failure_class.summary()),
+                // Only advertise a retry that is actually scheduled.
+                retry_after_seconds: retry_at.map(|at| retry_after_seconds(at)),
                 blocking_operation_id: blocking_operation_id.clone(),
             },
             Self::Opening {
                 next_retry,
                 failure_class,
-                last_error,
                 ..
             } => GraphAvailability {
-                state: "opening",
+                state: GraphState::Opening,
                 read_ready: false,
                 write_ready: false,
-                failure_class: failure_class.map(FailureClass::as_str),
-                last_error: last_error.clone(),
+                failure_class: *failure_class,
+                summary: failure_class.map(FailureClass::summary),
                 retry_after_seconds: Some(retry_after_seconds(*next_retry)),
                 blocking_operation_id: None,
             },
-            Self::Unavailable {
-                failure_class,
-                last_error,
-            } => GraphAvailability {
-                state: "unavailable",
+            Self::Unavailable { failure_class } => GraphAvailability {
+                state: GraphState::Unavailable,
                 read_ready: false,
                 write_ready: false,
-                failure_class: Some(failure_class.as_str()),
-                last_error: Some(last_error.clone()),
+                failure_class: Some(*failure_class),
+                summary: Some(failure_class.summary()),
                 retry_after_seconds: None,
                 blocking_operation_id: None,
             },
@@ -225,6 +289,10 @@ pub struct GraphEntry {
     pub policy_configured: bool,
     startup: Option<Arc<GraphStartupConfig>>,
     runtime: ArcSwap<GraphRuntimeState>,
+    /// Bumped under `mutation` on every new recovery trigger. An in-flight
+    /// attempt compares it before storing a result, so a request that arrived
+    /// mid-attempt is never clobbered by a conclusion drawn before it.
+    recovery_generation: AtomicU64,
     pub(crate) mutation: Mutex<()>,
     pub(crate) notify: Notify,
 }
@@ -241,11 +309,26 @@ impl GraphEntry {
                 handle,
                 writes: WriteState::Ready,
             }),
+            recovery_generation: AtomicU64::new(0),
             mutation: Mutex::new(()),
             notify: Notify::new(),
         })
     }
 
+    /// Build a configured entry.
+    ///
+    /// An invalid graph **id** is fatal, and the reason is mechanical rather
+    /// than philosophical: the registry is keyed by `GraphKey::cluster(GraphId)`,
+    /// so an unparseable id has no key to be stored under. A duplicate
+    /// canonical URI is fatal too, because ownership is genuinely ambiguous.
+    /// `cluster apply` validates ids, so this is reachable only from
+    /// hand-edited state.
+    ///
+    /// Everything else that is wrong with a *single* graph — an unusable URI,
+    /// stored queries that failed to parse, an embedding provider that would
+    /// not build — becomes an unavailable configured entry. Aborting the whole
+    /// server for one bad path would make a typo more fatal than a graph that
+    /// cannot open at all.
     fn from_config(mut config: GraphStartupConfig) -> Result<Self, InsertError> {
         let graph_id = GraphId::try_from(config.graph_id.clone()).map_err(|err| {
             InsertError::InvalidGraphId {
@@ -253,21 +336,31 @@ impl GraphEntry {
                 message: err.to_string(),
             }
         })?;
-        config.uri = normalize_root_uri(&config.uri).map_err(|err| InsertError::InvalidUri {
-            uri: config.uri.clone(),
-            message: err.to_string(),
-        })?;
         let policy_configured = config.policy.is_some();
-        let runtime = match config.startup_error.as_deref() {
-            Some(error) => GraphRuntimeState::Unavailable {
-                failure_class: FailureClass::InvalidConfiguration,
-                last_error: sanitize_status_error(error),
-            },
+        let mut startup_error = config.startup_error.clone();
+        match normalize_root_uri(&config.uri) {
+            Ok(canonical) => config.uri = canonical,
+            Err(err) => {
+                // Keep the raw value so `GET /graphs` can still identify which
+                // graph is misconfigured; it never becomes a routing key.
+                startup_error.get_or_insert_with(|| format!("invalid graph uri: {err}"));
+            }
+        }
+        let runtime = match startup_error.as_deref() {
+            Some(error) => {
+                warn!(
+                    graph_id = %config.graph_id,
+                    error,
+                    "configured graph is unavailable: startup settings failed to build"
+                );
+                GraphRuntimeState::Unavailable {
+                    failure_class: FailureClass::InvalidConfiguration,
+                }
+            }
             None => GraphRuntimeState::Opening {
                 attempts: 0,
                 next_retry: Instant::now(),
                 failure_class: None,
-                last_error: None,
             },
         };
         Ok(Self {
@@ -276,6 +369,7 @@ impl GraphEntry {
             policy_configured,
             startup: Some(Arc::new(config)),
             runtime: ArcSwap::from_pointee(runtime),
+            recovery_generation: AtomicU64::new(0),
             mutation: Mutex::new(()),
             notify: Notify::new(),
         })
@@ -283,6 +377,16 @@ impl GraphEntry {
 
     pub fn startup_config(&self) -> Option<Arc<GraphStartupConfig>> {
         self.startup.clone()
+    }
+
+    /// Invalidate any recovery attempt currently in flight and return the new
+    /// generation. Callers hold `mutation`.
+    pub(crate) fn bump_recovery_generation(&self) -> RecoveryGeneration {
+        self.recovery_generation.fetch_add(1, Ordering::SeqCst) + 1
+    }
+
+    pub(crate) fn recovery_generation(&self) -> RecoveryGeneration {
+        self.recovery_generation.load(Ordering::SeqCst)
     }
 
     pub fn runtime(&self) -> arc_swap::Guard<Arc<GraphRuntimeState>> {
@@ -435,6 +539,12 @@ impl GraphRegistry {
     /// Block new writes and coalesce a Full-recovery wake-up for a serving
     /// graph. The prior blocking operation remains the public diagnostic until
     /// recovery succeeds; later requests are never treated as replays of it.
+    ///
+    /// Coalescing preserves the attempt count and any scheduled retry deadline.
+    /// Resetting them would let write traffic against a broken graph hold the
+    /// supervisor at its shortest backoff indefinitely — every 503'd request
+    /// restarting the ladder — and each attempt is a full recovery sweep whose
+    /// cost grows with commit depth.
     pub async fn mark_recovering(
         &self,
         key: &GraphKey,
@@ -445,32 +555,54 @@ impl GraphRegistry {
         };
         let _guard = entry.mutation.lock().await;
         let current = entry.runtime().as_ref().clone();
-        let next = match current {
-            GraphRuntimeState::Serving { handle, writes } => {
-                let existing = match writes {
-                    WriteState::Ready => None,
-                    WriteState::Recovering {
-                        blocking_operation_id,
-                        ..
-                    }
-                    | WriteState::Blocked {
-                        blocking_operation_id,
-                        ..
-                    } => blocking_operation_id,
-                };
-                GraphRuntimeState::Serving {
-                    handle,
-                    writes: WriteState::Recovering {
-                        attempts: 0,
-                        blocking_operation_id: existing.or(blocking_operation_id),
-                    },
-                }
-            }
-            GraphRuntimeState::Opening { .. } | GraphRuntimeState::Unavailable { .. } => {
-                return false;
-            }
+        let GraphRuntimeState::Serving { handle, writes } = current else {
+            // Never opened, or already terminal for a reason recovery cannot
+            // address. Nothing to schedule.
+            return false;
         };
-        entry.store_runtime(next);
+        // A new trigger, so a conclusion already in flight no longer applies.
+        let generation = entry.bump_recovery_generation();
+        let writes = match writes {
+            WriteState::Ready => WriteState::Recovering {
+                generation,
+                attempts: 0,
+                blocking_operation_id,
+            },
+            WriteState::Recovering {
+                attempts,
+                blocking_operation_id: existing,
+                ..
+            } => WriteState::Recovering {
+                generation,
+                attempts,
+                blocking_operation_id: existing.or(blocking_operation_id),
+            },
+            // Already backing off. Keep the schedule — a new trigger is not a
+            // reason to retry sooner, only a reason to invalidate whatever
+            // attempt is in flight. A permanent failure (`retry_at: None`)
+            // becomes eligible again, since the trigger is new evidence.
+            WriteState::Blocked {
+                attempts,
+                retry_at,
+                failure_class,
+                blocking_operation_id: existing,
+                ..
+            } => match retry_at {
+                Some(retry_at) => WriteState::Blocked {
+                    generation,
+                    attempts,
+                    retry_at: Some(retry_at),
+                    failure_class,
+                    blocking_operation_id: existing.or(blocking_operation_id),
+                },
+                None => WriteState::Recovering {
+                    generation,
+                    attempts,
+                    blocking_operation_id: existing.or(blocking_operation_id),
+                },
+            },
+        };
+        entry.store_runtime(GraphRuntimeState::Serving { handle, writes });
         drop(_guard);
         entry.wake();
         true
@@ -604,7 +736,7 @@ mod tests {
         assert_eq!(registry.len(), 1);
         assert!(registry.snapshot_ref().any_per_graph_policy);
         let entry = registry.list().pop().unwrap();
-        assert_eq!(entry.availability().state, "opening");
+        assert_eq!(entry.availability().state, GraphState::Opening);
         assert!(!entry.availability().read_ready);
         assert!(matches!(
             registry.get(&entry.key),

--- a/crates/omnigraph-server/src/settings.rs
+++ b/crates/omnigraph-server/src/settings.rs
@@ -104,8 +104,8 @@ pub(crate) async fn load_cluster_settings(
     }
 
     let mut graphs = Vec::new();
-    let mut skipped_graphs = Vec::new();
     for graph in &snapshot.graphs {
+        let mut startup_errors = Vec::new();
         let specs: Vec<queries::RegistrySpec> = snapshot
             .queries
             .iter()
@@ -131,13 +131,10 @@ pub(crate) async fn load_cluster_settings(
                 warn!(
                     graph_id = %graph.graph_id,
                     errors = %details,
-                    "graph quarantined because stored queries failed to parse"
+                    "graph unavailable because stored queries failed to parse"
                 );
-                skipped_graphs.push(format!(
-                    "{}: stored queries failed to parse: {details}",
-                    graph.graph_id
-                ));
-                continue;
+                startup_errors.push(format!("stored queries failed to parse: {details}"));
+                QueryRegistry::default()
             }
         };
         let embedding = match graph
@@ -155,36 +152,34 @@ pub(crate) async fn load_cluster_settings(
                 warn!(
                     graph_id = %graph.graph_id,
                     error = %err,
-                    "graph quarantined because embedding provider configuration failed"
+                    "graph unavailable because embedding provider configuration failed"
                 );
-                skipped_graphs.push(format!("{}: {err}", graph.graph_id));
-                continue;
+                startup_errors.push(err.to_string());
+                None
             }
         };
         graphs.push(GraphStartupConfig {
             graph_id: graph.graph_id.clone(),
             uri: graph.root.to_string_lossy().to_string(),
             policy: graph_policies.get(&graph.graph_id).cloned(),
+            startup_error: (!startup_errors.is_empty()).then(|| startup_errors.join("; ")),
             embedding,
             queries: registry,
         });
     }
-    if graphs.is_empty() {
-        let skipped = skipped_graphs.join(", ");
+    let startup_failures = graphs
+        .iter()
+        .filter_map(|graph| {
+            graph
+                .startup_error
+                .as_ref()
+                .map(|error| format!("{}: {error}", graph.graph_id))
+        })
+        .collect::<Vec<_>>();
+    if require_all_graphs && !startup_failures.is_empty() {
         bail!(
-            "the cluster at '{}' has no healthy graphs to serve{}",
-            cluster_dir.display(),
-            if skipped.is_empty() {
-                String::new()
-            } else {
-                format!(" (quarantined: {skipped})")
-            }
-        );
-    }
-    if require_all_graphs && !skipped_graphs.is_empty() {
-        bail!(
-            "strict cluster boot requires every graph to build startup settings (quarantined: {})",
-            skipped_graphs.join(", ")
+            "strict cluster boot requires every graph to build startup settings (unavailable: {})",
+            startup_failures.join(", ")
         );
     }
 
@@ -640,6 +635,7 @@ mod tests {
                         .to_string_lossy()
                         .into_owned(),
                     policy: None,
+                    startup_error: None,
                     embedding: None,
                     queries: crate::queries::QueryRegistry::default(),
                 }],
@@ -693,6 +689,7 @@ mod tests {
                         .to_string_lossy()
                         .into_owned(),
                     policy: None,
+                    startup_error: None,
                     embedding: None,
                     queries: crate::queries::QueryRegistry::default(),
                 }],

--- a/crates/omnigraph-server/src/supervisor.rs
+++ b/crates/omnigraph-server/src/supervisor.rs
@@ -1,0 +1,584 @@
+use std::io::ErrorKind;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use futures::StreamExt;
+use omnigraph::db::Omnigraph;
+use omnigraph::error::{ManifestErrorKind, OmniError};
+use tokio::sync::{Semaphore, watch};
+use tokio::task::JoinHandle;
+use tokio::time::sleep_until;
+use tracing::{error, info, warn};
+
+use crate::registry::{
+    FailureClass, GraphEntry, GraphHandle, GraphRegistry, GraphRuntimeState, WriteState,
+};
+use crate::{GraphStartupConfig, load_graph_policy, validate_and_attach};
+
+const MAX_CONCURRENT_ATTEMPTS: usize = 4;
+const MAX_BACKOFF: Duration = Duration::from_secs(60);
+
+#[cfg(test)]
+mod attempt_probe {
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    static HOLD: AtomicBool = AtomicBool::new(false);
+    static ACTIVE: AtomicUsize = AtomicUsize::new(0);
+    static MAXIMUM: AtomicUsize = AtomicUsize::new(0);
+
+    struct ActiveAttempt;
+
+    impl Drop for ActiveAttempt {
+        fn drop(&mut self) {
+            ACTIVE.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    pub fn begin_hold() {
+        ACTIVE.store(0, Ordering::SeqCst);
+        MAXIMUM.store(0, Ordering::SeqCst);
+        HOLD.store(true, Ordering::Release);
+    }
+
+    pub fn maximum() -> usize {
+        MAXIMUM.load(Ordering::SeqCst)
+    }
+
+    pub fn release() {
+        HOLD.store(false, Ordering::Release);
+    }
+
+    pub async fn hold_if_enabled() {
+        if !HOLD.load(Ordering::Acquire) {
+            return;
+        }
+        let active = ACTIVE.fetch_add(1, Ordering::SeqCst) + 1;
+        MAXIMUM.fetch_max(active, Ordering::SeqCst);
+        let _active = ActiveAttempt;
+        while HOLD.load(Ordering::Acquire) {
+            tokio::task::yield_now().await;
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct GraphFailure {
+    pub class: FailureClass,
+    pub message: String,
+}
+
+impl GraphFailure {
+    fn new(class: FailureClass, message: impl Into<String>) -> Self {
+        Self {
+            class,
+            message: sanitize_error(message.into()),
+        }
+    }
+}
+
+fn sanitize_error(message: String) -> String {
+    let compact = message.split_whitespace().collect::<Vec<_>>().join(" ");
+    compact.chars().take(512).collect()
+}
+
+fn classify_engine_error(error: OmniError) -> GraphFailure {
+    match error {
+        OmniError::Io(error) => {
+            let class = match error.kind() {
+                ErrorKind::TimedOut => FailureClass::Timeout,
+                ErrorKind::InvalidInput
+                | ErrorKind::InvalidData
+                | ErrorKind::Unsupported
+                | ErrorKind::PermissionDenied => FailureClass::InvalidConfiguration,
+                _ => FailureClass::Io,
+            };
+            GraphFailure::new(class, error.to_string())
+        }
+        OmniError::Manifest(error)
+            if error.message.contains("internal schema v")
+                && (error.message.contains("upgrade omnigraph")
+                    || error.message.contains("reads only")) =>
+        {
+            GraphFailure::new(FailureClass::UnsupportedFormat, error.message)
+        }
+        OmniError::Manifest(error) => {
+            let class = match error.kind {
+                ManifestErrorKind::BadRequest | ManifestErrorKind::NotFound => {
+                    FailureClass::InvalidConfiguration
+                }
+                ManifestErrorKind::Conflict | ManifestErrorKind::Internal => {
+                    FailureClass::InvariantViolation
+                }
+            };
+            GraphFailure::new(class, error.message)
+        }
+        OmniError::Compiler(error) => {
+            GraphFailure::new(FailureClass::InvalidConfiguration, error.to_string())
+        }
+        error => GraphFailure::new(FailureClass::Unknown, error.to_string()),
+    }
+}
+
+fn full_jitter_backoff(attempts: u32) -> Duration {
+    let shift = attempts.saturating_sub(1).min(6);
+    let ceiling = Duration::from_secs(1u64 << shift).min(MAX_BACKOFF);
+    let ceiling_millis = ceiling.as_millis() as u64;
+    Duration::from_millis(fastrand::u64(1..=ceiling_millis.max(1)))
+}
+
+async fn open_graph(config: &GraphStartupConfig) -> Result<Arc<GraphHandle>, GraphFailure> {
+    let graph_id = crate::GraphId::try_from(config.graph_id.clone()).map_err(|error| {
+        GraphFailure::new(FailureClass::InvalidConfiguration, error.to_string())
+    })?;
+    let db = Omnigraph::open(&config.uri)
+        .await
+        .map_err(classify_engine_error)?;
+    let db = if let Some(embedding) = &config.embedding {
+        db.with_embedding_config(Arc::new(embedding.clone()))
+    } else {
+        db
+    };
+    let queries = validate_and_attach(config.queries.clone(), &db.catalog(), graph_id.as_str())
+        .map_err(|error| {
+            GraphFailure::new(FailureClass::InvalidConfiguration, error.to_string())
+        })?;
+    let (policy, db) = match &config.policy {
+        Some(source) => {
+            let policy = load_graph_policy(source, graph_id.as_str()).map_err(|error| {
+                GraphFailure::new(FailureClass::InvalidConfiguration, error.to_string())
+            })?;
+            let policy = Arc::new(policy);
+            let checker = Arc::clone(&policy) as Arc<dyn omnigraph_policy::PolicyChecker>;
+            (Some(policy), db.with_policy(checker))
+        }
+        None => (None, db),
+    };
+    Ok(Arc::new(GraphHandle {
+        key: crate::GraphKey::cluster(graph_id),
+        uri: config.uri.clone(),
+        engine: Arc::new(db),
+        policy,
+        queries,
+    }))
+}
+
+async fn attempt_open(entry: &Arc<GraphEntry>, semaphore: &Arc<Semaphore>) -> Option<GraphFailure> {
+    let config = entry.startup_config()?;
+    let attempts = match entry.runtime().as_ref() {
+        GraphRuntimeState::Opening { attempts, .. } => *attempts + 1,
+        _ => return None,
+    };
+    let _permit = semaphore
+        .acquire()
+        .await
+        .expect("supervisor semaphore closed");
+    #[cfg(test)]
+    attempt_probe::hold_if_enabled().await;
+    match open_graph(&config).await {
+        Ok(handle) => {
+            let _guard = entry.mutation.lock().await;
+            if matches!(entry.runtime().as_ref(), GraphRuntimeState::Opening { .. }) {
+                entry.store_runtime(GraphRuntimeState::Serving {
+                    handle,
+                    writes: WriteState::Ready,
+                });
+                info!(graph_id = %entry.key.graph_id, attempts, "graph opened");
+            }
+            None
+        }
+        Err(failure) => {
+            let _guard = entry.mutation.lock().await;
+            if failure.class.retryable() {
+                let delay = full_jitter_backoff(attempts);
+                entry.store_runtime(GraphRuntimeState::Opening {
+                    attempts,
+                    next_retry: Instant::now() + delay,
+                    failure_class: Some(failure.class),
+                    last_error: Some(failure.message.clone()),
+                });
+                warn!(
+                    graph_id = %entry.key.graph_id,
+                    attempts,
+                    retry_after_ms = delay.as_millis(),
+                    error = %failure.message,
+                    "graph open failed transiently"
+                );
+            } else {
+                entry.store_runtime(GraphRuntimeState::Unavailable {
+                    failure_class: failure.class,
+                    last_error: failure.message.clone(),
+                });
+                error!(
+                    graph_id = %entry.key.graph_id,
+                    failure_class = failure.class.as_str(),
+                    error = %failure.message,
+                    "graph open failed permanently"
+                );
+            }
+            Some(failure)
+        }
+    }
+}
+
+async fn attempt_recovery(
+    entry: &Arc<GraphEntry>,
+    semaphore: &Arc<Semaphore>,
+) -> Option<GraphFailure> {
+    let (handle, attempts, blocking_operation_id) = match entry.runtime().as_ref() {
+        GraphRuntimeState::Serving {
+            handle,
+            writes:
+                WriteState::Recovering {
+                    attempts,
+                    blocking_operation_id,
+                }
+                | WriteState::Blocked {
+                    attempts,
+                    blocking_operation_id,
+                    ..
+                },
+        } => (
+            Arc::clone(handle),
+            *attempts + 1,
+            blocking_operation_id.clone(),
+        ),
+        _ => return None,
+    };
+    let _permit = semaphore
+        .acquire()
+        .await
+        .expect("supervisor semaphore closed");
+    match handle.engine.refresh().await {
+        Ok(()) => {
+            let _guard = entry.mutation.lock().await;
+            if matches!(entry.runtime().as_ref(), GraphRuntimeState::Serving { .. }) {
+                entry.store_runtime(GraphRuntimeState::Serving {
+                    handle,
+                    writes: WriteState::Ready,
+                });
+                info!(graph_id = %entry.key.graph_id, attempts, "graph recovery completed");
+            }
+            None
+        }
+        Err(error) => {
+            let failure = classify_engine_error(error);
+            let _guard = entry.mutation.lock().await;
+            if failure.class.retryable() {
+                let delay = full_jitter_backoff(attempts);
+                entry.store_runtime(GraphRuntimeState::Serving {
+                    handle,
+                    writes: WriteState::Blocked {
+                        attempts,
+                        next_retry: Instant::now() + delay,
+                        failure_class: failure.class,
+                        last_error: failure.message.clone(),
+                        blocking_operation_id,
+                    },
+                });
+                warn!(
+                    graph_id = %entry.key.graph_id,
+                    attempts,
+                    retry_after_ms = delay.as_millis(),
+                    error = %failure.message,
+                    "graph recovery failed transiently; reads remain available"
+                );
+            } else {
+                entry.store_runtime(GraphRuntimeState::Unavailable {
+                    failure_class: failure.class,
+                    last_error: failure.message.clone(),
+                });
+                error!(
+                    graph_id = %entry.key.graph_id,
+                    failure_class = failure.class.as_str(),
+                    error = %failure.message,
+                    "graph recovery failed permanently; routing disabled"
+                );
+            }
+            Some(failure)
+        }
+    }
+}
+
+pub(crate) async fn initial_open_all(registry: Arc<GraphRegistry>) -> Vec<(String, GraphFailure)> {
+    let semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_ATTEMPTS));
+    futures::stream::iter(registry.list())
+        .map(|entry| {
+            let semaphore = Arc::clone(&semaphore);
+            async move {
+                let graph_id = entry.key.graph_id.as_str().to_string();
+                attempt_open(&entry, &semaphore)
+                    .await
+                    .map(|failure| (graph_id, failure))
+            }
+        })
+        .buffer_unordered(MAX_CONCURRENT_ATTEMPTS)
+        .filter_map(futures::future::ready)
+        .collect()
+        .await
+}
+
+pub(crate) struct SupervisorSet {
+    shutdown: watch::Sender<bool>,
+    tasks: Mutex<Vec<JoinHandle<()>>>,
+}
+
+impl SupervisorSet {
+    pub fn idle() -> Arc<Self> {
+        let (shutdown, _) = watch::channel(false);
+        Arc::new(Self {
+            shutdown,
+            tasks: Mutex::new(Vec::new()),
+        })
+    }
+
+    pub fn start(registry: Arc<GraphRegistry>) -> Arc<Self> {
+        let (shutdown, _) = watch::channel(false);
+        let set = Arc::new(Self {
+            shutdown,
+            tasks: Mutex::new(Vec::new()),
+        });
+        let semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_ATTEMPTS));
+        let mut tasks = Vec::with_capacity(registry.len());
+        for entry in registry.list() {
+            tasks.push(tokio::spawn(supervise_graph(
+                entry,
+                Arc::clone(&semaphore),
+                set.shutdown.subscribe(),
+            )));
+        }
+        *set.tasks.lock().expect("supervisor task mutex poisoned") = tasks;
+        set
+    }
+
+    #[allow(dead_code)]
+    pub async fn shutdown(&self) {
+        let _ = self.shutdown.send(true);
+        let tasks =
+            std::mem::take(&mut *self.tasks.lock().expect("supervisor task mutex poisoned"));
+        for task in tasks {
+            if let Err(error) = task.await {
+                warn!(error = %error, "graph supervisor task did not exit cleanly");
+            }
+        }
+    }
+}
+
+async fn supervise_graph(
+    entry: Arc<GraphEntry>,
+    semaphore: Arc<Semaphore>,
+    mut shutdown: watch::Receiver<bool>,
+) {
+    loop {
+        if *shutdown.borrow() {
+            return;
+        }
+        let deadline = match entry.runtime().as_ref() {
+            GraphRuntimeState::Opening { next_retry, .. } => Some(*next_retry),
+            GraphRuntimeState::Serving {
+                writes: WriteState::Recovering { .. },
+                ..
+            } => Some(Instant::now()),
+            GraphRuntimeState::Serving {
+                writes: WriteState::Blocked { next_retry, .. },
+                ..
+            } => Some(*next_retry),
+            GraphRuntimeState::Serving {
+                writes: WriteState::Ready,
+                ..
+            }
+            | GraphRuntimeState::Unavailable { .. } => None,
+        };
+
+        match deadline {
+            Some(deadline) if deadline <= Instant::now() => {}
+            Some(deadline) => {
+                tokio::select! {
+                    _ = sleep_until(deadline.into()) => {}
+                    _ = entry.notify.notified() => {}
+                    changed = shutdown.changed() => {
+                        if changed.is_err() || *shutdown.borrow() { return; }
+                    }
+                }
+            }
+            None => {
+                tokio::select! {
+                    _ = entry.notify.notified() => {}
+                    changed = shutdown.changed() => {
+                        if changed.is_err() || *shutdown.borrow() { return; }
+                    }
+                }
+            }
+        }
+
+        match entry.runtime().as_ref() {
+            GraphRuntimeState::Opening { next_retry, .. } if *next_retry <= Instant::now() => {
+                attempt_open(&entry, &semaphore).await;
+            }
+            GraphRuntimeState::Serving {
+                writes: WriteState::Recovering { .. },
+                ..
+            } => {
+                attempt_recovery(&entry, &semaphore).await;
+            }
+            GraphRuntimeState::Serving {
+                writes: WriteState::Blocked { next_retry, .. },
+                ..
+            } if *next_retry <= Instant::now() => {
+                attempt_recovery(&entry, &semaphore).await;
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::registry::GraphHandle;
+    use crate::{GraphId, GraphKey};
+
+    async fn serving_registry() -> (TempDir, Arc<GraphHandle>, Arc<GraphRegistry>) {
+        let dir = TempDir::new().unwrap();
+        let uri = dir.path().join("graph").to_string_lossy().to_string();
+        let engine = Omnigraph::init(&uri, "node Person { name: String @key }\n")
+            .await
+            .unwrap();
+        let handle = Arc::new(GraphHandle {
+            key: GraphKey::cluster(GraphId::try_from("test").unwrap()),
+            uri,
+            engine: Arc::new(engine),
+            policy: None,
+            queries: None,
+        });
+        let registry = Arc::new(GraphRegistry::from_handles(vec![Arc::clone(&handle)]).unwrap());
+        (dir, handle, registry)
+    }
+
+    #[test]
+    fn full_jitter_backoff_starts_bounded_and_caps_at_sixty_seconds() {
+        for attempts in 1..=20 {
+            let delay = full_jitter_backoff(attempts);
+            assert!(delay > Duration::ZERO);
+            assert!(delay <= MAX_BACKOFF);
+            let ceiling = Duration::from_secs(1u64 << attempts.saturating_sub(1).min(6));
+            assert!(delay <= ceiling.min(MAX_BACKOFF));
+        }
+    }
+
+    #[test]
+    fn error_classification_retries_only_proven_io_and_timeout_failures() {
+        let timed_out = classify_engine_error(OmniError::Io(std::io::Error::new(
+            ErrorKind::TimedOut,
+            "deadline",
+        )));
+        assert_eq!(timed_out.class, FailureClass::Timeout);
+        assert!(timed_out.class.retryable());
+
+        let io = classify_engine_error(OmniError::Io(std::io::Error::new(
+            ErrorKind::ConnectionReset,
+            "reset",
+        )));
+        assert_eq!(io.class, FailureClass::Io);
+        assert!(io.class.retryable());
+
+        let invalid = classify_engine_error(OmniError::Io(std::io::Error::new(
+            ErrorKind::InvalidInput,
+            "bad uri",
+        )));
+        assert_eq!(invalid.class, FailureClass::InvalidConfiguration);
+        assert!(!invalid.class.retryable());
+
+        let invariant = classify_engine_error(OmniError::manifest_internal("broken invariant"));
+        assert_eq!(invariant.class, FailureClass::InvariantViolation);
+        assert!(!invariant.class.retryable());
+
+        let unknown = classify_engine_error(OmniError::Lance("opaque storage error".into()));
+        assert_eq!(unknown.class, FailureClass::Unknown);
+        assert!(!unknown.class.retryable());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn repeated_notifications_coalesce_into_live_handle_refresh() {
+        let (_dir, handle, registry) = serving_registry().await;
+        for index in 0..32 {
+            registry
+                .mark_recovering(&handle.key, Some(format!("operation-{index}")))
+                .await;
+        }
+        let supervisors = SupervisorSet::start(Arc::clone(&registry));
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if registry
+                    .write_availability(&handle.key)
+                    .is_some_and(|availability| availability.write_ready)
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("coalesced supervisor wake must complete recovery");
+        let routed = match registry.get(&handle.key) {
+            crate::RegistryLookup::Ready(routed) => routed,
+            crate::RegistryLookup::Unavailable(_) | crate::RegistryLookup::Gone => {
+                panic!("same live handle must return to service")
+            }
+        };
+        assert!(
+            Arc::ptr_eq(&routed, &handle),
+            "recovery must not reopen/swap"
+        );
+        supervisors.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    #[serial_test::serial(supervisor_attempts)]
+    async fn initial_open_attempts_are_process_wide_bounded_to_four() {
+        let temp = TempDir::new().unwrap();
+        let mut configs = Vec::new();
+        for index in 0..5 {
+            let uri = temp
+                .path()
+                .join(format!("graph-{index}"))
+                .to_string_lossy()
+                .to_string();
+            Omnigraph::init(&uri, "node Person { name: String @key }\n")
+                .await
+                .unwrap();
+            configs.push(GraphStartupConfig {
+                graph_id: format!("graph-{index}"),
+                uri,
+                policy: None,
+                startup_error: None,
+                embedding: None,
+                queries: crate::QueryRegistry::default(),
+            });
+        }
+        let registry = Arc::new(GraphRegistry::from_configs(configs).unwrap());
+        attempt_probe::begin_hold();
+        let opener = {
+            let registry = Arc::clone(&registry);
+            tokio::spawn(async move { initial_open_all(registry).await })
+        };
+        let reached_four = tokio::time::timeout(Duration::from_secs(10), async {
+            while attempt_probe::maximum() < MAX_CONCURRENT_ATTEMPTS {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await;
+        attempt_probe::release();
+        reached_four.expect("four parallel attempts never entered the open seam");
+        assert_eq!(attempt_probe::maximum(), 4);
+        assert!(opener.await.unwrap().is_empty());
+        assert!(
+            registry
+                .list()
+                .iter()
+                .all(|entry| entry.availability().write_ready)
+        );
+    }
+}

--- a/crates/omnigraph-server/src/supervisor.rs
+++ b/crates/omnigraph-server/src/supervisor.rs
@@ -1,5 +1,5 @@
 use std::io::ErrorKind;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use futures::StreamExt;
@@ -9,6 +9,8 @@ use tokio::sync::{Semaphore, watch};
 use tokio::task::JoinHandle;
 use tokio::time::sleep_until;
 use tracing::{error, info, warn};
+
+use omnigraph::error::StorageFailureKind;
 
 use crate::registry::{
     FailureClass, GraphEntry, GraphHandle, GraphRegistry, GraphRuntimeState, WriteState,
@@ -81,7 +83,27 @@ fn sanitize_error(message: String) -> String {
     compact.chars().take(512).collect()
 }
 
+/// Map an engine failure onto the supervisor's retry decision.
+///
+/// The storage arm is the load-bearing one: the engine classifies Lance and
+/// object-store failures at the substrate boundary, so a transport condition
+/// arrives here already typed. Before that, every such failure was an opaque
+/// string that landed in `Unknown` — which meant a transient S3 error pinned a
+/// graph permanently and the retry ladder below was unreachable code.
+///
+/// Nothing here inspects error text. This drives a wire-visible field, and a
+/// wire-visible field must not depend on internal error prose.
 fn classify_engine_error(error: OmniError) -> GraphFailure {
+    if let Some(failure) = error.storage_failure() {
+        let class = match failure.kind {
+            StorageFailureKind::Transient => FailureClass::TransientStorage,
+            StorageFailureKind::Configuration | StorageFailureKind::NotFound => {
+                FailureClass::InvalidConfiguration
+            }
+            StorageFailureKind::Permanent => FailureClass::InvariantViolation,
+        };
+        return GraphFailure::new(class, failure.message.clone());
+    }
     match error {
         OmniError::Io(error) => {
             let class = match error.kind() {
@@ -93,13 +115,6 @@ fn classify_engine_error(error: OmniError) -> GraphFailure {
                 _ => FailureClass::Io,
             };
             GraphFailure::new(class, error.to_string())
-        }
-        OmniError::Manifest(error)
-            if error.message.contains("internal schema v")
-                && (error.message.contains("upgrade omnigraph")
-                    || error.message.contains("reads only")) =>
-        {
-            GraphFailure::new(FailureClass::UnsupportedFormat, error.message)
         }
         OmniError::Manifest(error) => {
             let class = match error.kind {
@@ -126,10 +141,15 @@ fn full_jitter_backoff(attempts: u32) -> Duration {
     Duration::from_millis(fastrand::u64(1..=ceiling_millis.max(1)))
 }
 
-async fn open_graph(config: &GraphStartupConfig) -> Result<Arc<GraphHandle>, GraphFailure> {
-    let graph_id = crate::GraphId::try_from(config.graph_id.clone()).map_err(|error| {
-        GraphFailure::new(FailureClass::InvalidConfiguration, error.to_string())
-    })?;
+/// Open one configured graph.
+///
+/// The id comes from the entry's key rather than being re-parsed: an entry only
+/// exists because `GraphEntry::from_config` already parsed it, so re-deriving it
+/// here would be a second source of truth with an unreachable error arm.
+async fn open_graph(
+    graph_id: &crate::GraphId,
+    config: &GraphStartupConfig,
+) -> Result<Arc<GraphHandle>, GraphFailure> {
     let db = Omnigraph::open(&config.uri)
         .await
         .map_err(classify_engine_error)?;
@@ -154,7 +174,7 @@ async fn open_graph(config: &GraphStartupConfig) -> Result<Arc<GraphHandle>, Gra
         None => (None, db),
     };
     Ok(Arc::new(GraphHandle {
-        key: crate::GraphKey::cluster(graph_id),
+        key: crate::GraphKey::cluster(graph_id.clone()),
         uri: config.uri.clone(),
         engine: Arc::new(db),
         policy,
@@ -174,7 +194,7 @@ async fn attempt_open(entry: &Arc<GraphEntry>, semaphore: &Arc<Semaphore>) -> Op
         .expect("supervisor semaphore closed");
     #[cfg(test)]
     attempt_probe::hold_if_enabled().await;
-    match open_graph(&config).await {
+    match open_graph(&entry.key.graph_id, &config).await {
         Ok(handle) => {
             let _guard = entry.mutation.lock().await;
             if matches!(entry.runtime().as_ref(), GraphRuntimeState::Opening { .. }) {
@@ -194,7 +214,6 @@ async fn attempt_open(entry: &Arc<GraphEntry>, semaphore: &Arc<Semaphore>) -> Op
                     attempts,
                     next_retry: Instant::now() + delay,
                     failure_class: Some(failure.class),
-                    last_error: Some(failure.message.clone()),
                 });
                 warn!(
                     graph_id = %entry.key.graph_id,
@@ -206,7 +225,6 @@ async fn attempt_open(entry: &Arc<GraphEntry>, semaphore: &Arc<Semaphore>) -> Op
             } else {
                 entry.store_runtime(GraphRuntimeState::Unavailable {
                     failure_class: failure.class,
-                    last_error: failure.message.clone(),
                 });
                 error!(
                     graph_id = %entry.key.graph_id,
@@ -220,87 +238,130 @@ async fn attempt_open(entry: &Arc<GraphEntry>, semaphore: &Arc<Semaphore>) -> Op
     }
 }
 
+/// One recovery attempt for a serving graph.
+///
+/// Two properties this must preserve:
+///
+/// **A serving graph never stops serving reads.** Recovery is a *write*
+/// concern. A failed `refresh()` leaves the engine's live coordinator and
+/// schema view exactly as they were, and the destructive actions recovery can
+/// take (`Dataset::restore`, prefix deletion) either append a version or are
+/// guarded to objects absent from the live manifest — so reads pinned to a
+/// version stay correct. Dropping the handle would trade a write outage for a
+/// total one, permanently, with nothing able to bring it back. A permanent
+/// failure is therefore `Blocked { retry_at: None }`, not `Unavailable`.
+///
+/// **A conclusion drawn before a newer request must not overwrite it.** The
+/// generation is captured after the permit is acquired — as late as possible —
+/// and re-checked under the entry lock before storing. If it moved, a newer
+/// trigger arrived during the refresh and its state stands.
 async fn attempt_recovery(
     entry: &Arc<GraphEntry>,
     semaphore: &Arc<Semaphore>,
 ) -> Option<GraphFailure> {
-    let (handle, attempts, blocking_operation_id) = match entry.runtime().as_ref() {
+    let handle = match entry.runtime().as_ref() {
         GraphRuntimeState::Serving {
             handle,
-            writes:
-                WriteState::Recovering {
-                    attempts,
-                    blocking_operation_id,
-                }
-                | WriteState::Blocked {
-                    attempts,
-                    blocking_operation_id,
-                    ..
-                },
-        } => (
-            Arc::clone(handle),
-            *attempts + 1,
-            blocking_operation_id.clone(),
-        ),
+            writes: WriteState::Recovering { .. } | WriteState::Blocked { .. },
+        } => Arc::clone(handle),
         _ => return None,
     };
     let _permit = semaphore
         .acquire()
         .await
         .expect("supervisor semaphore closed");
-    match handle.engine.refresh().await {
+    // Capture after the permit: the queue wait can be long, and anything that
+    // happened during it belongs to a later attempt, not this one.
+    let generation = entry.recovery_generation();
+    let (attempts, blocking_operation_id) = match entry.runtime().as_ref() {
+        GraphRuntimeState::Serving {
+            writes:
+                WriteState::Recovering {
+                    attempts,
+                    blocking_operation_id,
+                    ..
+                }
+                | WriteState::Blocked {
+                    attempts,
+                    blocking_operation_id,
+                    ..
+                },
+            ..
+        } => (*attempts + 1, blocking_operation_id.clone()),
+        _ => return None,
+    };
+    #[cfg(test)]
+    attempt_probe::hold_if_enabled().await;
+    let outcome = handle.engine.refresh().await;
+
+    let _guard = entry.mutation.lock().await;
+    if entry.recovery_generation() != generation {
+        // A newer trigger landed while this attempt ran. Whatever it concluded
+        // describes a superseded request; leave the newer state to be scanned.
+        entry.wake();
+        return outcome.err().map(classify_engine_error);
+    }
+    let GraphRuntimeState::Serving { .. } = entry.runtime().as_ref() else {
+        return outcome.err().map(classify_engine_error);
+    };
+    match outcome {
         Ok(()) => {
-            let _guard = entry.mutation.lock().await;
-            if matches!(entry.runtime().as_ref(), GraphRuntimeState::Serving { .. }) {
-                entry.store_runtime(GraphRuntimeState::Serving {
-                    handle,
-                    writes: WriteState::Ready,
-                });
-                info!(graph_id = %entry.key.graph_id, attempts, "graph recovery completed");
-            }
+            entry.store_runtime(GraphRuntimeState::Serving {
+                handle,
+                writes: WriteState::Ready,
+            });
+            info!(graph_id = %entry.key.graph_id, attempts, "graph recovery completed");
             None
         }
         Err(error) => {
             let failure = classify_engine_error(error);
-            let _guard = entry.mutation.lock().await;
-            if failure.class.retryable() {
-                let delay = full_jitter_backoff(attempts);
-                entry.store_runtime(GraphRuntimeState::Serving {
-                    handle,
-                    writes: WriteState::Blocked {
-                        attempts,
-                        next_retry: Instant::now() + delay,
-                        failure_class: failure.class,
-                        last_error: failure.message.clone(),
-                        blocking_operation_id,
-                    },
-                });
-                warn!(
+            let retry_at = failure
+                .class
+                .retryable()
+                .then(|| Instant::now() + full_jitter_backoff(attempts));
+            entry.store_runtime(GraphRuntimeState::Serving {
+                handle,
+                writes: WriteState::Blocked {
+                    generation,
+                    attempts,
+                    retry_at,
+                    failure_class: failure.class,
+                    blocking_operation_id,
+                },
+            });
+            match retry_at {
+                Some(at) => warn!(
                     graph_id = %entry.key.graph_id,
                     attempts,
-                    retry_after_ms = delay.as_millis(),
+                    retry_after_ms = at.saturating_duration_since(Instant::now()).as_millis(),
                     error = %failure.message,
                     "graph recovery failed transiently; reads remain available"
-                );
-            } else {
-                entry.store_runtime(GraphRuntimeState::Unavailable {
-                    failure_class: failure.class,
-                    last_error: failure.message.clone(),
-                });
-                error!(
+                ),
+                None => error!(
                     graph_id = %entry.key.graph_id,
                     failure_class = failure.class.as_str(),
                     error = %failure.message,
-                    "graph recovery failed permanently; routing disabled"
-                );
+                    "graph recovery failed permanently; writes blocked, reads remain available"
+                ),
             }
             Some(failure)
         }
     }
 }
 
+/// The one attempt-permit pool for this process.
+///
+/// Open and recovery attempts both perform unbounded-latency graph I/O, so the
+/// bound has to span every supervisor set and the boot sweep — otherwise two
+/// `AppState`s in one process quietly get twice the concurrency, and the test
+/// asserting a process-wide bound is asserting a property the code lacks.
+fn attempt_permits() -> &'static Arc<Semaphore> {
+    static PERMITS: OnceLock<Arc<Semaphore>> = OnceLock::new();
+    PERMITS.get_or_init(|| Arc::new(Semaphore::new(MAX_CONCURRENT_ATTEMPTS)))
+}
+
 pub(crate) async fn initial_open_all(registry: Arc<GraphRegistry>) -> Vec<(String, GraphFailure)> {
-    let semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_ATTEMPTS));
+    let semaphore = Arc::clone(attempt_permits());
     futures::stream::iter(registry.list())
         .map(|entry| {
             let semaphore = Arc::clone(&semaphore);
@@ -337,7 +398,7 @@ impl SupervisorSet {
             shutdown,
             tasks: Mutex::new(Vec::new()),
         });
-        let semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_ATTEMPTS));
+        let semaphore = Arc::clone(attempt_permits());
         let mut tasks = Vec::with_capacity(registry.len());
         for entry in registry.list() {
             tasks.push(tokio::spawn(supervise_graph(
@@ -379,9 +440,9 @@ async fn supervise_graph(
                 ..
             } => Some(Instant::now()),
             GraphRuntimeState::Serving {
-                writes: WriteState::Blocked { next_retry, .. },
+                writes: WriteState::Blocked { retry_at, .. },
                 ..
-            } => Some(*next_retry),
+            } => *retry_at,
             GraphRuntimeState::Serving {
                 writes: WriteState::Ready,
                 ..
@@ -421,9 +482,9 @@ async fn supervise_graph(
                 attempt_recovery(&entry, &semaphore).await;
             }
             GraphRuntimeState::Serving {
-                writes: WriteState::Blocked { next_retry, .. },
+                writes: WriteState::Blocked { retry_at, .. },
                 ..
-            } if *next_retry <= Instant::now() => {
+            } if retry_at.is_some_and(|at| at <= Instant::now()) => {
                 attempt_recovery(&entry, &semaphore).await;
             }
             _ => {}
@@ -494,7 +555,42 @@ mod tests {
         assert_eq!(invariant.class, FailureClass::InvariantViolation);
         assert!(!invariant.class.retryable());
 
-        let unknown = classify_engine_error(OmniError::Lance("opaque storage error".into()));
+        // The case that used to brick a graph. The engine classifies transport
+        // failures at the substrate boundary (pinned there against real Lance
+        // and object-store errors); this pins that the supervisor keeps that
+        // verdict, so the retry ladder is reachable rather than dead code.
+        for (kind, expected, retryable) in [
+            (
+                StorageFailureKind::Transient,
+                FailureClass::TransientStorage,
+                true,
+            ),
+            (
+                StorageFailureKind::Configuration,
+                FailureClass::InvalidConfiguration,
+                false,
+            ),
+            (
+                StorageFailureKind::NotFound,
+                FailureClass::InvalidConfiguration,
+                false,
+            ),
+            (
+                StorageFailureKind::Permanent,
+                FailureClass::InvariantViolation,
+                false,
+            ),
+        ] {
+            let classified = classify_engine_error(OmniError::Storage(
+                omnigraph::error::StorageFailure::new(kind, "storage said so"),
+            ));
+            assert_eq!(classified.class, expected, "{kind:?}");
+            assert_eq!(classified.class.retryable(), retryable, "{kind:?}");
+        }
+
+        // An engine error carrying no storage classification is still unknown,
+        // and unknown is still not retried.
+        let unknown = classify_engine_error(OmniError::Policy("denied".into()));
         assert_eq!(unknown.class, FailureClass::Unknown);
         assert!(!unknown.class.retryable());
     }
@@ -580,5 +676,139 @@ mod tests {
                 .iter()
                 .all(|entry| entry.availability().write_ready)
         );
+    }
+
+    /// A conclusion drawn before a newer request must not overwrite it.
+    ///
+    /// The supervisor reads state, refreshes without holding the entry lock,
+    /// then writes a result derived from that read. A `mark_recovering` landing
+    /// in that window used to be clobbered: the success path re-checked only
+    /// that the graph was still `Serving`, which is true for every write state,
+    /// so a brand-new recovery request was silently marked `Ready` and dropped.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    #[serial_test::serial(supervisor_attempts)]
+    async fn a_trigger_arriving_mid_attempt_is_not_clobbered() {
+        let (_dir, handle, registry) = serving_registry().await;
+        registry
+            .mark_recovering(&handle.key, Some("operation-first".into()))
+            .await;
+        let entry = registry.entry(&handle.key).unwrap();
+
+        attempt_probe::begin_hold();
+        let attempt = {
+            let entry = Arc::clone(&entry);
+            let permits = Arc::clone(attempt_permits());
+            tokio::spawn(async move { attempt_recovery(&entry, &permits).await })
+        };
+        // Wait until the attempt is parked inside the refresh seam.
+        tokio::time::timeout(Duration::from_secs(10), async {
+            while attempt_probe::maximum() == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("recovery attempt never reached the probe seam");
+
+        // A second failure arrives while that attempt is still running.
+        registry
+            .mark_recovering(&handle.key, Some("operation-second".into()))
+            .await;
+        attempt_probe::release();
+        attempt.await.unwrap();
+
+        let availability = entry.availability();
+        assert_eq!(
+            availability.state,
+            crate::registry::GraphState::Recovering,
+            "the newer request must survive the in-flight attempt's conclusion"
+        );
+        assert!(!availability.write_ready);
+        assert_eq!(
+            availability.blocking_operation_id.as_deref(),
+            Some("operation-first"),
+            "the original blocking operation stays the diagnostic"
+        );
+    }
+
+    /// Coalescing must not restart the backoff ladder.
+    ///
+    /// Every 503'd write against a broken graph calls `mark_recovering`. If that
+    /// reset the attempt count, sustained traffic would hold the supervisor at
+    /// its shortest delay forever — and each attempt is a full recovery sweep
+    /// whose cost grows with commit depth.
+    #[tokio::test]
+    async fn coalescing_preserves_the_backoff_ladder() {
+        let (_dir, handle, registry) = serving_registry().await;
+        let entry = registry.entry(&handle.key).unwrap();
+        let retry_at = Instant::now() + Duration::from_secs(45);
+        entry.store_runtime(GraphRuntimeState::Serving {
+            handle: entry.serving_handle().unwrap(),
+            writes: WriteState::Blocked {
+                generation: entry.recovery_generation(),
+                attempts: 6,
+                retry_at: Some(retry_at),
+                failure_class: FailureClass::TransientStorage,
+                blocking_operation_id: Some("operation-first".into()),
+            },
+        });
+
+        registry
+            .mark_recovering(&handle.key, Some("operation-second".into()))
+            .await;
+
+        match entry.runtime().as_ref() {
+            GraphRuntimeState::Serving {
+                writes:
+                    WriteState::Blocked {
+                        attempts,
+                        retry_at: scheduled,
+                        ..
+                    },
+                ..
+            } => {
+                assert_eq!(*attempts, 6, "a new trigger must not reset the ladder");
+                assert_eq!(
+                    *scheduled,
+                    Some(retry_at),
+                    "a new trigger must not pull the deadline earlier"
+                );
+            }
+            _ => panic!("a coalesced trigger must keep the scheduled backoff"),
+        }
+    }
+
+    /// A permanent recovery failure blocks writes and keeps serving reads.
+    ///
+    /// Recovery is a write concern: a failed `refresh()` leaves the engine's
+    /// live view exactly as it was, so reads pinned to a version stay correct.
+    /// Dropping the handle would trade a write outage for a total one,
+    /// permanently, with nothing able to bring it back.
+    #[tokio::test]
+    async fn a_permanent_recovery_failure_keeps_reads_available() {
+        let (_dir, handle, registry) = serving_registry().await;
+        let entry = registry.entry(&handle.key).unwrap();
+        entry.store_runtime(GraphRuntimeState::Serving {
+            handle: entry.serving_handle().unwrap(),
+            writes: WriteState::Blocked {
+                generation: entry.recovery_generation(),
+                attempts: 3,
+                retry_at: None,
+                failure_class: FailureClass::InvariantViolation,
+                blocking_operation_id: None,
+            },
+        });
+
+        let availability = entry.availability();
+        assert_eq!(availability.state, crate::registry::GraphState::Degraded);
+        assert!(availability.read_ready, "reads must survive");
+        assert!(!availability.write_ready);
+        assert_eq!(
+            availability.retry_after_seconds, None,
+            "advertise Retry-After only when a retry is actually scheduled"
+        );
+        assert!(matches!(
+            registry.get(&handle.key),
+            crate::RegistryLookup::Ready(_)
+        ));
     }
 }

--- a/crates/omnigraph-server/src/supervisor.rs
+++ b/crates/omnigraph-server/src/supervisor.rs
@@ -8,6 +8,7 @@ use omnigraph::error::{ManifestErrorKind, OmniError};
 use tokio::sync::{Semaphore, watch};
 use tokio::task::JoinHandle;
 use tokio::time::sleep_until;
+use tokio_util::task::TaskTracker;
 use tracing::{error, info, warn};
 
 use omnigraph::error::StorageFailureKind;
@@ -19,6 +20,11 @@ use crate::{GraphStartupConfig, load_graph_policy, validate_and_attach};
 
 const MAX_CONCURRENT_ATTEMPTS: usize = 4;
 const MAX_BACKOFF: Duration = Duration::from_secs(60);
+/// How long the supervisor waits on one open or recovery attempt before moving
+/// on. This bounds the *wait*, never the work: neither `Omnigraph::open` nor
+/// `refresh` is cancellation-safe mid-recovery, so the attempt keeps running
+/// and publishes its own result.
+const ATTEMPT_TIMEOUT: Duration = Duration::from_secs(240);
 
 #[cfg(test)]
 mod attempt_probe {
@@ -381,6 +387,11 @@ pub(crate) async fn initial_open_all(registry: Arc<GraphRegistry>) -> Vec<(Strin
 pub(crate) struct SupervisorSet {
     shutdown: watch::Sender<bool>,
     tasks: Mutex<Vec<JoinHandle<()>>>,
+    /// Owns every spawned attempt. An attempt mutates durable recovery state
+    /// under an armed sidecar, so it must reach a terminal result even when
+    /// nobody is waiting for it — the same ownership rule the write executor
+    /// applies to a request whose caller disconnected.
+    attempts: TaskTracker,
 }
 
 impl SupervisorSet {
@@ -389,6 +400,7 @@ impl SupervisorSet {
         Arc::new(Self {
             shutdown,
             tasks: Mutex::new(Vec::new()),
+            attempts: TaskTracker::new(),
         })
     }
 
@@ -397,6 +409,7 @@ impl SupervisorSet {
         let set = Arc::new(Self {
             shutdown,
             tasks: Mutex::new(Vec::new()),
+            attempts: TaskTracker::new(),
         });
         let semaphore = Arc::clone(attempt_permits());
         let mut tasks = Vec::with_capacity(registry.len());
@@ -404,6 +417,7 @@ impl SupervisorSet {
             tasks.push(tokio::spawn(supervise_graph(
                 entry,
                 Arc::clone(&semaphore),
+                set.attempts.clone(),
                 set.shutdown.subscribe(),
             )));
         }
@@ -422,16 +436,48 @@ impl SupervisorSet {
             }
         }
     }
+
+    /// Stop accepting new attempts and wait for the ones already owned. Bounded
+    /// by the caller; an attempt that outlives the bound keeps running and its
+    /// durable sidecar remains next-boot authority.
+    #[allow(dead_code)]
+    pub async fn drain_attempts(&self, timeout: Duration) {
+        self.attempts.close();
+        if tokio::time::timeout(timeout, self.attempts.wait())
+            .await
+            .is_err()
+        {
+            warn!(
+                timeout_seconds = timeout.as_secs(),
+                "timed out draining graph recovery attempts; durable sidecars remain next-boot authority"
+            );
+        }
+    }
 }
 
 async fn supervise_graph(
     entry: Arc<GraphEntry>,
     semaphore: Arc<Semaphore>,
+    attempts: TaskTracker,
     mut shutdown: watch::Receiver<bool>,
 ) {
+    // An attempt this loop stopped waiting for but still owns. No second
+    // attempt starts for this graph while it is set: two concurrent refreshes
+    // would contend on the engine's own gates for no benefit.
+    let mut in_flight: Option<JoinHandle<()>> = None;
     loop {
         if *shutdown.borrow() {
             return;
+        }
+        if let Some(mut running) = in_flight.take() {
+            tokio::select! {
+                _ = &mut running => {}
+                changed = shutdown.changed() => {
+                    if changed.is_err() || *shutdown.borrow() { return; }
+                    in_flight = Some(running);
+                }
+            }
+            continue;
         }
         let deadline = match entry.runtime().as_ref() {
             GraphRuntimeState::Opening { next_retry, .. } => Some(*next_retry),
@@ -471,25 +517,58 @@ async fn supervise_graph(
             }
         }
 
-        match entry.runtime().as_ref() {
+        let due = match entry.runtime().as_ref() {
             GraphRuntimeState::Opening { next_retry, .. } if *next_retry <= Instant::now() => {
-                attempt_open(&entry, &semaphore).await;
+                Some(Attempt::Open)
             }
             GraphRuntimeState::Serving {
                 writes: WriteState::Recovering { .. },
                 ..
-            } => {
-                attempt_recovery(&entry, &semaphore).await;
-            }
+            } => Some(Attempt::Recover),
             GraphRuntimeState::Serving {
                 writes: WriteState::Blocked { retry_at, .. },
                 ..
-            } if retry_at.is_some_and(|at| at <= Instant::now()) => {
-                attempt_recovery(&entry, &semaphore).await;
+            } if retry_at.is_some_and(|at| at <= Instant::now()) => Some(Attempt::Recover),
+            _ => None,
+        };
+        let Some(due) = due else { continue };
+
+        let task = {
+            let entry = Arc::clone(&entry);
+            let semaphore = Arc::clone(&semaphore);
+            attempts.spawn(async move {
+                match due {
+                    Attempt::Open => attempt_open(&entry, &semaphore).await,
+                    Attempt::Recover => attempt_recovery(&entry, &semaphore).await,
+                };
+            })
+        };
+        let mut task = task;
+        tokio::select! {
+            _ = &mut task => {}
+            _ = tokio::time::sleep(ATTEMPT_TIMEOUT) => {
+                // Stop waiting, keep owning. Dropping the future here would
+                // abandon a recovery mid-restore; the task runs to a terminal
+                // result and publishes under its own generation check.
+                warn!(
+                    graph_id = %entry.key.graph_id,
+                    timeout_seconds = ATTEMPT_TIMEOUT.as_secs(),
+                    "graph attempt exceeded its deadline; still owned, no new attempt will start"
+                );
+                in_flight = Some(task);
             }
-            _ => {}
+            changed = shutdown.changed() => {
+                if changed.is_err() || *shutdown.borrow() { return; }
+                in_flight = Some(task);
+            }
         }
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Attempt {
+    Open,
+    Recover,
 }
 
 #[cfg(test)]

--- a/crates/omnigraph-server/src/supervisor.rs
+++ b/crates/omnigraph-server/src/supervisor.rs
@@ -395,15 +395,12 @@ pub(crate) struct SupervisorSet {
 }
 
 impl SupervisorSet {
-    pub fn idle() -> Arc<Self> {
-        let (shutdown, _) = watch::channel(false);
-        Arc::new(Self {
-            shutdown,
-            tasks: Mutex::new(Vec::new()),
-            attempts: TaskTracker::new(),
-        })
-    }
-
+    /// Start supervising every configured graph.
+    ///
+    /// There is no idle variant. An `AppState` owns a write executor that can
+    /// mark a graph recovering, so a set with no per-graph task would leave
+    /// that graph write-blocked forever with no consumer for the wake-up. The
+    /// combination is simply not constructible.
     pub fn start(registry: Arc<GraphRegistry>) -> Arc<Self> {
         let (shutdown, _) = watch::channel(false);
         let set = Arc::new(Self {

--- a/crates/omnigraph-server/tests/auth_policy.rs
+++ b/crates/omnigraph-server/tests/auth_policy.rs
@@ -827,6 +827,9 @@ async fn engine_layer_policy_fires_via_direct_arc_omnigraph_from_new_single() {
     );
     let handle = match state.routing().registry.get(&key) {
         omnigraph_server::RegistryLookup::Ready(handle) => handle,
+        omnigraph_server::RegistryLookup::Unavailable(_) => {
+            panic!("default graph must be serving")
+        }
         omnigraph_server::RegistryLookup::Gone => panic!("default graph must be registered"),
     };
     let engine = Arc::clone(&handle.engine);

--- a/crates/omnigraph-server/tests/multi_graph.rs
+++ b/crates/omnigraph-server/tests/multi_graph.rs
@@ -475,6 +475,7 @@ async fn served_export_process_queue_budget_refuses_then_releases() {
             graph_id,
             uri: uri.to_string_lossy().to_string(),
             policy: None,
+            startup_error: None,
             embedding: None,
             queries: stored_query_registry(&[]),
         });
@@ -542,7 +543,7 @@ async fn served_export_process_queue_budget_refuses_then_releases() {
 }
 
 #[tokio::test]
-async fn cluster_boot_quarantines_graph_open_failures() {
+async fn cluster_boot_tracks_graph_open_failures() {
     let temp = tempfile::tempdir().unwrap();
     let schema = "\nnode Person {\n  name: String @key\n}\n";
     let good_uri = temp.path().join("good.omni");
@@ -568,6 +569,7 @@ rules:
             graph_id: "broken".to_string(),
             uri: bad_uri.to_string_lossy().to_string(),
             policy: None,
+            startup_error: None,
             embedding: None,
             queries: stored_query_registry(&[]),
         },
@@ -575,6 +577,7 @@ rules:
             graph_id: "good".to_string(),
             uri: good_uri.to_string_lossy().to_string(),
             policy: None,
+            startup_error: None,
             embedding: None,
             queries: stored_query_registry(&[]),
         },
@@ -606,15 +609,15 @@ rules:
     )
     .await
     .unwrap();
-    let mut ready: Vec<_> = state
+    let mut configured: Vec<_> = state
         .routing()
         .registry
         .list()
         .iter()
-        .map(|handle| handle.key.graph_id.as_str().to_string())
+        .map(|entry| entry.key.graph_id.as_str().to_string())
         .collect();
-    ready.sort();
-    assert_eq!(ready, vec!["good"]);
+    configured.sort();
+    assert_eq!(configured, vec!["broken", "good"]);
     let app = build_app(state);
 
     let (status, body) = json_response(
@@ -634,8 +637,15 @@ rules:
             .iter()
             .map(|graph| graph["graph_id"].as_str().unwrap())
             .collect::<Vec<_>>(),
-        vec!["good"]
+        vec!["broken", "good"]
     );
+    let graphs = body["graphs"].as_array().unwrap();
+    assert_eq!(graphs[0]["state"], "unavailable");
+    assert_eq!(graphs[0]["read_ready"], false);
+    assert_eq!(graphs[0]["write_ready"], false);
+    assert_eq!(graphs[1]["state"], "ready");
+    assert_eq!(graphs[1]["read_ready"], true);
+    assert_eq!(graphs[1]["write_ready"], true);
 
     let (status, body) = json_response(
         &app,
@@ -646,7 +656,62 @@ rules:
             .unwrap(),
     )
     .await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE, "{body}");
+    assert_eq!(body["graph_unavailable"]["graph_id"], "broken");
+    assert_eq!(body["graph_unavailable"]["state"], "unavailable");
+
+    let (status, body) = json_response(
+        &app,
+        Request::builder()
+            .uri("/graphs/unknown/queries")
+            .header("authorization", "Bearer admin-token")
+            .body(Body::empty())
+            .unwrap(),
+    )
+    .await;
     assert_eq!(status, StatusCode::NOT_FOUND, "{body}");
+    assert!(body.get("graph_unavailable").is_none(), "{body}");
+}
+
+#[tokio::test]
+async fn default_boot_serves_liveness_with_zero_open_graphs() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = omnigraph_server::open_multi_graph_state(
+        vec![omnigraph_server::GraphStartupConfig {
+            graph_id: "broken".to_string(),
+            uri: temp
+                .path()
+                .join("missing.omni")
+                .to_string_lossy()
+                .to_string(),
+            policy: None,
+            startup_error: None,
+            embedding: None,
+            queries: stored_query_registry(&[]),
+        }],
+        Vec::new(),
+        None,
+        temp.path().join("cluster.yaml"),
+        false,
+    )
+    .await
+    .expect("default boot must bind even when no graph opens");
+    assert_eq!(state.routing().registry.len(), 1);
+    assert_eq!(
+        state.routing().registry.list()[0].availability().state,
+        "unavailable"
+    );
+    let app = build_app(state);
+    let (status, body) = json_response(
+        &app,
+        Request::builder()
+            .uri("/healthz")
+            .body(Body::empty())
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["status"], "ok");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -770,7 +835,7 @@ graphs:
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
-async fn cluster_boot_refuses_missing_embedding_secret_env() {
+async fn cluster_boot_reports_missing_embedding_secret_env() {
     let temp = tempfile::tempdir().unwrap();
     fs::write(
         temp.path().join("people.pg"),
@@ -810,13 +875,29 @@ graphs:
         ("OG_TEST_MISSING_EMBED_KEY", None),
         ("OMNIGRAPH_EMBEDDINGS_MOCK", None),
     ]);
-    let err = cluster_settings(temp.path()).await.unwrap_err();
-    let message = err.to_string();
+    let settings = cluster_settings(temp.path()).await.unwrap();
+    let omnigraph_server::ServerConfigMode::Multi { graphs, .. } = &settings.mode;
+    assert_eq!(graphs.len(), 1);
+    let message = graphs[0]
+        .startup_error
+        .as_deref()
+        .expect("missing provider secret must be retained as graph status");
     assert!(
         message.contains("embedding provider for graph 'knowledge'"),
         "{message}"
     );
     assert!(message.contains("OG_TEST_MISSING_EMBED_KEY"), "{message}");
+
+    let strict =
+        omnigraph_server::load_server_settings(Some(&temp.path().to_path_buf()), None, true, true)
+            .await
+            .unwrap_err();
+    assert!(
+        strict
+            .to_string()
+            .contains("strict cluster boot requires every graph"),
+        "{strict}"
+    );
 }
 
 #[tokio::test]

--- a/crates/omnigraph-server/tests/multi_graph.rs
+++ b/crates/omnigraph-server/tests/multi_graph.rs
@@ -699,7 +699,7 @@ async fn default_boot_serves_liveness_with_zero_open_graphs() {
     assert_eq!(state.routing().registry.len(), 1);
     assert_eq!(
         state.routing().registry.list()[0].availability().state,
-        "unavailable"
+        omnigraph_server::registry::GraphState::Unavailable
     );
     let app = build_app(state);
     let (status, body) = json_response(

--- a/crates/omnigraph-server/tests/openapi.rs
+++ b/crates/omnigraph-server/tests/openapi.rs
@@ -426,6 +426,10 @@ const EXPECTED_SCHEMAS: &[&str] = &[
     "ErrorCode",
     "ErrorOutput",
     "ExportRequest",
+    "GraphInfo",
+    "GraphListResponse",
+    "GraphState",
+    "GraphUnavailableOutput",
     "HealthOutput",
     "IngestOutput",
     "IngestRequest",
@@ -666,6 +670,35 @@ fn error_output_schema_has_expected_fields() {
     assert!(props.contains_key("key_conflict"));
     assert!(props.contains_key("resource_limit"));
     assert!(props.contains_key("recovery_required"));
+    assert!(props.contains_key("graph_unavailable"));
+}
+
+#[test]
+fn graph_status_schemas_have_expected_fields() {
+    let doc = openapi_json();
+    let info = &doc["components"]["schemas"]["GraphInfo"];
+    let props = info["properties"].as_object().unwrap();
+    for field in [
+        "graph_id",
+        "uri",
+        "state",
+        "read_ready",
+        "write_ready",
+        "failure_class",
+        "last_error",
+        "retry_after_seconds",
+        "blocking_operation_id",
+    ] {
+        assert!(props.contains_key(field), "GraphInfo missing {field}");
+    }
+    assert_eq!(
+        doc["components"]["schemas"]["GraphState"]["enum"],
+        serde_json::json!(["ready", "recovering", "degraded", "opening", "unavailable"])
+    );
+    let unavailable = &doc["components"]["schemas"]["GraphUnavailableOutput"]["properties"];
+    assert!(unavailable.get("graph_id").is_some());
+    assert!(unavailable.get("state").is_some());
+    assert!(unavailable.get("retry_after_seconds").is_some());
 }
 
 #[test]

--- a/docs/user/clusters/index.md
+++ b/docs/user/clusters/index.md
@@ -236,7 +236,7 @@ applied revision is not safely servable. Each refusal names its remedy:
 |---|---|---|
 | `cluster_state_missing` | no ledger | `cluster import`, then `apply` |
 | `cluster_recovery_pending` | graph was quarantined because an interrupted operation awaits sweep | run `cluster apply` (or any state-mutating command), restart |
-| `cluster_no_healthy_graphs` | every applied graph is quarantined or failed startup | sweep/fix the graph-specific failures, then restart |
+| `cluster_no_healthy_graphs` | strict boot was requested and every applied graph failed startup | fix the graph-specific failures, then restart without `--require-all-graphs` for status-only boot |
 | `catalog_payload_missing` / `…_digest_mismatch` | catalog blob lost or tampered | `cluster refresh`, then `apply`, restart |
 | `policy_bindings_missing` | ledger predates binding metadata | re-run `cluster apply` (backfills), restart |
 | `cluster_empty` | applied revision has no graphs | apply a cluster with ≥1 graph |
@@ -246,12 +246,15 @@ A held *state lock* is deliberately **not** a boot error — the server reads
 the atomically-replaced ledger without locking, so serving never contends
 with an in-flight apply.
 
-When at least one graph is healthy, graph-attributed recovery sidecars and
-graph-local startup failures do not block the whole server. The affected
-graph is skipped, its graph-only policy bindings and queries are omitted,
-and `/graphs` lists only the ready graphs. Pass
+Graph-local startup failures do not block default server boot, even when zero
+graphs open. Every configured graph remains in the registry so its policy
+presence, URI ownership, and status cannot disappear. `/graphs` lists all
+configured graphs with `read_ready`/`write_ready`; a configured graph without a
+usable handle returns 503, while an unknown id returns 404. Proven transient
+I/O/timeouts retry under a bounded per-graph supervisor. Pass
 `omnigraph-server --require-all-graphs` or set
-`OMNIGRAPH_REQUIRE_ALL_GRAPHS=1` to make any such quarantine fail startup.
+`OMNIGRAPH_REQUIRE_ALL_GRAPHS=1` to make any initial graph-open failure abort
+startup.
 
 ## 6. Deployment patterns
 

--- a/openapi.json
+++ b/openapi.json
@@ -15,12 +15,12 @@
         "tags": [
           "management"
         ],
-        "summary": "List every graph currently registered with this server.",
-        "description": "Multi-graph mode only. In single mode, the route returns 405 — there's\nno registry to enumerate. Cedar-gated by the server-level policy via\nthe `graph_list` action against `Omnigraph::Server::\"root\"`.\n\nOrder: alphabetical by `graph_id` (server-sorted so clients see\ndeterministic output across requests).",
+        "summary": "List every graph configured for this server, including graphs that have not\nopened successfully.",
+        "description": "Cedar-gated by the server-level policy via the `graph_list` action against\n`Omnigraph::Server::\"root\"`.\n\nOrder: alphabetical by `graph_id` (server-sorted so clients see\ndeterministic output across requests).",
         "operationId": "listGraphs",
         "responses": {
           "200": {
-            "description": "List of registered graphs",
+            "description": "List of configured graphs and runtime status",
             "content": {
               "application/json": {
                 "schema": {
@@ -41,16 +41,6 @@
           },
           "403": {
             "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorOutput"
-                }
-              }
-            }
-          },
-          "405": {
-            "description": "Method not allowed (single-graph mode)",
             "content": {
               "application/json": {
                 "schema": {
@@ -2281,6 +2271,17 @@
           "error": {
             "type": "string"
           },
+          "graph_unavailable": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/GraphUnavailableOutput",
+                "description": "Present when the graph id is configured but cannot currently serve the\nrequested operation. Unknown graph ids remain ordinary 404 responses."
+              }
+            ]
+          },
           "key_conflict": {
             "oneOf": [
               {
@@ -2443,23 +2444,61 @@
       },
       "GraphInfo": {
         "type": "object",
-        "description": "One entry in the response from `GET /graphs`. Cluster operators\nconsume this list to discover which graphs the server is currently\nserving. The shape is intentionally minimal — `graph_id` and `uri`\nare the only fields a routing client needs.",
+        "description": "One configured graph and its current serving state.",
         "required": [
           "graph_id",
-          "uri"
+          "uri",
+          "state",
+          "read_ready",
+          "write_ready"
         ],
         "properties": {
+          "blocking_operation_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "failure_class": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "graph_id": {
             "type": "string"
           },
+          "last_error": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "read_ready": {
+            "type": "boolean"
+          },
+          "retry_after_seconds": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "minimum": 0
+          },
+          "state": {
+            "$ref": "#/components/schemas/GraphState"
+          },
           "uri": {
             "type": "string"
+          },
+          "write_ready": {
+            "type": "boolean"
           }
         }
       },
       "GraphListResponse": {
         "type": "object",
-        "description": "Response from `GET /graphs`. Lists every graph registered with the\nserver in alphabetical order by `graph_id` (sorted server-side so\nclients get deterministic output across requests).",
+        "description": "Response from `GET /graphs`. Lists every graph configured on the\nserver in alphabetical order by `graph_id` (sorted server-side so\nclients get deterministic output across requests).",
         "required": [
           "graphs"
         ],
@@ -2469,6 +2508,39 @@
             "items": {
               "$ref": "#/components/schemas/GraphInfo"
             }
+          }
+        }
+      },
+      "GraphState": {
+        "type": "string",
+        "enum": [
+          "ready",
+          "recovering",
+          "degraded",
+          "opening",
+          "unavailable"
+        ]
+      },
+      "GraphUnavailableOutput": {
+        "type": "object",
+        "required": [
+          "graph_id",
+          "state"
+        ],
+        "properties": {
+          "graph_id": {
+            "type": "string"
+          },
+          "retry_after_seconds": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "minimum": 0
+          },
+          "state": {
+            "$ref": "#/components/schemas/GraphState"
           }
         }
       },
@@ -2991,7 +3063,8 @@
         ],
         "properties": {
           "operation_id": {
-            "type": "string"
+            "type": "string",
+            "description": "The durable operation that blocked this request. This is not a request\nidentifier for the current HTTP call."
           }
         }
       },


### PR DESCRIPTION
## Summary

Stacked on #488. The registry retains every *configured* graph — including ones that fail to open — and a per-graph supervisor drives open and recovery. The first commit introduces that; the rest close what it landed with.

**The retry classifier could never return "retryable."** `FailureClass::Io`/`Timeout` came only from `OmniError::Io`, which the engine has no construction site for. Every Lance and object-store failure arrived as an opaque string and landed in `Unknown`, which is not retried — so a transient S3 error pinned a graph permanently and `full_jitter_backoff` plus the whole `Opening{next_retry}` arm were unreachable code. The existing unit test passed only because it hand-built `OmniError::Io` values nothing emits. Now consumes the classification #491 derives at the substrate boundary, and the arm that sniffed error text for `"internal schema v"` is gone — a wire-visible field must not depend on internal prose.

**One failed refresh could permanently kill reads.** The non-retryable branch dropped the live handle and stored `Unavailable`, a terminal state with no way back — and because of the above, *every* recovery failure took it. Recovery is a write concern: a failed `refresh()` leaves the engine's live view intact, `Dataset::restore` appends rather than removes, reads pin an exact version, `cleanup` refuses while a sidecar is pending, and byte-destructive paths are guarded to objects absent from the live manifest. `Serving` is now a one-way door: a permanent failure is `Blocked { retry_at: None }` — writes blocked, reads intact. `Unavailable` is reachable only from `Opening`.

**A newer recovery request could be clobbered.** Attempts read state, refresh without the entry lock, then store a result derived from that read; the success path re-checked only that the graph was still `Serving`, which every write state satisfies. Entries now carry a generation, bumped per trigger and captured after the permit, and an attempt publishes only if it still holds.

**Backoff never escalated.** Coalescing reset `attempts` to zero, so sustained write traffic held the supervisor at its shortest delay indefinitely — each retry a full recovery sweep whose cost grows with commit depth. Coalescing now preserves the attempt count and any scheduled deadline.

**Attempts were unbounded in time and awaited inline**, holding one of four permits. Four graphs stalled on an unresponsive store starved every other graph, and the loop saw neither shutdown nor new notifications while one ran. Wrapping the attempt in a timeout would be wrong — a recovery mutates durable state under an armed sidecar, and dropping that future mid-restore is exactly what the tracked-write executor exists to prevent. So the 240s deadline bounds the **wait**, not the work: attempts are spawned into a `TaskTracker` the set owns, run to a terminal result, and publish under their own generation check. The loop starts no second attempt for a graph while one is in flight.

Also: typed `GraphState` with one conversion to the wire form (replacing a `&'static str` re-parsed by two matches that each silently reported "unavailable" for anything unrecognised); public 503s carry graph id and class only, never backend text, since that response is built in middleware ahead of any per-graph policy check; `Retry-After` only when a retry is actually scheduled; a graph-local invalid URI becomes an unavailable entry instead of aborting the process; one process-global attempt-permit pool; and `SupervisorSet::idle()` is removed so a live write executor can never be paired with a set that has no consumer for its wake-ups.

## Verification

- Classification mapping across all four storage kinds, including that retryable stays retryable.
- `a_trigger_arriving_mid_attempt_is_not_clobbered` — drives the race through the attempt seam.
- `coalescing_preserves_the_backoff_ladder`; `a_permanent_recovery_failure_keeps_reads_available`.
- Public 503 asserts graph id + class and nothing else.
- `cargo test --workspace --locked --features omnigraph-engine/failpoints,omnigraph-cluster/failpoints` — 75 suites, zero failures.
- Workspace Clippy with warnings denied; `cargo fmt --all --check`.

## Known, deliberate

`mark_recovering` still has no production caller *at this commit* — the caller is the tracked-write executor in #490. Reviewers checking this PR in isolation will correctly observe that the recovery half of the state machine has no producer yet; that is a property of the stack split, not a defect.

Cluster-quarantined graphs (recovery sidecars) are still filtered before settings are built, so they 404 rather than 503. Converting them to configured entries is follow-up work.

No storage-format migration.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR retains all configured graphs in the registry and supervises opening and recovery independently while exposing bounded availability metadata.
- Adds atomic graph runtime states, retry classification, jittered backoff, and process-wide attempt limiting.
- Returns structured unavailable-graph responses and configured graph status through the HTTP API.
- Allows default boot with no healthy graphs while preserving strict all-graph startup.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the previously reported backend-diagnostic disclosure has been removed and no blocking failure remains.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/omnigraph-server/src/lib.rs | Integrates configured-registry startup and emits unavailable responses using bounded state and failure-class values rather than backend diagnostics. |
| crates/omnigraph-server/src/registry.rs | Introduces immutable configured entries with atomically readable serving, recovery, and unavailable runtime states. |
| crates/omnigraph-server/src/supervisor.rs | Implements bounded per-graph opening and recovery attempts with classification, coalescing, and retry backoff. |
| crates/omnigraph-server/src/handlers.rs | Lists configured graph availability and distinguishes unavailable configured graphs from unknown IDs. |
| crates/omnigraph-api-types/src/lib.rs | Adds shared graph-state and structured unavailable-response DTOs. |
| openapi.json | Updates the published API schema for graph status and unavailable responses. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Auth
    participant Registry
    participant Supervisor
    participant Engine
    Client->>Auth: "Request /graphs/{id}/..."
    Auth->>Registry: Resolve configured graph
    alt Graph is serving
        Registry-->>Client: Dispatch with live handle
    else Graph is opening or unavailable
        Registry-->>Client: 503 graph_unavailable
    end
    Supervisor->>Engine: Open or refresh
    alt Attempt succeeds
        Engine-->>Supervisor: Healthy handle
        Supervisor->>Registry: Mark ready
    else Retryable failure
        Engine-->>Supervisor: Classified failure
        Supervisor->>Registry: Publish retry metadata
        Supervisor->>Supervisor: Full-jitter backoff
    else Permanent failure
        Engine-->>Supervisor: Non-retryable failure
        Supervisor->>Registry: Mark unavailable/degraded
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(server): give every AppState a live ..."](https://github.com/modernrelay/omnigraph/commit/3fb26d8f78d01790b87a7da0dfb2f3dff4ee5bc8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52410932)</sub>

**Context used:**

- Knowledge Base — [Server Request Handling](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/server-request-handling.md)
- Knowledge Base — [CLI and Config](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/cli-and-config.md)

<!-- /greptile_comment -->