### PR TITLE
feat(engine): add transient in-memory graphs

### DIFF
--- a/crates/omnigraph-storage/src/lib.rs
+++ b/crates/omnigraph-storage/src/lib.rs
@@ -72,6 +72,8 @@ impl StorageError {
 
 const FILE_SCHEME_PREFIX: &str = "file://";
 const S3_SCHEME_PREFIX: &str = "s3://";
+/// Lance native shared-memory object-store scheme.
+pub const SHARED_MEMORY_SCHEME: &str = "shared-memory://";
 
 #[async_trait]
 pub trait StorageAdapter: Debug + Send + Sync {
@@ -328,9 +330,28 @@ impl ObjectStorageAdapter {
                     StorageError::internal(format!("invalid s3 object path for '{}': {}", uri, err))
                 })
             }
-            UriCodec::Memory => ObjectPath::parse(uri.trim_start_matches('/')).map_err(|err| {
-                StorageError::internal(format!("invalid memory object path for '{}': {}", uri, err))
-            }),
+            UriCodec::Memory => {
+                let key = if uri.starts_with(SHARED_MEMORY_SCHEME) {
+                    Url::parse(uri)
+                        .map_err(|err| {
+                            StorageError::internal(format!(
+                                "invalid shared-memory uri '{}': {}",
+                                uri, err
+                            ))
+                        })?
+                        .path()
+                        .trim_start_matches('/')
+                        .to_string()
+                } else {
+                    uri.trim_start_matches('/').to_string()
+                };
+                ObjectPath::parse(&key).map_err(|err| {
+                    StorageError::internal(format!(
+                        "invalid memory object path for '{}': {}",
+                        uri, err
+                    ))
+                })
+            }
         }
     }
 

--- a/crates/omnigraph/src/db/manifest/layout.rs
+++ b/crates/omnigraph/src/db/manifest/layout.rs
@@ -4,7 +4,7 @@ use lance::Dataset;
 use lance_namespace::Error as LanceNamespaceError;
 
 use crate::error::{OmniError, Result};
-use crate::storage::{StorageKind, join_uri, storage_kind_for_uri};
+use crate::storage::{StorageKind, is_shared_memory_uri, join_uri, storage_kind_for_uri};
 
 use super::TableIdentity;
 
@@ -91,6 +91,9 @@ pub(super) fn table_uri_for_path(root_uri: &str, table_path: &str, branch: Optio
         for segment in branch.split('/') {
             dataset_location = join_uri(&dataset_location, segment);
         }
+    }
+    if is_shared_memory_uri(root_uri) {
+        return dataset_location;
     }
     match storage_kind_for_uri(root_uri) {
         StorageKind::Local => url::Url::from_file_path(&dataset_location)

--- a/crates/omnigraph/src/db/manifest/metadata.rs
+++ b/crates/omnigraph/src/db/manifest/metadata.rs
@@ -8,7 +8,7 @@ use lance_namespace::models::TableVersion;
 use serde::{Deserialize, Serialize};
 
 use crate::error::{OmniError, Result};
-use crate::storage::{StorageKind, join_uri, storage_kind_for_uri};
+use crate::storage::{StorageKind, is_shared_memory_uri, join_uri, storage_kind_for_uri};
 
 use super::layout::table_id_to_key;
 
@@ -168,6 +168,12 @@ impl TableVersionMetadata {
 }
 
 fn object_store_path_from_uri(uri: &str) -> Result<String> {
+    if is_shared_memory_uri(uri) {
+        let url = url::Url::parse(uri).map_err(|e| {
+            OmniError::manifest_internal(format!("invalid object-store uri {}: {}", uri, e))
+        })?;
+        return Ok(url.path().trim_start_matches('/').to_string());
+    }
     match storage_kind_for_uri(uri) {
         StorageKind::Local => {
             if uri.strip_prefix("file://").is_some() {
@@ -186,7 +192,7 @@ fn object_store_path_from_uri(uri: &str) -> Result<String> {
         }
         StorageKind::S3 => {
             let url = url::Url::parse(uri).map_err(|e| {
-                OmniError::manifest_internal(format!("invalid s3 uri '{}': {}", uri, e))
+                OmniError::manifest_internal(format!("invalid object-store uri '{}': {}", uri, e))
             })?;
             Ok(url.path().trim_start_matches('/').to_string())
         }

--- a/crates/omnigraph/src/db/omnigraph.rs
+++ b/crates/omnigraph/src/db/omnigraph.rs
@@ -27,8 +27,8 @@ use crate::db::graph_coordinator::{GraphCoordinator, PublishedSnapshot, Resolved
 use crate::error::{OmniError, Result};
 use crate::runtime_cache::RuntimeCache;
 use crate::storage::{
-    StorageAdapter, StorageKind, join_uri, normalize_root_uri, storage_for_uri,
-    storage_kind_for_uri, write_queue_root_identity,
+    ObjectStorageAdapter, StorageAdapter, StorageKind, join_uri, normalize_root_uri,
+    storage_for_uri, storage_kind_for_uri, write_queue_root_identity,
 };
 use crate::storage_layer::SnapshotHandle;
 use crate::table_store::TableStore;
@@ -308,6 +308,23 @@ pub struct InitOptions {
 }
 
 impl Omnigraph {
+    /// Create an isolated transient graph backed entirely by process memory.
+    ///
+    /// It supports the same graph operations as a durable graph, but cannot be
+    /// reopened by URI and is discarded when the process exits.
+    pub async fn in_memory(schema_source: &str) -> Result<Self> {
+        let uri = format!("shared-memory://omnigraph-{}", Ulid::new());
+        // ponytail: Lance retains shared-memory authorities until process exit;
+        // add explicit reclamation only if long-lived embedded hosts show pressure.
+        Self::init_with_storage(
+            &uri,
+            schema_source,
+            Arc::new(ObjectStorageAdapter::in_memory()),
+            InitOptions::default(),
+        )
+        .await
+    }
+
     /// Create a new graph at `uri` from schema source.
     ///
     /// Strict mode errors with [`OmniError::AlreadyInitialized`] if `uri`

--- a/crates/omnigraph/src/storage.rs
+++ b/crates/omnigraph/src/storage.rs
@@ -14,10 +14,8 @@ use crate::error::Result;
 
 pub use omnigraph_storage::{ListDirBounds, StorageKind};
 
-const SHARED_MEMORY_SCHEME: &str = "shared-memory://";
-
 pub(crate) fn is_shared_memory_uri(uri: &str) -> bool {
-    uri.starts_with(SHARED_MEMORY_SCHEME)
+    uri.starts_with(omnigraph_storage::SHARED_MEMORY_SCHEME)
 }
 
 #[async_trait]

--- a/crates/omnigraph/src/storage.rs
+++ b/crates/omnigraph/src/storage.rs
@@ -12,7 +12,13 @@ use async_trait::async_trait;
 
 use crate::error::Result;
 
-pub use omnigraph_storage::{ListDirBounds, StorageKind, join_uri};
+pub use omnigraph_storage::{ListDirBounds, StorageKind};
+
+const SHARED_MEMORY_SCHEME: &str = "shared-memory://";
+
+pub(crate) fn is_shared_memory_uri(uri: &str) -> bool {
+    uri.starts_with(SHARED_MEMORY_SCHEME)
+}
 
 #[async_trait]
 pub trait StorageAdapter: Debug + Send + Sync {
@@ -227,6 +233,18 @@ pub fn storage_kind_for_uri(uri: &str) -> StorageKind {
     omnigraph_storage::storage_kind_for_uri(uri)
 }
 
+pub fn join_uri(root_uri: &str, relative_path: &str) -> String {
+    if is_shared_memory_uri(root_uri) {
+        format!(
+            "{}/{}",
+            root_uri.trim_end_matches('/'),
+            relative_path.trim_start_matches('/')
+        )
+    } else {
+        omnigraph_storage::join_uri(root_uri, relative_path)
+    }
+}
+
 pub fn storage_for_uri(uri: &str) -> Result<Arc<dyn StorageAdapter>> {
     match storage_kind_for_uri(uri) {
         StorageKind::Local => Ok(Arc::new(ObjectStorageAdapter::local())),
@@ -235,7 +253,11 @@ pub fn storage_for_uri(uri: &str) -> Result<Arc<dyn StorageAdapter>> {
 }
 
 pub fn normalize_root_uri(uri: &str) -> Result<String> {
-    Ok(omnigraph_storage::normalize_root_uri(uri)?)
+    if is_shared_memory_uri(uri) {
+        Ok(uri.trim_end_matches('/').to_string())
+    } else {
+        Ok(omnigraph_storage::normalize_root_uri(uri)?)
+    }
 }
 
 pub(crate) fn write_queue_root_identity(normalized_root: &str) -> Result<String> {

--- a/crates/omnigraph/tests/forbidden_apis.rs
+++ b/crates/omnigraph/tests/forbidden_apis.rs
@@ -219,7 +219,7 @@ macro_rules! write_surfaces {
 }
 
 write_surfaces! {
-    "db/omnigraph.rs" => WriteProtocol::Bootstrap => ["init", "init_with_options"],
+    "db/omnigraph.rs" => WriteProtocol::Bootstrap => ["in_memory", "init", "init_with_options"],
     "db/omnigraph.rs" => WriteProtocol::RecoveryExecutor => ["open", "open_with_storage", "refresh"],
     "exec/mutation.rs" => MUTATION_V9 => ["mutate", "mutate_with_receipt", "mutate_as", "mutate_as_with_receipt", "mutate_as_with_expected_head", "mutate_as_with_expected_head_receipt"],
     "loader/mod.rs" => LOAD_V9 => ["load_jsonl", "load_jsonl_file", "load", "load_with_receipt", "load_file", "load_graph_batch"],

--- a/crates/omnigraph/tests/lifecycle.rs
+++ b/crates/omnigraph/tests/lifecycle.rs
@@ -1077,3 +1077,27 @@ mod local_create_if_absent_probe {
         );
     }
 }
+
+#[tokio::test]
+async fn in_memory_graph_supports_typed_mutation_and_query() {
+    let mut db = Omnigraph::in_memory(TEST_SCHEMA).await.unwrap();
+
+    mutate_main(
+        &mut db,
+        MUTATION_QUERIES,
+        "insert_person",
+        &mixed_params(&[("$name", "Eve")], &[("$age", 22)]),
+    )
+    .await
+    .unwrap();
+
+    let result = query_main(
+        &mut db,
+        TEST_QUERIES,
+        "get_person",
+        &params(&[("$name", "Eve")]),
+    )
+    .await
+    .unwrap();
+    assert_eq!(result.num_rows(), 1);
+}

--- a/docs/user/concepts/storage.md
+++ b/docs/user/concepts/storage.md
@@ -115,6 +115,14 @@ The split — L2 owns the cross-dataset catalog; L1 owns the per-dataset interna
 | `s3://bucket/prefix` | S3 object store | Honors `AWS_ENDPOINT_URL_S3`, `AWS_ALLOW_HTTP`, `AWS_S3_FORCE_PATH_STYLE` |
 | `http(s)://host:port` | HTTP client to `omnigraph-server` | Used by CLI as a target, not a storage backend |
 
+### Transient embedded graphs
+
+Rust applications can create an isolated process-memory graph with
+`Omnigraph::in_memory(schema_source).await`. It uses the same schema, query,
+mutation, manifest, and branch machinery as durable graphs, but it has no
+public URI and cannot be reopened. Data is lost when the process exits. This
+mode is embedded-only: it is not a CLI, server, or cluster storage target.
+
 ### Local filesystem requirement: hard links
 
 The local backend publishes every atomic create-if-absent write — the


### PR DESCRIPTION
## What changed

- add Omnigraph::in_memory(schema) for isolated transient embedded graphs
- reuse Lance native shared-memory object store instead of adding another backend implementation
- keep the shared-memory URI private and preserve the existing local/S3 storage API
- add an insert then select integration test

## Why

Embedded runtimes need the normal typed graph operations without filesystem hard-link requirements or a durable graph directory. This gives them the same schema, mutation, query, manifest, and branch machinery as durable graphs while keeping lifecycle explicitly process-local.

## Validation

- cargo fmt --all -- --check
- git diff --check
- focused lifecycle test added; GitHub CI is the execution gate because the available local Cargo targets were cold and a full Android/Termux rebuild was intentionally not repeated

## Known ceiling

Lance retains shared-memory authorities for the process lifetime. Explicit reclamation is deferred until long-lived embedded hosts demonstrate that it is needed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds isolated, process-local in-memory graphs while preserving the existing graph initialization, manifest, mutation, query, and branch machinery.
- Adds `Omnigraph::in_memory(schema_source)` using Lance’s native shared-memory URI scheme.
- Extends URI and object-path handling for shared-memory datasets.
- Registers the constructor in the closed public API registry.
- Documents the transient lifecycle and adds an insert/query integration test.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the public API registry now classifies the constructor, and the owning user documentation describes its transient and non-reopenable lifecycle.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/omnigraph/src/db/omnigraph.rs | Adds the documented transient constructor and routes it through the established initialization machinery with an isolated ULID-backed authority. |
| crates/omnigraph/src/storage.rs | Preserves shared-memory URIs during joining and normalization while leaving the public local/S3 storage-selection API unchanged. |
| crates/omnigraph-storage/src/lib.rs | Adds shared-memory URI path decoding for the existing in-memory object-store adapter. |
| crates/omnigraph/src/db/manifest/layout.rs | Keeps shared-memory table locations as native URIs instead of converting them to filesystem URLs. |
| crates/omnigraph/src/db/manifest/metadata.rs | Converts shared-memory dataset URIs into object-store-relative metadata paths. |
| crates/omnigraph/tests/forbidden_apis.rs | Correctly classifies `in_memory` as a bootstrap write surface, resolving the previously reported registry failure. |
| crates/omnigraph/tests/lifecycle.rs | Covers initialization, typed mutation, and query behavior for a transient graph. |
| docs/user/concepts/storage.md | Resolves the previously reported documentation gap by describing discoverability, process-local lifetime, non-reopenability, and supported usage. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Caller[Embedded Rust caller] --> Constructor[Omnigraph::in_memory]
    Constructor --> URI[Private shared-memory URI]
    Constructor --> Init[Shared graph initialization path]
    Init --> Metadata[In-memory schema and recovery metadata]
    Init --> Lance[Lance shared-memory datasets]
    Lance --> Operations[Typed mutation, query, manifest, and branch operations]
    Operations --> Exit[State discarded at process exit]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["docs(storage): document transient graphs"](https://github.com/modernrelay/omnigraph/commit/9c92628667660f88a8cea1f7af3bd4975fb9cfb5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53087436)</sub>

**Context used:**

- Knowledge Base — [OmniGraph core storage: manifest, table store, and Lance access](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/omnigraph-core-storage.md)

<!-- /greptile_comment -->