### PR TITLE
Governance: issue-first intake, Discussions retired

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,13 +6,13 @@ body:
   - type: markdown
     attributes:
       value: |
-        Issues are for **reporting problems** — concrete, reproducible bugs.
-        For ideas, feature requests, or questions, please use
-        [Discussions](../../discussions) instead.
-        For a security vulnerability, follow [SECURITY.md](../../blob/main/SECURITY.md) — do **not** file it here.
+        This form is for **reporting problems** — concrete, reproducible bugs.
+        For an idea or feature request, use the
+        [feature proposal form](https://github.com/ModernRelay/omnigraph/issues/new/choose) instead.
+        For a security vulnerability, follow [SECURITY.md](https://github.com/ModernRelay/omnigraph/blob/main/SECURITY.md) — do **not** file it here.
 
         A maintainer will triage this; once labelled **`accepted`** it's open for a pull request
-        (see [GOVERNANCE.md](../../blob/main/GOVERNANCE.md)).
+        (see [GOVERNANCE.md](https://github.com/ModernRelay/omnigraph/blob/main/GOVERNANCE.md)).
   - type: textarea
     id: what-happened
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,13 +1,7 @@
-# Issues are for problem reports only. Disable blank issues so everything is
-# routed: bugs through the form, everything else to Discussions / SECURITY.md.
+# Issues are the only inbound channel (see GOVERNANCE.md). Blank issues stay
+# disabled so every report lands on a form; security goes to SECURITY.md.
 blank_issues_enabled: false
 contact_links:
-  - name: 💡 Idea, feature request, or RFC
-    url: https://github.com/ModernRelay/omnigraph/discussions
-    about: Propose features and designs in Discussions. RFCs graduate from there into a docs/rfcs/ pull request.
-  - name: ❓ Question or help
-    url: https://github.com/ModernRelay/omnigraph/discussions
-    about: Ask in Discussions — questions are not tracked as Issues.
   - name: 🔒 Security vulnerability
     url: https://github.com/ModernRelay/omnigraph/blob/main/SECURITY.md
     about: Report security issues privately per SECURITY.md — never as a public Issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: 💡 Feature proposal
+description: Propose a change. A maintainer triages it; work starts once it is labelled `accepted`.
+labels: ["feature", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Every change starts as an issue (see [GOVERNANCE.md](https://github.com/ModernRelay/omnigraph/blob/main/GOVERNANCE.md)).
+        A maintainer triages this: **`accepted`** is the green light for a PR, and a
+        larger design gets **`needs-rfc`** and goes through an RFC first
+        ([docs/rfcs/README.md](https://github.com/ModernRelay/omnigraph/blob/main/docs/rfcs/README.md)).
+        Trivial fixes (typos, obvious small corrections) can skip the issue and go straight to a PR.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What can't you do today, or what costs too much? Concrete scenarios beat abstractions.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: What should exist? If it adds user-visible surface (CLI, API, query/schema language), sketch it.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other ways to solve it, including doing nothing.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/rfc_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/rfc_proposal.yml
@@ -1,0 +1,35 @@
+name: 📐 Design / RFC proposal
+description: Propose a design-level change. The issue is accepted first; the RFC document follows as its own PR.
+labels: ["rfc", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For design-level changes: new user-facing surface, on-disk or wire formats,
+        new substrate dependencies, anything irreversible. Do **not** write the RFC
+        document yet — this issue gets `accepted` first, so nobody invests in a
+        design a maintainer hasn't agreed should exist. Once accepted (and labelled
+        `needs-rfc`), open an RFC PR per
+        [docs/rfcs/README.md](https://github.com/ModernRelay/omnigraph/blob/main/docs/rfcs/README.md);
+        the merged RFC then sanctions the implementation PRs, and this issue tracks them.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is wrong or missing, and why does it matter?
+    validations:
+      required: true
+  - type: textarea
+    id: direction
+    attributes:
+      label: Proposed design direction
+      description: The shape of the solution — enough to judge whether the problem is worth an RFC, not the full design.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Blast radius
+      description: What does this touch — storage format, wire protocol, query language, dependencies? What becomes hard to reverse?
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,6 @@
 <!--
   Thanks for contributing! See CONTRIBUTING.md and GOVERNANCE.md.
-  A substantive PR needs a backing accepted issue or accepted RFC.
-  Maintainers: your internal process applies; the link requirement below
-  is for external contributions.
+  A substantive PR needs a backing accepted issue or merged RFC.
 -->
 
 ## What & why
@@ -14,7 +12,7 @@
 <!-- Pick one. A substantive change needs (1) or (2). -->
 
 - [ ] Fixes an **accepted** issue: Closes #
-- [ ] Implements / is an **accepted** RFC: <link to docs/rfcs/NNNN-*.md>
+- [ ] Is an RFC PR, or implements a **merged** RFC: <link to docs/rfcs/NNNN-*.md>
 - [ ] **Trivial fast-lane** (typo / docs / dependency bump / comment / one-line CI) — no issue/RFC required
 
 ## Checklist

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,25 +7,33 @@ rules and decision authority behind it live in [GOVERNANCE.md](GOVERNANCE.md).
 
 | I want to… | Go to | Notes |
 |---|---|---|
-| **Report a bug** or wrong behavior | **[Open an Issue](../../issues/new/choose)** | Concrete and reproducible. A maintainer triages it; once labelled **`accepted`** it's open for a PR. |
-| **Suggest a feature / share an idea / ask** | **[Start a Discussion](../../discussions)** | Ideas and questions live here, not in Issues. |
-| **Propose a design / RFC** | **An RFC pull request** | Anyone can copy the public template and declare `Author track: Public contribution` — see [docs/rfcs/README.md](docs/rfcs/README.md). A maintainer merging a public RFC is acceptance; maintainer design series use their explicit status lifecycle. |
-| **Fix something / implement a change** | **A pull request** | Must link an `accepted` issue or an accepted RFC — unless it's trivial (below). |
+| **Report a bug** or wrong behavior | **[Open an Issue](../../issues/new/choose)** — bug form | Concrete and reproducible. A maintainer triages it; once labelled **`accepted`** it's open for a PR. |
+| **Propose a feature / share an idea** | **[Open an Issue](../../issues/new/choose)** — feature form | A maintainer triages it. **`accepted`** means a PR may follow; a larger design gets **`needs-rfc`** and goes through an RFC first. |
+| **Propose a design / RFC** | **An Issue first**, then an RFC pull request | Get the issue `accepted` before investing in the RFC document. A maintainer merging the RFC PR is acceptance; the merged RFC then sanctions implementation PRs — see [docs/rfcs/README.md](docs/rfcs/README.md). |
+| **Fix something / implement a change** | **A pull request** | Must link an `accepted` issue or a merged RFC — unless it's trivial (below). |
 | **Report a security vulnerability** | **[SECURITY.md](SECURITY.md)** | Do **not** open a public Issue. |
 
+GitHub Discussions are not used — Issues are the only inbound channel.
+
 ### When can I just open a PR?
-The **trivial fast-lane** — open directly, no prior issue/RFC needed: typo and
-wording fixes, doc corrections, dependency bumps, comment fixes, obvious
-one-line CI tweaks. Anything more substantial needs a backing `accepted` issue
-or accepted RFC first, so the *why* is agreed before the *how* is reviewed. A PR
+The **trivial fast-lane** — open directly, no prior issue/RFC needed, when the
+change is clearly broken-fixing with small blast radius and no design impact:
+typo and wording fixes, doc corrections, dependency bumps, comment fixes,
+obvious one-line CI tweaks. **If you cannot tell trivial from real, it is real
+— open the issue.** Anything more substantial needs a backing `accepted` issue
+or merged RFC first, so the *why* is agreed before the *how* is reviewed. A PR
 that turns out to be non-trivial will be redirected — that's about process, not
 the merit of the change.
 
-> **Maintainers (ModernRelay team)** follow a separate internal process and are
-> not bound by the intake rules above. Everyone is bound by review, branch
-> protection, and CI.
-
 ## Development
+
+Building requires the Rust stable toolchain and `protoc` (the Protocol Buffers
+compiler — a build dependency of the storage substrate):
+
+```bash
+brew install protobuf                                  # macOS
+sudo apt-get install -y protobuf-compiler libprotobuf-dev   # Debian/Ubuntu
+```
 
 ```bash
 cargo build --workspace
@@ -38,17 +46,14 @@ integration tests.
 ### OpenAPI spec
 
 `openapi.json` is a committed artifact generated from the Utoipa annotations in
-`crates/omnigraph-server`. For PRs opened from this repository, a CI job
-regenerates it automatically and commits the updated file back to the PR
-branch. For PRs from forks (where CI cannot push), run the regeneration
-manually:
+`crates/omnigraph-server`. CI never regenerates or commits it — it only checks
+for drift and fails the build if the committed copy disagrees with the source.
+When your change touches the server API surface, regenerate locally and commit
+the result in the same PR:
 
 ```bash
 OMNIGRAPH_UPDATE_OPENAPI=1 cargo test -p omnigraph-server --test openapi openapi_spec_is_up_to_date
 ```
-
-The workspace test run fails if the committed `openapi.json` drifts from what
-the source generates.
 
 ### Cargo features
 
@@ -68,8 +73,8 @@ CI runs both.
 
 ## Pull Requests
 
-- **Link the backing issue or RFC** (`Closes #123`, or reference the RFC) — or
-  mark the PR as trivial per the fast-lane.
+- **Link the backing `accepted` issue or merged RFC** (`Closes #123`, or
+  reference the RFC) — or mark the PR as trivial per the fast-lane.
 - Keep changes focused; one logical change per PR.
 - Include tests for behavior changes when practical.
 - Update public docs when the user-facing surface changes.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -48,9 +48,11 @@ process, not the merit of the change.
 Labels are the state machine; an issue has exactly one status label.
 
 - `needs-triage` — default on arrival. No work should start.
-- `accepted` — a maintainer agreed the change should exist. The green light
-  for the next step in its lane: a code PR for S/M, an RFC PR for L.
-- `needs-rfc` — size L: the design must land before any code.
+- `accepted` — a maintainer agreed the change should exist; a code PR may
+  follow. For size L, this is also the state after the RFC merges.
+- `needs-rfc` — size L, accepted with the design outstanding. It replaces
+  `accepted` until the RFC PR merges (writing the RFC is authorized); the
+  issue then returns to `accepted`, and code may start.
 - `blocked` — accepted, but waiting on something named in the thread.
 - `declined` — closed, with a reason.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,106 +1,119 @@
 # Governance
 
-This document describes how **external contributions** to OmniGraph are
-proposed, accepted, and merged. It exists so an outside contributor can answer,
-without asking: *where does my report/idea/change go, who decides, and what has
-to happen before code lands?*
-
-> **Scope.** This governs the public contribution surface — Issues,
-> Discussions, RFCs, and pull requests from people outside the ModernRelay
-> team. **Maintainers operate under a separate internal process** and are not
-> bound by the intake gates below. Everyone, maintainer or not, is still bound
-> by the universal gates: branch protection on `main` and CI
-> (see [docs/dev/branch-protection.md](docs/dev/branch-protection.md)).
+How change enters OmniGraph: who decides, what each change needs before code
+lands, and what reviewers and CI enforce. It exists so an outside contributor
+can answer, without asking: *where does my report or idea go, who decides, and
+what has to happen before code lands?* The practical how-to lives in
+[CONTRIBUTING.md](CONTRIBUTING.md); this file is the rules behind it.
 
 ## Roles
 
-| Role | Who | Authority |
-|---|---|---|
-| **Maintainer** | The ModernRelay team (repository admins) | Validate issues, accept/reject RFCs, review and merge PRs, set direction. Final decision authority. |
-| **Contributor** | Anyone else | Report problems (Issues), propose ideas (Discussions), author RFCs, and open pull requests. |
+- **Maintainers** — triage issues, accept or decline proposals and RFCs,
+  review and merge PRs, and set direction. Final decision authority.
+- **Contributors** — everyone else. Report bugs, propose features, author
+  RFCs, and open pull requests.
 
-Decision authority rests with the maintainers (the ModernRelay team holding
-repository-admin access).
+The intake gates below govern contributions. The universal gates — review,
+branch protection on `main`, and CI (see
+[docs/dev/branch-protection.md](docs/dev/branch-protection.md)) — apply to
+everyone, maintainers included.
 
-## The three channels
+## One channel in
 
-Each channel has one job. Using the right one is the first thing we ask of a
-contribution.
+**Issues are the only inbound channel.** Bugs and feature proposals each have
+an issue form; GitHub Discussions are not used. The one exception is
+security: report vulnerabilities privately per [SECURITY.md](SECURITY.md),
+never as a public issue — a public security issue is closed on sight and
+re-routed.
 
-| Channel | Purpose | Not for |
-|---|---|---|
-| **[Issues](../../issues)** | **Report a problem** — a bug, a regression, a documented behavior that's wrong. Something concrete and reproducible. | Feature requests, ideas, questions, or design proposals (→ Discussions). |
-| **[Discussions](../../discussions)** | **Propose and explore** — new ideas, feature requests, questions, and the incubation of RFCs. | Bug reports (→ Issues). |
-| **Pull requests** | **Land a sanctioned change** — a fix for a *validated* issue, an *accepted* RFC, or a trivial change (see fast-lane). | Substantive change with no backing issue/RFC — it will be redirected. |
+## Change sizes
 
-## How a change becomes mergeable
+The lane is set by **blast radius and design impact**, not line count.
 
-```
-            ┌─────────── bug ───────────┐        ┌──────── idea / feature ────────┐
-            ▼                            │        ▼                                │
-        Issue (problem report)           │   Discussion (idea / RFC incubation)    │
-            │                            │        │                                │
-   maintainer triage                     │   rough consensus                        │
-            │                            │        │ graduate                         │
-            ▼                            │        ▼                                  │
-  label: accepted  ──────────┐          │   RFC PR  (docs/rfcs/NNNN-*.md)           │
-            │                 │          │        │                                  │
-            │                 │          │   maintainer review                       │
-            ▼                 ▼          │        ▼                                  │
-     Pull request  ◀──────────┴──────────│──  merged == accepted                     │
-   (links the issue or the accepted RFC) ◀───────┘ (implementation PRs reference it) │
-            │
-   review + branch protection + CI
-            ▼
-         merged
-```
+- **S — trivial.** Clearly broken, small blast radius, no design impact.
+  Open a PR directly; no issue required.
+- **M — feature or fix.** A real change, consistent with the existing
+  design. Path: **issue → `accepted` → PR**.
+- **L — design.** Creates or changes a design: new user-facing surface
+  (query/schema/CLI/HTTP), on-disk or wire formats, a new substrate
+  dependency, anything irreversible, or anything touching an accepted RFC.
+  Path: **issue → `accepted` → RFC PR → merged → code PRs**.
 
-### Issues → validated
-A new issue starts unlabeled. A maintainer triages it and, if it's a real,
-in-scope problem, applies the **`accepted`** label. **Only `accepted` issues are
-open for a contributor PR.** This prevents the "I fixed an issue you hadn't
-agreed was a problem" rejection. Want to fix something? Get the issue accepted
-first, or pick one already labelled `accepted` / `help wanted`.
+If you cannot tell S from M, it is M. A reviewer who reclassifies a change
+upward closes the PR and restarts it on the correct path — that is about
+process, not the merit of the change.
 
-### Discussions → RFCs → accepted
-Ideas and feature requests start in **Discussions**. Anyone — including external
-contributors — may then **author an RFC** by opening a pull request that adds
-`docs/rfcs/NNNN-title.md` from the public template with
-`Author track: Public contribution` (see
-[docs/rfcs/README.md](docs/rfcs/README.md)). The RFC is reviewed as code; **a
-maintainer merging it is the act of acceptance** (it becomes the durable
-decision record). Implementation PRs then reference the accepted RFC.
+## Issue lifecycle
 
-Authoring an RFC is open to everyone; **accepting one is a maintainer
-decision.** Maintainers may also decline an RFC, with rationale, by closing it.
+Labels are the state machine; an issue has exactly one status label.
 
-### Pull requests → sanctioned
-A contributor PR must do one of:
-1. link a maintainer-**`accepted`** issue it fixes, or
-2. be (or reference) an **accepted RFC**, or
-3. qualify for the **trivial fast-lane**.
+- `needs-triage` — default on arrival. No work should start.
+- `accepted` — a maintainer agreed the change should exist. The green light
+  for the next step in its lane: a code PR for S/M, an RFC PR for L.
+- `needs-rfc` — size L: the design must land before any code.
+- `blocked` — accepted, but waiting on something named in the thread.
+- `declined` — closed, with a reason.
 
-**Trivial fast-lane** — these may be opened directly, no prior issue/RFC:
-typo and wording fixes, documentation corrections, dependency bumps, comment
-fixes, and obviously-correct one-line CI tweaks. When in doubt, open an Issue or
-Discussion first; a PR that turns out to be non-trivial will be asked to.
+`accepted` precedes implementation effort — including the effort of writing
+an RFC. Its purpose is that nobody invests before a maintainer has agreed the
+change should exist. An accepted issue with no assignee is open to anyone.
 
-A substantive PR with no backing issue/RFC will be closed with a pointer to the
-right channel — not as a judgment of the idea, but to keep design discussion
-where it's reviewable.
+## RFCs
 
-## What maintainers do *not* gate
-Maintainers' own changes do not pass through the intake gates above — the team
-runs a separate internal process. The universal gates (review, branch
-protection, CI) apply to everyone. Enforcement of the intake rules is, to
-start, **by convention and review** (PR template + labels); an automated check
-keyed to author association may be added later if volume warrants.
+An RFC lives in two vessels: its **issue** (discussion, then implementation
+tracking) and its **document** (`docs/rfcs/NNNN-title.md`). Numbering,
+statuses, and the template live in
+[docs/rfcs/README.md](docs/rfcs/README.md).
+
+- **Merging the RFC PR is the green light to write code.** An accepted issue
+  alone is not enough for an L change — it only authorizes writing the RFC.
+- **A merged RFC sanctions its implementation PRs directly**: code PRs
+  reference the RFC, and the RFC's issue is the umbrella that tracks them.
+- **Amending an accepted RFC is itself a size-L change**: issue → `accepted`
+  → amendment PR → merged → code. Discovering mid-implementation that the
+  design is wrong is normal and welcome — stop, amend, then continue. A code
+  PR that rewrites an accepted RFC on the way through is rejected regardless
+  of the code's quality.
+
+## Pull requests
+
+### Draft vs ready
+
+A **draft** PR is work shared for visibility: nobody is expected to review
+it, gates need not be green, and no backing issue is required. Use drafts
+freely — prototyping an approach, exploring a design space, cross-checking a
+measurement, sharing direction before it is right. A **ready** PR requests
+review and must meet everything below. Do not leave finished work in draft:
+draft means unfinished, not unreviewed.
+
+### A ready PR must
+
+- reference its `accepted` issue or a merged RFC — or be size S;
+- keep to one kind of content: an RFC PR touches only `docs/rfcs/`; a
+  contributor code PR does not modify RFC documents (amend first, then code);
+- be green on CI (build, `fmt`, `clippy`, tests, and the repo's drift
+  checks);
+- describe its blast radius and what was tested beyond the happy path.
+
+Review and merge are maintainer decisions.
+
+## Enforcement
+
+A PR that skips this process is closed plainly, with a link to this document
+— not as a judgment of the idea, but to keep design discussion where it is
+reviewable. Reclassified changes restart on the correct path rather than
+being renegotiated in the thread. Low-effort PRs with no evident mental model
+and no testing beyond the happy path may be closed without detailed review.
+
+Enforcement is by convention and review to start; automated checks (an
+RFC-path guard, an issue-link check) may be added as volume warrants.
 
 ## Code of conduct & security
+
 - Conduct: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 - Security issues are **not** public Issues — see [SECURITY.md](SECURITY.md).
 
 ## Changing this document
+
 Governance changes the same way code does: a pull request, reviewed by
-maintainers. This file describes the external surface; the internal maintainer
-process is intentionally out of scope here.
+maintainers.

--- a/README.md
+++ b/README.md
@@ -252,9 +252,10 @@ Notes:
 
 ## Contributing
 
-Please open an issue, spec, or design discussion before sending large code
-changes. Design feedback and concrete problem statements are the fastest way to
-collaborate on the roadmap.
+Please open an issue before sending large code changes — a maintainer triages
+it, and the `accepted` label is the green light for a PR (see
+[GOVERNANCE.md](GOVERNANCE.md)). Concrete problem statements are the fastest
+way to collaborate on the roadmap.
 
 ## Community
 

--- a/docs/rfcs/0029-azure-blob-storage.md
+++ b/docs/rfcs/0029-azure-blob-storage.md
@@ -5,7 +5,7 @@
 | **Status** | Accepted |
 | **Author track** | Public contribution |
 | **Author(s)** | Roey Zalta ([@roy2392](https://github.com/roy2392)) |
-| **Discussion** | [ModernRelay/omnigraph#439](https://github.com/ModernRelay/omnigraph/discussions/439) |
+| **Discussion** | [ModernRelay/omnigraph#509](https://github.com/ModernRelay/omnigraph/issues/509) (migrated from the retired Discussions forum) |
 | **Implementation** | Not yet implemented |
 
 ## Summary

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -31,14 +31,14 @@ how*.
 - **RFC not required:** bug fixes for an `accepted` issue, and the trivial
   fast-lane (typos, docs, deps) — see [../../CONTRIBUTING.md](../../CONTRIBUTING.md).
 
-If you're unsure, start a [Discussion](../../../discussions); a maintainer will
-tell you whether it needs an RFC.
+If you're unsure, open the issue anyway — triage routes it: `accepted` alone
+means code may follow, while `needs-rfc` means the design lands first.
 
 ## Public contribution lifecycle
 
 ```
-Discussion (incubate, get rough consensus)
-      │ graduate
+Issue (feature/rfc + needs-triage)
+      │ maintainer accepts the problem → accepted (+ needs-rfc)
       ▼
 RFC pull request  →  adds docs/rfcs/NNNN-title.md
                          (Author track: Public contribution; Status: Proposed)

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -38,7 +38,7 @@ means code may follow, while `needs-rfc` means the design lands first.
 
 ```
 Issue (feature/rfc + needs-triage)
-      │ maintainer accepts the problem → accepted (+ needs-rfc)
+      │ maintainer accepts the problem → needs-rfc
       ▼
 RFC pull request  →  adds docs/rfcs/NNNN-title.md
                          (Author track: Public contribution; Status: Proposed)


### PR DESCRIPTION
## What & why

Implements the simplified contribution model: **issues are the only inbound channel**, the `accepted` label is the gate before implementation effort, and small fixes keep a direct-PR fast-lane.

- **GOVERNANCE.md** rewritten: change sizes (S/M/L), issue label state machine, issue-first RFC lifecycle, draft-vs-ready PR guidance. Internal review mechanics (approval counts, maintainer-process references) are no longer part of the public surface.
- **CONTRIBUTING.md**: intake table routes features to the new issue form; fast-lane reworded ("if you cannot tell trivial from real, it is real"). Also corrects two inaccuracies: CI checks `openapi.json` for drift but never regenerates it, and `protoc` is a required build dependency.
- **docs/rfcs/README.md**: public RFC lifecycle starts at an issue instead of a Discussion.
- **Issue forms**: new `feature_request.yml` and `rfc_proposal.yml` (auto-label `feature`/`rfc` + `needs-triage`); `config.yml` reduced to the security link; `bug_report.yml` re-routed (its relative links were also broken — now absolute).
- **PR template**: aligned to "accepted issue or merged RFC".
- **RFC-0029**: provenance link repointed — Discussion #439 was migrated to #509 before Discussions were turned off (all four open threads became #508–#511).

## Backing issue / RFC

- [x] Governance change — a pull request reviewed by maintainers, per GOVERNANCE.md's "Changing this document".

## Checklist

- [x] Change is focused (one logical change)
- [ ] Tests added/updated for behavior changes — N/A (docs, templates)
- [x] Public docs updated if user-facing surface changed
- [x] Reviewed against docs/dev/invariants.md — no Hard Invariant weakened, no deny-list item hit

## Local verification

- `ruby -ryaml` parse of all four issue-template files — OK
- `grep` sweep for stale Discussions references across GOVERNANCE, CONTRIBUTING, README, rfcs README, templates — zero (RFC-0029's historical link repointed)
- `scripts/check-agents-md.sh` — no new failures

## Notes for reviewers

Labels (`accepted`, `needs-rfc`, `blocked`, `declined`, `feature`, `rfc`, `size/S`) already exist on the repo, and Discussions are already disabled, so this merge completes the cutover.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR retires Discussions and establishes issue-first contribution intake, with accepted issues and merged RFCs gating implementation.
- Adds dedicated feature and RFC issue forms and updates existing GitHub templates.
- Rewrites governance and contribution documentation around S/M/L changes and the issue-label lifecycle.
- Updates RFC intake guidance and migrates RFC-0029 provenance to its replacement issue.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| GOVERNANCE.md | Replaces the former Discussions-based model with issue-first intake, explicit size classes, and a single-status issue lifecycle. |
| .github/ISSUE_TEMPLATE/rfc_proposal.yml | Adds the design-level proposal intake form and routes accepted proposals into the RFC process. |
| CONTRIBUTING.md | Aligns contributor guidance with issue-first intake and corrects local build and OpenAPI drift instructions. |
| docs/rfcs/README.md | Updates the public RFC lifecycle to begin with a triaged issue rather than a Discussion. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  I[Issue: needs-triage] --> T{Maintainer triage}
  T -->|Size M| A[accepted]
  A --> P[Implementation PR]
  T -->|Size L| R[needs-rfc]
  R --> D[RFC PR]
  D -->|Merged| A
  T -->|Declined| X[declined]
  A -->|Dependency pending| B[blocked]
  B --> A
```
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(governance): needs-rfc replaces acc..."](https://github.com/modernrelay/omnigraph/commit/4984c4d6c3930651f3421578d04e62c878b7bfda) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53644257)</sub>

<!-- /greptile_comment -->