### PR TITLE
fix(merge): source-qualify managed Blob descriptor identity

### DIFF
--- a/crates/omnigraph/src/exec/merge.rs
+++ b/crates/omnigraph/src/exec/merge.rs
@@ -410,14 +410,26 @@ impl OrderedTableCursor {
                 KEYED_WRITE_MAX_BYTES,
             );
             Some(Box::pin(
-                crate::table_store::TableStore::scan_stream_bounded(
+                crate::table_store::TableStore::scan_stream_with(
                     ds,
                     None,
                     None,
                     Some(vec![ColumnOrdering::asc_nulls_last("id".to_string())]),
                     true,
-                    KEYED_WRITE_MAX_ROWS,
-                    KEYED_WRITE_MAX_BYTES,
+                    |scanner| {
+                        scanner.batch_size(KEYED_WRITE_MAX_ROWS);
+                        scanner.batch_size_bytes(KEYED_WRITE_MAX_BYTES);
+                        // Managed Blob descriptors are resolved by Lance relative
+                        // to the owning data file, so the row signature needs the
+                        // owning fragment (high 32 bits of `_rowaddr`) to tell an
+                        // in-place unchanged row from a same-length Blob-only
+                        // update that moved to a new fragment with colliding local
+                        // descriptor coordinates. The staged writers project to
+                        // the target schema by name, so this extra system column
+                        // (like `_rowid`) never reaches the delta.
+                        scanner.with_row_address();
+                        Ok(())
+                    },
                 )
                 .await?,
             ))
@@ -1760,15 +1772,47 @@ fn classify_merge_conflict(
 /// presence and rendered value. Ephemeral, internal to merge classification —
 /// never persisted, so the format is free to change.
 ///
-/// Blob columns are still rendered via `array_value_to_string`, preserving
-/// today's behavior; full unification with `changes::row_compare` (which
-/// compares Blob columns by descriptor identity) is a larger follow-up gated on
-/// the merge cursor's scan mode.
+/// Blob columns compare by source-qualified physical identity, not a display of
+/// the descriptor. Lance resolves a managed (inline/packed/dedicated) descriptor
+/// RELATIVE to the owning data file (the row's fragment), so byte-identical
+/// descriptors in different fragments reference different bytes — a same-length
+/// Blob-only update moves the row to a new fragment and can reuse the same local
+/// coordinates. Qualifying the managed identity with the owning fragment (high
+/// 32 bits of `_rowaddr`) makes equal signatures imply equal bytes; external
+/// references resolve by URI independently of placement and stay
+/// source-independent. This is the same identity `changes::row_compare` uses for
+/// the CDC comparator.
 fn row_signature(batch: &RecordBatch, row: usize) -> Result<String> {
     use std::fmt::Write as _;
+    let fragment_id = batch
+        .column_by_name("_rowaddr")
+        .and_then(|column| column.as_any().downcast_ref::<UInt64Array>())
+        .map(|addresses| (addresses.value(row) >> 32) as u32);
     let mut signature = String::new();
     for (field, column) in batch.schema().fields().iter().zip(batch.columns()) {
         if crate::changes::model::is_reserved_storage_system_column(field.name()) {
+            continue;
+        }
+        let lance_field = lance::datatypes::Field::try_from(field.as_ref())
+            .map_err(|error| OmniError::Lance(error.to_string()))?;
+        if lance_field.is_blob() {
+            let descriptions = column
+                .as_any()
+                .downcast_ref::<arrow_array::StructArray>()
+                .ok_or_else(|| {
+                    OmniError::Lance(format!(
+                        "expected blob descriptions for merge column '{}'",
+                        field.name()
+                    ))
+                })?;
+            let fragment_id = fragment_id.ok_or_else(|| {
+                OmniError::manifest_internal(
+                    "merge Blob comparison requires _rowaddr; cursor must scan row addresses",
+                )
+            })?;
+            let identity = crate::blob::BlobDescriptorDecoder::try_new(descriptions)?
+                .physical_identity(row, fragment_id)?;
+            let _ = write!(signature, "B{}:{identity};", identity.len());
             continue;
         }
         if column.is_null(row) {

--- a/crates/omnigraph/tests/branching.rs
+++ b/crates/omnigraph/tests/branching.rs
@@ -426,6 +426,62 @@ async fn branch_merge_updates_main_traversal() {
     assert_eq!(merged.num_rows(), 3);
 }
 
+/// A same-length Blob-only update on a branch must survive a three-way merge.
+/// Merge classifies changed-vs-unchanged rows from a display of the Blob
+/// descriptor, which is resolved by Lance relative to the owning fragment — so
+/// a one-byte A -> B update that moves the row to a new fragment with colliding
+/// local descriptor coordinates was misread as unchanged and its change was
+/// silently dropped at merge (data loss). The comparator must qualify managed
+/// descriptor identity with the owning fragment.
+#[tokio::test]
+async fn three_way_merge_detects_same_length_blob_only_update() {
+    const SCHEMA: &str = "node Document {\n    title: String @key\n    content: Blob?\n}";
+    let dir = tempfile::tempdir().unwrap();
+    let uri = dir.path().to_str().unwrap();
+    let main = Omnigraph::init(uri, SCHEMA).await.unwrap();
+    main.load(
+        "main",
+        "{\"type\":\"Document\",\"data\":{\"title\":\"d1\",\"content\":\"base64:QQ==\"}}\n{\"type\":\"Document\",\"data\":{\"title\":\"d2\",\"content\":\"base64:QQ==\"}}",
+        LoadMode::Overwrite,
+    )
+    .await
+    .unwrap();
+
+    main.branch_create("feature").await.unwrap();
+    let feature = Omnigraph::open(uri).await.unwrap();
+    // feature: d1 content A -> B (one byte, same length).
+    feature
+        .load(
+            "feature",
+            "{\"type\":\"Document\",\"data\":{\"title\":\"d1\",\"content\":\"base64:Qg==\"}}",
+            LoadMode::Merge,
+        )
+        .await
+        .unwrap();
+    // main diverges on d2 so the merge is a genuine three-way, not fast-forward.
+    main.load(
+        "main",
+        "{\"type\":\"Document\",\"data\":{\"title\":\"d2\",\"content\":\"base64:Qg==\"}}",
+        LoadMode::Merge,
+    )
+    .await
+    .unwrap();
+
+    let outcome = main.branch_merge("feature", "main").await.unwrap();
+    assert_eq!(outcome, MergeOutcome::Merged);
+
+    let merged_d1 = read_managed_blob_bytes(
+        &main,
+        ReadTarget::branch("main"),
+        node_blob_cell("Document", "d1", "content"),
+    )
+    .await;
+    assert_eq!(
+        merged_d1, b"B",
+        "feature's same-length Blob-only update was dropped by the merge"
+    );
+}
+
 #[tokio::test]
 async fn branch_merge_with_blob_columns_preserves_blob_data() {
     let dir = tempfile::tempdir().unwrap();

--- a/docs/dev/merge-complexity.md
+++ b/docs/dev/merge-complexity.md
@@ -178,15 +178,18 @@ reads that each sort only a bounded chunk. RFC-030 §14 tracks this as the open
 it skips **only the five reserved Lance virtual columns** (a legal
 `_row_`-prefixed user property participates), distinguishes null from every
 rendered value including `""`, and length-prefixes each value so no value can
-spoof a column boundary. It still stringifies every user column including
-**Vector embeddings**, so cost per row ≈ O(columns + serialized bytes). On the
-three-way path this runs for **every** base/source/target row (eager); on the
-adopt fallback only for matched ids (lazy). (The former `starts_with("_row")`
-skip plus raw `\x1f` join conflated null with `""` and hid `_row_`-prefixed
-properties — merge silently dropped such changes. Full unification with the
-change feed's `changes::row_compare` comparator, which additionally compares
-Blob columns by descriptor identity, is a larger follow-up gated on the merge
-cursor's scan mode.)
+spoof a column boundary. Scalar/Vector columns are stringified (so cost per row
+≈ O(columns + serialized bytes)); **Blob columns compare by source-qualified
+physical identity** — the managed descriptor plus the owning fragment (high 32
+bits of `_rowaddr`, projected by the cursor via `with_row_address`), the same
+identity `changes::row_compare` uses. On the three-way path this runs for
+**every** base/source/target row (eager); on the adopt fallback only for matched
+ids (lazy). (The former `starts_with("_row")` skip plus raw `\x1f` join
+conflated null with `""` and hid `_row_`-prefixed properties, and rendering the
+Blob descriptor directly conflated a same-length Blob-only update across
+fragments — merge silently dropped all three change classes. The Blob identity
+is fragment-qualified because Lance resolves a managed descriptor relative to
+the owning data file.)
 
 ### D. Validation — `validate_merge_candidates`
 


### PR DESCRIPTION
## What & why

`branch_merge`'s `row_signature` classified changed-vs-unchanged rows from a **display of the Blob descriptor**. Lance resolves a managed (inline/packed/dedicated) descriptor *relative to the owning data file* (the row's fragment), so byte-identical descriptors in different fragments reference different bytes. A same-length Blob-only update (e.g. one byte `A`→`B`) moves the row to a new fragment that can reuse the same local `position`/`size`/`blob_id`, so the collision was misread as **unchanged** and the update was **silently dropped at merge** — data loss.

This is the merge counterpart of the CDC descriptor-collision fix in #519 (`fix(changes): source-qualify managed Blob descriptor identity in CDC`) and closes the last surface of that bug class.

## The fix

- Scan `_rowaddr` on the merge cursor via `Scanner::with_row_address()` (switching `OrderedTableCursor` to `scan_stream_with`).
- Compare Blob columns by `BlobDescriptorDecoder::physical_identity(row, fragment_id)` — the **same source-qualified identity the CDC comparator uses**: managed identity carries the owning fragment (high 32 bits of `_rowaddr`); external references resolve by URI and stay source-independent.
- The staged writers already project to the target schema by name, so the extra system column never reaches the delta (same as the pre-existing `_rowid`).

## Backing issue / RFC

- [x] Related to the CDC change-feed work in #519 (RFC-030); this is the branch-merge counterpart of the same descriptor-collision class.

## Local verification

- New regression `branching::three_way_merge_detects_same_length_blob_only_update` — RED against the descriptor-display comparator (merged `main` keeps `[65]` `'A'` instead of the merged `[66]` `'B'`), GREEN after.
- `cargo test -p omnigraph-engine --test branching --test merge_fast_forward --test merge_truth_table --test merge_cost --test validators` — 37 + 16 + 1 + 2 + 24 pass (blob-merge, truth table, and cost budget all unaffected).
- `cargo fmt --all --check` and `cargo clippy -p omnigraph-engine --all-targets --locked -- -D warnings` — clean.

## Notes for reviewers

- **Base is `change-feed` (#519), not `main`** — the fix reuses `BlobDescriptorDecoder::physical_identity(row, fragment_id)` introduced there. Retarget to `main` once #519 merges.
- Confirmed against pinned Lance 10.0.0 source: `dataset/blob.rs` resolves the descriptor's `location` from `row_addr` → fragment → data file (`RowAddress::fragment_id`); only `External` skips it.
- Blob comparison cost: `row_signature` now builds one `BlobDescriptorDecoder` per Blob column per row (merge already stringifies every scalar/vector column per row); `merge_cost` stays green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core three-way merge change detection for Blob tables; correctness-critical but narrowly scoped and aligned with existing CDC identity logic—wrong behavior would drop or mis-merge branch updates rather than corrupt unrelated paths.
> 
> **Overview**
> Fixes **silent data loss** in `branch_merge` when a same-length Blob-only change moved a row to a new Lance fragment: `row_signature` used to treat colliding local descriptor coordinates as **unchanged** and drop the update.
> 
> The ordered merge cursor now scans with **`_rowaddr`** (`scan_stream_with` + `with_row_address`) and signs Blob columns with **`BlobDescriptorDecoder::physical_identity`**, matching the CDC comparator in #519. Staged writers still project by target schema name, so the extra column does not reach the delta.
> 
> Adds regression **`three_way_merge_detects_same_length_blob_only_update`** and updates **`merge-complexity.md`** to describe Blob identity in signatures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21ce3584f167f8b790c9114a27b8bb48b5334580. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes three-way merge comparison so managed Blob descriptors are qualified by their owning fragment, preventing same-coordinate descriptors from hiding Blob-only updates.

- Enables `_rowaddr` on ordered merge scans.
- Uses `BlobDescriptorDecoder::physical_identity` in row signatures.
- Adds a regression test for a same-length Blob-only update and updates merge-complexity documentation.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking risk that physically relocated but byte-identical Blobs can be classified as logical updates or conflicts.

The source-qualification fix closes the demonstrated descriptor-collision data-loss path, but merge uses physical-identity inequality directly even though that inequality does not prove different Blob payloads.

**Files Needing Attention:** crates/omnigraph/src/exec/merge.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/omnigraph/src/exec/merge.rs | Adds fragment-qualified Blob signatures and row-address scanning, but direct identity comparison can treat relocated identical payloads as changes. |
| crates/omnigraph/tests/branching.rs | Adds focused coverage proving that a same-length Blob-only branch update survives a genuine three-way merge. |
| docs/dev/merge-complexity.md | Updates contributor documentation to describe row-address projection and fragment-qualified Blob identity. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Scan merge rows with _rowaddr] --> B[Extract fragment ID]
  B --> C[Build Blob physical identity]
  C --> D[Build row signature]
  D --> E{Compare base/source/target}
  E -->|one side changed| F[Stage selected row]
  E -->|both changed equally| G[Accept shared result]
  E -->|both signatures differ| H[DivergentUpdate conflict]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20modernrelay%2Fomnigraph%20PR%20%23521%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=modernrelay%2Fomnigraph&pr=521&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Acrates%2Fomnigraph%2Fsrc%2Fexec%2Fmerge.rs%3A1814-1815%0A**Physical%20identity%20creates%20phantom%20changes**%0A%0AWhen%20unchanged%20managed%20Blob%20bytes%20are%20rewritten%20into%20another%20fragment%2C%20%60physical_identity%60%20changes%20even%20though%20the%20logical%20value%20does%20not.%20Comparing%20these%20identities%20directly%20can%20classify%20the%20row%20as%20updated%20or%20produce%20a%20%60DivergentUpdate%60%20conflict%3B%20use%20the%20same%20payload%20comparison%20fallback%20as%20the%20CDC%20comparator%20when%20identities%20differ.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=modernrelay%2Fomnigraph&pr=521&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(merge): source-qualify managed Blob ..."](https://github.com/modernrelay/omnigraph/commit/21ce3584f167f8b790c9114a27b8bb48b5334580) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53766668)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Branching and merge](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/branching-and-merge.md)

<!-- /greptile_comment -->