### PR TITLE
Carry a typed classification on storage failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5125,6 +5125,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sha2 0.10.9",
+ "snafu",
  "syn",
  "tempfile",
  "thiserror",

--- a/crates/omnigraph-server/src/lib.rs
+++ b/crates/omnigraph-server/src/lib.rs
@@ -918,7 +918,7 @@ impl ApiError {
                 format!("recovery required for operation {operation_id}: {reason}"),
                 operation_id,
             ),
-            OmniError::Lance(message) => Self::internal(format!("storage: {message}")),
+            OmniError::Storage(failure) => Self::internal(format!("storage: {failure}")),
             OmniError::RetryableCommitConflict(message) => {
                 Self::conflict(format!("retryable storage commit conflict: {message}"))
             }
@@ -934,6 +934,11 @@ impl ApiError {
             // single canonical translation when a future runtime
             // create endpoint lands.
             err @ OmniError::AlreadyInitialized { .. } => Self::conflict(err.to_string()),
+            // `OmniError` is `#[non_exhaustive]`: a variant added by a newer
+            // engine must not stop this crate from compiling. Every arm above
+            // is an explicit, reviewed translation; anything unrecognised is an
+            // internal failure until it gets one.
+            err => Self::internal(err.to_string()),
         }
     }
 }

--- a/crates/omnigraph-storage/src/lib.rs
+++ b/crates/omnigraph-storage/src/lib.rs
@@ -34,16 +34,177 @@ pub struct ListDirBounds {
     pub max_uri_bytes: u64,
 }
 
+/// How a storage-layer failure should be treated by a caller deciding whether
+/// to retry, reconfigure, or escalate.
+///
+/// This models the *decision*, not the upstream taxonomy. `object_store` and
+/// Lance error enums are deliberately not re-exported through it: doing so
+/// would make every substrate bump a semver break for consumers of this crate
+/// and of the engine. Classification is derived once, at each substrate
+/// boundary, and travels as this enum from there on. Nothing above the
+/// boundary parses error text.
+///
+/// Closed on purpose. Adding a discriminant should be a compile error at every
+/// consumer that switches on it, so a new class cannot silently land in an
+/// existing bucket.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StorageFailureKind {
+    /// Transport failure, timeout, throttling, or retry-budget exhaustion. The
+    /// same call may succeed later; no durable effect is implied either way.
+    Transient,
+    /// Credentials, permissions, an unsupported operation, or a malformed URI.
+    /// Retrying with the same configuration cannot succeed.
+    Configuration,
+    /// The object, dataset, version, or ref genuinely does not exist.
+    NotFound,
+    /// Corruption, a schema mismatch, or a substrate-internal failure. Never
+    /// retry; escalate.
+    Permanent,
+}
+
+impl StorageFailureKind {
+    /// Whether a bounded retry of the same call can plausibly succeed.
+    pub fn is_transient(self) -> bool {
+        matches!(self, Self::Transient)
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Transient => "transient",
+            Self::Configuration => "configuration",
+            Self::NotFound => "not_found",
+            Self::Permanent => "permanent",
+        }
+    }
+}
+
+/// A classified storage-layer failure plus the operator-facing message.
+///
+/// The message keeps the substrate's own wording so diagnostics are unchanged;
+/// `kind` is what callers switch on.
+#[derive(Debug, Clone, Error)]
+#[error("{message}")]
+pub struct StorageFailure {
+    pub kind: StorageFailureKind,
+    pub message: String,
+}
+
+impl StorageFailure {
+    pub fn new(kind: StorageFailureKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
+
+    /// Prefix caller context onto an already-classified failure. The
+    /// classification is preserved — context never changes what a failure is.
+    pub fn with_context(mut self, context: impl std::fmt::Display) -> Self {
+        self.message = format!("{context}: {}", self.message);
+        self
+    }
+}
+
+/// Depth bound for the source walk under `object_store::Error::Generic`.
+const MAX_IO_SOURCE_DEPTH: usize = 8;
+
+/// Recover a classification from a `std::io::Error` in an error's source chain.
+///
+/// `None` means the chain held no `io::Error`, or held one whose kind does not
+/// determine the answer — the caller keeps its own default rather than being
+/// handed a guess.
+fn classify_io_source(
+    source: &(dyn std::error::Error + 'static),
+    depth: usize,
+) -> Option<StorageFailureKind> {
+    if depth >= MAX_IO_SOURCE_DEPTH {
+        return None;
+    }
+    if let Some(error) = source.downcast_ref::<std::io::Error>() {
+        return match error.kind() {
+            std::io::ErrorKind::NotFound => Some(StorageFailureKind::NotFound),
+            std::io::ErrorKind::PermissionDenied
+            | std::io::ErrorKind::InvalidInput
+            | std::io::ErrorKind::InvalidData
+            | std::io::ErrorKind::Unsupported
+            | std::io::ErrorKind::AlreadyExists => Some(StorageFailureKind::Configuration),
+            std::io::ErrorKind::TimedOut
+            | std::io::ErrorKind::Interrupted
+            | std::io::ErrorKind::WouldBlock
+            | std::io::ErrorKind::ConnectionReset
+            | std::io::ErrorKind::ConnectionAborted
+            | std::io::ErrorKind::ConnectionRefused
+            | std::io::ErrorKind::BrokenPipe
+            | std::io::ErrorKind::NotConnected => Some(StorageFailureKind::Transient),
+            // `io::ErrorKind` is `#[non_exhaustive]` and many local conditions
+            // (`NotADirectory`, `ReadOnlyFilesystem`, `StorageFull`, …) are
+            // still unstable or platform-specific. Reading the raw OS error is
+            // the portable way to separate "the path is wrong" from "the disk
+            // hiccuped": a local filesystem does not produce transport errors,
+            // so anything it reports that is not in the transient set above is
+            // a condition retrying cannot fix.
+            _ if error.raw_os_error().is_some() => Some(StorageFailureKind::Configuration),
+            _ => None,
+        };
+    }
+    source
+        .source()
+        .and_then(|inner| classify_io_source(inner, depth + 1))
+}
+
+/// Classify an `object_store` failure.
+///
+/// `Generic` is the bucket every retried-and-exhausted HTTP condition lands in:
+/// `RetryError::error` maps recognised statuses onto dedicated variants
+/// (404/304/412/409/403/401) and routes everything else — 5xx, connection
+/// resets, DNS, TLS, timeouts, budget exhaustion — to `Generic`. Treating it as
+/// transient is therefore the accurate reading, not a guess.
+///
+/// `object_store::Error` is `#[non_exhaustive]`, so the fallthrough is
+/// load-bearing. It resolves to `Transient`: a bounded retry that ultimately
+/// fails is a strictly better outcome than permanently disabling a resource
+/// over a condition this crate has not seen before.
+pub fn classify_object_store_error(error: &object_store::Error) -> StorageFailureKind {
+    match error {
+        // `LocalFileSystem` also routes plain OS errors through `Generic`, so a
+        // permanent local condition (a bad path, a read-only mount) would read
+        // as transient. Inspect the underlying `io::Error` when there is one;
+        // remote stores carry a `RetryError` instead and fall through to
+        // `Transient`, which is the accurate reading for them.
+        object_store::Error::Generic { source, .. } => {
+            classify_io_source(source.as_ref(), 0).unwrap_or(StorageFailureKind::Transient)
+        }
+        object_store::Error::JoinError { .. } => StorageFailureKind::Transient,
+        object_store::Error::NotFound { .. } | object_store::Error::NotModified { .. } => {
+            StorageFailureKind::NotFound
+        }
+        object_store::Error::PermissionDenied { .. }
+        | object_store::Error::Unauthenticated { .. }
+        | object_store::Error::NotSupported { .. }
+        | object_store::Error::NotImplemented { .. }
+        | object_store::Error::InvalidPath { .. }
+        | object_store::Error::UnknownConfigurationKey { .. } => StorageFailureKind::Configuration,
+        object_store::Error::Precondition { .. } | object_store::Error::AlreadyExists { .. } => {
+            StorageFailureKind::Permanent
+        }
+        _ => StorageFailureKind::Transient,
+    }
+}
+
 /// Backend-neutral failure from the shared control-object storage boundary.
 ///
 /// `Internal` preserves the engine's historical manifest-internal message
 /// verbatim when converted by the compatibility facade. `Io` remains distinct
 /// so local recursive-delete failures keep the engine's established `io: ...`
-/// display and error classification.
+/// display and error classification. `Backend` carries a classified failure
+/// from the object store itself, so callers can distinguish a transient
+/// transport condition from a permanent one without parsing text.
 #[derive(Debug, Error)]
 pub enum StorageError {
     #[error("{0}")]
     Internal(String),
+    #[error("{0}")]
+    Backend(StorageFailure),
     #[error("io: {0}")]
     Io(#[from] std::io::Error),
     #[error("storage resource '{resource}' for '{uri}' exceeds limit {limit} (actual {actual})")]
@@ -1008,8 +1169,15 @@ fn parse_s3_uri(uri: &str) -> Result<S3Location> {
     })
 }
 
-fn storage_backend_error(action: &str, uri: &str, err: impl std::fmt::Display) -> StorageError {
-    StorageError::internal(format!("storage {} failed for '{}': {}", action, uri, err))
+/// The one place an `object_store` failure crosses into this crate's error
+/// type. Taking the typed value rather than `impl Display` is what lets the
+/// classification survive the boundary; the message is unchanged.
+fn storage_backend_error(action: &str, uri: &str, err: object_store::Error) -> StorageError {
+    let kind = classify_object_store_error(&err);
+    StorageError::Backend(StorageFailure::new(
+        kind,
+        format!("storage {} failed for '{}': {}", action, uri, err),
+    ))
 }
 
 fn normalize_local_path(path: &Path) -> String {
@@ -1039,6 +1207,64 @@ fn env_var_truthy(key: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The classification an operator's availability depends on. `Generic` is
+    /// where `object_store` puts every retried-and-exhausted HTTP condition,
+    /// so reading it as anything but transient would turn an S3 blip into a
+    /// permanent outage.
+    #[test]
+    fn object_store_failures_classify_by_variant_not_by_message() {
+        assert_eq!(
+            classify_object_store_error(&object_store::Error::Generic {
+                store: "S3",
+                source: "503 Service Unavailable".into(),
+            }),
+            StorageFailureKind::Transient
+        );
+        assert_eq!(
+            classify_object_store_error(&object_store::Error::NotFound {
+                path: "graph/__manifest".to_string(),
+                source: "absent".into(),
+            }),
+            StorageFailureKind::NotFound
+        );
+        assert_eq!(
+            classify_object_store_error(&object_store::Error::PermissionDenied {
+                path: "graph/__manifest".to_string(),
+                source: "expired credentials".into(),
+            }),
+            StorageFailureKind::Configuration
+        );
+        assert_eq!(
+            classify_object_store_error(&object_store::Error::Precondition {
+                path: "graph/__manifest".to_string(),
+                source: "etag mismatch".into(),
+            }),
+            StorageFailureKind::Permanent
+        );
+    }
+
+    #[test]
+    fn backend_errors_keep_their_classification_and_message() {
+        let error = storage_backend_error(
+            "read",
+            "s3://bucket/graph/__manifest",
+            object_store::Error::Generic {
+                store: "S3",
+                source: "connection reset".into(),
+            },
+        );
+        let StorageError::Backend(failure) = &error else {
+            panic!("an object-store failure must cross the boundary classified");
+        };
+        assert_eq!(failure.kind, StorageFailureKind::Transient);
+        // The operator-facing wording is unchanged by classification.
+        assert!(
+            failure
+                .message
+                .starts_with("storage read failed for 's3://bucket/graph/__manifest': ")
+        );
+    }
 
     /// The executable backend contract: every assertion here must hold for
     /// EVERY backend (the divergence class this adapter closed was "two
@@ -1735,9 +1961,47 @@ mod tests {
         let err = StorageAdapter::write_text_if_absent(&adapter, &uri, "x")
             .await
             .expect_err("staging under a regular file must fail");
-        assert!(
-            matches!(err, StorageError::Internal(ref message) if message.contains("write_if_absent")),
-            "got: {err}"
+        let StorageError::Backend(failure) = &err else {
+            panic!("got: {err}");
+        };
+        assert!(failure.message.contains("write_if_absent"), "got: {err}");
+        // A wrong path is not something retrying fixes. `LocalFileSystem`
+        // reports it through `Generic`, so this also pins that local OS errors
+        // are not mistaken for the transport conditions `Generic` carries on a
+        // remote store.
+        assert_eq!(failure.kind, StorageFailureKind::Configuration);
+    }
+
+    /// The local and remote readings of `Generic` must stay distinguishable:
+    /// a remote transport failure has to remain retryable even though a local
+    /// OS error arrives through the same variant.
+    #[test]
+    fn remote_generic_failures_stay_transient_while_local_os_errors_do_not() {
+        let remote = object_store::Error::Generic {
+            store: "S3",
+            source: "503 Service Unavailable".into(),
+        };
+        assert_eq!(
+            classify_object_store_error(&remote),
+            StorageFailureKind::Transient
+        );
+
+        let local = object_store::Error::Generic {
+            store: "LocalFileSystem",
+            source: Box::new(std::io::Error::from(std::io::ErrorKind::PermissionDenied)),
+        };
+        assert_eq!(
+            classify_object_store_error(&local),
+            StorageFailureKind::Configuration
+        );
+
+        let local_transient = object_store::Error::Generic {
+            store: "LocalFileSystem",
+            source: Box::new(std::io::Error::from(std::io::ErrorKind::Interrupted)),
+        };
+        assert_eq!(
+            classify_object_store_error(&local_transient),
+            StorageFailureKind::Transient
         );
     }
 }

--- a/crates/omnigraph/Cargo.toml
+++ b/crates/omnigraph/Cargo.toml
@@ -64,6 +64,10 @@ lance-namespace-impls = { workspace = true }
 lance-io = { version = "9.0.0", features = ["test-util"] }
 serial_test = "3"
 proptest = "1"
+# Lance's error variants are snafu-generated. The error-classification tests
+# construct the exact upstream shapes rather than approximations, so a Lance
+# change to those shapes fails the build instead of silently drifting.
+snafu = "0.9"
 syn = { version = "2", features = ["full", "visit"] }
 # benches/scenarios.rs: wait4/rusage peak-RSS and benchmark memory caps.
 libc = "0.2"

--- a/crates/omnigraph/src/branch_control.rs
+++ b/crates/omnigraph/src/branch_control.rs
@@ -28,7 +28,7 @@ pub(crate) enum BranchCreateOutcome {
 }
 
 fn lance_error(error: lance::Error) -> OmniError {
-    OmniError::Lance(error.to_string())
+    OmniError::from(error)
 }
 
 /// Pinned Lance treats an already-absent target tree as success. OmniGraph

--- a/crates/omnigraph/src/db/manifest.rs
+++ b/crates/omnigraph/src/db/manifest.rs
@@ -174,17 +174,13 @@ pub struct SnapshotScanner {
 impl SnapshotScanner {
     /// Select the output columns.
     pub fn project<T: AsRef<str>>(&mut self, columns: &[T]) -> Result<&mut Self> {
-        self.scanner
-            .project(columns)
-            .map_err(|error| OmniError::Lance(error.to_string()))?;
+        self.scanner.project(columns).map_err(OmniError::from)?;
         Ok(self)
     }
 
     /// Apply a SQL filter expression.
     pub fn filter(&mut self, filter: &str) -> Result<&mut Self> {
-        self.scanner
-            .filter(filter)
-            .map_err(|error| OmniError::Lance(error.to_string()))?;
+        self.scanner.filter(filter).map_err(OmniError::from)?;
         Ok(self)
     }
 
@@ -220,9 +216,7 @@ impl SnapshotScanner {
 
     /// Apply a row limit and offset.
     pub fn limit(&mut self, limit: Option<i64>, offset: Option<i64>) -> Result<&mut Self> {
-        self.scanner
-            .limit(limit, offset)
-            .map_err(|error| OmniError::Lance(error.to_string()))?;
+        self.scanner.limit(limit, offset).map_err(OmniError::from)?;
         Ok(self)
     }
 
@@ -243,7 +237,7 @@ impl SnapshotScanner {
         self.scanner
             .try_into_stream()
             .await
-            .map_err(|error| OmniError::Lance(error.to_string()))
+            .map_err(OmniError::from)
     }
 }
 
@@ -264,7 +258,7 @@ impl SnapshotTable {
         self.dataset
             .count_rows(filter)
             .await
-            .map_err(|error| OmniError::Lance(error.to_string()))
+            .map_err(OmniError::from)
     }
 
     /// Lance schema of this pinned table version.
@@ -279,10 +273,7 @@ impl SnapshotTable {
 
     /// Read-only physical index metadata for this pinned table version.
     pub async fn load_indices(&self) -> Result<Arc<Vec<IndexMetadata>>> {
-        self.dataset
-            .load_indices()
-            .await
-            .map_err(|error| OmniError::Lance(error.to_string()))
+        self.dataset.load_indices().await.map_err(OmniError::from)
     }
 
     /// Whether `column` has complete usable BTREE coverage.
@@ -490,18 +481,12 @@ async fn probe_dataset_latest_incarnation(
 ) -> Result<ManifestIncarnation> {
     if active_branch.is_none() {
         return Ok(ManifestIncarnation {
-            version: dataset
-                .latest_version_id()
-                .await
-                .map_err(|e| OmniError::Lance(e.to_string()))?,
+            version: dataset.latest_version_id().await.map_err(OmniError::from)?,
             e_tag: dataset.manifest_location().e_tag.clone(),
             timestamp_nanos: Some(dataset.manifest().timestamp_nanos),
         });
     }
-    let (manifest, location) = dataset
-        .latest_manifest()
-        .await
-        .map_err(|e| OmniError::Lance(e.to_string()))?;
+    let (manifest, location) = dataset.latest_manifest().await.map_err(OmniError::from)?;
     Ok(ManifestIncarnation {
         version: manifest.version,
         e_tag: location.e_tag,
@@ -1043,7 +1028,7 @@ impl ManifestCoordinator {
         self.dataset
             .latest_version_id()
             .await
-            .map_err(|error| OmniError::Lance(error.to_string()))
+            .map_err(OmniError::from)
     }
 
     /// Lance-native stable identity for the active manifest branch. Unlike a
@@ -1053,7 +1038,7 @@ impl ManifestCoordinator {
         self.dataset
             .branch_identifier()
             .await
-            .map_err(|e| OmniError::Lance(e.to_string()))
+            .map_err(OmniError::from)
     }
 
     /// Exact materialized `graph_head:<active-branch>` from the same pinned
@@ -1109,10 +1094,7 @@ impl ManifestCoordinator {
 
     pub(crate) async fn delete_branch(&mut self, name: &str) -> Result<()> {
         let mut ds = self.open_branch_control_dataset().await?;
-        let branches = ds
-            .list_branches()
-            .await
-            .map_err(|error| OmniError::Lance(error.to_string()))?;
+        let branches = ds.list_branches().await.map_err(OmniError::from)?;
         let expected_identifier = branches
             .get(name)
             .ok_or_else(|| OmniError::manifest_not_found(format!("branch '{}' not found", name)))?
@@ -1145,7 +1127,7 @@ impl ManifestCoordinator {
             .dataset
             .list_branches()
             .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+            .map_err(OmniError::from)?;
         let mut names: Vec<String> = branches.into_keys().filter(|name| name != "main").collect();
         names.sort();
         let mut all = vec!["main".to_string()];
@@ -1158,7 +1140,7 @@ impl ManifestCoordinator {
             .dataset
             .list_branches()
             .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+            .map_err(OmniError::from)?;
         let mut frontier = vec![name.to_string()];
         let mut descendants = Vec::new();
         let mut seen = HashSet::new();

--- a/crates/omnigraph/src/db/manifest/graph.rs
+++ b/crates/omnigraph/src/db/manifest/graph.rs
@@ -65,11 +65,11 @@ pub(super) async fn init_manifest_graph(
     let manifest_path = manifest_uri(root);
     let mut dataset = Dataset::write(reader, &manifest_path, Some(params))
         .await
-        .map_err(|e| OmniError::Lance(e.to_string()))?;
+        .map_err(OmniError::from)?;
     dataset
         .update_config([(TABLE_VERSION_MANAGEMENT_KEY, Some("true"))])
         .await
-        .map_err(|e| OmniError::Lance(e.to_string()))?;
+        .map_err(OmniError::from)?;
     stamp_current_version(&mut dataset).await?;
 
     let (known_state, lineage_rows) = read_manifest_state_and_lineage(&dataset).await?;
@@ -115,7 +115,7 @@ pub(super) async fn snapshot_state_at(
     let dataset = dataset
         .checkout_version(version)
         .await
-        .map_err(|e| OmniError::Lance(e.to_string()))?;
+        .map_err(OmniError::from)?;
     read_manifest_state(&dataset).await
 }
 
@@ -222,7 +222,7 @@ async fn create_empty_dataset(
     };
     Dataset::write(reader, uri, Some(params))
         .await
-        .map_err(|e| OmniError::Lance(e.to_string()))
+        .map_err(OmniError::from)
 }
 
 fn keyed_graph_table_schema(schema: &SchemaRef) -> Result<SchemaRef> {

--- a/crates/omnigraph/src/db/manifest/layout.rs
+++ b/crates/omnigraph/src/db/manifest/layout.rs
@@ -37,7 +37,7 @@ pub(super) async fn open_manifest_dataset_with_session(
         Some(branch) if branch != "main" => dataset
             .checkout_branch(branch)
             .await
-            .map_err(|e| OmniError::Lance(e.to_string())),
+            .map_err(OmniError::from),
         _ => Ok(dataset),
     }
 }

--- a/crates/omnigraph/src/db/manifest/metadata.rs
+++ b/crates/omnigraph/src/db/manifest/metadata.rs
@@ -249,15 +249,12 @@ pub(super) async fn table_version_metadata_for_state(
     )
     .await?;
     let ds = match branch {
-        Some(branch) => ds
-            .checkout_branch(branch)
-            .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?,
+        Some(branch) => ds.checkout_branch(branch).await.map_err(OmniError::from)?,
         None => ds,
     };
     let ds = ds
         .checkout_version(version)
         .await
-        .map_err(|e| OmniError::Lance(e.to_string()))?;
+        .map_err(OmniError::from)?;
     TableVersionMetadata::from_dataset(root_uri, table_path, &ds)
 }

--- a/crates/omnigraph/src/db/manifest/migrations.rs
+++ b/crates/omnigraph/src/db/manifest/migrations.rs
@@ -159,7 +159,7 @@ async fn set_stamp(dataset: &mut Dataset, version: u32) -> Result<()> {
     dataset
         .update_schema_metadata([(INTERNAL_SCHEMA_VERSION_KEY.to_string(), version.to_string())])
         .await
-        .map_err(|e| OmniError::Lance(e.to_string()))?;
+        .map_err(OmniError::from)?;
     Ok(())
 }
 

--- a/crates/omnigraph/src/db/manifest/namespace.rs
+++ b/crates/omnigraph/src/db/manifest/namespace.rs
@@ -127,9 +127,7 @@ impl StagedTableNamespace {
         if ds.version().version == version {
             Ok(ds)
         } else {
-            ds.checkout_version(version)
-                .await
-                .map_err(|e| OmniError::Lance(e.to_string()))
+            ds.checkout_version(version).await.map_err(OmniError::from)
         }
     }
 

--- a/crates/omnigraph/src/db/manifest/publisher.rs
+++ b/crates/omnigraph/src/db/manifest/publisher.rs
@@ -300,7 +300,7 @@ impl GraphNamespacePublisher {
                         registration.identity,
                     )?;
                     if canonical_path != registration.table_path {
-                        return Err(OmniError::Lance(
+                        return Err(OmniError::storage_permanent(
                             NamespaceError::ConcurrentModification {
                                 message: format!(
                                     "table {} identity {} must use canonical path {}, got {}",
@@ -317,7 +317,7 @@ impl GraphNamespacePublisher {
                         if existing == registration {
                             continue;
                         }
-                        return Err(OmniError::Lance(
+                        return Err(OmniError::storage_permanent(
                             NamespaceError::ConcurrentModification {
                                 message: format!(
                                     "table identity {} is already registered as {} at {}",
@@ -359,7 +359,7 @@ impl GraphNamespacePublisher {
                         )));
                     }
                     let existing = known_tables.get(identity).ok_or_else(|| {
-                        OmniError::Lance(
+                        OmniError::storage_permanent(
                             NamespaceError::TableNotFound {
                                 message: format!("table identity {identity} not found"),
                             }
@@ -367,7 +367,7 @@ impl GraphNamespacePublisher {
                         )
                     })?;
                     if !Self::is_live_identity(*identity, existing_versions, existing_tombstones) {
-                        return Err(OmniError::Lance(
+                        return Err(OmniError::storage_permanent(
                             NamespaceError::TableNotFound {
                                 message: format!(
                                     "live table identity {identity} not found for rename"
@@ -424,10 +424,9 @@ impl GraphNamespacePublisher {
                     update.identity.validate()?;
                     let request = update.to_create_table_version_request();
                     let (table_key, table_version, row_count, table_branch, version_metadata) =
-                        parse_namespace_version_request(&request)
-                            .map_err(|e| OmniError::Lance(e.to_string()))?;
+                        parse_namespace_version_request(&request).map_err(OmniError::from)?;
                     let registration = known_tables.get(&update.identity).ok_or_else(|| {
-                        OmniError::Lance(
+                        OmniError::storage_permanent(
                             NamespaceError::TableNotFound {
                                 message: format!("table identity {} not found", update.identity),
                             }
@@ -435,7 +434,7 @@ impl GraphNamespacePublisher {
                         )
                     })?;
                     if registration.table_key != table_key {
-                        return Err(OmniError::Lance(
+                        return Err(OmniError::storage_permanent(
                             NamespaceError::ConcurrentModification {
                                 message: format!(
                                     "table identity {} is bound to {}, not {}",
@@ -449,7 +448,7 @@ impl GraphNamespacePublisher {
                         .insert((update.identity, table_version), ())
                         .is_some()
                     {
-                        return Err(OmniError::Lance(
+                        return Err(OmniError::storage_permanent(
                             NamespaceError::ConcurrentModification {
                                 message: format!(
                                     "table version {} already exists for identity {} ({})",
@@ -464,7 +463,7 @@ impl GraphNamespacePublisher {
                         let is_owner_branch_handoff = existing.row_count == row_count
                             && existing.table_branch != table_branch;
                         if !is_owner_branch_handoff {
-                            return Err(OmniError::Lance(
+                            return Err(OmniError::storage_permanent(
                                 NamespaceError::ConcurrentModification {
                                     message: format!(
                                         "table version {} already exists for identity {} ({})",
@@ -495,7 +494,7 @@ impl GraphNamespacePublisher {
                 }) => {
                     identity.validate()?;
                     let registration = known_tables.get(identity).ok_or_else(|| {
-                        OmniError::Lance(
+                        OmniError::storage_permanent(
                             NamespaceError::TableNotFound {
                                 message: format!("table identity {identity} not found"),
                             }
@@ -503,7 +502,7 @@ impl GraphNamespacePublisher {
                         )
                     })?;
                     if registration.table_key != *table_key {
-                        return Err(OmniError::Lance(
+                        return Err(OmniError::storage_permanent(
                             NamespaceError::ConcurrentModification {
                                 message: format!(
                                     "table identity {identity} is bound to {}, not {}",
@@ -514,7 +513,7 @@ impl GraphNamespacePublisher {
                         ));
                     }
                     if existing_tombstones.contains_key(&(*identity, *tombstone_version)) {
-                        return Err(OmniError::Lance(
+                        return Err(OmniError::storage_permanent(
                             NamespaceError::ConcurrentModification {
                                 message: format!(
                                     "table tombstone {} already exists for identity {} ({})",
@@ -889,7 +888,7 @@ impl GraphNamespacePublisher {
                     None,
                 ));
             }
-            Err(err) => return Err(OmniError::Lance(err.to_string())),
+            Err(err) => return Err(OmniError::from(err)),
         };
         if actual_branch_identifier != expected.branch_identifier {
             let actual = serde_json::to_string(&actual_branch_identifier).map_err(|e| {
@@ -924,7 +923,7 @@ impl GraphNamespacePublisher {
         let reader = RecordBatchIterator::new(vec![Ok(batch)], manifest_schema());
         let dataset = Arc::new(dataset);
         let mut merge_builder = MergeInsertBuilder::try_new(dataset, vec!["object_id".to_string()])
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+            .map_err(OmniError::from)?;
         merge_builder.when_matched(WhenMatched::UpdateAll);
         merge_builder.when_not_matched(WhenNotMatched::InsertAll);
         // 0 here is intentional: Lance's built-in retry uses transparent rebase,
@@ -941,7 +940,7 @@ impl GraphNamespacePublisher {
         merge_builder.skip_auto_cleanup(true);
         let (new_dataset, _stats) = merge_builder
             .try_build()
-            .map_err(|e| OmniError::Lance(e.to_string()))?
+            .map_err(OmniError::from)?
             .execute_reader(Box::new(reader))
             .await
             .map_err(map_lance_publish_error)?;
@@ -958,8 +957,7 @@ impl GraphNamespacePublisher {
             .iter()
             .map(|request| {
                 let (table_key, table_version, row_count, table_branch, version_metadata) =
-                    parse_namespace_version_request(request)
-                        .map_err(|e| OmniError::Lance(e.to_string()))?;
+                    parse_namespace_version_request(request).map_err(OmniError::from)?;
                 let identity = registrations
                     .values()
                     .find(|registration| registration.table_key == table_key)
@@ -1024,7 +1022,7 @@ pub(crate) fn map_lance_publish_error(err: LanceError) -> OmniError {
             err
         ));
     }
-    OmniError::Lance(err.to_string())
+    OmniError::from(err)
 }
 
 #[async_trait]

--- a/crates/omnigraph/src/db/manifest/recovery.rs
+++ b/crates/omnigraph/src/db/manifest/recovery.rs
@@ -2981,20 +2981,14 @@ pub(crate) async fn restore_table_to_version(
     )
     .await?;
     let head = match branch {
-        Some(b) if b != "main" => head
-            .checkout_branch(b)
-            .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?,
+        Some(b) if b != "main" => head.checkout_branch(b).await.map_err(OmniError::from)?,
         _ => head,
     };
     let mut to_restore = head
         .checkout_version(target_version)
         .await
-        .map_err(|e| OmniError::Lance(e.to_string()))?;
-    to_restore
-        .restore()
-        .await
-        .map_err(|e| OmniError::Lance(e.to_string()))?;
+        .map_err(OmniError::from)?;
+    to_restore.restore().await.map_err(OmniError::from)?;
     Ok(())
 }
 
@@ -4230,10 +4224,7 @@ async fn observe_branch_merge_target_ref(
         .as_deref()
         .filter(|branch| *branch != "main")
     else {
-        let branch_identifier = dataset
-            .branch_identifier()
-            .await
-            .map_err(|error| OmniError::Lance(error.to_string()))?;
+        let branch_identifier = dataset.branch_identifier().await.map_err(OmniError::from)?;
         let version = dataset.version().version;
         return Ok(Some(BranchMergeRefObservation {
             dataset,
@@ -4242,17 +4233,14 @@ async fn observe_branch_merge_target_ref(
             parent_version: None,
         }));
     };
-    let branches = dataset
-        .list_branches()
-        .await
-        .map_err(|error| OmniError::Lance(error.to_string()))?;
+    let branches = dataset.list_branches().await.map_err(OmniError::from)?;
     let Some(contents) = branches.get(branch) else {
         return Ok(None);
     };
     let target = dataset
         .checkout_branch(branch)
         .await
-        .map_err(|error| OmniError::Lance(error.to_string()))?;
+        .map_err(OmniError::from)?;
     let version = target.version().version;
     Ok(Some(BranchMergeRefObservation {
         dataset: target,
@@ -4291,15 +4279,12 @@ async fn prove_ensure_indices_create_index_operation(
     }
     for version in first_version..=head {
         let transaction = if version == head {
-            dataset
-                .read_transaction()
-                .await
-                .map_err(|error| OmniError::Lance(error.to_string()))?
+            dataset.read_transaction().await.map_err(OmniError::from)?
         } else {
             dataset
                 .read_transaction_by_version(version)
                 .await
-                .map_err(|error| OmniError::Lance(error.to_string()))?
+                .map_err(OmniError::from)?
         };
         let Some(transaction) = transaction else {
             return Ok(false);
@@ -4373,13 +4358,13 @@ async fn prove_branch_merge_multi_commit_effect(
                 .dataset
                 .read_transaction()
                 .await
-                .map_err(|error| OmniError::Lance(error.to_string()))?
+                .map_err(OmniError::from)?
         } else {
             observation
                 .dataset
                 .read_transaction_by_version(version)
                 .await
-                .map_err(|error| OmniError::Lance(error.to_string()))?
+                .map_err(OmniError::from)?
         };
         let Some(transaction) = transaction else {
             return Ok(BranchMergeMultiCommitProof::unverifiable(format!(
@@ -4789,10 +4774,7 @@ async fn roll_back_ensure_indices_v8(
             crate::instrumentation::table_wrapper(),
         )
         .await?;
-        let branches = dataset
-            .list_branches()
-            .await
-            .map_err(|error| OmniError::Lance(error.to_string()))?;
+        let branches = dataset.list_branches().await.map_err(OmniError::from)?;
         if let Some(child) = crate::branch_control::path_descendant(&branches, target_branch) {
             return Err(OmniError::manifest_internal(format!(
                 "EnsureIndices sidecar '{}' cannot reclaim first-touch '{}:{}' while path-child '{}' is live",
@@ -4833,7 +4815,7 @@ async fn roll_back_ensure_indices_v8(
                 let target = dataset
                     .checkout_branch(target_branch)
                     .await
-                    .map_err(|error| OmniError::Lance(error.to_string()))?;
+                    .map_err(OmniError::from)?;
                 if target.version().version != state.lance_head
                     || !prove_ensure_indices_create_index_operation(
                         &target,
@@ -4849,7 +4831,7 @@ async fn roll_back_ensure_indices_v8(
                 dataset
                     .force_delete_branch(target_branch)
                     .await
-                    .map_err(|error| OmniError::Lance(error.to_string()))?;
+                    .map_err(OmniError::from)?;
             }
             EffectOwnership::None => {
                 // An untouched owned fork was removed by the helper above. A
@@ -6196,10 +6178,7 @@ async fn cleanup_unpublished_no_effect_forks(
             crate::instrumentation::table_wrapper(),
         )
         .await?;
-        let branches = dataset
-            .list_branches()
-            .await
-            .map_err(|error| OmniError::Lance(error.to_string()))?;
+        let branches = dataset.list_branches().await.map_err(OmniError::from)?;
         if let Some(child) = crate::branch_control::path_descendant(&branches, target_branch) {
             // Lance cannot reclaim an ancestor tree while a slash-separated
             // path-child remains. Old stores could admit that namespace shape.
@@ -6268,7 +6247,7 @@ async fn cleanup_unpublished_no_effect_forks(
         let target = dataset
             .checkout_branch(target_branch)
             .await
-            .map_err(|error| OmniError::Lance(error.to_string()))?;
+            .map_err(OmniError::from)?;
         if target.version().version != exact_fork_version {
             return Err(OmniError::manifest_internal(format!(
                 "OCC recovery sidecar '{}' cannot discard unpublished fork '{}:{}': \
@@ -6283,7 +6262,7 @@ async fn cleanup_unpublished_no_effect_forks(
         dataset
             .force_delete_branch(target_branch)
             .await
-            .map_err(|error| OmniError::Lance(error.to_string()))?;
+            .map_err(OmniError::from)?;
     }
     Ok(NoEffectForkCleanup::Complete)
 }
@@ -7631,17 +7610,11 @@ async fn roll_forward_all(
         )
         .await?;
         let head_ds = match reg.table_branch.as_deref() {
-            Some(b) if b != "main" => head_ds
-                .checkout_branch(b)
-                .await
-                .map_err(|e| OmniError::Lance(e.to_string()))?,
+            Some(b) if b != "main" => head_ds.checkout_branch(b).await.map_err(OmniError::from)?,
             _ => head_ds,
         };
         let head_version = head_ds.version().version;
-        let row_count = head_ds
-            .count_rows(None)
-            .await
-            .map_err(|e| OmniError::Lance(e.to_string()))? as u64;
+        let row_count = head_ds.count_rows(None).await.map_err(OmniError::from)? as u64;
         let version_metadata = super::metadata::TableVersionMetadata::from_dataset(
             root_uri,
             &reg.table_path,
@@ -7754,24 +7727,15 @@ async fn push_table_update(
     )
     .await?;
     let ds = match branch {
-        Some(b) if b != "main" => ds
-            .checkout_branch(b)
-            .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?,
+        Some(b) if b != "main" => ds.checkout_branch(b).await.map_err(OmniError::from)?,
         _ => ds,
     };
     let ds = match target_version {
-        Some(v) => ds
-            .checkout_version(v)
-            .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?,
+        Some(v) => ds.checkout_version(v).await.map_err(OmniError::from)?,
         None => ds,
     };
     let published_version = ds.version().version;
-    let row_count = ds
-        .count_rows(None)
-        .await
-        .map_err(|e| OmniError::Lance(e.to_string()))? as u64;
+    let row_count = ds.count_rows(None).await.map_err(OmniError::from)? as u64;
     let table_relative_path = super::table_path_for_identity(table_key, identity)?;
     let version_metadata =
         super::metadata::TableVersionMetadata::from_dataset(root_uri, &table_relative_path, &ds)?;
@@ -7869,9 +7833,10 @@ async fn open_lance_head_if_present(
 ) -> Result<Option<LanceHeadObservation>> {
     let ds = if allow_missing_dataset {
         // A schema-v7 first-touch create may crash after writing staged data
-        // files but before committing version one. Preserve Lance's typed
-        // DatasetNotFound distinction here; the shared instrumented opener
-        // intentionally erases it into OmniError::Lance for ordinary callers.
+        // files but before committing version one. Recovery needs absence as a
+        // control-flow branch, not an error: the shared instrumented opener
+        // classifies a missing dataset as `StorageFailureKind::NotFound`, which
+        // is the right disposition for ordinary callers but still an `Err` here.
         let control_session = crate::lance_access::control_session();
         match lance::dataset::builder::DatasetBuilder::from_uri(table_path)
             .with_session(control_session)
@@ -7882,7 +7847,7 @@ async fn open_lance_head_if_present(
             Err(lance::Error::DatasetNotFound { .. } | lance::Error::NotFound { .. }) => {
                 return Ok(None);
             }
-            Err(error) => return Err(OmniError::Lance(error.to_string())),
+            Err(error) => return Err(OmniError::from(error)),
         }
     } else {
         crate::instrumentation::open_dataset(
@@ -7896,24 +7861,17 @@ async fn open_lance_head_if_present(
     let ds = match branch {
         Some(b) if b != "main" => {
             if allow_missing_branch {
-                let branches = ds
-                    .list_branches()
-                    .await
-                    .map_err(|error| OmniError::Lance(error.to_string()))?;
+                let branches = ds.list_branches().await.map_err(OmniError::from)?;
                 if !branches.contains_key(b) {
                     return Ok(None);
                 }
             }
-            ds.checkout_branch(b)
-                .await
-                .map_err(|e| OmniError::Lance(e.to_string()))?
+            ds.checkout_branch(b).await.map_err(OmniError::from)?
         }
         _ => ds,
     };
     let head_transaction = if planned_effect.is_some() {
-        ds.read_transaction()
-            .await
-            .map_err(|error| OmniError::Lance(error.to_string()))?
+        ds.read_transaction().await.map_err(OmniError::from)?
     } else {
         None
     };
@@ -7949,7 +7907,7 @@ async fn open_lance_head_if_present(
                 } else {
                     ds.read_transaction_by_version(version)
                         .await
-                        .map_err(|error| OmniError::Lance(error.to_string()))?
+                        .map_err(OmniError::from)?
                         .as_ref()
                         .map(StagedTransactionIdentity::from)
                 };

--- a/crates/omnigraph/src/db/manifest/state.rs
+++ b/crates/omnigraph/src/db/manifest/state.rs
@@ -409,16 +409,14 @@ async fn read_manifest_scan(dataset: &Dataset, collect_lineage: bool) -> Result<
         "row_count",
     ];
     let mut scanner = dataset.scan();
-    scanner
-        .project(&projection)
-        .map_err(|e| OmniError::Lance(e.to_string()))?;
+    scanner.project(&projection).map_err(OmniError::from)?;
     let batches: Vec<RecordBatch> = scanner
         .try_into_stream()
         .await
-        .map_err(|e| OmniError::Lance(e.to_string()))?
+        .map_err(OmniError::from)?
         .try_collect()
         .await
-        .map_err(|e| OmniError::Lance(e.to_string()))?;
+        .map_err(OmniError::from)?;
 
     let mut table_registrations = HashMap::new();
     let mut version_entries = Vec::new();
@@ -627,10 +625,10 @@ pub(crate) async fn read_graph_lineage(
         .scan()
         .try_into_stream()
         .await
-        .map_err(|e| OmniError::Lance(e.to_string()))?
+        .map_err(OmniError::from)?
         .try_collect()
         .await
-        .map_err(|e| OmniError::Lance(e.to_string()))?;
+        .map_err(OmniError::from)?;
 
     let mut graph_commits = Vec::new();
     let mut graph_heads = HashMap::new();
@@ -921,7 +919,7 @@ pub(super) fn manifest_rows_batch(
             Arc::new(UInt64Array::from(row_counts)),
         ],
     )
-    .map_err(|e| OmniError::Lance(e.to_string()))
+    .map_err(OmniError::from)
 }
 
 pub(super) fn string_column<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a StringArray> {

--- a/crates/omnigraph/src/db/omnigraph.rs
+++ b/crates/omnigraph/src/db/omnigraph.rs
@@ -1798,7 +1798,7 @@ impl Omnigraph {
             .dataset()
             .latest_version_id()
             .await
-            .map_err(|error| OmniError::Lance(error.to_string()))?;
+            .map_err(OmniError::from)?;
         if head < expected_version {
             return Err(OmniError::manifest_internal(format!(
                 "table '{}' Lance HEAD version {} is behind manifest version {}",
@@ -2350,7 +2350,7 @@ impl Omnigraph {
         let mut blobs = ds
             .take_blobs(&[row_id], property)
             .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+            .map_err(OmniError::from)?;
 
         blobs.pop().ok_or_else(|| {
             OmniError::manifest(format!(
@@ -3082,8 +3082,7 @@ fn concat_or_empty_batches(schema: Arc<Schema>, batches: Vec<RecordBatch>) -> Re
         return Ok(batches.into_iter().next().unwrap());
     }
     let batch_schema = batches[0].schema();
-    arrow_select::concat::concat_batches(&batch_schema, &batches)
-        .map_err(|e| OmniError::Lance(e.to_string()))
+    arrow_select::concat::concat_batches(&batch_schema, &batches).map_err(OmniError::from)
 }
 
 fn blob_properties_for_table_key<'a>(
@@ -3141,7 +3140,7 @@ fn blob_description_is_null(descriptions: &StructArray, row: usize) -> Result<bo
     let Some(kind) = kind else {
         return Ok(true);
     };
-    let kind = BlobKind::try_from(kind).map_err(|e| OmniError::Lance(e.to_string()))?;
+    let kind = BlobKind::try_from(kind).map_err(OmniError::from)?;
     if kind != BlobKind::Inline {
         return Ok(false);
     }
@@ -3428,7 +3427,9 @@ fn json_value_from_array(array: &dyn Array, row: usize) -> Result<serde_json::Va
             array
                 .as_any()
                 .downcast_ref::<LargeStringArray>()
-                .ok_or_else(|| OmniError::manifest_internal("expected LargeStringArray".to_string()))?
+                .ok_or_else(|| {
+                    OmniError::manifest_internal("expected LargeStringArray".to_string())
+                })?
                 .value(row)
                 .to_string(),
         )),
@@ -3475,7 +3476,10 @@ fn json_value_from_array(array: &dyn Array, row: usize) -> Result<serde_json::Va
                 .value(row) as f64;
             Ok(serde_json::Value::Number(
                 serde_json::Number::from_f64(value).ok_or_else(|| {
-                    OmniError::manifest_internal(format!("cannot encode f32 value '{}' as JSON", value))
+                    OmniError::manifest_internal(format!(
+                        "cannot encode f32 value '{}' as JSON",
+                        value
+                    ))
                 })?,
             ))
         }
@@ -3487,7 +3491,10 @@ fn json_value_from_array(array: &dyn Array, row: usize) -> Result<serde_json::Va
                 .value(row);
             Ok(serde_json::Value::Number(
                 serde_json::Number::from_f64(value).ok_or_else(|| {
-                    OmniError::manifest_internal(format!("cannot encode f64 value '{}' as JSON", value))
+                    OmniError::manifest_internal(format!(
+                        "cannot encode f64 value '{}' as JSON",
+                        value
+                    ))
                 })?,
             ))
         }
@@ -3518,7 +3525,9 @@ fn json_value_from_array(array: &dyn Array, row: usize) -> Result<serde_json::Va
             array
                 .as_any()
                 .downcast_ref::<LargeBinaryArray>()
-                .ok_or_else(|| OmniError::manifest_internal("expected LargeBinaryArray".to_string()))?
+                .ok_or_else(|| {
+                    OmniError::manifest_internal("expected LargeBinaryArray".to_string())
+                })?
                 .value(row),
         ))),
         DataType::List(_) => {
@@ -3537,7 +3546,9 @@ fn json_value_from_array(array: &dyn Array, row: usize) -> Result<serde_json::Va
             let list = array
                 .as_any()
                 .downcast_ref::<LargeListArray>()
-                .ok_or_else(|| OmniError::manifest_internal("expected LargeListArray".to_string()))?;
+                .ok_or_else(|| {
+                    OmniError::manifest_internal("expected LargeListArray".to_string())
+                })?;
             let values = list.value(row);
             let mut out = Vec::with_capacity(values.len());
             for idx in 0..values.len() {
@@ -3549,7 +3560,9 @@ fn json_value_from_array(array: &dyn Array, row: usize) -> Result<serde_json::Va
             let list = array
                 .as_any()
                 .downcast_ref::<FixedSizeListArray>()
-                .ok_or_else(|| OmniError::manifest_internal("expected FixedSizeListArray".to_string()))?;
+                .ok_or_else(|| {
+                    OmniError::manifest_internal("expected FixedSizeListArray".to_string())
+                })?;
             let values = list.value(row);
             let mut out = Vec::with_capacity(values.len());
             for idx in 0..values.len() {
@@ -3572,8 +3585,8 @@ fn json_value_from_array(array: &dyn Array, row: usize) -> Result<serde_json::Va
             Ok(serde_json::Value::Object(obj))
         }
         _ => {
-            let value = arrow_cast::display::array_value_to_string(array, row)
-                .map_err(|e| OmniError::Lance(e.to_string()))?;
+            let value =
+                arrow_cast::display::array_value_to_string(array, row).map_err(OmniError::from)?;
             Ok(serde_json::Value::String(value))
         }
     }

--- a/crates/omnigraph/src/db/omnigraph.rs
+++ b/crates/omnigraph/src/db/omnigraph.rs
@@ -3420,7 +3420,7 @@ fn json_value_from_array(array: &dyn Array, row: usize) -> Result<serde_json::Va
             array
                 .as_any()
                 .downcast_ref::<StringArray>()
-                .ok_or_else(|| OmniError::Lance("expected StringArray".to_string()))?
+                .ok_or_else(|| OmniError::manifest_internal("expected StringArray".to_string()))?
                 .value(row)
                 .to_string(),
         )),
@@ -3428,7 +3428,7 @@ fn json_value_from_array(array: &dyn Array, row: usize) -> Result<serde_json::Va
             array
                 .as_any()
                 .downcast_ref::<LargeStringArray>()
-                .ok_or_else(|| OmniError::Lance("expected LargeStringArray".to_string()))?
+                .ok_or_else(|| OmniError::manifest_internal("expected LargeStringArray".to_string()))?
                 .value(row)
                 .to_string(),
         )),
@@ -3436,46 +3436,46 @@ fn json_value_from_array(array: &dyn Array, row: usize) -> Result<serde_json::Va
             array
                 .as_any()
                 .downcast_ref::<BooleanArray>()
-                .ok_or_else(|| OmniError::Lance("expected BooleanArray".to_string()))?
+                .ok_or_else(|| OmniError::manifest_internal("expected BooleanArray".to_string()))?
                 .value(row),
         )),
         DataType::Int32 => Ok(serde_json::Value::Number(serde_json::Number::from(
             array
                 .as_any()
                 .downcast_ref::<Int32Array>()
-                .ok_or_else(|| OmniError::Lance("expected Int32Array".to_string()))?
+                .ok_or_else(|| OmniError::manifest_internal("expected Int32Array".to_string()))?
                 .value(row),
         ))),
         DataType::Int64 => Ok(serde_json::Value::Number(serde_json::Number::from(
             array
                 .as_any()
                 .downcast_ref::<Int64Array>()
-                .ok_or_else(|| OmniError::Lance("expected Int64Array".to_string()))?
+                .ok_or_else(|| OmniError::manifest_internal("expected Int64Array".to_string()))?
                 .value(row),
         ))),
         DataType::UInt32 => Ok(serde_json::Value::Number(serde_json::Number::from(
             array
                 .as_any()
                 .downcast_ref::<UInt32Array>()
-                .ok_or_else(|| OmniError::Lance("expected UInt32Array".to_string()))?
+                .ok_or_else(|| OmniError::manifest_internal("expected UInt32Array".to_string()))?
                 .value(row),
         ))),
         DataType::UInt64 => Ok(serde_json::Value::Number(serde_json::Number::from(
             array
                 .as_any()
                 .downcast_ref::<UInt64Array>()
-                .ok_or_else(|| OmniError::Lance("expected UInt64Array".to_string()))?
+                .ok_or_else(|| OmniError::manifest_internal("expected UInt64Array".to_string()))?
                 .value(row),
         ))),
         DataType::Float32 => {
             let value = array
                 .as_any()
                 .downcast_ref::<Float32Array>()
-                .ok_or_else(|| OmniError::Lance("expected Float32Array".to_string()))?
+                .ok_or_else(|| OmniError::manifest_internal("expected Float32Array".to_string()))?
                 .value(row) as f64;
             Ok(serde_json::Value::Number(
                 serde_json::Number::from_f64(value).ok_or_else(|| {
-                    OmniError::Lance(format!("cannot encode f32 value '{}' as JSON", value))
+                    OmniError::manifest_internal(format!("cannot encode f32 value '{}' as JSON", value))
                 })?,
             ))
         }
@@ -3483,11 +3483,11 @@ fn json_value_from_array(array: &dyn Array, row: usize) -> Result<serde_json::Va
             let value = array
                 .as_any()
                 .downcast_ref::<Float64Array>()
-                .ok_or_else(|| OmniError::Lance("expected Float64Array".to_string()))?
+                .ok_or_else(|| OmniError::manifest_internal("expected Float64Array".to_string()))?
                 .value(row);
             Ok(serde_json::Value::Number(
                 serde_json::Number::from_f64(value).ok_or_else(|| {
-                    OmniError::Lance(format!("cannot encode f64 value '{}' as JSON", value))
+                    OmniError::manifest_internal(format!("cannot encode f64 value '{}' as JSON", value))
                 })?,
             ))
         }
@@ -3495,14 +3495,14 @@ fn json_value_from_array(array: &dyn Array, row: usize) -> Result<serde_json::Va
             array
                 .as_any()
                 .downcast_ref::<Date32Array>()
-                .ok_or_else(|| OmniError::Lance("expected Date32Array".to_string()))?
+                .ok_or_else(|| OmniError::manifest_internal("expected Date32Array".to_string()))?
                 .value(row),
         ))),
         DataType::Date64 => Ok(serde_json::Value::Number(serde_json::Number::from(
             array
                 .as_any()
                 .downcast_ref::<Date64Array>()
-                .ok_or_else(|| OmniError::Lance("expected Date64Array".to_string()))?
+                .ok_or_else(|| OmniError::manifest_internal("expected Date64Array".to_string()))?
                 .value(row),
         ))),
         DataType::Binary => Ok(serde_json::Value::String(base64::Engine::encode(
@@ -3510,7 +3510,7 @@ fn json_value_from_array(array: &dyn Array, row: usize) -> Result<serde_json::Va
             array
                 .as_any()
                 .downcast_ref::<BinaryArray>()
-                .ok_or_else(|| OmniError::Lance("expected BinaryArray".to_string()))?
+                .ok_or_else(|| OmniError::manifest_internal("expected BinaryArray".to_string()))?
                 .value(row),
         ))),
         DataType::LargeBinary => Ok(serde_json::Value::String(base64::Engine::encode(
@@ -3518,14 +3518,14 @@ fn json_value_from_array(array: &dyn Array, row: usize) -> Result<serde_json::Va
             array
                 .as_any()
                 .downcast_ref::<LargeBinaryArray>()
-                .ok_or_else(|| OmniError::Lance("expected LargeBinaryArray".to_string()))?
+                .ok_or_else(|| OmniError::manifest_internal("expected LargeBinaryArray".to_string()))?
                 .value(row),
         ))),
         DataType::List(_) => {
             let list = array
                 .as_any()
                 .downcast_ref::<ListArray>()
-                .ok_or_else(|| OmniError::Lance("expected ListArray".to_string()))?;
+                .ok_or_else(|| OmniError::manifest_internal("expected ListArray".to_string()))?;
             let values = list.value(row);
             let mut out = Vec::with_capacity(values.len());
             for idx in 0..values.len() {
@@ -3537,7 +3537,7 @@ fn json_value_from_array(array: &dyn Array, row: usize) -> Result<serde_json::Va
             let list = array
                 .as_any()
                 .downcast_ref::<LargeListArray>()
-                .ok_or_else(|| OmniError::Lance("expected LargeListArray".to_string()))?;
+                .ok_or_else(|| OmniError::manifest_internal("expected LargeListArray".to_string()))?;
             let values = list.value(row);
             let mut out = Vec::with_capacity(values.len());
             for idx in 0..values.len() {
@@ -3549,7 +3549,7 @@ fn json_value_from_array(array: &dyn Array, row: usize) -> Result<serde_json::Va
             let list = array
                 .as_any()
                 .downcast_ref::<FixedSizeListArray>()
-                .ok_or_else(|| OmniError::Lance("expected FixedSizeListArray".to_string()))?;
+                .ok_or_else(|| OmniError::manifest_internal("expected FixedSizeListArray".to_string()))?;
             let values = list.value(row);
             let mut out = Vec::with_capacity(values.len());
             for idx in 0..values.len() {
@@ -3561,7 +3561,7 @@ fn json_value_from_array(array: &dyn Array, row: usize) -> Result<serde_json::Va
             let struct_array = array
                 .as_any()
                 .downcast_ref::<StructArray>()
-                .ok_or_else(|| OmniError::Lance("expected StructArray".to_string()))?;
+                .ok_or_else(|| OmniError::manifest_internal("expected StructArray".to_string()))?;
             let mut obj = serde_json::Map::new();
             for (field_idx, field) in fields.iter().enumerate() {
                 obj.insert(

--- a/crates/omnigraph/src/db/omnigraph/export.rs
+++ b/crates/omnigraph/src/db/omnigraph/export.rs
@@ -307,11 +307,7 @@ where
                 EXPORT_SCAN_TARGET_BYTES,
             )
             .await?;
-        while let Some(batch) = batches
-            .try_next()
-            .await
-            .map_err(|error| OmniError::Lance(error.to_string()))?
-        {
+        while let Some(batch) = batches.try_next().await.map_err(OmniError::from)? {
             emit_export_rows_from_batch(catalog, table_key, &batch, None, emit).await?;
         }
         return Ok(());
@@ -334,11 +330,7 @@ where
             EXPORT_SCAN_TARGET_BYTES,
         )
         .await?;
-    while let Some(batch) = batches
-        .try_next()
-        .await
-        .map_err(|error| OmniError::Lance(error.to_string()))?
-    {
+    while let Some(batch) = batches.try_next().await.map_err(OmniError::from)? {
         for row_index in 0..batch.num_rows() {
             let row = batch.slice(row_index, 1);
             let row_id = row
@@ -531,7 +523,7 @@ async fn export_blob_column_values(
     let sorted_blobs = Arc::new(source_ds.clone())
         .take_blobs(&sorted_ids, column_name)
         .await
-        .map_err(|e| OmniError::Lance(e.to_string()))?;
+        .map_err(OmniError::from)?;
 
     if sorted_blobs.len() != non_null_positions.len() {
         return Err(OmniError::manifest_internal(format!(
@@ -550,10 +542,7 @@ async fn export_blob_column_values(
         let value = if let Some(uri) = blob.uri() {
             uri.to_string()
         } else {
-            let bytes = blob
-                .read()
-                .await
-                .map_err(|e| OmniError::Lance(e.to_string()))?;
+            let bytes = blob.read().await.map_err(OmniError::from)?;
             format!(
                 "base64:{}",
                 base64::Engine::encode(&base64::engine::general_purpose::STANDARD, bytes)
@@ -599,7 +588,9 @@ fn named_string_value(batch: &RecordBatch, field_name: &str, row: usize) -> Resu
     let array = column
         .as_any()
         .downcast_ref::<StringArray>()
-        .ok_or_else(|| OmniError::manifest_internal(format!("expected Utf8 column '{}'", field_name)))?;
+        .ok_or_else(|| {
+            OmniError::manifest_internal(format!("expected Utf8 column '{}'", field_name))
+        })?;
     if array.is_null(row) {
         return Err(OmniError::manifest_internal(format!(
             "unexpected null in export column '{}'",

--- a/crates/omnigraph/src/db/omnigraph/export.rs
+++ b/crates/omnigraph/src/db/omnigraph/export.rs
@@ -345,7 +345,7 @@ where
                 .column_by_name("_rowid")
                 .and_then(|col| col.as_any().downcast_ref::<UInt64Array>())
                 .ok_or_else(|| {
-                    OmniError::Lance(format!(
+                    OmniError::manifest_internal(format!(
                         "expected _rowid column when exporting '{}'",
                         table_key
                     ))
@@ -376,7 +376,7 @@ async fn export_blob_values(
             .column_by_name(property)
             .and_then(|col| col.as_any().downcast_ref::<StructArray>())
             .ok_or_else(|| {
-                OmniError::Lance(format!(
+                OmniError::manifest_internal(format!(
                     "expected blob descriptions for export column '{}'",
                     property
                 ))
@@ -534,7 +534,7 @@ async fn export_blob_column_values(
         .map_err(|e| OmniError::Lance(e.to_string()))?;
 
     if sorted_blobs.len() != non_null_positions.len() {
-        return Err(OmniError::Lance(format!(
+        return Err(OmniError::manifest_internal(format!(
             "blob export for '{}' lost alignment with selected rows",
             column_name
         )));
@@ -587,21 +587,21 @@ fn json_value_from_named_column(
     row: usize,
 ) -> Result<serde_json::Value> {
     let column = batch.column_by_name(field_name).ok_or_else(|| {
-        OmniError::Lance(format!("missing column '{}' in export batch", field_name))
+        OmniError::manifest_internal(format!("missing column '{}' in export batch", field_name))
     })?;
     json_value_from_array(column.as_ref(), row)
 }
 
 fn named_string_value(batch: &RecordBatch, field_name: &str, row: usize) -> Result<String> {
     let column = batch.column_by_name(field_name).ok_or_else(|| {
-        OmniError::Lance(format!("missing column '{}' in export batch", field_name))
+        OmniError::manifest_internal(format!("missing column '{}' in export batch", field_name))
     })?;
     let array = column
         .as_any()
         .downcast_ref::<StringArray>()
-        .ok_or_else(|| OmniError::Lance(format!("expected Utf8 column '{}'", field_name)))?;
+        .ok_or_else(|| OmniError::manifest_internal(format!("expected Utf8 column '{}'", field_name)))?;
     if array.is_null(row) {
-        return Err(OmniError::Lance(format!(
+        return Err(OmniError::manifest_internal(format!(
             "unexpected null in export column '{}'",
             field_name
         )));

--- a/crates/omnigraph/src/db/omnigraph/optimize.rs
+++ b/crates/omnigraph/src/db/omnigraph/optimize.rs
@@ -469,7 +469,7 @@ async fn prepare_optimize_table(
     let options = CompactionOptions::default();
     let will_compact = plan_compaction(snapshot.dataset(), &options)
         .await
-        .map_err(|e| OmniError::Lance(e.to_string()))?
+        .map_err(OmniError::from)?
         .num_tasks()
         > 0;
     let needs_reindex = TableStore::has_unindexed_fragments(snapshot.dataset()).await?;
@@ -561,7 +561,7 @@ async fn apply_optimize_table_effects(
         let options = CompactionOptions::default();
         let plan = plan_compaction(selected.dataset(), &options)
             .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+            .map_err(OmniError::from)?;
         let will_compact = plan.num_tasks() > 0;
         // Even with nothing to compact, the table may still have index work
         // (needs_reindex: rows appended since the index was built; needs_index_create:
@@ -619,7 +619,7 @@ async fn apply_optimize_table_effects(
             Err(e) if attempt < COMPACTION_RETRY_BUDGET && is_retryable_lance_conflict(&e) => {
                 continue;
             }
-            Err(e) => return Err(OmniError::Lance(e.to_string())),
+            Err(e) => return Err(OmniError::from(e)),
         }
         let metrics: CompactionMetrics = if will_compact {
             match compact_files(&mut ds, options, None).await {
@@ -630,7 +630,7 @@ async fn apply_optimize_table_effects(
                 Err(e) if attempt < COMPACTION_RETRY_BUDGET && is_retryable_lance_conflict(&e) => {
                     continue;
                 }
-                Err(e) => return Err(OmniError::Lance(e.to_string())),
+                Err(e) => return Err(OmniError::from(e)),
             }
         } else {
             CompactionMetrics::default()
@@ -651,10 +651,10 @@ async fn apply_optimize_table_effects(
                 continue;
             }
             Err(e) => {
-                return Err(OmniError::Lance(format!(
-                    "optimize_indices on {}: {}",
-                    table_key, e
-                )));
+                return Err(OmniError::storage_context(
+                    e,
+                    format!("optimize_indices on {}", table_key),
+                ));
             }
         }
 
@@ -938,14 +938,14 @@ async fn compact_internal_table(
                 if attempt + 1 < COMPACTION_RETRY_BUDGET && is_retryable_lance_conflict(&e) {
                     continue;
                 }
-                return Err(OmniError::Lance(e.to_string()));
+                return Err(OmniError::from(e));
             }
         };
 
         let options = CompactionOptions::default();
         let plan = plan_compaction(&ds, &options)
             .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+            .map_err(OmniError::from)?;
         if plan.num_tasks() == 0 {
             // No compaction work, but a config-strip still advanced HEAD — refresh
             // the warm coordinator handles so they observe it deterministically
@@ -976,7 +976,7 @@ async fn compact_internal_table(
             Err(e) if attempt + 1 < COMPACTION_RETRY_BUDGET && is_retryable_lance_conflict(&e) => {
                 continue;
             }
-            Err(e) => return Err(OmniError::Lance(e.to_string())),
+            Err(e) => return Err(OmniError::from(e)),
         }
     }
     Err(OmniError::manifest_conflict(format!(
@@ -1197,10 +1197,7 @@ pub async fn cleanup_all_tables(
                     // version list so `keep=N` retains exactly the newest N
                     // available versions (with HEAD as the unavoidable floor
                     // when N=0).
-                    let versions = ds
-                        .versions()
-                        .await
-                        .map_err(|error| OmniError::Lance(error.to_string()))?;
+                    let versions = ds.versions().await.map_err(OmniError::from)?;
                     let retain = (keep as usize).max(1);
                     let cutoff = if versions.len() <= retain {
                         versions.first()
@@ -1231,7 +1228,7 @@ pub async fn cleanup_all_tables(
                 };
                 lance::dataset::cleanup::cleanup_old_versions(ds, policy)
                     .await
-                    .map_err(|e| OmniError::Lance(e.to_string()))
+                    .map_err(OmniError::from)
             }
             .await;
             match outcome {

--- a/crates/omnigraph/src/db/omnigraph/schema_apply.rs
+++ b/crates/omnigraph/src/db/omnigraph/schema_apply.rs
@@ -1204,7 +1204,7 @@ async fn cleanup_dataset_old_versions(db: &Omnigraph, full_uri: &str) -> Result<
     };
     let _removed = lance::dataset::cleanup::cleanup_old_versions(&ds, policy)
         .await
-        .map_err(|e| OmniError::Lance(e.to_string()))?;
+        .map_err(OmniError::from)?;
     let _ = db;
     Ok(())
 }
@@ -1369,7 +1369,7 @@ pub(super) async fn batch_for_schema_apply_rewrite(
         }
     }
 
-    RecordBatch::try_new(target_schema, columns).map_err(|e| OmniError::Lance(e.to_string()))
+    RecordBatch::try_new(target_schema, columns).map_err(OmniError::from)
 }
 
 async fn rebuild_blob_column(
@@ -1397,15 +1397,13 @@ async fn rebuild_blob_column(
         Arc::new(source_ds.dataset().clone())
             .take_blobs(&non_null_row_ids, column_name)
             .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?
+            .map_err(OmniError::from)?
     };
 
     let mut files = blob_files.into_iter();
     for has_blob in row_has_blob {
         if !has_blob {
-            builder
-                .push_null()
-                .map_err(|e| OmniError::Lance(e.to_string()))?;
+            builder.push_null().map_err(OmniError::from)?;
             continue;
         }
 
@@ -1416,17 +1414,11 @@ async fn rebuild_blob_column(
             ))
         })?;
         if let Some(uri) = blob.uri() {
-            builder
-                .push_uri(uri)
-                .map_err(|e| OmniError::Lance(e.to_string()))?;
+            builder.push_uri(uri).map_err(OmniError::from)?;
         } else {
             builder
-                .push_bytes(
-                    blob.read()
-                        .await
-                        .map_err(|e| OmniError::Lance(e.to_string()))?,
-                )
-                .map_err(|e| OmniError::Lance(e.to_string()))?;
+                .push_bytes(blob.read().await.map_err(OmniError::from)?)
+                .map_err(OmniError::from)?;
         }
     }
 
@@ -1437,7 +1429,5 @@ async fn rebuild_blob_column(
         )));
     }
 
-    builder
-        .finish()
-        .map_err(|e| OmniError::Lance(e.to_string()))
+    builder.finish().map_err(OmniError::from)
 }

--- a/crates/omnigraph/src/db/omnigraph/schema_apply.rs
+++ b/crates/omnigraph/src/db/omnigraph/schema_apply.rs
@@ -1318,7 +1318,7 @@ pub(super) async fn batch_for_schema_apply_rewrite(
                 .column_by_name("_rowid")
                 .and_then(|col| col.as_any().downcast_ref::<UInt64Array>())
                 .ok_or_else(|| {
-                    OmniError::Lance(format!(
+                    OmniError::manifest_internal(format!(
                         "expected _rowid column when rewriting '{}'",
                         source_table_key
                     ))
@@ -1347,7 +1347,7 @@ pub(super) async fn batch_for_schema_apply_rewrite(
                         .as_any()
                         .downcast_ref::<StructArray>()
                         .ok_or_else(|| {
-                            OmniError::Lance(format!(
+                            OmniError::manifest_internal(format!(
                                 "expected blob descriptions for '{}.{}'",
                                 source_table_key, source_name
                             ))
@@ -1410,7 +1410,7 @@ async fn rebuild_blob_column(
         }
 
         let blob = files.next().ok_or_else(|| {
-            OmniError::Lance(format!(
+            OmniError::manifest_internal(format!(
                 "blob rewrite for '{}' lost alignment with source rows",
                 column_name
             ))
@@ -1431,7 +1431,7 @@ async fn rebuild_blob_column(
     }
 
     if files.next().is_some() {
-        return Err(OmniError::Lance(format!(
+        return Err(OmniError::manifest_internal(format!(
             "blob rewrite for '{}' produced extra source blobs",
             column_name
         )));

--- a/crates/omnigraph/src/db/omnigraph/table_ops.rs
+++ b/crates/omnigraph/src/db/omnigraph/table_ops.rs
@@ -164,9 +164,9 @@ pub(super) async fn ensure_indices_for_branch(
                     .stage_create_indices(&ds, &work.specs)
                     .await
                     .map_err(|error| {
-                        OmniError::Lance(format!(
-                            "stage index batch on {} ({:?}): {}",
-                            table_key, work.specs, error
+                        error.with_context(format!(
+                            "stage index batch on {} ({:?})",
+                            table_key, work.specs
                         ))
                     })?;
                 crate::failpoints::maybe_fail(
@@ -221,9 +221,9 @@ pub(super) async fn ensure_indices_for_branch(
                     .stage_create_indices(&ds, &work.specs)
                     .await
                     .map_err(|error| {
-                        OmniError::Lance(format!(
-                            "stage index batch on {} ({:?}): {}",
-                            table_key, work.specs, error
+                        error.with_context(format!(
+                            "stage index batch on {} ({:?})",
+                            table_key, work.specs
                         ))
                     })?;
                 crate::failpoints::maybe_fail(
@@ -320,7 +320,7 @@ pub(super) async fn ensure_indices_for_branch(
                 .dataset()
                 .list_branches()
                 .await
-                .map_err(|error| OmniError::Lance(error.to_string()))?;
+                .map_err(OmniError::from)?;
             if branches.contains_key(target_branch) {
                 return Err(OmniError::manifest_conflict(format!(
                     "index target ref '{}:{}' already exists while the graph manifest still \
@@ -449,9 +449,9 @@ pub(super) async fn ensure_indices_for_branch(
                         .stage_create_indices(&ds, &work.specs)
                         .await
                         .map_err(|error| {
-                            OmniError::Lance(format!(
-                                "stage first-touch index batch on {} ({:?}): {}",
-                                table_key, work.specs, error
+                            error.with_context(format!(
+                                "stage first-touch index batch on {} ({:?})",
+                                table_key, work.specs
                             ))
                         })?;
                     crate::failpoints::maybe_fail(
@@ -1430,9 +1430,9 @@ pub(super) async fn build_indices_on_dataset_for_catalog(
         .stage_create_indices(ds, &work.specs)
         .await
         .map_err(|error| {
-            OmniError::Lance(format!(
-                "stage index batch on {} ({:?}): {}",
-                table_key, work.specs, error
+            error.with_context(format!(
+                "stage index batch on {} ({:?})",
+                table_key, work.specs
             ))
         })?;
     // Retain the established test seam at the now-batched stage/commit
@@ -1447,9 +1447,9 @@ pub(super) async fn build_indices_on_dataset_for_catalog(
         .commit_staged(ds.clone(), staged)
         .await
         .map_err(|error| {
-            OmniError::Lance(format!(
-                "commit index batch on {} ({:?}): {}",
-                table_key, work.specs, error
+            error.with_context(format!(
+                "commit index batch on {} ({:?})",
+                table_key, work.specs
             ))
         })?;
     *ds = new_ds;

--- a/crates/omnigraph/src/db/recovery_audit.rs
+++ b/crates/omnigraph/src/db/recovery_audit.rs
@@ -129,7 +129,7 @@ impl RecoveryAudit {
         dataset
             .append(reader, None)
             .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+            .map_err(OmniError::from)?;
         self.dataset = Some(dataset);
         Ok(())
     }
@@ -145,10 +145,10 @@ impl RecoveryAudit {
             .scan()
             .try_into_stream()
             .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?
+            .map_err(OmniError::from)?
             .try_collect()
             .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+            .map_err(OmniError::from)?;
 
         let mut out = Vec::new();
         for batch in batches {
@@ -214,7 +214,7 @@ async fn create_recoveries_dataset(root_uri: &str) -> Result<Dataset> {
             )
             .await
         }
-        Err(err) => Err(OmniError::Lance(err.to_string())),
+        Err(err) => Err(OmniError::from(err)),
     }
 }
 
@@ -237,7 +237,7 @@ fn recovery_record_to_batch(record: &RecoveryAuditRecord) -> Result<RecordBatch>
             Arc::new(TimestampMicrosecondArray::from(vec![record.created_at])),
         ],
     )
-    .map_err(|e| OmniError::Lance(e.to_string()))
+    .map_err(OmniError::from)
 }
 
 fn decode_row(batch: &RecordBatch, row: usize) -> Result<RecoveryAuditRecord> {

--- a/crates/omnigraph/src/error.rs
+++ b/crates/omnigraph/src/error.rs
@@ -1,6 +1,83 @@
 use thiserror::Error;
 
+pub use omnigraph_storage::{StorageFailure, StorageFailureKind};
+
 pub type Result<T> = std::result::Result<T, OmniError>;
+
+/// Depth bound for the `lance::Error::IO` source walk.
+///
+/// Lance boxes the originating `object_store::Error` and may wrap it again on
+/// the way out, so the classification has to look past the first layer. The
+/// bound keeps a pathological or cyclic chain from turning error handling into
+/// an unbounded walk.
+const MAX_ERROR_SOURCE_DEPTH: usize = 8;
+
+/// Classify a Lance failure into the storage decision space.
+///
+/// Nothing here parses error text. Lance keeps the originating
+/// `object_store::Error` reachable through `IO { source }`, so the transport
+/// classification is recovered by downcast and delegated to the one
+/// object-store classifier in `omnigraph-storage`.
+///
+/// `lance::Error` is not `#[non_exhaustive]`, but a Lance minor bump can still
+/// add a variant, so the fallthrough is deliberate: an unrecognised Lance
+/// failure is `Permanent`. That is the safe default *here* — unlike the
+/// object-store boundary, an unknown Lance condition is far more likely to be
+/// an invariant violation than a transport blip, and the transport cases are
+/// already reached through `IO`.
+fn classify_lance_error(error: &lance::Error) -> StorageFailureKind {
+    use lance::Error as Lance;
+    match error {
+        Lance::Timeout { .. } | Lance::DiskCapExceeded { .. } => StorageFailureKind::Transient,
+        Lance::IO { source, .. } => classify_error_source(source.as_ref(), 0),
+        Lance::NotFound { .. }
+        | Lance::DatasetNotFound { .. }
+        | Lance::RefNotFound { .. }
+        | Lance::VersionNotFound { .. }
+        | Lance::IndexNotFound { .. } => StorageFailureKind::NotFound,
+        Lance::InvalidInput { .. }
+        | Lance::NotSupported { .. }
+        | Lance::InvalidRef { .. }
+        | Lance::InvalidTableLocation { .. } => StorageFailureKind::Configuration,
+        // `Fenced` belongs to Lance's MemWAL writer, which OmniGraph does not
+        // operate (see docs/dev/wal-removal.md). Unreachable in practice;
+        // classified conservatively rather than given a speculative retry.
+        _ => StorageFailureKind::Permanent,
+    }
+}
+
+/// Walk an error's source chain looking for a classifiable substrate failure.
+/// Mirrors Lance's own `error_source_is_not_found` walk, bounded by depth.
+/// `None` means the chain held no recognisable substrate error.
+fn find_substrate_kind(
+    source: &(dyn std::error::Error + 'static),
+    depth: usize,
+) -> Option<StorageFailureKind> {
+    if depth >= MAX_ERROR_SOURCE_DEPTH {
+        return None;
+    }
+    if let Some(error) = source.downcast_ref::<object_store::Error>() {
+        return Some(omnigraph_storage::classify_object_store_error(error));
+    }
+    if let Some(error) = source.downcast_ref::<lance::Error>() {
+        return Some(classify_lance_error(error));
+    }
+    source
+        .source()
+        .and_then(|inner| find_substrate_kind(inner, depth + 1))
+}
+
+/// Classify the boxed source of a `lance::Error::IO`.
+///
+/// An unrecognisable source is still an I/O source, so it resolves to
+/// `Transient`: a bounded retry that ultimately fails beats permanently
+/// condemning a resource over an unfamiliar transport condition.
+fn classify_error_source(
+    source: &(dyn std::error::Error + 'static),
+    depth: usize,
+) -> StorageFailureKind {
+    find_substrate_kind(source, depth).unwrap_or(StorageFailureKind::Transient)
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ManifestErrorKind {
@@ -80,12 +157,20 @@ pub enum MergeConflictKind {
     ValueConstraintViolation,
 }
 
+/// `#[non_exhaustive]` so a future failure class can be added without breaking
+/// every downstream match. Consumers already carry a catch-all arm.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum OmniError {
     #[error("{0}")]
     Compiler(#[from] omnigraph_compiler::error::CompilerError),
+    /// A classified failure from the storage substrate — Lance or the object
+    /// store beneath it. `kind` is the retry/escalation decision; the message
+    /// keeps the substrate's own wording. Produced at the boundary by
+    /// `From<lance::Error>` and by the storage adapter, so no caller has to
+    /// re-derive it and none may parse the text.
     #[error("storage: {0}")]
-    Lance(String),
+    Storage(StorageFailure),
     /// Lance rejected a stale transaction as semantically retryable. Kept
     /// typed at the storage boundary so RFC-023 can distinguish an
     /// effect-free key fence from an arbitrary I/O or execution failure
@@ -149,10 +234,53 @@ pub enum OmniError {
     AlreadyInitialized { uri: String },
 }
 
+impl From<lance::Error> for OmniError {
+    /// The single classification point for every Lance failure in the engine.
+    ///
+    /// The two commit-conflict variants keep their existing dedicated variant:
+    /// RFC-023's effect-free key fence distinguishes them from arbitrary
+    /// storage failures, and that contract predates this classification.
+    fn from(error: lance::Error) -> Self {
+        if matches!(
+            error,
+            lance::Error::RetryableCommitConflict { .. }
+                | lance::Error::TooMuchWriteContention { .. }
+        ) {
+            return Self::RetryableCommitConflict(error.to_string());
+        }
+        let kind = classify_lance_error(&error);
+        Self::Storage(StorageFailure::new(kind, error.to_string()))
+    }
+}
+
+impl From<arrow_schema::ArrowError> for OmniError {
+    /// Arrow failures are shape and compute violations inside the engine — a
+    /// batch that did not match its schema, a cast that could not be built.
+    /// They never describe the storage layer, so they must not be classifiable
+    /// as a storage condition a caller might retry.
+    fn from(error: arrow_schema::ArrowError) -> Self {
+        Self::manifest_internal(error.to_string())
+    }
+}
+
+impl From<datafusion::error::DataFusionError> for OmniError {
+    /// DataFusion is both the in-memory execution engine and the carrier for
+    /// failures raised *during* a Lance scan, so the source chain decides
+    /// rather than the call site: a substrate failure underneath keeps its
+    /// storage classification, and everything else is an execution failure.
+    fn from(error: datafusion::error::DataFusionError) -> Self {
+        match find_substrate_kind(&error, 0) {
+            Some(kind) => Self::Storage(StorageFailure::new(kind, error.to_string())),
+            None => Self::DataFusion(error.to_string()),
+        }
+    }
+}
+
 impl From<omnigraph_storage::StorageError> for OmniError {
     fn from(error: omnigraph_storage::StorageError) -> Self {
         match error {
             omnigraph_storage::StorageError::Internal(message) => Self::manifest_internal(message),
+            omnigraph_storage::StorageError::Backend(failure) => Self::Storage(failure),
             omnigraph_storage::StorageError::Io(error) => Self::Io(error),
             omnigraph_storage::StorageError::ResourceLimit {
                 resource,
@@ -189,11 +317,55 @@ impl OmniError {
         }
     }
 
-    pub(crate) fn is_retryable_commit_conflict(&self) -> bool {
+    /// Wrap a Lance failure with caller context while preserving the
+    /// classification derived at the boundary. Use this instead of formatting
+    /// the error into a string: context describes *where* a failure happened,
+    /// never *what* it is.
+    pub(crate) fn storage_context(error: lance::Error, context: impl std::fmt::Display) -> Self {
+        match Self::from(error) {
+            Self::Storage(failure) => Self::Storage(failure.with_context(context)),
+            other => other,
+        }
+    }
+
+    /// A storage failure with no substrate error behind it — an engine-detected
+    /// violation of what the storage layer promised. Never retryable.
+    pub(crate) fn storage_permanent(message: impl Into<String>) -> Self {
+        Self::Storage(StorageFailure::new(StorageFailureKind::Permanent, message))
+    }
+
+    /// Prefix caller context onto an error that is already classified.
+    ///
+    /// Formatting an `OmniError` into a *new* error's message throws away the
+    /// classification derived at the substrate boundary — the failure arrives
+    /// upstream as an opaque string and every retry decision above it degrades.
+    /// This keeps the classification and adds the context. Variants whose
+    /// payload is structured rather than a message pass through unchanged.
+    pub(crate) fn with_context(self, context: impl std::fmt::Display) -> Self {
+        match self {
+            Self::Storage(failure) => Self::Storage(failure.with_context(context)),
+            Self::Manifest(mut error) => {
+                error.message = format!("{context}: {}", error.message);
+                Self::Manifest(error)
+            }
+            other => other,
+        }
+    }
+
+    /// The classified storage failure behind this error, if it is one. Lets a
+    /// caller decide retry/escalation without matching engine internals.
+    pub fn storage_failure(&self) -> Option<&StorageFailure> {
+        match self {
+            Self::Storage(failure) => Some(failure),
+            _ => None,
+        }
+    }
+
+    pub fn is_retryable_commit_conflict(&self) -> bool {
         matches!(self, Self::RetryableCommitConflict(_))
     }
 
-    pub(crate) fn is_read_set_changed(&self) -> bool {
+    pub fn is_read_set_changed(&self) -> bool {
         matches!(
             self,
             Self::Manifest(ManifestError {
@@ -275,5 +447,148 @@ impl OmniError {
             operation_id: operation_id.into(),
             reason: reason.into(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn generic_object_store_error() -> object_store::Error {
+        // The bucket every retried-and-exhausted HTTP condition lands in: a
+        // 5xx, a connection reset, DNS, TLS, or budget exhaustion. This is the
+        // production shape that must survive as `Transient`.
+        object_store::Error::Generic {
+            store: "S3",
+            source: "connection reset by peer".into(),
+        }
+    }
+
+    #[test]
+    fn transient_object_store_failure_survives_the_lance_boundary() {
+        let error = OmniError::from(lance::Error::io_source(lance_core::error::box_error(
+            generic_object_store_error(),
+        )));
+        let failure = error
+            .storage_failure()
+            .expect("a Lance IO failure must classify as a storage failure");
+        assert_eq!(failure.kind, StorageFailureKind::Transient);
+        assert!(failure.kind.is_transient());
+    }
+
+    #[test]
+    fn permission_and_absence_survive_the_lance_boundary_as_permanent_classes() {
+        let denied = OmniError::from(lance::Error::io_source(lance_core::error::box_error(
+            object_store::Error::PermissionDenied {
+                path: "graph/__manifest".to_string(),
+                source: "expired credentials".into(),
+            },
+        )));
+        assert_eq!(
+            denied.storage_failure().map(|failure| failure.kind),
+            Some(StorageFailureKind::Configuration)
+        );
+        assert!(!denied.storage_failure().unwrap().kind.is_transient());
+
+        let absent = OmniError::from(lance::Error::not_found("s3://bucket/graph"));
+        assert_eq!(
+            absent.storage_failure().map(|failure| failure.kind),
+            Some(StorageFailureKind::NotFound)
+        );
+    }
+
+    #[test]
+    fn lance_timeout_is_transient_and_internal_is_permanent() {
+        let timeout = OmniError::from(lance::Error::timeout("commit deadline exceeded"));
+        assert_eq!(
+            timeout.storage_failure().map(|failure| failure.kind),
+            Some(StorageFailureKind::Transient)
+        );
+
+        let internal = OmniError::from(lance::Error::internal("broken invariant"));
+        assert_eq!(
+            internal.storage_failure().map(|failure| failure.kind),
+            Some(StorageFailureKind::Permanent)
+        );
+    }
+
+    #[test]
+    fn commit_conflicts_keep_their_dedicated_variant() {
+        // RFC-023's effect-free key fence distinguishes these from arbitrary
+        // storage failures; classification must not swallow them.
+        let conflict = OmniError::from(lance::Error::RetryableCommitConflict {
+            version: 7,
+            source: "stale transaction".into(),
+            location: snafu::location!(),
+            backtrace: snafu::GenerateImplicitData::generate(),
+        });
+        assert!(conflict.is_retryable_commit_conflict());
+        assert!(conflict.storage_failure().is_none());
+    }
+
+    #[test]
+    fn arrow_failures_are_never_classified_as_storage() {
+        // An Arrow shape violation is an engine bug. If it reached a caller as
+        // a storage failure, a supervisor could reason about retrying it.
+        let error = OmniError::from(arrow_schema::ArrowError::InvalidArgumentError(
+            "column count mismatch".to_string(),
+        ));
+        assert!(error.storage_failure().is_none());
+        assert!(matches!(
+            error,
+            OmniError::Manifest(ManifestError {
+                kind: ManifestErrorKind::Internal,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn datafusion_failures_classify_by_source_not_by_call_site() {
+        // The same error type carries both in-memory execution failures and
+        // failures raised during a Lance scan.
+        let in_memory = OmniError::from(datafusion::error::DataFusionError::Plan(
+            "no such column".to_string(),
+        ));
+        assert!(in_memory.storage_failure().is_none());
+        assert!(matches!(in_memory, OmniError::DataFusion(_)));
+
+        let during_scan = OmniError::from(datafusion::error::DataFusionError::External(Box::new(
+            generic_object_store_error(),
+        )));
+        assert_eq!(
+            during_scan.storage_failure().map(|failure| failure.kind),
+            Some(StorageFailureKind::Transient)
+        );
+    }
+
+    #[test]
+    fn storage_display_is_unchanged_and_context_preserves_classification() {
+        let error = OmniError::storage_context(
+            lance::Error::io_source(lance_core::error::box_error(generic_object_store_error())),
+            "optimize_indices on node:Person",
+        );
+        let failure = error.storage_failure().expect("still a storage failure");
+        assert_eq!(
+            failure.kind,
+            StorageFailureKind::Transient,
+            "context describes where a failure happened, never what it is"
+        );
+        assert!(
+            failure
+                .message
+                .starts_with("optimize_indices on node:Person: ")
+        );
+        // Operators and logs still see the historical `storage: ...` prefix.
+        assert!(error.to_string().starts_with("storage: "));
+    }
+
+    #[test]
+    fn engine_detected_storage_violations_are_permanent() {
+        let error = OmniError::storage_permanent("manifest registration vanished");
+        assert_eq!(
+            error.storage_failure().map(|failure| failure.kind),
+            Some(StorageFailureKind::Permanent)
+        );
     }
 }

--- a/crates/omnigraph/src/exec/merge.rs
+++ b/crates/omnigraph/src/exec/merge.rs
@@ -476,7 +476,7 @@ impl OrderedTableCursor {
                     self.current_batch = None;
                     return Ok(None);
                 }
-                Err(err) => return Err(OmniError::Lance(err.to_string())),
+                Err(err) => return Err(OmniError::from(err)),
             }
         }
     }
@@ -556,8 +556,8 @@ impl StagedTableWriter {
         // and buffering many slices would retain those backing buffers. Take
         // copies exactly one row so the byte ceiling measures owned payload.
         let indices = UInt64Array::from(vec![row.row_index as u64]);
-        let batch = arrow_select::take::take_record_batch(&row.batch, &indices)
-            .map_err(|error| OmniError::Lance(error.to_string()))?;
+        let batch =
+            arrow_select::take::take_record_batch(&row.batch, &indices).map_err(OmniError::from)?;
         let has_blob_columns = row
             .dataset
             .schema()
@@ -581,8 +581,7 @@ impl StagedTableWriter {
                 })
             })
             .collect::<Result<Vec<_>>>()?;
-        RecordBatch::try_new(self.schema.clone(), columns)
-            .map_err(|e| OmniError::Lance(e.to_string()))
+        RecordBatch::try_new(self.schema.clone(), columns).map_err(OmniError::from)
     }
 
     async fn finish(mut self) -> Result<StagedTable> {
@@ -613,8 +612,7 @@ impl StagedTableWriter {
             self.batches.pop().unwrap()
         } else {
             let batches = std::mem::take(&mut self.batches);
-            arrow_select::concat::concat_batches(&self.schema, &batches)
-                .map_err(|e| OmniError::Lance(e.to_string()))?
+            arrow_select::concat::concat_batches(&self.schema, &batches).map_err(OmniError::from)?
         };
         self.buffered_rows = 0;
         self.buffered_bytes = 0;
@@ -720,14 +718,8 @@ async fn try_proven_pure_insert_adopt(
     {
         return Ok(None);
     }
-    let base_identifier = base
-        .branch_identifier()
-        .await
-        .map_err(|error| OmniError::Lance(error.to_string()))?;
-    let source_identifier = source
-        .branch_identifier()
-        .await
-        .map_err(|error| OmniError::Lance(error.to_string()))?;
+    let base_identifier = base.branch_identifier().await.map_err(OmniError::from)?;
+    let source_identifier = source.branch_identifier().await.map_err(OmniError::from)?;
     if base_entry.table_branch == source_entry.table_branch && source_identifier != base_identifier
     {
         return Err(OmniError::manifest_read_set_changed(
@@ -1019,11 +1011,7 @@ async fn plan_proven_pure_insert_chunks(
         .await?;
     let mut chunk_rows = Vec::new();
     let mut observed_rows = 0_u64;
-    while let Some(batch) = stream
-        .try_next()
-        .await
-        .map_err(|error| OmniError::Lance(error.to_string()))?
-    {
+    while let Some(batch) = stream.try_next().await.map_err(OmniError::from)? {
         if batch.num_rows() == 0 {
             continue;
         }
@@ -1487,10 +1475,7 @@ fn row_signature(batch: &RecordBatch, row: usize) -> Result<String> {
         if field.name().starts_with("_row") {
             continue;
         }
-        values.push(
-            array_value_to_string(column.as_ref(), row)
-                .map_err(|e| OmniError::Lance(e.to_string()))?,
-        );
+        values.push(array_value_to_string(column.as_ref(), row).map_err(OmniError::from)?);
     }
     Ok(values.join("\u{1f}"))
 }
@@ -1728,11 +1713,7 @@ async fn scan_staged_for_validation(
             KEYED_WRITE_MAX_BYTES,
         )
         .await?;
-    while let Some(batch) = stream
-        .try_next()
-        .await
-        .map_err(|error| OmniError::Lance(error.to_string()))?
-    {
+    while let Some(batch) = stream.try_next().await.map_err(OmniError::from)? {
         if batch.num_rows() == 0 {
             continue;
         }
@@ -1778,11 +1759,7 @@ async fn scan_proven_pure_inserts_for_validation(
         )
         .await?;
     let mut observed_rows = 0_u64;
-    while let Some(batch) = stream
-        .try_next()
-        .await
-        .map_err(|error| OmniError::Lance(error.to_string()))?
-    {
+    while let Some(batch) = stream.try_next().await.map_err(OmniError::from)? {
         if batch.num_rows() == 0 {
             continue;
         }
@@ -2528,11 +2505,7 @@ async fn next_exact_staged_chunk(
         let batch = match carry.take() {
             Some(batch) => batch,
             None => loop {
-                match stream
-                    .try_next()
-                    .await
-                    .map_err(|error| OmniError::Lance(error.to_string()))?
-                {
+                match stream.try_next().await.map_err(OmniError::from)? {
                     Some(batch) if batch.num_rows() > 0 => break batch,
                     Some(_) => continue,
                     None => {
@@ -2553,8 +2526,7 @@ async fn next_exact_staged_chunk(
     let chunk = if slices.len() == 1 {
         slices.pop().expect("one slice")
     } else {
-        arrow_select::concat::concat_batches(schema, &slices)
-            .map_err(|error| OmniError::Lance(error.to_string()))?
+        arrow_select::concat::concat_batches(schema, &slices).map_err(OmniError::from)?
     };
     let chunk_bytes = u64::try_from(chunk.get_array_memory_size())
         .map_err(|_| OmniError::manifest_internal("branch merge chunk bytes exceed u64"))?;
@@ -2676,11 +2648,7 @@ async fn commit_keyed_stream_chunks(
 
     let mut has_extra_rows = carry.as_ref().is_some_and(|batch| batch.num_rows() > 0);
     while !has_extra_rows {
-        match stream
-            .try_next()
-            .await
-            .map_err(|error| OmniError::Lance(error.to_string()))?
-        {
+        match stream.try_next().await.map_err(OmniError::from)? {
             Some(batch) => has_extra_rows = batch.num_rows() > 0,
             None => break,
         }

--- a/crates/omnigraph/src/exec/merge.rs
+++ b/crates/omnigraph/src/exec/merge.rs
@@ -577,7 +577,7 @@ impl StagedTableWriter {
             .iter()
             .map(|field| {
                 batch.column_by_name(field.name()).cloned().ok_or_else(|| {
-                    OmniError::Lance(format!("batch missing column '{}'", field.name()))
+                    OmniError::manifest_internal(format!("batch missing column '{}'", field.name()))
                 })
             })
             .collect::<Result<Vec<_>>>()?;

--- a/crates/omnigraph/src/exec/mutation.rs
+++ b/crates/omnigraph/src/exec/mutation.rs
@@ -325,20 +325,14 @@ fn typed_list_literal_to_array(
 fn build_blob_array_from_value(value: &str) -> Result<ArrayRef> {
     let mut builder = BlobArrayBuilder::new(1);
     crate::loader::append_blob_value(&mut builder, value)?;
-    builder
-        .finish()
-        .map_err(|e| OmniError::Lance(e.to_string()))
+    builder.finish().map_err(OmniError::from)
 }
 
 /// Build a null blob array with one element.
 fn build_null_blob_array() -> Result<ArrayRef> {
     let mut builder = BlobArrayBuilder::new(1);
-    builder
-        .push_null()
-        .map_err(|e| OmniError::Lance(e.to_string()))?;
-    builder
-        .finish()
-        .map_err(|e| OmniError::Lance(e.to_string()))
+    builder.push_null().map_err(OmniError::from)?;
+    builder.finish().map_err(OmniError::from)
 }
 
 /// Build a single-row RecordBatch from resolved assignments.
@@ -386,7 +380,7 @@ fn build_insert_batch(
         }
     }
 
-    RecordBatch::try_new(schema.clone(), columns).map_err(|e| OmniError::Lance(e.to_string()))
+    RecordBatch::try_new(schema.clone(), columns).map_err(OmniError::from)
 }
 
 /// Convert an IRMutationPredicate to a Lance SQL filter string.
@@ -462,11 +456,7 @@ fn apply_assignments(
                 for _ in 0..batch.num_rows() {
                     crate::loader::append_blob_value(&mut builder, uri)?;
                 }
-                columns.push(
-                    builder
-                        .finish()
-                        .map_err(|e| OmniError::Lance(e.to_string()))?,
-                );
+                columns.push(builder.finish().map_err(OmniError::from)?);
             } else {
                 // Unassigned: the materializing scan must have normalized the
                 // committed value (or pending value) to the logical blob
@@ -497,7 +487,7 @@ fn apply_assignments(
         }
     }
 
-    RecordBatch::try_new(full_schema.clone(), columns).map_err(|e| OmniError::Lance(e.to_string()))
+    RecordBatch::try_new(full_schema.clone(), columns).map_err(OmniError::from)
 }
 
 // ─── Mutation execution ──────────────────────────────────────────────────────
@@ -1492,7 +1482,7 @@ fn concat_match_batches_to_schema(
     if batches.len() == 1 {
         let batch = batches.into_iter().next().unwrap();
         return RecordBatch::try_new(schema.clone(), batch.columns().to_vec())
-            .map_err(|e| OmniError::Lance(e.to_string()));
+            .map_err(OmniError::from);
     }
     arrow_select::concat::concat_batches(schema, &batches).map_err(|e| {
         OmniError::manifest_internal(format!(

--- a/crates/omnigraph/src/exec/mutation.rs
+++ b/crates/omnigraph/src/exec/mutation.rs
@@ -473,7 +473,7 @@ fn apply_assignments(
                 // schema, so copying it preserves both bytes and full-schema
                 // merge compatibility.
                 let col = batch.column_by_name(field.name()).ok_or_else(|| {
-                    OmniError::Lance(format!(
+                    OmniError::manifest_internal(format!(
                         "blob column '{}' not found in full-schema mutation scan",
                         field.name()
                     ))
@@ -488,7 +488,7 @@ fn apply_assignments(
             )?);
         } else {
             let col = batch.column_by_name(field.name()).ok_or_else(|| {
-                OmniError::Lance(format!(
+                OmniError::manifest_internal(format!(
                     "column '{}' not found in scan result",
                     field.name()
                 ))
@@ -1495,7 +1495,7 @@ fn concat_match_batches_to_schema(
             .map_err(|e| OmniError::Lance(e.to_string()));
     }
     arrow_select::concat::concat_batches(schema, &batches).map_err(|e| {
-        OmniError::Lance(format!(
+        OmniError::manifest_internal(format!(
             "mutation scan returned batches that violate the full logical schema \
              across the committed/pending boundary ({})",
             e

--- a/crates/omnigraph/src/exec/projection.rs
+++ b/crates/omnigraph/src/exec/projection.rs
@@ -7,8 +7,8 @@ pub(super) fn apply_filter(
 ) -> Result<()> {
     crate::instrumentation::record_in_memory_filter();
     let mask = evaluate_filter(batch, filter, params)?;
-    let filtered = arrow_select::filter::filter_record_batch(batch, &mask)
-        .map_err(|e| OmniError::Lance(e.to_string()))?;
+    let filtered =
+        arrow_select::filter::filter_record_batch(batch, &mask).map_err(OmniError::from)?;
     *batch = filtered;
     Ok(())
 }
@@ -31,8 +31,7 @@ fn evaluate_filter(
 
     // Cast right to match left's type if needed (e.g. Int64 literal vs Int32 column)
     let right = if left.data_type() != right.data_type() {
-        arrow_cast::cast::cast(&right, left.data_type())
-            .map_err(|e| OmniError::Lance(e.to_string()))?
+        arrow_cast::cast::cast(&right, left.data_type()).map_err(OmniError::from)?
     } else {
         right
     };
@@ -49,7 +48,7 @@ fn evaluate_filter(
             unreachable!("handled above")
         }
     }
-    .map_err(|e| OmniError::Lance(e.to_string()))?;
+    .map_err(OmniError::from)?;
 
     Ok(result)
 }
@@ -111,8 +110,7 @@ fn evaluate_contains_filter(left: &ArrayRef, right: &ArrayRef) -> Result<Boolean
         ));
     };
     let right = if right.data_type() != field.data_type() {
-        arrow_cast::cast::cast(right, field.data_type())
-            .map_err(|e| OmniError::Lance(e.to_string()))?
+        arrow_cast::cast::cast(right, field.data_type()).map_err(OmniError::from)?
     } else {
         Arc::clone(right)
     };
@@ -157,8 +155,7 @@ fn evaluate_string_match_filter(
     // typically a broadcast literal already matching, so this cast is usually
     // a no-op.
     let right = if right.data_type() != left.data_type() {
-        arrow_cast::cast::cast(right, left.data_type())
-            .map_err(|e| OmniError::Lance(e.to_string()))?
+        arrow_cast::cast::cast(right, left.data_type()).map_err(OmniError::from)?
     } else {
         Arc::clone(right)
     };
@@ -184,10 +181,8 @@ fn array_value_eq(
     if left.is_null(left_index) || right.is_null(right_index) {
         return Ok(false);
     }
-    let left_value =
-        array_value_to_string(left, left_index).map_err(|e| OmniError::Lance(e.to_string()))?;
-    let right_value =
-        array_value_to_string(right, right_index).map_err(|e| OmniError::Lance(e.to_string()))?;
+    let left_value = array_value_to_string(left, left_index).map_err(OmniError::from)?;
+    let right_value = array_value_to_string(right, right_index).map_err(OmniError::from)?;
     Ok(left_value == right_value)
 }
 
@@ -377,7 +372,7 @@ pub(super) fn project_return(
     }
 
     let schema = Arc::new(Schema::new(fields));
-    RecordBatch::try_new(schema, columns).map_err(|e| OmniError::Lance(e.to_string()))
+    RecordBatch::try_new(schema, columns).map_err(OmniError::from)
 }
 
 /// Evaluate a single projection expression against a wide batch.
@@ -496,17 +491,16 @@ pub(super) fn apply_ordering(
         }
     }
 
-    let indices =
-        lexsort_to_indices(&sort_columns, None).map_err(|e| OmniError::Lance(e.to_string()))?;
+    let indices = lexsort_to_indices(&sort_columns, None).map_err(OmniError::from)?;
 
     let columns: Vec<ArrayRef> = batch
         .columns()
         .iter()
         .map(|col| arrow_select::take::take(col.as_ref(), &indices, None))
         .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(|e| OmniError::Lance(e.to_string()))?;
+        .map_err(OmniError::from)?;
 
-    RecordBatch::try_new(batch.schema(), columns).map_err(|e| OmniError::Lance(e.to_string()))
+    RecordBatch::try_new(batch.schema(), columns).map_err(OmniError::from)
 }
 
 // ─── Aggregate execution ───────────────────────────────────────────────────
@@ -593,7 +587,7 @@ fn aggregate_return(
         let first_row_indices: Vec<u32> = group_indices.iter().map(|rows| rows[0] as u32).collect();
         let take_idx = UInt32Array::from(first_row_indices);
         let col = arrow_select::take::take(gk.column.as_ref(), &take_idx, None)
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+            .map_err(OmniError::from)?;
         result_columns.push((gk.proj_idx, gk.name.clone(), col));
     }
 
@@ -611,7 +605,7 @@ fn aggregate_return(
     let columns: Vec<ArrayRef> = result_columns.into_iter().map(|(_, _, col)| col).collect();
 
     let schema = Arc::new(Schema::new(fields));
-    RecordBatch::try_new(schema, columns).map_err(|e| OmniError::Lance(e.to_string()))
+    RecordBatch::try_new(schema, columns).map_err(OmniError::from)
 }
 
 /// Build a string key for grouping using length-prefixed encoding.
@@ -855,5 +849,5 @@ fn build_empty_aggregate_result(projections: &[IRProjection]) -> Result<RecordBa
     }
 
     let schema = Arc::new(Schema::new(fields));
-    RecordBatch::try_new(schema, columns).map_err(|e| OmniError::Lance(e.to_string()))
+    RecordBatch::try_new(schema, columns).map_err(OmniError::from)
 }

--- a/crates/omnigraph/src/exec/query.rs
+++ b/crates/omnigraph/src/exec/query.rs
@@ -663,8 +663,7 @@ fn build_fused_batch(
     }
 
     let schema = row_slices[0].schema();
-    arrow_select::concat::concat_batches(&schema, &row_slices)
-        .map_err(|e| OmniError::Lance(e.to_string()))
+    arrow_select::concat::concat_batches(&schema, &row_slices).map_err(OmniError::from)
 }
 
 /// Check if a filter is a text search filter that needs Lance SQL pushdown.
@@ -2182,7 +2181,7 @@ async fn hydrate_nodes(
     .await?
     .try_collect::<Vec<RecordBatch>>()
     .await
-    .map_err(|e| OmniError::Lance(e.to_string()))?;
+    .map_err(OmniError::from)?;
 
     let scan_result = if batches.is_empty() {
         return Ok(RecordBatch::new_empty(node_type.arrow_schema.clone()));
@@ -2190,8 +2189,7 @@ async fn hydrate_nodes(
         batches.into_iter().next().unwrap()
     } else {
         let schema = batches[0].schema();
-        arrow_select::concat::concat_batches(&schema, &batches)
-            .map_err(|e| OmniError::Lance(e.to_string()))?
+        arrow_select::concat::concat_batches(&schema, &batches).map_err(OmniError::from)?
     };
 
     if has_blobs {
@@ -2304,8 +2302,7 @@ async fn execute_anti_join(
     };
     // Fast path: bulk CSR existence check (O(N), zero Lance I/O)
     if let Some(mask) = try_bulk_anti_join_mask(wide, inner_pipeline, gi, catalog, outer_var) {
-        *wide = arrow_select::filter::filter_record_batch(wide, &mask)
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+        *wide = arrow_select::filter::filter_record_batch(wide, &mask).map_err(OmniError::from)?;
         return Ok(());
     }
 
@@ -2348,8 +2345,8 @@ async fn execute_anti_join(
     fields.push(Field::new(tag_col.as_str(), DataType::UInt32, false));
     let mut columns: Vec<ArrayRef> = wide.columns().to_vec();
     columns.push(Arc::new(UInt32Array::from_iter_values(0..num_rows as u32)));
-    let tagged = RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
-        .map_err(|e| OmniError::Lance(e.to_string()))?;
+    let tagged =
+        RecordBatch::try_new(Arc::new(Schema::new(fields)), columns).map_err(OmniError::from)?;
 
     let mut inner_wide: Option<RecordBatch> = Some(tagged);
     let no_search = SearchMode::default();
@@ -2392,8 +2389,7 @@ async fn execute_anti_join(
         .map(|i| !matched.contains(&i))
         .collect();
     let mask = BooleanArray::from(keep_mask);
-    *wide = arrow_select::filter::filter_record_batch(wide, &mask)
-        .map_err(|e| OmniError::Lance(e.to_string()))?;
+    *wide = arrow_select::filter::filter_record_batch(wide, &mask).map_err(OmniError::from)?;
     Ok(())
 }
 
@@ -2465,7 +2461,7 @@ async fn execute_node_scan(
                 if is_search_filter(filter) {
                     if let Some(fts_query) = build_fts_query(&filter.left, params) {
                         scanner.full_text_search(fts_query).map_err(|e| {
-                            OmniError::Lance(format!("full_text_search filter: {}", e))
+                            OmniError::storage_context(e, "full_text_search filter")
                         })?;
                     }
                 }
@@ -2477,7 +2473,7 @@ async fn execute_node_scan(
                     let query_arr = Float32Array::from(vec.clone());
                     scanner
                         .nearest(prop, &query_arr, k)
-                        .map_err(|e| OmniError::Lance(format!("nearest: {}", e)))?;
+                        .map_err(|e| OmniError::storage_context(e, "nearest"))?;
                 }
             }
 
@@ -2486,10 +2482,10 @@ async fn execute_node_scan(
                 if var == variable {
                     let fts_query = lance_index::scalar::FullTextSearchQuery::new(text.clone())
                         .with_column(prop.clone())
-                        .map_err(|e| OmniError::Lance(format!("fts with_column: {}", e)))?;
+                        .map_err(|e| OmniError::storage_context(e, "fts with_column"))?;
                     scanner
                         .full_text_search(fts_query)
-                        .map_err(|e| OmniError::Lance(format!("full_text_search: {}", e)))?;
+                        .map_err(|e| OmniError::storage_context(e, "full_text_search"))?;
                 }
             }
             Ok(())
@@ -2498,7 +2494,7 @@ async fn execute_node_scan(
     .await?
     .try_collect::<Vec<RecordBatch>>()
     .await
-    .map_err(|e| OmniError::Lance(e.to_string()))?;
+    .map_err(OmniError::from)?;
 
     let scan_result = if batches.is_empty() {
         RecordBatch::new_empty(batches.first().map(|b| b.schema()).unwrap_or_else(|| {
@@ -2516,8 +2512,7 @@ async fn execute_node_scan(
         batches.into_iter().next().unwrap()
     } else {
         let schema = batches[0].schema();
-        arrow_select::concat::concat_batches(&schema, &batches)
-            .map_err(|e| OmniError::Lance(e.to_string()))?
+        arrow_select::concat::concat_batches(&schema, &batches).map_err(OmniError::from)?
     };
 
     // Add null placeholder columns for excluded blob properties
@@ -2545,14 +2540,13 @@ fn add_null_blob_columns(
             let batch_schema = batch.schema();
             let batch_field = batch_schema
                 .field_with_name(field.name())
-                .map_err(|e| OmniError::Lance(e.to_string()))?;
+                .map_err(OmniError::from)?;
             fields.push(batch_field.clone());
             columns.push(col.clone());
         }
     }
 
-    RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
-        .map_err(|e| OmniError::Lance(e.to_string()))
+    RecordBatch::try_new(Arc::new(Schema::new(fields)), columns).map_err(OmniError::from)
 }
 
 /// Build a FullTextSearchQuery from a search IR expression.
@@ -2883,8 +2877,7 @@ fn prefix_batch(batch: &RecordBatch, variable: &str) -> Result<RecordBatch> {
         })
         .collect();
     let schema = Arc::new(Schema::new(fields));
-    RecordBatch::try_new(schema, batch.columns().to_vec())
-        .map_err(|e| OmniError::Lance(e.to_string()))
+    RecordBatch::try_new(schema, batch.columns().to_vec()).map_err(OmniError::from)
 }
 
 fn cross_join_batches(left: &RecordBatch, right: &RecordBatch) -> Result<RecordBatch> {
@@ -2935,8 +2928,7 @@ fn hconcat_batches(left: &RecordBatch, right: &RecordBatch) -> Result<RecordBatc
     fields.extend(right.schema().fields().iter().map(|f| f.as_ref().clone()));
     let mut columns: Vec<ArrayRef> = left.columns().to_vec();
     columns.extend(right.columns().to_vec());
-    RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
-        .map_err(|e| OmniError::Lance(e.to_string()))
+    RecordBatch::try_new(Arc::new(Schema::new(fields)), columns).map_err(OmniError::from)
 }
 
 fn take_batch(batch: &RecordBatch, indices: &UInt32Array) -> Result<RecordBatch> {
@@ -2945,8 +2937,8 @@ fn take_batch(batch: &RecordBatch, indices: &UInt32Array) -> Result<RecordBatch>
         .iter()
         .map(|col| arrow_select::take::take(col.as_ref(), indices, None))
         .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(|e| OmniError::Lance(e.to_string()))?;
-    RecordBatch::try_new(batch.schema(), columns).map_err(|e| OmniError::Lance(e.to_string()))
+        .map_err(OmniError::from)?;
+    RecordBatch::try_new(batch.schema(), columns).map_err(OmniError::from)
 }
 
 #[cfg(test)]

--- a/crates/omnigraph/src/exec/staging.rs
+++ b/crates/omnigraph/src/exec/staging.rs
@@ -618,7 +618,7 @@ async fn stage_pending_table(
                 table.batches.into_iter().next().unwrap()
             } else {
                 arrow_select::concat::concat_batches(&table.schema, &table.batches)
-                    .map_err(|e| OmniError::Lance(e.to_string()))?
+                    .map_err(OmniError::from)?
             }
         }
     };
@@ -1520,8 +1520,7 @@ fn dedupe_merge_batches_by_id(
         if batches.len() == 1 {
             return Ok(batches.into_iter().next().unwrap());
         }
-        return arrow_select::concat::concat_batches(schema, &batches)
-            .map_err(|e| OmniError::Lance(e.to_string()));
+        return arrow_select::concat::concat_batches(schema, &batches).map_err(OmniError::from);
     }
 
     // Slow path: build per-batch slices via `take`, then concat.
@@ -1536,9 +1535,9 @@ fn dedupe_merge_batches_by_id(
             .iter()
             .map(|col| arrow_select::take::take(col, &take_array, None))
             .collect::<std::result::Result<_, _>>()
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
-        let new_batch = RecordBatch::try_new(batches[b_idx].schema(), columns)
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+            .map_err(OmniError::from)?;
+        let new_batch =
+            RecordBatch::try_new(batches[b_idx].schema(), columns).map_err(OmniError::from)?;
         sliced.push(new_batch);
     }
     if sliced.is_empty() {
@@ -1549,6 +1548,5 @@ fn dedupe_merge_batches_by_id(
     if sliced.len() == 1 {
         return Ok(sliced.into_iter().next().unwrap());
     }
-    arrow_select::concat::concat_batches(schema, &sliced)
-        .map_err(|e| OmniError::Lance(e.to_string()))
+    arrow_select::concat::concat_batches(schema, &sliced).map_err(OmniError::from)
 }

--- a/crates/omnigraph/src/graph_index/mod.rs
+++ b/crates/omnigraph/src/graph_index/mod.rs
@@ -140,13 +140,13 @@ impl GraphIndex {
             let batches: Vec<arrow_array::RecordBatch> = ds
                 .scan()
                 .project(&["src", "dst"])
-                .map_err(|e| OmniError::Lance(e.to_string()))?
+                .map_err(OmniError::from)?
                 .try_into_stream()
                 .await
-                .map_err(|e| OmniError::Lance(e.to_string()))?
+                .map_err(OmniError::from)?
                 .try_collect()
                 .await
-                .map_err(|e| OmniError::Lance(e.to_string()))?;
+                .map_err(OmniError::from)?;
 
             type_indices
                 .entry(from_type.clone())

--- a/crates/omnigraph/src/instrumentation.rs
+++ b/crates/omnigraph/src/instrumentation.rs
@@ -548,10 +548,7 @@ pub(crate) async fn open_dataset(
             ..Default::default()
         });
     }
-    builder
-        .load()
-        .await
-        .map_err(|e| OmniError::Lance(e.to_string()))
+    builder.load().await.map_err(OmniError::from)
 }
 
 /// Per-method call counts for [`CountingStorageAdapter`].

--- a/crates/omnigraph/src/loader/mod.rs
+++ b/crates/omnigraph/src/loader/mod.rs
@@ -1427,7 +1427,7 @@ fn build_node_batch(
     columns.push(Arc::new(StringArray::from(ids)));
     columns.extend(property_columns);
 
-    RecordBatch::try_new(schema, columns).map_err(|e| OmniError::Lance(e.to_string()))
+    RecordBatch::try_new(schema, columns).map_err(OmniError::from)
 }
 
 fn build_edge_batch(
@@ -1494,7 +1494,7 @@ fn build_edge_batch(
         }
     }
 
-    RecordBatch::try_new(schema, columns).map_err(|e| OmniError::Lance(e.to_string()))
+    RecordBatch::try_new(schema, columns).map_err(OmniError::from)
 }
 
 /// Normalize a bounded group of caller-shaped rows into one dense logical
@@ -1622,7 +1622,7 @@ fn normalize_strict_node_rows(node_type: &NodeType, rows: &[JsonValue]) -> Resul
     let mut columns = Vec::with_capacity(schema.fields().len());
     columns.push(Arc::new(StringArray::from(ids)) as ArrayRef);
     columns.extend(property_columns);
-    RecordBatch::try_new(schema, columns).map_err(|error| OmniError::Lance(error.to_string()))
+    RecordBatch::try_new(schema, columns).map_err(OmniError::from)
 }
 
 fn normalize_strict_edge_rows(edge_type: &EdgeType, rows: &[JsonValue]) -> Result<RecordBatch> {
@@ -1682,7 +1682,7 @@ fn normalize_strict_edge_rows(edge_type: &EdgeType, rows: &[JsonValue]) -> Resul
         };
         columns.push(column);
     }
-    RecordBatch::try_new(schema, columns).map_err(|error| OmniError::Lance(error.to_string()))
+    RecordBatch::try_new(schema, columns).map_err(OmniError::from)
 }
 
 fn strict_row_objects(rows: &[JsonValue]) -> Result<Vec<&serde_json::Map<String, JsonValue>>> {
@@ -1960,14 +1960,10 @@ pub(crate) fn append_blob_value(builder: &mut BlobArrayBuilder, value: &str) -> 
         let bytes = base64::engine::general_purpose::STANDARD
             .decode(encoded)
             .map_err(|e| OmniError::manifest(format!("invalid base64 blob data: {}", e)))?;
-        builder
-            .push_bytes(bytes)
-            .map_err(|e| OmniError::Lance(e.to_string()))
+        builder.push_bytes(bytes).map_err(OmniError::from)
     } else {
         // Treat as URI (file://, s3://, gs://, or any other scheme)
-        builder
-            .push_uri(value)
-            .map_err(|e| OmniError::Lance(e.to_string()))
+        builder.push_uri(value).map_err(OmniError::from)
     }
 }
 
@@ -1980,9 +1976,7 @@ fn build_blob_column(name: &str, nullable: bool, rows: &[JsonValue]) -> Result<A
                 append_blob_value(&mut builder, s)?;
             }
             Some(JsonValue::Null) | None if nullable => {
-                builder
-                    .push_null()
-                    .map_err(|e| OmniError::Lance(e.to_string()))?;
+                builder.push_null().map_err(OmniError::from)?;
             }
             Some(JsonValue::Null) | None => {
                 return Err(OmniError::manifest(format!(
@@ -1998,9 +1992,7 @@ fn build_blob_column(name: &str, nullable: bool, rows: &[JsonValue]) -> Result<A
             }
         }
     }
-    builder
-        .finish()
-        .map_err(|e| OmniError::Lance(e.to_string()))
+    builder.finish().map_err(OmniError::from)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/omnigraph/src/storage_layer.rs
+++ b/crates/omnigraph/src/storage_layer.rs
@@ -803,7 +803,7 @@ impl TableStorage for TableStore {
             .dataset()
             .branch_identifier()
             .await
-            .map_err(|error| OmniError::Lance(error.to_string()))
+            .map_err(OmniError::from)
     }
 
     async fn fork_branch_from_state(

--- a/crates/omnigraph/src/table_store.rs
+++ b/crates/omnigraph/src/table_store.rs
@@ -690,7 +690,7 @@ impl TableStore {
             .column_by_name("_rowid")
             .and_then(|col| col.as_any().downcast_ref::<UInt64Array>())
             .ok_or_else(|| {
-                OmniError::Lance("expected _rowid column when materializing blobs".to_string())
+                OmniError::manifest_internal("expected _rowid column when materializing blobs".to_string())
             })?
             .values()
             .iter()
@@ -715,7 +715,7 @@ impl TableStore {
         max_blob_bytes: Option<u64>,
     ) -> Result<RecordBatch> {
         if batch.num_rows() != row_ids.len() {
-            return Err(OmniError::Lance(format!(
+            return Err(OmniError::manifest_internal(format!(
                 "blob materialization row count {} does not match {} row ids",
                 batch.num_rows(),
                 row_ids.len()
@@ -729,7 +729,7 @@ impl TableStore {
             let lance_field = lance::datatypes::Field::try_from(field.as_ref())
                 .map_err(|e| OmniError::Lance(e.to_string()))?;
             let column = batch.column_by_name(field.name()).ok_or_else(|| {
-                OmniError::Lance(format!("batch missing column '{}'", field.name()))
+                OmniError::manifest_internal(format!("batch missing column '{}'", field.name()))
             })?;
             if lance_field.is_blob() {
                 let descriptions =
@@ -737,7 +737,7 @@ impl TableStore {
                         .as_any()
                         .downcast_ref::<StructArray>()
                         .ok_or_else(|| {
-                            OmniError::Lance(format!(
+                            OmniError::manifest_internal(format!(
                                 "expected blob descriptions for '{}'",
                                 field.name()
                             ))
@@ -800,7 +800,7 @@ impl TableStore {
             }
 
             let blob = files.next().ok_or_else(|| {
-                OmniError::Lance(format!(
+                OmniError::manifest_internal(format!(
                     "blob rewrite for '{}' lost alignment with source rows",
                     column_name
                 ))
@@ -829,7 +829,7 @@ impl TableStore {
         }
 
         if files.next().is_some() {
-            return Err(OmniError::Lance(format!(
+            return Err(OmniError::manifest_internal(format!(
                 "blob rewrite for '{}' produced extra source blobs",
                 column_name
             )));
@@ -849,7 +849,7 @@ impl TableStore {
             .column_by_name("position")
             .and_then(|col| col.as_any().downcast_ref::<UInt64Array>())
             .ok_or_else(|| {
-                OmniError::Lance(format!(
+                OmniError::manifest_internal(format!(
                     "unrecognized blob description schema {:?}: missing UInt64 position field",
                     descriptions.fields()
                 ))
@@ -858,7 +858,7 @@ impl TableStore {
             .column_by_name("size")
             .and_then(|col| col.as_any().downcast_ref::<UInt64Array>())
             .ok_or_else(|| {
-                OmniError::Lance(format!(
+                OmniError::manifest_internal(format!(
                     "unrecognized blob description schema {:?}: missing UInt64 size field",
                     descriptions.fields()
                 ))
@@ -878,7 +878,7 @@ impl TableStore {
             }
             kind.value(row) as u8
         } else {
-            return Err(OmniError::Lance(format!(
+            return Err(OmniError::manifest_internal(format!(
                 "unrecognized blob description schema {:?}: kind field must be UInt8 or UInt32",
                 descriptions.fields()
             )));
@@ -2710,7 +2710,7 @@ impl TableStore {
         // `key_column` if union is what they wanted.
         if let (Some(key_col), Some(cols)) = (key_column, projection) {
             if !cols.contains(&key_col) {
-                return Err(OmniError::Lance(format!(
+                return Err(OmniError::manifest_internal(format!(
                     "scan_with_pending: key_column '{}' must appear in projection \
                      when merge-shadow semantics are requested (got projection = {:?})",
                     key_col, cols
@@ -2902,7 +2902,7 @@ impl TableStore {
                 .column_by_name("_rowid")
                 .and_then(|column| column.as_any().downcast_ref::<UInt64Array>())
                 .ok_or_else(|| {
-                    OmniError::Lance("expected _rowid in predicate-matched blob scan".to_string())
+                    OmniError::manifest_internal("expected _rowid in predicate-matched blob scan".to_string())
                 })?
                 .values()
                 .to_vec();
@@ -3321,7 +3321,7 @@ fn non_blob_column_bytes(ds: &Dataset, batch: &RecordBatch) -> Result<u64> {
         .filter(|field| !field.is_blob())
         .try_fold(0_u64, |total, field| {
             let column = batch.column_by_name(&field.name).ok_or_else(|| {
-                OmniError::Lance(format!("batch missing column '{}'", field.name))
+                OmniError::manifest_internal(format!("batch missing column '{}'", field.name))
             })?;
             let bytes = u64::try_from(column.get_array_memory_size()).map_err(|_| {
                 OmniError::manifest_internal("non-blob pending scan bytes exceed u64")
@@ -3344,13 +3344,13 @@ fn collect_string_column_values(
     let mut out = std::collections::HashSet::new();
     for batch in batches {
         let Some(col) = batch.column_by_name(column) else {
-            return Err(OmniError::Lance(format!(
+            return Err(OmniError::manifest_internal(format!(
                 "scan_with_pending: pending batch missing key column '{}'",
                 column
             )));
         };
         let arr = col.as_any().downcast_ref::<StringArray>().ok_or_else(|| {
-            OmniError::Lance(format!(
+            OmniError::manifest_internal(format!(
                 "scan_with_pending: key column '{}' is not Utf8",
                 column
             ))
@@ -3392,7 +3392,7 @@ fn filter_out_rows_where_string_in(
             ))
         })?;
         let arr = col.as_any().downcast_ref::<StringArray>().ok_or_else(|| {
-            OmniError::Lance(format!(
+            OmniError::manifest_internal(format!(
                 "scan_with_pending: committed column '{}' is not Utf8",
                 column
             ))
@@ -3517,7 +3517,7 @@ async fn materialize_external_blob_inputs(
             .as_any()
             .downcast_ref::<StructArray>()
             .ok_or_else(|| {
-                OmniError::Lance(format!("expected blob struct input for '{}'", field.name()))
+                OmniError::manifest_internal(format!("expected blob struct input for '{}'", field.name()))
             })?;
         // Dataset scans can already yield prepared descriptors. Those are
         // handled by the branch-merge materializer before this adapter.
@@ -3529,7 +3529,7 @@ async fn materialize_external_blob_inputs(
             .column_by_name("uri")
             .and_then(|array| array.as_any().downcast_ref::<StringArray>())
             .ok_or_else(|| {
-                OmniError::Lance(format!(
+                OmniError::manifest_internal(format!(
                     "logical blob input '{}' is missing Utf8 child 'uri'",
                     field.name()
                 ))
@@ -3544,7 +3544,7 @@ async fn materialize_external_blob_inputs(
             .column_by_name("data")
             .and_then(|array| array.as_any().downcast_ref::<LargeBinaryArray>())
             .ok_or_else(|| {
-                OmniError::Lance(format!(
+                OmniError::manifest_internal(format!(
                     "logical blob input '{}' is missing LargeBinary child 'data'",
                     field.name()
                 ))
@@ -3553,7 +3553,7 @@ async fn materialize_external_blob_inputs(
             .column_by_name("position")
             .map(|array| {
                 array.as_any().downcast_ref::<UInt64Array>().ok_or_else(|| {
-                    OmniError::Lance(format!(
+                    OmniError::manifest_internal(format!(
                         "logical blob input '{}' has non-UInt64 child 'position'",
                         field.name()
                     ))
@@ -3564,7 +3564,7 @@ async fn materialize_external_blob_inputs(
             .column_by_name("size")
             .map(|array| {
                 array.as_any().downcast_ref::<UInt64Array>().ok_or_else(|| {
-                    OmniError::Lance(format!(
+                    OmniError::manifest_internal(format!(
                         "logical blob input '{}' has non-UInt64 child 'size'",
                         field.name()
                     ))

--- a/crates/omnigraph/src/table_store.rs
+++ b/crates/omnigraph/src/table_store.rs
@@ -370,10 +370,9 @@ impl TableStore {
         )
         .await?;
         match branch {
-            Some(branch) if branch != "main" => ds
-                .checkout_branch(branch)
-                .await
-                .map_err(|e| OmniError::Lance(e.to_string())),
+            Some(branch) if branch != "main" => {
+                ds.checkout_branch(branch).await.map_err(OmniError::from)
+            }
             _ => Ok(ds),
         }
     }
@@ -390,10 +389,7 @@ impl TableStore {
             crate::instrumentation::table_wrapper(),
         )
         .await?;
-        let branches = ds
-            .list_branches()
-            .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+        let branches = ds.list_branches().await.map_err(OmniError::from)?;
         Ok(branches.into_keys().collect())
     }
 
@@ -469,7 +465,7 @@ impl TableStore {
             .await?
             .checkout_version(source_version)
             .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+            .map_err(OmniError::from)?;
         self.ensure_expected_version(&source_ds, table_key, source_version)?;
 
         let created = match crate::branch_control::create_branch_recoverably(
@@ -517,7 +513,7 @@ impl TableStore {
             .await?
             .try_collect::<Vec<RecordBatch>>()
             .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+            .map_err(OmniError::from)?;
         let mut materialized = Vec::with_capacity(batches.len());
         for batch in batches {
             materialized.push(Self::materialize_blob_batch(ds, batch).await?);
@@ -690,7 +686,9 @@ impl TableStore {
             .column_by_name("_rowid")
             .and_then(|col| col.as_any().downcast_ref::<UInt64Array>())
             .ok_or_else(|| {
-                OmniError::manifest_internal("expected _rowid column when materializing blobs".to_string())
+                OmniError::manifest_internal(
+                    "expected _rowid column when materializing blobs".to_string(),
+                )
             })?
             .values()
             .iter()
@@ -726,8 +724,8 @@ impl TableStore {
         let mut columns = Vec::with_capacity(schema.fields().len());
         let mut materialized_blob_bytes = 0_u64;
         for field in schema.fields() {
-            let lance_field = lance::datatypes::Field::try_from(field.as_ref())
-                .map_err(|e| OmniError::Lance(e.to_string()))?;
+            let lance_field =
+                lance::datatypes::Field::try_from(field.as_ref()).map_err(OmniError::from)?;
             let column = batch.column_by_name(field.name()).ok_or_else(|| {
                 OmniError::manifest_internal(format!("batch missing column '{}'", field.name()))
             })?;
@@ -758,7 +756,7 @@ impl TableStore {
             }
         }
 
-        RecordBatch::try_new(schema, columns).map_err(|e| OmniError::Lance(e.to_string()))
+        RecordBatch::try_new(schema, columns).map_err(OmniError::from)
     }
 
     async fn rebuild_blob_column(
@@ -787,15 +785,13 @@ impl TableStore {
             Arc::new(ds.clone())
                 .take_blobs(&non_null_row_ids, column_name)
                 .await
-                .map_err(|e| OmniError::Lance(e.to_string()))?
+                .map_err(OmniError::from)?
         };
 
         let mut files = blob_files.into_iter();
         for has_blob in row_has_blob {
             if !has_blob {
-                builder
-                    .push_null()
-                    .map_err(|e| OmniError::Lance(e.to_string()))?;
+                builder.push_null().map_err(OmniError::from)?;
                 continue;
             }
 
@@ -820,12 +816,8 @@ impl TableStore {
             *materialized_blob_bytes = next_blob_bytes;
             crate::instrumentation::record_blob_payload_read();
             builder
-                .push_bytes(
-                    blob.read()
-                        .await
-                        .map_err(|e| OmniError::Lance(e.to_string()))?,
-                )
-                .map_err(|e| OmniError::Lance(e.to_string()))?;
+                .push_bytes(blob.read().await.map_err(OmniError::from)?)
+                .map_err(OmniError::from)?;
         }
 
         if files.next().is_some() {
@@ -835,9 +827,7 @@ impl TableStore {
             )));
         }
 
-        builder
-            .finish()
-            .map_err(|e| OmniError::Lance(e.to_string()))
+        builder.finish().map_err(OmniError::from)
     }
 
     fn blob_description_is_null(descriptions: &StructArray, row: usize) -> Result<bool> {
@@ -884,7 +874,7 @@ impl TableStore {
             )));
         };
 
-        let kind = BlobKind::try_from(kind).map_err(|e| OmniError::Lance(e.to_string()))?;
+        let kind = BlobKind::try_from(kind).map_err(OmniError::from)?;
         if kind != BlobKind::Inline {
             return Ok(false);
         }
@@ -952,25 +942,16 @@ impl TableStore {
             scanner.with_row_id();
         }
         if let Some(columns) = projection {
-            scanner
-                .project(columns)
-                .map_err(|e| OmniError::Lance(e.to_string()))?;
+            scanner.project(columns).map_err(OmniError::from)?;
         }
         if let Some(filter_sql) = filter {
-            scanner
-                .filter(filter_sql)
-                .map_err(|e| OmniError::Lance(e.to_string()))?;
+            scanner.filter(filter_sql).map_err(OmniError::from)?;
         }
         if let Some(ordering) = order_by {
-            scanner
-                .order_by(Some(ordering))
-                .map_err(|e| OmniError::Lance(e.to_string()))?;
+            scanner.order_by(Some(ordering)).map_err(OmniError::from)?;
         }
         configure(&mut scanner)?;
-        scanner
-            .try_into_stream()
-            .await
-            .map_err(|e| OmniError::Lance(e.to_string()))
+        scanner.try_into_stream().await.map_err(OmniError::from)
     }
 
     pub async fn scan(
@@ -984,7 +965,7 @@ impl TableStore {
             .await?
             .try_collect()
             .await
-            .map_err(|e| OmniError::Lance(e.to_string()))
+            .map_err(OmniError::from)
     }
 
     pub async fn scan_with<F>(
@@ -1003,7 +984,7 @@ impl TableStore {
             .await?
             .try_collect()
             .await
-            .map_err(|e| OmniError::Lance(e.to_string()))
+            .map_err(OmniError::from)
     }
 
     /// Indexed neighbor lookup for graph traversal. Given an edge dataset and a
@@ -1066,7 +1047,7 @@ impl TableStore {
         .await?
         .try_collect()
         .await
-        .map_err(|e| OmniError::Lance(e.to_string()))
+        .map_err(OmniError::from)
     }
 
     /// Metadata-only check (no IO) of whether `scan_edges_by_endpoint` — a
@@ -1083,10 +1064,7 @@ impl TableStore {
                 reason: format!("column '{}' not in schema", column),
             });
         };
-        let indices = ds
-            .load_indices()
-            .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+        let indices = ds.load_indices().await.map_err(OmniError::from)?;
         let btree = indices
             .iter()
             .filter(|index| !is_system_index(index))
@@ -1146,10 +1124,7 @@ impl TableStore {
     /// Used by `optimize` to decide whether an otherwise-already-compacted
     /// table still has index work to do.
     pub async fn has_unindexed_fragments(ds: &Dataset) -> Result<bool> {
-        let indices = ds
-            .load_indices()
-            .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+        let indices = ds.load_indices().await.map_err(OmniError::from)?;
         let frag_ids: Vec<u32> = ds.fragments().iter().map(|f| f.id as u32).collect();
         for index in indices.iter() {
             if is_system_index(index) {
@@ -1165,9 +1140,7 @@ impl TableStore {
     }
 
     pub async fn count_rows(&self, ds: &Dataset, filter: Option<String>) -> Result<usize> {
-        ds.count_rows(filter)
-            .await
-            .map_err(|e| OmniError::Lance(e.to_string()))
+        ds.count_rows(filter).await.map_err(OmniError::from)
     }
 
     pub fn dataset_version(&self, ds: &Dataset) -> u64 {
@@ -1212,7 +1185,7 @@ impl TableStore {
         };
         ds.append(reader, Some(params))
             .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+            .map_err(OmniError::from)?;
         self.table_state(dataset_uri, ds).await
     }
 
@@ -1233,7 +1206,7 @@ impl TableStore {
                 };
                 ds.append(reader, Some(params))
                     .await
-                    .map_err(|e| OmniError::Lance(e.to_string()))?;
+                    .map_err(OmniError::from)?;
                 Ok(ds)
             }
             None => {
@@ -1250,7 +1223,7 @@ impl TableStore {
                 };
                 Dataset::write(reader, dataset_uri, Some(params))
                     .await
-                    .map_err(|e| OmniError::Lance(e.to_string()))
+                    .map_err(OmniError::from)
             }
         }
     }
@@ -1272,7 +1245,7 @@ impl TableStore {
         let uncommitted = DeleteBuilder::new(Arc::new(ds.clone()), filter)
             .execute_uncommitted()
             .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+            .map_err(OmniError::from)?;
 
         if uncommitted.num_deleted_rows == 0 {
             return Ok(None);
@@ -1379,7 +1352,7 @@ impl TableStore {
             .with_params(&params)
             .execute_uncommitted(vec![batch])
             .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+            .map_err(OmniError::from)?;
         // Record only after the staging write succeeds, so a failed write does
         // not inflate the probe (matches `stage_append_stream`'s ordering).
         crate::instrumentation::record_stage_append(appended_rows);
@@ -1446,7 +1419,7 @@ impl TableStore {
             .with_params(&params)
             .execute_uncommitted_stream(stream)
             .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+            .map_err(OmniError::from)?;
         let mut new_fragments = match &transaction.operation {
             Operation::Append { fragments } => fragments.clone(),
             Operation::Overwrite { fragments, .. } => fragments.clone(),
@@ -1648,7 +1621,7 @@ impl TableStore {
         for id in &source_ids {
             filter_builder
                 .insert(KeyValue::String(id.clone()))
-                .map_err(|error| OmniError::Lance(error.to_string()))?;
+                .map_err(OmniError::from)?;
         }
         if filter_builder.len() != batch.num_rows()
             || source_ids
@@ -1685,7 +1658,7 @@ impl TableStore {
             .with_params(&params)
             .execute_uncommitted(vec![batch])
             .await
-            .map_err(|error| OmniError::Lance(error.to_string()))?;
+            .map_err(OmniError::from)?;
         if transaction.read_version != expected_read_version {
             return Err(OmniError::manifest_internal(format!(
                 "stage_proven_strict_insert wrote against version {}, expected {expected_read_version}",
@@ -1807,11 +1780,7 @@ impl TableStore {
         exact_id_primary_key_field_id(source, "stage_keyed_write_stream source")?;
         let mut id_stream = Self::scan_stream(source, Some(&["id"]), None, None, false).await?;
         let mut merged_rows = 0_u64;
-        while let Some(batch) = id_stream
-            .try_next()
-            .await
-            .map_err(|error| OmniError::Lance(error.to_string()))?
-        {
+        while let Some(batch) = id_stream.try_next().await.map_err(OmniError::from)? {
             merged_rows = merged_rows
                 .checked_add(batch.num_rows() as u64)
                 .ok_or_else(|| {
@@ -1880,11 +1849,7 @@ impl TableStore {
                 Ok(())
             })
             .await?;
-        while let Some(batch) = target_ids
-            .try_next()
-            .await
-            .map_err(|error| OmniError::Lance(error.to_string()))?
-        {
+        while let Some(batch) = target_ids.try_next().await.map_err(OmniError::from)? {
             let ids = string_id_column(&batch, "stage_keyed_write strict preflight")?;
             for row in 0..ids.len() {
                 if ids.is_valid(row) {
@@ -1905,7 +1870,7 @@ impl TableStore {
         context: &'static str,
     ) -> Result<(StagedWrite, MergeStats)> {
         let mut builder = MergeInsertBuilder::try_new(Arc::new(ds), vec!["id".to_string()])
-            .map_err(|error| OmniError::Lance(error.to_string()))?;
+            .map_err(OmniError::from)?;
         builder.when_matched(match semantics {
             KeyedWriteSemantics::StrictInsert => WhenMatched::Fail,
             KeyedWriteSemantics::Upsert => WhenMatched::UpdateAll,
@@ -1923,10 +1888,10 @@ impl TableStore {
         builder.source_dedupe_behavior(SourceDedupeBehavior::FirstSeen);
         let uncommitted = builder
             .try_build()
-            .map_err(|error| OmniError::Lance(error.to_string()))?
+            .map_err(OmniError::from)?
             .execute_uncommitted(stream)
             .await
-            .map_err(|error| OmniError::Lance(error.to_string()))?;
+            .map_err(OmniError::from)?;
 
         validate_exact_id_filter(&uncommitted, id_field_id, context)?;
         if semantics == KeyedWriteSemantics::StrictInsert {
@@ -2139,8 +2104,7 @@ impl TableStore {
         check_batch_unique_by_keys(&batch, &key_columns, "stage_merge_insert")?;
 
         let ds = Arc::new(ds);
-        let mut builder = MergeInsertBuilder::try_new(ds, key_columns)
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+        let mut builder = MergeInsertBuilder::try_new(ds, key_columns).map_err(OmniError::from)?;
         builder.when_matched(when_matched);
         builder.when_not_matched(when_not_matched);
         // Workaround for a Lance bug class where sequential merge_insert calls
@@ -2159,16 +2123,14 @@ impl TableStore {
         // walk in `exec/merge.rs`). Retire when upstream Lance fixes the bug
         // class. Tracked at MR-957; upstream: lance-format/lance#6877.
         builder.source_dedupe_behavior(SourceDedupeBehavior::FirstSeen);
-        let job = builder
-            .try_build()
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+        let job = builder.try_build().map_err(OmniError::from)?;
         let schema = batch.schema();
         let reader = arrow_array::RecordBatchIterator::new(vec![Ok(batch)], schema);
         let stream = lance_datafusion::utils::reader_to_stream(Box::new(reader));
         let uncommitted = job
             .execute_uncommitted(stream)
             .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+            .map_err(OmniError::from)?;
         // Record only after the staging write succeeds, so a failed write does
         // not inflate the probe (matches `stage_append`/`stage_append_stream`).
         crate::instrumentation::record_stage_merge_insert(merged_rows);
@@ -2282,11 +2244,11 @@ impl TableStore {
             .with_max_retries(0)
             .execute(staged.transaction)
             .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+            .map_err(OmniError::from)?;
         let committed_identity = dataset
             .read_transaction()
             .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?
+            .map_err(OmniError::from)?
             .as_ref()
             .map(StagedTransactionIdentity::from)
             .ok_or_else(|| {
@@ -2326,7 +2288,7 @@ impl TableStore {
             dataset
                 .read_transaction()
                 .await
-                .map_err(|e| OmniError::Lance(e.to_string()))?
+                .map_err(OmniError::from)?
                 .as_ref()
                 .map(StagedTransactionIdentity::from)
         } else {
@@ -2357,7 +2319,7 @@ impl TableStore {
             .with_params(&params)
             .execute_uncommitted(vec![batch])
             .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+            .map_err(OmniError::from)?;
         if transaction.read_version != 0 {
             return Err(OmniError::manifest_internal(format!(
                 "stage_create resolved '{}' at existing version {}; expected an absent dataset",
@@ -2398,8 +2360,7 @@ impl TableStore {
         // Lance's row-id-lineage spec, so this stays correct for legacy
         // datasets.
         let (transaction, mut new_fragments) = if batch.num_rows() == 0 {
-            let schema = LanceSchema::try_from(batch.schema().as_ref())
-                .map_err(|e| OmniError::Lance(e.to_string()))?;
+            let schema = LanceSchema::try_from(batch.schema().as_ref()).map_err(OmniError::from)?;
             let transaction = TransactionBuilder::new(
                 ds.manifest.version,
                 Operation::Overwrite {
@@ -2424,7 +2385,7 @@ impl TableStore {
                 .with_params(&params)
                 .execute_uncommitted(vec![batch])
                 .await
-                .map_err(|e| OmniError::Lance(e.to_string()))?;
+                .map_err(OmniError::from)?;
             let new_fragments = match &transaction.operation {
                 Operation::Overwrite { fragments, .. } => fragments.clone(),
                 other => {
@@ -2491,7 +2452,7 @@ impl TableStore {
         let existing_indices = ds
             .load_indices()
             .await
-            .map_err(|e| OmniError::Lance(format!("stage_create_indices: {e}")))?;
+            .map_err(|e| OmniError::storage_context(e, "stage_create_indices"))?;
         let mut new_indices = Vec::with_capacity(specs.len());
         let mut new_names = std::collections::HashSet::with_capacity(specs.len());
         let mut vector_builds = 0usize;
@@ -2546,9 +2507,10 @@ impl TableStore {
                 }
             }
             .map_err(|e| {
-                OmniError::Lance(format!(
-                    "stage_create_indices: build {index_type} index on '{column}': {e}"
-                ))
+                OmniError::storage_context(
+                    e,
+                    format!("stage_create_indices: build {index_type} index on '{column}'"),
+                )
             })?;
 
             if new_idx.dataset_version != read_version {
@@ -2631,24 +2593,14 @@ impl TableStore {
         let mut scanner = ds.scan();
         if let Some(cols) = projection {
             let owned: Vec<String> = cols.iter().map(|s| s.to_string()).collect();
-            scanner
-                .project(&owned)
-                .map_err(|e| OmniError::Lance(e.to_string()))?;
+            scanner.project(&owned).map_err(OmniError::from)?;
         }
         if let Some(f) = filter {
-            scanner
-                .filter(f)
-                .map_err(|e| OmniError::Lance(e.to_string()))?;
+            scanner.filter(f).map_err(OmniError::from)?;
         }
         scanner.with_fragments(combine_committed_with_staged(ds, staged));
-        let stream = scanner
-            .try_into_stream()
-            .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
-        stream
-            .try_collect()
-            .await
-            .map_err(|e| OmniError::Lance(e.to_string()))
+        let stream = scanner.try_into_stream().await.map_err(OmniError::from)?;
+        stream.try_collect().await.map_err(OmniError::from)
     }
 
     /// Scan committed via Lance + apply the same filter to in-memory
@@ -2749,11 +2701,7 @@ impl TableStore {
             .await?;
 
         let mut committed = Vec::new();
-        while let Some(batch) = stream
-            .try_next()
-            .await
-            .map_err(|error| OmniError::Lance(error.to_string()))?
-        {
+        while let Some(batch) = stream.try_next().await.map_err(OmniError::from)? {
             let batch = if let Some(key_col) = key_column
                 && !pending_keys.is_empty()
             {
@@ -2869,11 +2817,7 @@ impl TableStore {
         .await?;
 
         let mut committed = Vec::new();
-        while let Some(batch) = matched
-            .try_next()
-            .await
-            .map_err(|error| OmniError::Lance(error.to_string()))?
-        {
+        while let Some(batch) = matched.try_next().await.map_err(OmniError::from)? {
             // Shadow before row charging and before any blob handle/read. A
             // prior pending row owns the logical id even when it no longer
             // matches this update predicate.
@@ -2902,7 +2846,9 @@ impl TableStore {
                 .column_by_name("_rowid")
                 .and_then(|column| column.as_any().downcast_ref::<UInt64Array>())
                 .ok_or_else(|| {
-                    OmniError::manifest_internal("expected _rowid in predicate-matched blob scan".to_string())
+                    OmniError::manifest_internal(
+                        "expected _rowid in predicate-matched blob scan".to_string(),
+                    )
                 })?
                 .values()
                 .to_vec();
@@ -2912,7 +2858,7 @@ impl TableStore {
             let descriptors = committed_ds
                 .take_rows(&row_ids, committed_ds.schema().clone())
                 .await
-                .map_err(|error| OmniError::Lance(error.to_string()))?;
+                .map_err(OmniError::from)?;
             let materialized = match Self::materialize_blob_batch_with_row_ids(
                 committed_ds,
                 descriptors,
@@ -2962,15 +2908,10 @@ impl TableStore {
         }
         let mut scanner = ds.scan();
         if let Some(f) = filter {
-            scanner
-                .filter(&f)
-                .map_err(|e| OmniError::Lance(e.to_string()))?;
+            scanner.filter(&f).map_err(OmniError::from)?;
         }
         scanner.with_fragments(combine_committed_with_staged(ds, staged));
-        let count = scanner
-            .count_rows()
-            .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+        let count = scanner.count_rows().await.map_err(OmniError::from)?;
         Ok(count as usize)
     }
 
@@ -2985,10 +2926,7 @@ impl TableStore {
                     column
                 ))
             })?;
-        let indices = ds
-            .load_indices()
-            .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+        let indices = ds.load_indices().await.map_err(OmniError::from)?;
         Ok(indices
             .iter()
             .filter(|index| !is_system_index(index))
@@ -3052,7 +2990,7 @@ impl TableStore {
             .await?
             .try_collect::<Vec<RecordBatch>>()
             .await
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+            .map_err(OmniError::from)?;
         Ok(batches.iter().find_map(|batch| {
             batch
                 .column_by_name("_rowid")
@@ -3076,7 +3014,7 @@ impl TableStore {
         };
         Dataset::write(reader, dataset_uri, Some(params))
             .await
-            .map_err(|e| OmniError::Lance(e.to_string()))
+            .map_err(OmniError::from)
     }
 }
 
@@ -3086,7 +3024,7 @@ fn map_lance_commit_error(error: lance::Error) -> OmniError {
         | lance::Error::TooMuchWriteContention { .. }) => {
             OmniError::RetryableCommitConflict(error.to_string())
         }
-        error => OmniError::Lance(error.to_string()),
+        error => OmniError::from(error),
     }
 }
 
@@ -3406,8 +3344,8 @@ fn filter_out_rows_where_string_in(
                 }
             })
             .collect();
-        let filtered = arrow_select::filter::filter_record_batch(&batch, &mask)
-            .map_err(|e| OmniError::Lance(e.to_string()))?;
+        let filtered =
+            arrow_select::filter::filter_record_batch(&batch, &mask).map_err(OmniError::from)?;
         out.push(filtered);
     }
     Ok(out)
@@ -3445,9 +3383,9 @@ async fn scan_pending_batches(
     config.options_mut().sql_parser.enable_ident_normalization = false;
     let ctx = datafusion::execution::context::SessionContext::new_with_config(config);
     let mem = datafusion::datasource::MemTable::try_new(schema, vec![pending_batches.to_vec()])
-        .map_err(|e| OmniError::Lance(e.to_string()))?;
+        .map_err(OmniError::from)?;
     ctx.register_table("pending", Arc::new(mem))
-        .map_err(|e| OmniError::Lance(e.to_string()))?;
+        .map_err(OmniError::from)?;
 
     let proj = projection
         .map(|cols| {
@@ -3459,13 +3397,8 @@ async fn scan_pending_batches(
         .unwrap_or_else(|| "*".to_string());
     let where_clause = filter.map(|f| format!("WHERE {f}")).unwrap_or_default();
     let sql = format!("SELECT {proj} FROM pending {where_clause}");
-    let df = ctx
-        .sql(&sql)
-        .await
-        .map_err(|e| OmniError::Lance(e.to_string()))?;
-    df.collect()
-        .await
-        .map_err(|e| OmniError::Lance(e.to_string()))
+    let df = ctx.sql(&sql).await.map_err(OmniError::from)?;
+    df.collect().await.map_err(OmniError::from)
 }
 
 // Staged-write helper retained alongside the sealed storage surface; its
@@ -3507,8 +3440,8 @@ async fn materialize_external_blob_inputs(
     let registry = Arc::new(lance::io::ObjectStoreRegistry::default());
 
     for (field, column) in schema.fields().iter().zip(batch.columns()) {
-        let lance_field = lance::datatypes::Field::try_from(field.as_ref())
-            .map_err(|error| OmniError::Lance(error.to_string()))?;
+        let lance_field =
+            lance::datatypes::Field::try_from(field.as_ref()).map_err(OmniError::from)?;
         if !lance_field.is_blob() {
             columns.push(column.clone());
             continue;
@@ -3517,7 +3450,10 @@ async fn materialize_external_blob_inputs(
             .as_any()
             .downcast_ref::<StructArray>()
             .ok_or_else(|| {
-                OmniError::manifest_internal(format!("expected blob struct input for '{}'", field.name()))
+                OmniError::manifest_internal(format!(
+                    "expected blob struct input for '{}'",
+                    field.name()
+                ))
             })?;
         // Dataset scans can already yield prepared descriptors. Those are
         // handled by the branch-merge materializer before this adapter.
@@ -3575,9 +3511,7 @@ async fn materialize_external_blob_inputs(
         let mut builder = BlobArrayBuilder::new(descriptions.len());
         for row in 0..descriptions.len() {
             if descriptions.is_null(row) {
-                builder
-                    .push_null()
-                    .map_err(|error| OmniError::Lance(error.to_string()))?;
+                builder.push_null().map_err(OmniError::from)?;
                 continue;
             }
             let has_data = data.is_valid(row);
@@ -3585,7 +3519,7 @@ async fn materialize_external_blob_inputs(
             match (has_data, has_uri) {
                 (true, false) => builder
                     .push_bytes(data.value(row))
-                    .map_err(|error| OmniError::Lance(error.to_string()))?,
+                    .map_err(OmniError::from)?,
                 (false, true) => {
                     let uri = uris.value(row);
                     url::Url::parse(uri).map_err(|_| {
@@ -3599,11 +3533,8 @@ async fn materialize_external_blob_inputs(
                         &lance::io::ObjectStoreParams::default(),
                     )
                     .await
-                    .map_err(|error| OmniError::Lance(error.to_string()))?;
-                    let object_size = store
-                        .size(&path)
-                        .await
-                        .map_err(|error| OmniError::Lance(error.to_string()))?;
+                    .map_err(OmniError::from)?;
+                    let object_size = store.size(&path).await.map_err(OmniError::from)?;
                     let position =
                         positions.and_then(|array| array.is_valid(row).then(|| array.value(row)));
                     let declared_size =
@@ -3654,10 +3585,8 @@ async fn materialize_external_blob_inputs(
                     let bytes = store
                         .read_one_range(&path, start..end)
                         .await
-                        .map_err(|error| OmniError::Lance(error.to_string()))?;
-                    builder
-                        .push_bytes(bytes)
-                        .map_err(|error| OmniError::Lance(error.to_string()))?;
+                        .map_err(OmniError::from)?;
+                    builder.push_bytes(bytes).map_err(OmniError::from)?;
                 }
                 (true, true) => {
                     return Err(OmniError::manifest(format!(
@@ -3673,18 +3602,14 @@ async fn materialize_external_blob_inputs(
                 }
             }
         }
-        columns.push(
-            builder
-                .finish()
-                .map_err(|error| OmniError::Lance(error.to_string()))?,
-        );
+        columns.push(builder.finish().map_err(OmniError::from)?);
         changed = true;
     }
 
     if !changed {
         return Ok(batch);
     }
-    RecordBatch::try_new(schema, columns).map_err(|error| OmniError::Lance(error.to_string()))
+    RecordBatch::try_new(schema, columns).map_err(OmniError::from)
 }
 
 /// The provenance scanner copies every source blob into a logical in-memory
@@ -3695,8 +3620,8 @@ async fn materialize_external_blob_inputs(
 /// target dataset.
 fn ensure_proven_insert_blobs_are_materialized(batch: &RecordBatch, table_key: &str) -> Result<()> {
     for (field, column) in batch.schema().fields().iter().zip(batch.columns()) {
-        let lance_field = lance::datatypes::Field::try_from(field.as_ref())
-            .map_err(|error| OmniError::Lance(error.to_string()))?;
+        let lance_field =
+            lance::datatypes::Field::try_from(field.as_ref()).map_err(OmniError::from)?;
         if !lance_field.is_blob() {
             continue;
         }
@@ -3947,7 +3872,7 @@ fn certify_insert_absence(
     for id in source_ids {
         expected_filter
             .insert(KeyValue::String(id.clone()))
-            .map_err(|error| OmniError::Lance(error.to_string()))?;
+            .map_err(OmniError::from)?;
     }
     if expected_filter.len() != source_ids.len()
         || source_ids
@@ -4311,7 +4236,7 @@ fn proven_insert_slice_memory_size(batch: &RecordBatch, offset: usize, rows: usi
             .slice(offset, rows)
             .to_data()
             .get_slice_memory_size()
-            .map_err(|error| OmniError::Lance(error.to_string()))?;
+            .map_err(OmniError::from)?;
         total
             .checked_add(u64::try_from(bytes).map_err(|_| {
                 OmniError::manifest_internal("proven insert logical slice bytes exceed u64")
@@ -4330,8 +4255,7 @@ fn finish_proven_insert_batch(
     let batch = if batches.len() == 1 {
         batches.pop().expect("length checked")
     } else {
-        arrow_select::concat::concat_batches(schema, &batches)
-            .map_err(|error| OmniError::Lance(error.to_string()))?
+        arrow_select::concat::concat_batches(schema, &batches).map_err(OmniError::from)?
     };
     validate_proven_insert_source_batch(&batch, table_key)?;
     Ok(batch)
@@ -4350,8 +4274,7 @@ fn copy_proven_insert_batch_range(
     let end = u64::try_from(end)
         .map_err(|_| OmniError::manifest_internal("proven insert delta end exceeds u64"))?;
     let indices = UInt64Array::from_iter_values(offset..end);
-    arrow_select::take::take_record_batch(batch, &indices)
-        .map_err(|error| OmniError::Lance(error.to_string()))
+    arrow_select::take::take_record_batch(batch, &indices).map_err(OmniError::from)
 }
 
 fn validate_proven_insert_source_batch(batch: &RecordBatch, table_key: &str) -> Result<()> {

--- a/crates/omnigraph/src/validate.rs
+++ b/crates/omnigraph/src/validate.rs
@@ -549,7 +549,7 @@ async fn scan_filtered(ds: &Dataset, projection: &[&str], expr: Expr) -> Result<
     .await?
     .try_collect()
     .await
-    .map_err(|e| OmniError::Lance(e.to_string()))
+    .map_err(OmniError::from)
 }
 
 /// Scan `projection` from every row (no filter). Used to enumerate a table's
@@ -559,7 +559,7 @@ async fn scan_all(ds: &Dataset, projection: &[&str]) -> Result<Vec<RecordBatch>>
         .await?
         .try_collect()
         .await
-        .map_err(|e| OmniError::Lance(e.to_string()))
+        .map_err(OmniError::from)
 }
 
 /// Ids an `Overwrite` of `table_key` removes: committed ids in `base` that are

--- a/crates/omnigraph/tests/failpoints.rs
+++ b/crates/omnigraph/tests/failpoints.rs
@@ -10876,11 +10876,11 @@ async fn branch_merge_pure_insert_rejects_source_table_ref_aba_before_arm() {
     let replacement_result = async {
         let mut root = lance::Dataset::open(&person_uri)
             .await
-            .map_err(|error| OmniError::Lance(error.to_string()))?;
+            .map_err(OmniError::from)?;
         let main_version = root.version().version;
         root.force_delete_branch("source")
             .await
-            .map_err(|error| OmniError::Lance(error.to_string()))?;
+            .map_err(OmniError::from)?;
         if let Err(error) = std::fs::remove_dir_all(
             std::path::Path::new(&person_uri)
                 .join("tree")
@@ -10891,11 +10891,11 @@ async fn branch_merge_pure_insert_rejects_source_table_ref_aba_before_arm() {
         }
         root.create_branch("source", main_version, None)
             .await
-            .map_err(|error| OmniError::Lance(error.to_string()))?;
+            .map_err(OmniError::from)?;
         let mut replacement = root
             .checkout_branch("source")
             .await
-            .map_err(|error| OmniError::Lance(error.to_string()))?;
+            .map_err(OmniError::from)?;
         // The manifest publisher refuses to register the same table version a
         // second time for one logical table identity, so advance the recreated
         // ref beyond the captured version. The final native identifier check,
@@ -10914,7 +10914,7 @@ async fn branch_merge_pure_insert_rejects_source_table_ref_aba_before_arm() {
             replacement
                 .branch_identifier()
                 .await
-                .map_err(|error| OmniError::Lance(error.to_string()))?,
+                .map_err(OmniError::from)?,
         ))
     }
     .await;

--- a/crates/omnigraph/tests/helpers/recovery.rs
+++ b/crates/omnigraph/tests/helpers/recovery.rs
@@ -537,14 +537,11 @@ async fn entry_and_lance_head(
 
 async fn lance_head_for_entry(root_uri: &str, entry: &SubTableEntry) -> Result<u64> {
     let table_uri = format!("{}/{}", root_uri.trim_end_matches('/'), entry.table_path);
-    let ds = Dataset::open(&table_uri)
-        .await
-        .map_err(|err| OmniError::Lance(err.to_string()))?;
+    let ds = Dataset::open(&table_uri).await.map_err(OmniError::from)?;
     let ds = match entry.table_branch.as_deref() {
-        Some(branch) if branch != "main" => ds
-            .checkout_branch(branch)
-            .await
-            .map_err(|err| OmniError::Lance(err.to_string()))?,
+        Some(branch) if branch != "main" => {
+            ds.checkout_branch(branch).await.map_err(OmniError::from)?
+        }
         _ => ds,
     };
     Ok(ds.version().version)
@@ -594,15 +591,15 @@ async fn matching_audit_rows(
     }
     let ds = Dataset::open(recoveries_dir.to_str().unwrap())
         .await
-        .map_err(|err| OmniError::Lance(err.to_string()))?;
+        .map_err(OmniError::from)?;
     let batches: Vec<RecordBatch> = ds
         .scan()
         .try_into_stream()
         .await
-        .map_err(|err| OmniError::Lance(err.to_string()))?
+        .map_err(OmniError::from)?
         .try_collect()
         .await
-        .map_err(|err| OmniError::Lance(err.to_string()))?;
+        .map_err(OmniError::from)?;
 
     let mut rows = Vec::new();
     for batch in batches {

--- a/docs/user/operations/errors.md
+++ b/docs/user/operations/errors.md
@@ -3,8 +3,31 @@
 ## Error taxonomy (`omnigraph::error::OmniError`)
 
 - `Compiler(...)` — schema/query parse/typecheck errors
-- `Lance(String)` — storage layer
-- `DataFusion(String)` — execution layer
+- `Storage(StorageFailure { kind, message })` — the storage layer (Lance, and
+  the object store beneath it). `kind` is the classification a caller uses to
+  decide whether to retry, reconfigure, or escalate; `message` keeps the
+  substrate's own wording. Classification happens once, at the boundary, and
+  travels with the error — nothing above the boundary parses error text.
+  - `StorageFailureKind::Transient` — transport failure, timeout, throttling,
+    or a retry budget the object store already exhausted. A bounded retry of
+    the same call can plausibly succeed. This is where an S3 5xx, a connection
+    reset, a DNS failure, or a TLS error arrives.
+  - `StorageFailureKind::Configuration` — credentials, permissions, an
+    unsupported operation, or a malformed URI. Retrying the same call with the
+    same configuration cannot succeed; an operator must change something.
+  - `StorageFailureKind::NotFound` — the object, dataset, version, or ref
+    genuinely does not exist.
+  - `StorageFailureKind::Permanent` — corruption, a schema mismatch, or a
+    substrate-internal failure. Never retry.
+
+  `OmniError::storage_failure()` returns the classified failure for any error
+  that is one, so a caller never matches on engine internals. The `Display`
+  form is unchanged (`storage: <message>`), so logs and existing operator
+  runbooks are unaffected.
+- `DataFusion(String)` — execution layer. A DataFusion failure that carries a
+  substrate error in its source chain is classified as `Storage` instead, since
+  the same type carries both in-memory execution failures and failures raised
+  during a Lance scan.
 - `Io(io::Error)`
 - `Manifest(ManifestError { kind: BadRequest|NotFound|Conflict|Internal, details: Option<ManifestConflictDetails>, … })`
   - `ManifestConflictDetails::ExpectedVersionMismatch { table_key, expected, actual }` — caller's `expected_table_versions` did not match the manifest's current latest non-tombstoned version (set by `OmniError::manifest_expected_version_mismatch`).
@@ -21,7 +44,9 @@
 - `RetryableCommitConflict(String)` — the typed internal signal that Lance
   rejected a stale filtered transaction. Upsert writers consume an effect-free
   instance by discarding and fully repreparing the logical operation; a strict
-  writer does the same when its fresh attempted-ID probe finds no match. No code
+  writer does the same when its fresh attempted-ID probe finds no match. Kept as
+  its own variant rather than folded into `Storage` because the effect-free key
+  fence depends on telling it apart from an arbitrary storage failure. No code
   parses Lance error text. If this signal escapes an enrolled writer, HTTP maps
   it to a generic **409** conflict.
 - `ResourceLimitExceeded { resource, limit, actual }` — a keyed Mutation/Load


### PR DESCRIPTION
## Summary

Every Lance and object-store failure was flattened into `OmniError::Lance(String)`, so nothing above the substrate boundary could distinguish a transient transport condition from a permanent one without parsing error text.

That is not hypothetical. `object_store` routes every retried-and-exhausted HTTP condition — 5xx, connection resets, DNS, TLS, retry-budget exhaustion — into `Error::Generic`, and Lance keeps that value reachable through `IO { source }`. All of it arrived upstream as an opaque string, indistinguishable from a corrupt file.

This adds `StorageFailureKind` (`Transient` / `Configuration` / `NotFound` / `Permanent`) and derives it **once**, at each substrate boundary:

- `From<lance::Error>` classifies by variant and, for `IO`, downcasts through the source chain to the originating `object_store::Error`. No text parsing anywhere.
- The storage adapter's `storage_backend_error` takes the typed `object_store::Error` instead of `impl Display`, so the classification survives the boundary it previously died at. `LocalFileSystem` reports plain OS errors through `Generic` too, so that path inspects the underlying `io::Error` — a wrong path is not something retrying fixes.
- `From<ArrowError>` maps to a manifest-internal failure: an Arrow shape violation is an engine bug and must never be classifiable as storage.
- `From<DataFusionError>` classifies by source chain, since the same type carries both in-memory execution failures and failures raised during a Lance scan.

`OmniError` becomes `#[non_exhaustive]` (one catch-all arm added in the server). `StorageFailureKind` stays closed on purpose: adding a class should be a compile error at every consumer that switches on it.

The first commit is separable and lands first: ~50 call sites raised `OmniError::Lance` for failures that never touched storage — missing columns, unexpected Arrow array types, blob-descriptor shape mismatches. Harmless while the variant was an untyped string bucket; actively wrong once storage failures carry a retryability signal.

## Behavior

`Display` is byte-identical (`storage: <message>`), so logs, operator runbooks, and the HTTP mapping are unchanged. This PR adds the signal; **no caller consumes it yet**.

One deliberate omission: the publisher's namespace-validation conflicts keep the storage variant as `Permanent` rather than becoming manifest conflicts. That retargeting would change their HTTP status, which is a behavior change that does not belong in a classification refactor.

## Verification

- 8 new classification tests construct the exact upstream `lance::Error` and `object_store::Error` shapes (not approximations) and pin: transient survives the Lance boundary, permission/absence classify correctly, commit conflicts keep their dedicated variant, Arrow failures are never storage, DataFusion classifies by source not call site, `Display` is unchanged, and context preserves classification.
- New storage-crate tests pin that a remote `Generic` stays transient while a local OS error through the same variant does not.
- `cargo test --workspace --locked --features omnigraph-engine/failpoints,omnigraph-cluster/failpoints` — 75 suites, 2019 tests, zero failures.
- `cargo clippy --workspace --all-targets --locked -- -D warnings -W clippy::dbg_macro` — clean.
- `cargo fmt --all --check`.

No storage-format migration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide mechanical refactor across manifest, recovery, exec, and HTTP error translation; wrong classification could mislead future retry logic, though current HTTP/logs behavior is intended to stay the same.
> 
> **Overview**
> Replaces the flat **`OmniError::Lance(String)`** bucket with **`OmniError::Storage(StorageFailure)`**, carrying **`StorageFailureKind`** (`Transient`, `Configuration`, `NotFound`, `Permanent`) derived once at substrate boundaries—no error-text parsing above storage.
> 
> **`omnigraph-storage`** adds `classify_object_store_error` (including `Generic` → transient for remote S3 vs local `io::Error` inspection), wraps failures in **`StorageError::Backend`**, and changes `storage_backend_error` to accept typed **`object_store::Error`**.
> 
> **`omnigraph`** centralizes Lance mapping in **`From<lance::Error>`** (commit conflicts stay **`RetryableCommitConflict`**), walks source chains for **`DataFusionError`**, maps **`ArrowError`** to manifest-internal, and adds **`storage_context` / `storage_permanent` / `with_context`**. Hundreds of call sites switch from **`OmniError::Lance(...)`** to **`OmniError::from`** or **`manifest_internal`** for engine/shape bugs that were mislabeled as storage.
> 
> **`omnigraph-server`** maps **`OmniError::Storage`** to HTTP internal and adds a catch-all for **`#[non_exhaustive]`** **`OmniError`**. Operator-facing **`storage: …`** display is unchanged; classification is additive (not yet consumed for retry/HTTP branching beyond mapping).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 496bee9ec1e9f5ada65d3c81621bd7844f84b774. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces string-flattened storage errors with typed failure classifications while preserving existing operator-facing messages.
- Adds transient, configuration, not-found, and permanent storage failure classes at the object-store and Lance boundaries.
- Retargets non-storage Arrow, DataFusion, and engine validation failures to appropriate error variants.
- Makes `OmniError` non-exhaustive and updates the server fallback mapping.
- Adds focused classification and message-compatibility tests and documents the new public error taxonomy.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no actionable changed-code defects were identified.

Storage errors are classified at typed substrate boundaries, non-storage failures remain separately represented, existing display behavior is preserved, and the dependency advisories inspected are unchanged from the base branch.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/omnigraph-storage/src/lib.rs | Introduces the shared storage-failure model and classifies typed object-store and local I/O failures at the adapter boundary. |
| crates/omnigraph/src/error.rs | Centralizes Lance and DataFusion source-chain classification, adds typed storage accessors, and keeps non-storage failures outside the storage taxonomy. |
| crates/omnigraph-server/src/lib.rs | Updates the HTTP translation for typed storage failures and adds a forward-compatible fallback for the non-exhaustive engine error. |
| crates/omnigraph/src/db/manifest/recovery.rs | Propagates typed Lance failures through recovery paths while preserving manifest and recovery-specific error semantics. |
| crates/omnigraph/src/exec/query.rs | Replaces string flattening with typed conversions so scan-originated storage failures retain their classification. |
| docs/user/operations/errors.md | Documents the new storage classification API without claiming an HTTP behavior change. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  OS[object_store::Error] --> OC[classify_object_store_error]
  OC --> SF[StorageFailure]
  LE[lance::Error] --> LC[classify_lance_error]
  LC --> SF
  DF[DataFusionError] --> SC{Storage source chain?}
  SC -->|yes| SF
  SC -->|no| DE[DataFusion execution error]
  AE[ArrowError] --> ME[Manifest internal error]
  SF --> OE[OmniError::Storage]
  OE --> API[Existing HTTP 500 storage message]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(error): carry a typed classificatio..."](https://github.com/modernrelay/omnigraph/commit/496bee9ec1e9f5ada65d3c81621bd7844f84b774) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52713309)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Knowledge Base — [OmniGraph core storage: manifest, table store, and Lance access](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/omnigraph-core-storage.md)
- Knowledge Base — [OmniGraph write path](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/omnigraph-write-path.md)
- Knowledge Base — [Query execution engine](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/omnigraph-query-exec.md)
- Knowledge Base — [Server Request Handling](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/server-request-handling.md)
- Knowledge Base — [Branching and merge](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/branching-and-merge.md)
</details>

<!-- /greptile_comment -->