### PR TITLE
docs(rfc): define typed storage failures

### DIFF
--- a/docs/rfcs/0034-durable-recovery-authority.md
+++ b/docs/rfcs/0034-durable-recovery-authority.md
@@ -173,9 +173,9 @@ This RFC does not define:
 - a new recovery, manifest, schema, or Lance format.
 
 RFC-035 owns served-operation lifetime and shutdown. RFC-036 owns runtime
-activation and supervision. The typed storage-failure work in PR #491 remains
-independent: failure retryability and durable recovery progress are different
-contracts.
+activation and supervision. RFC-038 owns typed storage-failure classification,
+which remains independent: an observed failure condition and durable recovery
+progress are different contracts, and neither alone authorizes replay.
 
 ## 3. Terminology and invariants
 
@@ -515,8 +515,8 @@ effect retry. If recapture proves the outcome, classification resumes. If it
 remains unknown, the unit requires operator action.
 
 A typed substrate failure classification may inform an external scheduler, but
-this RFC never equates `Unknown` with transient. PR #491 remains the owner of
-that separate classification.
+this RFC never equates `Unknown` with transient or treats classification as
+retry authority. RFC-038 owns that separate classification.
 
 Orphan-control disposition explicitly reports any main-lineage publication,
 audit append, and cleanup. No caller may reduce it to an unqualified boolean

--- a/docs/rfcs/0035-served-operation-ownership.md
+++ b/docs/rfcs/0035-served-operation-ownership.md
@@ -347,10 +347,10 @@ from signal receipt to process exit, not from one participant's close to a log.
 
 ## 9. Failure and observability contract
 
-RFC-035 owns lifecycle outcomes; PR #491 classifies only engine/substrate
-failures. `ErrorOutput` gains an optional rolling-safe `lifecycle` detail whose
-`kind` and `outcome` are strings (unknown values must deserialize). The stable
-mapping is:
+RFC-035 owns lifecycle outcomes; RFC-038 classifies only engine/substrate
+failure conditions and supplies no replay decision. `ErrorOutput` gains an
+optional rolling-safe `lifecycle` detail whose `kind` and `outcome` are strings
+(unknown values must deserialize). The stable mapping is:
 
 | Event | HTTP / transport | `kind` | `outcome` |
 |---|---|---|---|
@@ -483,7 +483,7 @@ wall bound, asserting one shared deadline and retaining child logs on failure.
 
 No disk/manifest/Lance/query/success shape changes. Optional
 `ErrorOutput.lifecycle` is additive; closed `ErrorCode` stays unchanged, with
-OpenAPI/old-client tests. PR #491 owns none of these meanings.
+OpenAPI/old-client tests. RFC-038 owns none of these meanings.
 
 Observable changes are additive lifecycle failures and an admitted write may
 finish after disconnect/timeout. Docs state transport cancellation is not

--- a/docs/rfcs/0036-atomic-runtime-activation.md
+++ b/docs/rfcs/0036-atomic-runtime-activation.md
@@ -14,8 +14,8 @@ owner: OmniGraph maintainers
 - **Date:** 2026-08-13
 - **Author track:** Maintainer design series
 - **Depends on:** RFC-034 durable recovery authority; RFC-035 served-operation
-  admission and lifetime; the typed storage-failure classifier retained in PR
-  #491; internal manifest schema v6; Lance 10.0.0.
+  admission and lifetime; RFC-038 typed storage-failure classification;
+  internal manifest schema v6; Lance 10.0.0.
 - **Replaces:** the unmerged graph-supervision direction in PR #489. Useful
   tests and operational requirements from that PR remain inputs, but its
   implementation is not the architecture.
@@ -93,9 +93,10 @@ before recovery or build, and only `Drained(DrainedProof)` authorizes progress.
 `DrainPending` parks the strong drain and does not authorize work. Recovery tasks
 join RFC-035's one `ShutdownDeadline`; this RFC neither resets it nor defines cutoff.
 
-PR #491's retained classifier owns the mapping from substrate errors to stable
-retry classes. This RFC consumes that class; it does not classify by matching
-error strings or redefine the taxonomy.
+RFC-038 owns the mapping from substrate errors to stable condition classes. A
+condition class is not replay authority. This RFC may consider `Transient` only
+after its operation-local effect and recovery rules authorize another attempt;
+it does not classify by matching error strings or redefine the taxonomy.
 
 This RFC does not define recovery formats or choices, HTTP-write cancellation
 or acknowledgement, shutdown, hot config reload, graph add/remove, multi-writer
@@ -458,10 +459,12 @@ from applied configuration and durable graph authority.
 
 ### 11.2 Retry and stale-attempt fencing
 
-The supervisor consumes PR #491's typed class. Retryable attempt failures use
-capped exponential backoff with full jitter. Non-retryable failures remain
-blocked until an explicit operator/configuration/authority change. Unknown is
-not silently retryable.
+The supervisor consumes RFC-038's typed condition class only after the
+operation-local recovery disposition authorizes another attempt. Authorized
+attempts whose condition is `Transient` use capped exponential backoff with
+full jitter. Other conditions remain blocked until an explicit
+operator/configuration/authority change. `Unknown` is not silently retryable,
+and RFC-038 exposes no generic retry decision.
 
 `RecoveryDisposition::NeedsCompensation` bypasses managed retry: no wake can mint an
 `ExclusiveRecoveryPermit`. Only completed offline recovery after all serving

--- a/docs/rfcs/0038-typed-storage-failures.md
+++ b/docs/rfcs/0038-typed-storage-failures.md
@@ -1,0 +1,339 @@
+# RFC 0038: Typed storage failures
+
+| | |
+|---|---|
+| **Status** | Proposed |
+| **Author track** | Public contribution |
+| **Author(s)** | Ragnor Comerford ([`ragnorc`](https://github.com/ragnorc)) |
+| **Discussion** | [PR #491](https://github.com/ModernRelay/omnigraph/pull/491) and its [maintainer review](https://github.com/ModernRelay/omnigraph/pull/491#issuecomment-5281302575) |
+| **Implementation** | [PR #491](https://github.com/ModernRelay/omnigraph/pull/491) is the obsolete prototype; a replacement PR will implement this RFC from current `main`. |
+
+> Status is maintained by maintainers: `Proposed` while the PR is open,
+> `Accepted` on merge, `Declined` on close, and `Superseded by NNNN` later.
+
+## Summary
+
+OmniGraph will expose storage failures as a closed, typed Rust API without
+turning that classification into a generic retry decision. `OmniError::Lance`
+becomes `OmniError::Storage(StorageFailure)`, and `StorageFailureKind`
+distinguishes positive evidence of transient, configuration, absence,
+precondition, and permanent conditions from `Unknown`. Storage diagnostics keep
+their historical operator-facing text. HTTP, OpenAPI, and persisted graph data
+do not change.
+
+## Motivation
+
+Today `OmniError::Lance(String)` erases the structured condition reported by
+Lance, `object_store`, `std::io`, and Lance Namespace. A caller can display the
+message but cannot distinguish a timeout from a missing dataset, bad
+credentials, a stale compare-and-swap, or corruption without parsing text.
+That invites two long-lived liabilities:
+
+1. Every consumer has to rediscover an incomplete, string-based taxonomy.
+2. A broad label such as "retryable" can accidentally authorize replay where
+   the operation has not proved that replay is safe.
+
+The prototype in PR #491 moved in the right direction but made three unsafe
+collapses. Opaque `object_store::Error::Generic` sources defaulted to transient,
+`NotModified` and already-exists conditions lost their precondition meaning,
+and every Lance retryable commit conflict became an engine replay signal.
+It also inherited stale Arrow, DataFusion, Blob, and conflict conversions from
+an older `main`, including doubled `storage:` display prefixes.
+
+The durable contract needs to represent only what the typed cause proves. The
+operation that knows whether an effect occurred remains the only layer allowed
+to decide whether and how to retry.
+
+## Guide-level explanation
+
+The Rust API becomes:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StorageFailureKind {
+    Transient,
+    Configuration,
+    NotFound,
+    Precondition,
+    Permanent,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StorageFailure {
+    pub kind: StorageFailureKind,
+    pub message: String,
+}
+
+impl StorageFailure {
+    pub fn is_transient(&self) -> bool {
+        self.kind == StorageFailureKind::Transient
+    }
+}
+
+pub enum OmniError {
+    // Existing exhaustive variants remain.
+    Storage(StorageFailure),
+}
+```
+
+`StorageFailureKind` means:
+
+| Kind | Evidence carried |
+|---|---|
+| `Transient` | A timeout, throttling response, cancellation, or recognized transport interruption occurred. |
+| `Configuration` | Authentication, permission, unsupported operation, malformed input/location, or an exhausted configured disk cap prevents the request as configured. |
+| `NotFound` | The requested object, dataset, ref, version, index, or namespace entity is absent. |
+| `Precondition` | Already-exists, not-modified, CAS/concurrency conflict, stale transaction/ref, or fenced authority requires state to be re-evaluated. |
+| `Permanent` | Typed evidence reports corruption, a schema/storage invariant failure, panic, or substrate-internal failure. |
+| `Unknown` | The typed evidence is insufficient. Neither retry nor permanent escalation is implied. |
+
+The enum classifies the observed failure, not the safety of repeating an
+operation. `is_transient()` is deliberately equivalent to
+`kind == StorageFailureKind::Transient`. There is no `should_retry`, replay, or
+idempotency API. A caller may use the classification as one input to an
+operation-local policy, but it must separately prove the operation's effect and
+replay boundary.
+
+`StorageFailure.message` is the complete operator-facing diagnostic, and
+`OmniError::Storage` displays it unchanged. Existing genuine storage messages
+therefore remain exact:
+
+```text
+storage read failed for 's3://bucket/key': <object-store error>
+storage: <Lance error>
+storage: nearest: <Lance error>
+```
+
+The server maps `OmniError::Storage` explicitly to its existing generic HTTP
+500 response and uses this complete display string. It does not add another
+prefix or expose `StorageFailureKind` in a response body or OpenAPI schema.
+Existing domain errors retain their operation-specific status codes.
+
+## Reference-level design
+
+### Ownership and dependency boundaries
+
+`omnigraph-storage` owns `StorageFailure`, `StorageFailureKind`, and the bounded
+classification of `object_store::Error` and storage-owned `std::io::Error`.
+The engine re-exports the public types and owns Lance and Lance Namespace
+classification because the storage adapter deliberately does not depend on
+Lance.
+
+There is no blanket `From<lance::Error> for OmniError`. Named engine helpers
+construct a direct storage diagnostic or a contextual storage diagnostic. The
+absence of a blanket conversion forces each Lance call site to choose one of
+three meanings:
+
+- a substrate storage failure;
+- an existing operation-local domain error; or
+- an OmniGraph internal/integrity failure.
+
+There are likewise no blanket `From<ArrowError>` or
+`From<DataFusionError>` implementations. Arrow batch, shape, and computation
+failures in manifest machinery are manifest-internal errors. Persisted Blob
+descriptor contradictions remain `BlobIntegrity`. User query planning, schema,
+and execution failures remain `DataFusion`.
+
+`ExternalBlobPolicy` and `ExternalBlobSource` continue to describe user-supplied
+external Blob references. Failure to admit or fetch such a reference is not a
+failure of the graph's own storage substrate and is not folded into `Storage`.
+
+### Bounded typed-source traversal
+
+Classification follows typed sources only. It never searches upstream display
+text for status codes, phrases, provider names, or retry hints. At most eight
+source links are inspected. Reaching the bound without typed evidence returns
+`Unknown`. Cyclic source chains also terminate at the bound and return
+`Unknown`.
+
+For wrappers with both an outer typed condition and a source, the explicit
+outer condition wins. Only opaque wrappers such as object-store `Generic` and
+Lance `IO`, `Wrapped`, and `External` recurse into the source.
+
+### `object_store` and storage-owned I/O
+
+The adapter maps `object_store` 0.13.2 as follows:
+
+| Upstream condition | `StorageFailureKind` |
+|---|---|
+| `NotFound` | `NotFound` |
+| `NotModified`, `Precondition`, `AlreadyExists` | `Precondition` |
+| `InvalidPath`, `NotSupported`, `NotImplemented`, `PermissionDenied`, `Unauthenticated`, `UnknownConfigurationKey` | `Configuration` |
+| `JoinError` cancelled | `Transient` |
+| `JoinError` panic | `Permanent` |
+| `Generic` | recursively classify its typed source; otherwise `Unknown` |
+| future non-exhaustive variant | `Unknown` |
+
+Storage-owned `std::io::ErrorKind` values map as follows:
+
+| I/O condition | `StorageFailureKind` |
+|---|---|
+| `NotFound` | `NotFound` |
+| `AlreadyExists` | `Precondition` |
+| `PermissionDenied`, `InvalidInput`, `Unsupported` | `Configuration` |
+| `TimedOut`, `Interrupted`, `ConnectionAborted`, `ConnectionRefused`, `ConnectionReset`, `BrokenPipe`, `NotConnected`, `HostUnreachable`, `NetworkUnreachable`, `WouldBlock` | `Transient` |
+| `InvalidData` | `Permanent` |
+| every other kind without stronger typed evidence | `Unknown` |
+
+Local filesystem backend failures use this same path. `OmniError::Io` remains
+for non-storage I/O only. The adapter's
+`CreateIfAbsentUnsupported` condition becomes `Configuration`. These changes
+carry the existing complete display text, including `io: ...` and
+`storage <operation> failed for ...` where those are the historical messages.
+
+### Lance 10 mapping
+
+Every current `lance::Error` variant is mapped explicitly:
+
+| `StorageFailureKind` | Lance variants |
+|---|---|
+| `Transient` | `Timeout` |
+| `Configuration` | `DiskCapExceeded`, `InvalidInput`, `InvalidTableLocation`, `InvalidRef`, `NotSupported`, `FieldNotFound`, `Unprocessable` |
+| `NotFound` | `DatasetNotFound`, `NotFound`, `RefNotFound`, `VersionNotFound`, `IndexNotFound` |
+| `Precondition` | `DatasetAlreadyExists`, `CommitConflict`, `IncompatibleTransaction`, `RetryableCommitConflict`, `TooMuchWriteContention`, `RefConflict`, `VersionConflict`, `Fenced` |
+| `Permanent` | `CorruptFile`, `SchemaMismatch`, `Internal`, `Arrow`, `Schema` |
+| `Unknown` | source-free `Execution`, `Index`, `Cleanup`, `Cloned`, `PrerequisiteFailed`, and `Stop` |
+
+`IO`, `Wrapped`, and `External` recursively classify their typed source and
+otherwise become `Unknown`. `Namespace` downcasts its source to
+`lance_namespace::NamespaceError`; a failed downcast uses the same bounded
+typed-source rule and otherwise becomes `Unknown`.
+
+The apparently counterintuitive corrections are deliberate. A Lance
+`Execution` string is not automatically a DataFusion user error, and a
+source-free execution/index/cleanup failure contains no typed proof of either a
+transient transport condition or a permanent substrate invariant failure.
+Conversely Lance's own `Arrow`, `Schema`, and `Internal` variants are positive
+evidence of a substrate-internal or persisted-schema failure and are
+`Permanent`, not generic query errors.
+
+### Lance Namespace 10 mapping
+
+All 24 current `lance_namespace::ErrorCode` values are exhaustive inputs:
+
+| `StorageFailureKind` | Namespace codes |
+|---|---|
+| `Transient` | `ServiceUnavailable`, `Throttling` |
+| `NotFound` | `NamespaceNotFound`, `TableNotFound`, `TableIndexNotFound`, `TableTagNotFound`, `TransactionNotFound`, `TableVersionNotFound`, `TableColumnNotFound`, `TableBranchNotFound` |
+| `Configuration` | `Unsupported`, `InvalidInput`, `PermissionDenied`, `Unauthenticated`, `TableSchemaValidationError` |
+| `Precondition` | `NamespaceAlreadyExists`, `TableAlreadyExists`, `TableIndexAlreadyExists`, `TableTagAlreadyExists`, `TableBranchAlreadyExists`, `ConcurrentModification`, `NamespaceNotEmpty`, `InvalidTableState` |
+| `Permanent` | `Internal` |
+
+If Lance Namespace later adds a code, the exhaustive mapping must be reviewed
+when the dependency is upgraded. No namespace code currently maps to
+`Unknown`.
+
+### Conflict and retry boundaries
+
+The generic Lance classifier maps every Lance conflict family, including
+`RetryableCommitConflict`, to `Storage(Precondition)`. That result means only
+that current state must be re-evaluated.
+
+Existing operation-local boundaries retain their narrower meanings:
+
+- the exact table commit adapter may translate an effect-free Lance contention
+  result to `RetryableCommitConflict` after its existing proof;
+- manifest row CAS contention remains
+  `ManifestConflictDetails::RowLevelCasContention`;
+- optimize keeps its local raw-Lance retry classifier; and
+- no other Lance conflict becomes a replay signal.
+
+RFC-034 recovery disposition and RFC-036 supervision remain separate
+contracts. A future supervisor may consider `Transient` after its recovery and
+effect-state rules authorize another attempt, but this RFC supplies neither
+that authorization nor scheduling policy.
+
+### Compatibility
+
+This is an intentional pre-1.0 Rust API break:
+
+- `OmniError::Lance(String)` is removed;
+- exhaustive consumers must handle `OmniError::Storage(StorageFailure)`; and
+- callers may inspect `StorageFailureKind` instead of parsing text.
+
+Exact operator text is preserved for genuine adapter and Lance storage
+failures. Some errors intentionally change category: manifest-owned Arrow
+failures become manifest-internal, persisted Blob contradictions become
+`BlobIntegrity`, and user DataFusion failures remain `DataFusion`. Those
+corrections may change Rust matching and existing operation-specific HTTP
+status behavior, but they restore the domain boundary instead of preserving a
+misclassification.
+
+There is no graph-format, manifest-schema, Lance-format, recovery-sidecar, wire,
+HTTP-schema, or OpenAPI migration. No persisted data changes.
+
+### Acceptance evidence
+
+Tests extend the existing in-source owners and staged table-store suite:
+
+- every object-store variant, recognized and opaque `Generic` sources, nested
+  depth seven/eight, a cyclic source, and future/depth fallback;
+- local I/O cases for all six categories plus cancelled/panicked join tasks;
+- all 24 Lance Namespace codes and every Lance family, including recursive
+  `IO`, `Wrapped`, and `External` sources;
+- exact direct-adapter, direct-Lance, and contextual-Lance display strings;
+- DataFusion user errors, nested typed substrate errors, Arrow/internal
+  failures, and Blob-integrity contradictions at their owning boundaries;
+- the table-store proof that only the effect-free adapter emits
+  `RetryableCommitConflict`, while the generic classifier reports the same
+  Lance variants as `Precondition`;
+- unchanged publisher and optimize retry vocabularies;
+- exact server status/message mapping and an unchanged generated OpenAPI spec;
+  and
+- a source guard forbidding global `From<lance::Error>`, `From<ArrowError>`,
+  or `From<DataFusionError>` implementations.
+
+The implementation must pass the affected baseline before editing, focused
+storage/engine/server tests, the canonical failpoint-superset workspace test,
+both all-target Clippy graphs with warnings denied, formatting, OpenAPI drift,
+and the server AWS-feature suite.
+
+## Invariants & deny-list check
+
+This RFC strengthens Hard Invariant 13: failures become typed and bounded, and
+uncertain evidence stays explicit. Its tests follow Invariant 14 by asserting
+the adapter, substrate, conflict, and transport boundaries separately. It does
+not change graph publication, recovery, schema identity, or source-of-truth
+rules.
+
+It also closes two deny-list risks. No caller needs to parse string-flattened
+errors for semantics, and exact observable error text is treated as a contract.
+The change does not add a transaction manager, retry queue, alternate write
+path, or side channel for replay semantics.
+
+## Drawbacks & alternatives
+
+The exhaustive mapping adds maintenance whenever Lance adds an error variant or
+Namespace code. That is intentional review pressure at the substrate boundary.
+The closed public `StorageFailureKind` is also a pre-1.0 compatibility surface;
+adding a kind will break exhaustive downstream matches.
+
+Alternatives rejected:
+
+- **Keep strings.** This preserves ambiguity and forces every consumer to parse
+  unstable text.
+- **Expose `should_retry`.** Failure class alone cannot prove effect certainty,
+  idempotency, or safe replay.
+- **Default unknown sources to transient.** That turns missing evidence into an
+  operational promise and can create retry storms or replay unsafe work.
+- **Default unknown sources to permanent.** That can strand recoverable
+  failures and also claims evidence the substrate did not provide.
+- **Expose classification over HTTP.** No current client contract needs it, and
+  it would prematurely make the taxonomy a wire-compatibility surface.
+- **Reuse PR #491's branch.** It predates current Lance 10 Blob, recovery,
+  precondition, and manifest code. Resolving its textual conflicts would risk
+  resurrecting deleted helpers and obsolete control flow.
+
+## Reversibility
+
+The source and Rust API changes are reversible before 1.0, though reverting
+would again erase useful typed evidence. Persisted state and public wire
+formats are untouched, so no data migration or rollback procedure is needed.
+The implementation will be a fresh patch over current `main`; PR #491 remains
+available as historical context but is not merged or rebased.
+
+## Unresolved questions
+
+None. New typed substrate evidence may justify finer classification in a later
+RFC, but provider message parsing is not an acceptable substitute.

--- a/docs/rfcs/0038-typed-storage-failures.md
+++ b/docs/rfcs/0038-typed-storage-failures.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Status** | Proposed |
+| **Status** | Accepted |
 | **Author track** | Public contribution |
 | **Author(s)** | Ragnor Comerford ([`ragnorc`](https://github.com/ragnorc)) |
 | **Discussion** | [PR #491](https://github.com/ModernRelay/omnigraph/pull/491) and its [maintainer review](https://github.com/ModernRelay/omnigraph/pull/491#issuecomment-5281302575) |


### PR DESCRIPTION
## Summary

- define a closed typed storage-failure taxonomy without generic retry semantics
- preserve exact operator-facing storage diagnostics and keep HTTP/OpenAPI unchanged
- repair RFC-034/035/036 references so classification is not treated as replay authority

## Context

This is the design replacement requested in the maintainer review of #491. The original plan called this RFC-034, but current `main` already reserves 0034–0036 and open PR #507 reserves 0037, so the next available public-contribution number is RFC-038.

This PR contains RFC documents only. Implementation will start from the accepted `main` state in a fresh branch; none of #491's obsolete code or conflicts are carried forward.

## Validation

- `git diff --check`
- `scripts/check-agents-md.sh`

Related: #491

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only RFC and cross-reference edits; no runtime, API, or persisted format changes in this PR.
> 
> **Overview**
> Adds **RFC-038**, the accepted design that replaces the obsolete PR #491 prototype: storage errors become `OmniError::Storage(StorageFailure)` with a closed `StorageFailureKind` taxonomy, bounded typed-source mapping for object-store, I/O, Lance, and Lance Namespace, and **no** generic `should_retry` or wire/OpenAPI exposure. Operator-facing storage message text and HTTP behavior stay unchanged at the API boundary.
> 
> **RFC-034**, **RFC-035**, and **RFC-036** are updated to point at RFC-038 instead of PR #491 and to state explicitly that substrate failure classification is separate from durable recovery progress, lifecycle outcomes, and replay/retry authority (including that `Transient` backoff in supervision requires operation-local authorization first).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29d42a15e73ee39037f0c62f95f16aa6eb577482. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

RFC-038 defines a closed typed taxonomy for storage failures while keeping replay authority operation-local and preserving existing wire and persistence contracts.
- Replaces the proposed string-based Lance error representation with typed storage failure kinds.
- Assigns classification ownership across object-store, I/O, Lance, and Lance Namespace boundaries.
- Updates RFC-034, RFC-035, and RFC-036 to distinguish failure classification from recovery and replay authority.

<h3>Confidence Score: 5/5</h3>

The documentation-only PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/rfcs/0038-typed-storage-failures.md | Defines the typed storage-failure taxonomy, source mappings, compatibility boundaries, and acceptance evidence. |
| docs/rfcs/0034-durable-recovery-authority.md | Clarifies that storage classification and durable recovery progress do not independently authorize replay. |
| docs/rfcs/0035-served-operation-ownership.md | Replaces obsolete prototype references and keeps lifecycle outcomes separate from substrate classification. |
| docs/rfcs/0036-atomic-runtime-activation.md | Requires operation-local recovery authorization before supervision considers transient storage conditions. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Sources[object_store / I-O / Lance / Lance Namespace] --> Classifier[RFC-038 typed classification]
    Classifier --> Kind[StorageFailureKind]
    Kind --> Policy[Operation-local effect and recovery policy]
    Policy -->|authorizes another attempt| Retry[Retry or supervision scheduling]
    Policy -->|does not authorize| Block[Block or require operator/state change]
    Classifier -. no replay authority .-> Retry
```
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(rfc): accept typed storage failures"](https://github.com/modernrelay/omnigraph/commit/29d42a15e73ee39037f0c62f95f16aa6eb577482) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53822329)</sub>

<!-- /greptile_comment -->