### PR TITLE
feat(optimize): surface vector index layout so coverage answers can-it-prune

### DIFF
--- a/crates/omnigraph-cli/src/main.rs
+++ b/crates/omnigraph-cli/src/main.rs
@@ -978,6 +978,14 @@ async fn main() -> Result<()> {
                             "column": p.column,
                             "reason": p.reason,
                         })).collect::<Vec<_>>(),
+                        "vector_index_layouts": s.vector_index_layouts.iter().map(|v| serde_json::json!({
+                            "column": v.column,
+                            "index_name": v.index_name,
+                            "partitions": v.partitions,
+                            "indexed_rows": v.indexed_rows,
+                            "max_rows_per_partition": v.max_rows_per_partition,
+                            "degenerate": v.degenerate,
+                        })).collect::<Vec<_>>(),
                     })).collect::<Vec<_>>(),
                 });
                 print_json(&value)?;
@@ -996,6 +1004,19 @@ async fn main() -> Result<()> {
                     }
                     for p in &s.pending_indexes {
                         println!("    ↳ index pending on '{}': {}", p.column, p.reason);
+                    }
+                    for v in &s.vector_index_layouts {
+                        if v.degenerate {
+                            println!(
+                                "    ↳ DEGENERATE vector index on '{}': {} partition(s) over {} rows ({} rows/partition worst segment) — cannot prune; delta optimize will not re-partition (#485)",
+                                v.column, v.partitions, v.indexed_rows, v.max_rows_per_partition
+                            );
+                        } else {
+                            println!(
+                                "    ↳ vector index on '{}': {} partition(s) / {} rows",
+                                v.column, v.partitions, v.indexed_rows
+                            );
+                        }
                     }
                 }
             }

--- a/crates/omnigraph/src/db/mod.rs
+++ b/crates/omnigraph/src/db/mod.rs
@@ -12,7 +12,7 @@ pub use manifest::{Snapshot, SnapshotScanner, SnapshotTable, SubTableEntry, SubT
 pub(crate) use omnigraph::ensure_public_branch_ref;
 pub use omnigraph::{
     CleanupPolicyOptions, EXPORT_CHUNK_MAX_BYTES, ExportCut, InitOptions, MergeOutcome, Omnigraph,
-    OpenMode, PendingIndex, RepairAction, RepairClassification, RepairOptions, RepairStats,
+    OpenMode, PendingIndex, VectorIndexLayout, RepairAction, RepairClassification, RepairOptions, RepairStats,
     SchemaApplyOptions, SchemaApplyResult, SkipReason, TableCleanupStats, TableOptimizeStats,
     TableRepairStats,
 };

--- a/crates/omnigraph/src/db/mod.rs
+++ b/crates/omnigraph/src/db/mod.rs
@@ -12,9 +12,9 @@ pub use manifest::{Snapshot, SnapshotScanner, SnapshotTable, SubTableEntry, SubT
 pub(crate) use omnigraph::ensure_public_branch_ref;
 pub use omnigraph::{
     CleanupPolicyOptions, EXPORT_CHUNK_MAX_BYTES, ExportCut, InitOptions, MergeOutcome, Omnigraph,
-    OpenMode, PendingIndex, VectorIndexLayout, RepairAction, RepairClassification, RepairOptions, RepairStats,
+    OpenMode, PendingIndex, RepairAction, RepairClassification, RepairOptions, RepairStats,
     SchemaApplyOptions, SchemaApplyResult, SkipReason, TableCleanupStats, TableOptimizeStats,
-    TableRepairStats,
+    TableRepairStats, VectorIndexLayout,
 };
 pub(crate) use omnigraph::{DeferredTableFork, WriteAuthorityToken, WriteTxn};
 

--- a/crates/omnigraph/src/db/omnigraph.rs
+++ b/crates/omnigraph/src/db/omnigraph.rs
@@ -46,8 +46,8 @@ pub use repair::{
     RepairAction, RepairClassification, RepairOptions, RepairStats, TableRepairStats,
 };
 pub use schema_apply::SchemaApplyOptions;
-pub use table_ops::{PendingIndex, VectorIndexLayout};
 pub(crate) use table_ops::{DeferredTableFork, OpenedForMutation};
+pub use table_ops::{PendingIndex, VectorIndexLayout};
 
 use super::commit_graph::GraphCommit;
 use super::manifest::{

--- a/crates/omnigraph/src/db/omnigraph.rs
+++ b/crates/omnigraph/src/db/omnigraph.rs
@@ -46,7 +46,7 @@ pub use repair::{
     RepairAction, RepairClassification, RepairOptions, RepairStats, TableRepairStats,
 };
 pub use schema_apply::SchemaApplyOptions;
-pub use table_ops::PendingIndex;
+pub use table_ops::{PendingIndex, VectorIndexLayout};
 pub(crate) use table_ops::{DeferredTableFork, OpenedForMutation};
 
 use super::commit_graph::GraphCommit;

--- a/crates/omnigraph/src/db/omnigraph/optimize.rs
+++ b/crates/omnigraph/src/db/omnigraph/optimize.rs
@@ -126,6 +126,11 @@ pub struct TableOptimizeStats {
     /// later `optimize` retries; the `list_indices`/`indisvalid` analog so
     /// operators can see which index is pending and why.
     pub pending_indexes: Vec<super::PendingIndex>,
+    /// Physical layout of each built vector index on this table (#486):
+    /// partition count, indexed rows, and a degenerate flag for layouts that
+    /// cannot prune. Coverage that omits this reports a mono-partition index
+    /// as healthy while every query flat-scans the index payload.
+    pub vector_index_layouts: Vec<super::VectorIndexLayout>,
 }
 
 impl TableOptimizeStats {
@@ -140,6 +145,7 @@ impl TableOptimizeStats {
             manifest_version: None,
             lance_head_version: None,
             pending_indexes: Vec::new(),
+            vector_index_layouts: Vec::new(),
         }
     }
 
@@ -158,6 +164,7 @@ impl TableOptimizeStats {
             manifest_version: Some(manifest_version),
             lance_head_version: Some(lance_head_version),
             pending_indexes: Vec::new(),
+            vector_index_layouts: Vec::new(),
         }
     }
 }
@@ -484,6 +491,7 @@ async fn prepare_optimize_table(
         let mut stat =
             TableOptimizeStats::compacted(task.table_key, &CompactionMetrics::default(), false);
         stat.pending_indexes = index_work.pending;
+        stat.vector_index_layouts = index_work.vector_layouts;
         return Ok(OptimizePreparation::Stat(stat));
     }
 
@@ -594,6 +602,7 @@ async fn apply_optimize_table_effects(
                 false,
             );
             stat.pending_indexes = index_work.pending;
+            stat.vector_index_layouts = index_work.vector_layouts;
             return Ok(OptimizeEffectOutcome { stat, update: None });
         }
 
@@ -675,8 +684,12 @@ async fn apply_optimize_table_effects(
         break (snapshot, metrics, pending_indexes, head_advanced);
     };
 
-    let mut stat = TableOptimizeStats::compacted(table_key, &metrics, committed);
+    let mut stat = TableOptimizeStats::compacted(table_key.clone(), &metrics, committed);
     stat.pending_indexes = pending_indexes;
+    stat.vector_index_layouts = super::table_ops::vector_index_layouts_on_dataset(
+        db, catalog, &table_key, &snapshot,
+    )
+    .await?;
     let update = if committed {
         let state = db.storage().table_state(&full_path, &snapshot).await?;
         Some(crate::db::SubTableUpdate {

--- a/crates/omnigraph/src/db/omnigraph/optimize.rs
+++ b/crates/omnigraph/src/db/omnigraph/optimize.rs
@@ -686,10 +686,9 @@ async fn apply_optimize_table_effects(
 
     let mut stat = TableOptimizeStats::compacted(table_key.clone(), &metrics, committed);
     stat.pending_indexes = pending_indexes;
-    stat.vector_index_layouts = super::table_ops::vector_index_layouts_on_dataset(
-        db, catalog, &table_key, &snapshot,
-    )
-    .await?;
+    stat.vector_index_layouts =
+        super::table_ops::vector_index_layouts_on_dataset(db, catalog, &table_key, &snapshot)
+            .await?;
     let update = if committed {
         let state = db.storage().table_state(&full_path, &snapshot).await?;
         Some(crate::db::SubTableUpdate {

--- a/crates/omnigraph/src/db/omnigraph/table_ops.rs
+++ b/crates/omnigraph/src/db/omnigraph/table_ops.rs
@@ -631,6 +631,7 @@ async fn vector_column_trainable(
 pub(super) struct IndexWorkStatus {
     pub(super) needs_commit: bool,
     pub(super) pending: Vec<PendingIndex>,
+    pub(super) vector_layouts: Vec<VectorIndexLayout>,
 }
 
 /// Returns the declared scalar/vector index work that
@@ -769,9 +770,11 @@ pub(super) async fn index_work_status_on_dataset_for_catalog(
             table_key
         )));
     };
+    let vector_layouts = vector_index_layouts_on_dataset(db, catalog, table_key, ds).await?;
     Ok(IndexWorkStatus {
         needs_commit: work.needs_commit(),
         pending: work.pending,
+        vector_layouts,
     })
 }
 
@@ -1393,6 +1396,117 @@ pub struct PendingIndex {
     pub table_key: String,
     pub column: String,
     pub reason: String,
+}
+
+/// Physical layout of a built vector index, surfaced on optimize stats so
+/// coverage answers "can this index prune", not just "does an index exist"
+/// (#486). A mono-partition IVF index over a large table reports complete
+/// coverage while every `nearest()` reads the full index payload; delta
+/// `optimize_indices` folds never re-partition, so without this signal the
+/// state is invisible to anyone watching coverage.
+#[derive(Debug, Clone)]
+pub struct VectorIndexLayout {
+    pub table_key: String,
+    pub column: String,
+    pub index_name: String,
+    /// Best partition count across the index's delta segments (display
+    /// summary; the degenerate flag is computed per segment, not from this).
+    pub partitions: u64,
+    pub indexed_rows: u64,
+    /// Worst rows-per-partition across delta segments — the honest prune
+    /// signal, since Lance searches each delta segment independently and a
+    /// good later segment cannot repair a bad earlier one.
+    pub max_rows_per_partition: u64,
+    /// True when some segment averages more than
+    /// [`DEGENERATE_VECTOR_ROWS_PER_PARTITION`] rows per partition, i.e. a
+    /// nearest() against it reads a partition so large the index is
+    /// functionally a flat scan. Catches both the mono-partition case and the
+    /// under-partitioned case (8 partitions over 852k rows).
+    pub degenerate: bool,
+}
+
+/// Below this many rows per partition a scan of the partition is trivially
+/// cheap; above it, the partition is so large that probing it approaches a
+/// flat read of the segment. Healthy IVF sizing targets ~sqrt(N) rows per
+/// partition, so 4096 leaves generous slack before the flag fires.
+pub(crate) const DEGENERATE_VECTOR_ROWS_PER_PARTITION: u64 = 4096;
+
+/// Per segment, because Lance searches delta segments independently: one
+/// degenerate segment forces its full payload onto every query no matter how
+/// well-partitioned its siblings are.
+fn vector_layout_is_degenerate(per_segment: &[(u64, u64)]) -> bool {
+    per_segment
+        .iter()
+        .any(|(partitions, rows)| rows / partitions.max(&1) > DEGENERATE_VECTOR_ROWS_PER_PARTITION)
+}
+
+/// Collect [`VectorIndexLayout`]s for every declared vector column on a node
+/// table that already has a built index. Edge tables have no vector columns.
+pub(super) async fn vector_index_layouts_on_dataset(
+    db: &Omnigraph,
+    catalog: &Catalog,
+    table_key: &str,
+    ds: &SnapshotHandle,
+) -> Result<Vec<VectorIndexLayout>> {
+    let Some(type_name) = table_key.strip_prefix("node:") else {
+        return Ok(Vec::new());
+    };
+    let Some(node_type) = catalog.node_types.get(type_name) else {
+        return Ok(Vec::new());
+    };
+    let mut layouts = Vec::new();
+    for index_cols in &node_type.indices {
+        if index_cols.len() != 1 {
+            continue;
+        }
+        let prop_name = &index_cols[0];
+        let Some(prop_type) = node_type.properties.get(prop_name) else {
+            continue;
+        };
+        if !matches!(
+            node_prop_index_kind(prop_type),
+            Some(NodePropIndexKind::Vector)
+        ) {
+            continue;
+        }
+        if let Some((index_name, indexed_rows, per_segment)) =
+            db.storage().vector_index_layout(ds, prop_name).await?
+        {
+            layouts.push(VectorIndexLayout {
+                table_key: table_key.to_string(),
+                column: prop_name.clone(),
+                index_name,
+                partitions: per_segment.iter().map(|(p, _)| *p).max().unwrap_or(0),
+                indexed_rows,
+                max_rows_per_partition: per_segment
+                    .iter()
+                    .map(|(p, r)| r / p.max(&1))
+                    .max()
+                    .unwrap_or(0),
+                degenerate: vector_layout_is_degenerate(&per_segment),
+            });
+        }
+    }
+    Ok(layouts)
+}
+
+#[cfg(test)]
+mod vector_layout_tests {
+    use super::{DEGENERATE_VECTOR_ROWS_PER_PARTITION, vector_layout_is_degenerate};
+
+    #[test]
+    fn degenerate_boundary() {
+        let floor = DEGENERATE_VECTOR_ROWS_PER_PARTITION;
+        assert!(!vector_layout_is_degenerate(&[(1, floor)]));
+        assert!(vector_layout_is_degenerate(&[(1, floor + 1)]));
+        // The #432 incident shape: 8 partitions over 852k rows must flag.
+        assert!(vector_layout_is_degenerate(&[(8, 852_000)]));
+        // Healthy sizing: ~sqrt(N) partitions stays quiet.
+        assert!(!vector_layout_is_degenerate(&[(923, 852_000)]));
+        // One bad delta segment cannot hide behind a good later one.
+        assert!(vector_layout_is_degenerate(&[(1, 100_000), (64, 5_000)]));
+        assert!(!vector_layout_is_degenerate(&[(1, 0)]));
+    }
 }
 
 pub(super) async fn build_indices_on_dataset(

--- a/crates/omnigraph/src/storage_layer.rs
+++ b/crates/omnigraph/src/storage_layer.rs
@@ -759,6 +759,13 @@ pub trait TableStorage: sealed::Sealed + Send + Sync + Debug {
     async fn has_btree_index(&self, snapshot: &SnapshotHandle, column: &str) -> Result<bool>;
     async fn has_fts_index(&self, snapshot: &SnapshotHandle, column: &str) -> Result<bool>;
     async fn has_vector_index(&self, snapshot: &SnapshotHandle, column: &str) -> Result<bool>;
+    /// Physical layout of the column's vector index, if one exists:
+    /// `(index_name, total_indexed_rows, per_segment (partitions, rows))`.
+    async fn vector_index_layout(
+        &self,
+        snapshot: &SnapshotHandle,
+        column: &str,
+    ) -> Result<Option<(String, u64, Vec<(u64, u64)>)>>;
 
     // ── URI helpers ────────────────────────────────────────────────────
     //
@@ -1263,6 +1270,14 @@ impl TableStorage for TableStore {
 
     async fn has_vector_index(&self, snapshot: &SnapshotHandle, column: &str) -> Result<bool> {
         TableStore::has_vector_index(self, snapshot.dataset(), column).await
+    }
+
+    async fn vector_index_layout(
+        &self,
+        snapshot: &SnapshotHandle,
+        column: &str,
+    ) -> Result<Option<(String, u64, Vec<(u64, u64)>)>> {
+        TableStore::vector_index_layout_on(snapshot.dataset(), column).await
     }
 
     fn root_uri(&self) -> &str {

--- a/crates/omnigraph/src/table_store.rs
+++ b/crates/omnigraph/src/table_store.rs
@@ -3832,7 +3832,7 @@ impl TableStore {
             .map(|rows| rows.iter().filter_map(|r| r.as_u64()).collect())
             .unwrap_or_default();
         if segment_partitions.is_empty()
-            || segment_partitions.iter().any(|p| *p == 0)
+            || segment_partitions.contains(&0)
             || segment_rows.len() != segment_partitions.len()
         {
             return Err(OmniError::Lance(format!(

--- a/crates/omnigraph/src/table_store.rs
+++ b/crates/omnigraph/src/table_store.rs
@@ -3778,6 +3778,76 @@ impl TableStore {
         Self::has_vector_index_on(ds, column).await
     }
 
+    /// `(index_name, total_indexed_rows, per_segment)` for the column's vector
+    /// index, or `None` when the column has no vector index. `per_segment` is
+    /// one `(partitions, rows)` pair per delta segment, zipped from
+    /// `indices[]` and `num_indexed_rows_per_delta`: Lance searches delta
+    /// segments independently, so prune capability is per segment and any
+    /// summary that collapses them can hide a bad one. Statistics missing any
+    /// expected field is an error, not a silent skip — `lance_surface_guards`
+    /// pins the shape.
+    pub(crate) async fn vector_index_layout_on(
+        ds: &Dataset,
+        column: &str,
+    ) -> Result<Option<(String, u64, Vec<(u64, u64)>)>> {
+        let indices = Self::user_indices_for_column(ds, column).await?;
+        let Some(index) = indices.iter().find(|index| {
+            index
+                .index_details
+                .as_ref()
+                .map(|details| IndexDetails(details.clone()).is_vector())
+                .unwrap_or(false)
+        }) else {
+            return Ok(None);
+        };
+        let raw = ds.index_statistics(&index.name).await.map_err(|e| {
+            OmniError::Lance(format!(
+                "index_statistics on '{}' ('{}'): {}",
+                index.name, column, e
+            ))
+        })?;
+        let stats: serde_json::Value = serde_json::from_str(&raw).map_err(|e| {
+            OmniError::Lance(format!(
+                "index_statistics on '{}' returned unparseable JSON: {}",
+                index.name, e
+            ))
+        })?;
+        let indexed_rows = stats["num_indexed_rows"].as_u64().ok_or_else(|| {
+            OmniError::Lance(format!(
+                "index_statistics on '{}' missing num_indexed_rows: {}",
+                index.name, stats
+            ))
+        })?;
+        let segment_partitions: Vec<u64> = stats["indices"]
+            .as_array()
+            .map(|segments| {
+                segments
+                    .iter()
+                    .filter_map(|s| s["num_partitions"].as_u64())
+                    .collect()
+            })
+            .unwrap_or_default();
+        let segment_rows: Vec<u64> = stats["num_indexed_rows_per_delta"]
+            .as_array()
+            .map(|rows| rows.iter().filter_map(|r| r.as_u64()).collect())
+            .unwrap_or_default();
+        if segment_partitions.is_empty()
+            || segment_partitions.iter().any(|p| *p == 0)
+            || segment_rows.len() != segment_partitions.len()
+        {
+            return Err(OmniError::Lance(format!(
+                "index_statistics on '{}' did not expose aligned num_partitions / \
+                 num_indexed_rows_per_delta: {}",
+                index.name, stats
+            )));
+        }
+        let per_segment = segment_partitions
+            .into_iter()
+            .zip(segment_rows)
+            .collect::<Vec<_>>();
+        Ok(Some((index.name.clone(), indexed_rows, per_segment)))
+    }
+
     pub(crate) async fn has_vector_index_on(ds: &Dataset, column: &str) -> Result<bool> {
         let indices = Self::user_indices_for_column(ds, column).await?;
         Ok(indices.iter().any(|index| {

--- a/crates/omnigraph/tests/lance_surface_guards.rs
+++ b/crates/omnigraph/tests/lance_surface_guards.rs
@@ -2165,6 +2165,21 @@ async fn vector_optimize_after_delete_keeps_stable_ids_and_addresses_aligned() {
     let partition_count = stats["indices"][0]["num_partitions"]
         .as_u64()
         .expect("IVF statistics must expose num_partitions") as usize;
+    // Pinned because `TableStore::vector_index_layout_on` parses both fields
+    // for #486 coverage reporting: total rows plus per-delta rows aligned with
+    // `indices[]`. An upgrade that drops or renames either must fail here,
+    // not silently degrade optimize's layout stats.
+    stats["num_indexed_rows"]
+        .as_u64()
+        .expect("index statistics must expose top-level num_indexed_rows");
+    let per_delta = stats["num_indexed_rows_per_delta"]
+        .as_array()
+        .expect("index statistics must expose num_indexed_rows_per_delta");
+    assert_eq!(
+        per_delta.len(),
+        stats["indices"].as_array().unwrap().len(),
+        "num_indexed_rows_per_delta must align one-to-one with indices[]"
+    );
     assert!(
         partition_count > 1,
         "the guard must exercise the split/reshuffle path fixed by lance#7704; stats: {stats}"

--- a/crates/omnigraph/tests/maintenance.rs
+++ b/crates/omnigraph/tests/maintenance.rs
@@ -1822,3 +1822,46 @@ async fn optimize_materializes_index_after_type_rename() {
         "optimize must build the renamed table's deferred rank index"
     );
 }
+
+// #486: coverage must answer "can this index prune", not just "does an index
+// exist over these rows". A mono-partition IVF index over a large table
+// reports complete coverage while every nearest() reads the full index
+// payload; optimize's stats now carry each vector index's physical layout so
+// that state is visible to whoever watches coverage.
+#[tokio::test]
+async fn optimize_stats_surface_vector_index_layout() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = dir.path().to_str().unwrap();
+    let schema = "node Doc {\n    \
+        slug: String @key\n    \
+        embedding: Vector(4)? @index\n\
+        }\n";
+    let db = Omnigraph::init(uri, schema).await.unwrap();
+    let rows: String = (0..8)
+        .map(|i| {
+            format!(
+                "{{\"type\":\"Doc\",\"data\":{{\"slug\":\"d{i}\",\"embedding\":[{i}.0,1.0,0.0,0.0]}}}}\n"
+            )
+        })
+        .collect();
+    load_jsonl(&db, &rows, LoadMode::Merge).await.unwrap();
+    db.ensure_indices().await.unwrap();
+
+    let stats = db.optimize().await.unwrap();
+    let doc = stats
+        .iter()
+        .find(|s| s.table_key == "node:Doc")
+        .expect("optimize must report node:Doc");
+    let layout = doc
+        .vector_index_layouts
+        .iter()
+        .find(|l| l.column == "embedding")
+        .expect("optimize stats must surface the vector index layout (#486)");
+    assert!(layout.partitions >= 1, "a built IVF index has partitions");
+    assert_eq!(layout.indexed_rows, 8, "all rows are covered");
+    assert!(
+        !layout.degenerate,
+        "one partition over 8 rows prunes nothing but also costs nothing; \
+         the degenerate flag is reserved for layouts where the flat read hurts"
+    );
+}


### PR DESCRIPTION
Resolves #486.

Coverage currently answers "does an index exist over these rows" but not "can it prune" — the exact blindspot from the #432 incident, where `pending_indexes: []` reported a healthy index while every `nearest()` flat-read ~10 GB.

**What this adds (reporting only; the repair remains #485):**
- `TableOptimizeStats.vector_index_layouts`: per built vector index — name, partition summary, indexed rows, worst rows-per-partition across delta segments, and a `degenerate` flag.
- The flag is computed **per segment**: Lance searches delta segments independently, so a well-partitioned later segment cannot repair a mono-partition earlier one. It fires on rows-per-partition (> 4096, generous slack over ~sqrt(N) healthy sizing), which catches both the mono-partition case and the incident's own 8-partitions-over-852k shape — partition count alone would miss the latter.
- CLI: layouts print under each table; degenerate ones loudly, with the worst segment's rows/partition. `--json` carries the full struct.
- Statistics missing the expected fields are a loud error, not a silent skip — a silent skip would recreate the exact failure mode this issue is about. `lance_surface_guards` now pins `num_indexed_rows` and `num_indexed_rows_per_delta` (aligned with `indices[]`) beside the existing `num_partitions` pin, so a Lance upgrade that changes the shape fails the guard instead of degrading the stats.

**Scope checked:** `skipped_for_drift` intentionally reports no layout (that HEAD is not manifest-accepted); `TableOptimizeStats` is not serialized by the server, so no OpenAPI drift.

**Tests:** classifier unit tests including the incident shape and the bad-segment-behind-good-segment case; an end-to-end maintenance test asserting layouts surface through `optimize()` on a real vector index; the guard pins. Maintenance suite 34/34. CLI smoke on a local graph verified both text and `--json` output, and a no-vector-column graph stays clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4S9Xpe9G7pLEv9JaoXUAb

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR extends optimize statistics with physical vector-index layouts so callers can distinguish index coverage from actual pruning capability.
- Collects per-segment Lance partition and indexed-row statistics.
- Classifies layouts using the worst rows-per-partition segment.
- Exposes layout details through library statistics and CLI JSON/human output.
- Adds classifier, Lance-surface, and end-to-end maintenance coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/omnigraph/src/table_store.rs | Parses Lance vector-index statistics into aligned per-segment partition and row counts with loud shape validation. |
| crates/omnigraph/src/db/omnigraph/table_ops.rs | Defines the public layout report and classifies degeneracy from the worst independently searched delta segment. |
| crates/omnigraph/src/db/omnigraph/optimize.rs | Threads vector-index layouts through the optimize result paths. |
| crates/omnigraph-cli/src/main.rs | Adds vector-index layout details to optimize JSON and human-readable output. |
| crates/omnigraph/tests/maintenance.rs | Verifies that optimize surfaces a real vector index's physical layout. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Lance[Lance index statistics] --> Store[TableStore layout parser]
  Store --> Classifier[Per-segment degeneracy classifier]
  Classifier --> Stats[TableOptimizeStats]
  Stats --> JSON[CLI JSON output]
  Stats --> Human[CLI human output]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: satisfy the fmt and clippy gates"](https://github.com/modernrelay/omnigraph/commit/9a44f04b34a762e3dbc8030357738b09cfe37eed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54209504)</sub>

**Context used:**

- Knowledge Base — [OmniGraph core storage: manifest, table store, and Lance access](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/omnigraph-core-storage.md)
- Knowledge Base — [CLI and Config](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/cli-and-config.md)

<!-- /greptile_comment -->