### PR TITLE
feat(bench): RFC 0039 benchmark harness, branch merge as first workload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Tools that support `@`-imports (Claude Code) auto-include all three files via th
 `CLAUDE.md` is a symlink to this file — there is exactly one source of truth. Edit `AGENTS.md`.
 
 **Version surveyed:** 0.10.0
-**Workspace crates:** `omnigraph-compiler`, `omnigraph-storage` (shared control-object storage), `omnigraph` (engine), `omnigraph-policy`, `omnigraph-api-types` (shared HTTP wire DTOs), `omnigraph-cluster`, `omnigraph-cli`, `omnigraph-server`
+**Workspace crates:** `omnigraph-compiler`, `omnigraph-storage` (shared control-object storage), `omnigraph` (engine), `omnigraph-policy`, `omnigraph-api-types` (shared HTTP wire DTOs), `omnigraph-cluster`, `omnigraph-cli`, `omnigraph-server`, `omnigraph-bench` (branch-merge micro-benchmark harness, internal instrument)
 **Storage substrate:** Lance 10.0.0 (columnar, versioned, branchable; crates.io release)
 **License:** MIT
 **Toolchain:** Rust stable, edition 2024
@@ -123,6 +123,7 @@ Full diagram and concurrency model: [docs/dev/architecture.md](docs/dev/architec
 | CI / release workflows | [docs/dev/ci.md](docs/dev/ci.md) |
 | Branch protection policy (declarative, applied via `scripts/apply-branch-protection.sh`) | [docs/dev/branch-protection.md](docs/dev/branch-protection.md) |
 | Constants & tunables cheat sheet | [docs/user/reference/constants.md](docs/user/reference/constants.md) |
+| Benchmark harness (RFC 0039 micro profile: merge wall-clock, phases, storage calls; `scripts/generate_merge_bench_fixtures.py` generates the merge-bench v1 fixtures) | [crates/omnigraph-bench/README.md](crates/omnigraph-bench/README.md) |
 | RFC process — public contribution and maintainer design-series tracks | [docs/rfcs/README.md](docs/rfcs/README.md) |
 | Per-version release notes | [docs/releases/](docs/releases/) |
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5048,6 +5048,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "omnigraph-bench"
+version = "0.10.0"
+dependencies = [
+ "async-trait",
+ "clap",
+ "futures",
+ "lance",
+ "object_store",
+ "omnigraph-compiler",
+ "omnigraph-engine",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempfile",
+ "tokio",
+ "ulid",
+]
+
+[[package]]
 name = "omnigraph-cli"
 version = "0.10.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/omnigraph-cluster",
     "crates/omnigraph-policy",
     "crates/omnigraph-server",
+    "crates/omnigraph-bench",
 ]
 default-members = [
     "crates/omnigraph",

--- a/crates/omnigraph-bench/Cargo.toml
+++ b/crates/omnigraph-bench/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "omnigraph-bench"
+version = "0.10.0"
+edition = "2024"
+description = "In-tree benchmark harness for Omnigraph (branch-control micro-benchmark, merge scenarios)."
+license = "MIT"
+repository = "https://github.com/ModernRelay/omnigraph"
+# Internal instrument, never published: keeps the release-coherence contract
+# (AGENTS.md maintenance rule 4) scoped to the shipped crates.
+publish = false
+
+[[bin]]
+name = "omnigraph-bench"
+path = "src/main.rs"
+
+[dependencies]
+omnigraph = { package = "omnigraph-engine", path = "../omnigraph" }
+omnigraph-compiler = { path = "../omnigraph-compiler" }
+async-trait = { workspace = true }
+clap = { workspace = true }
+futures = { workspace = true }
+lance = { workspace = true }
+object_store = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }
+ulid = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/omnigraph-bench/README.md
+++ b/crates/omnigraph-bench/README.md
@@ -1,0 +1,325 @@
+# omnigraph-bench
+
+The **end-to-end benchmark**'s harness (RFC 0039), currently implementing the
+**micro profile** for branch-control workloads: one instrument measuring both
+elapsed time (wall-clock + the 14-phase `MergeTimingPhase` attribution) and
+storage calls per run, driving `branch_merge` on a parameterized multi-table
+fixture. It is *not* the logical-cost comparator (DST counting golden) or the
+real-backend qualifier — those are RFC-031's counting instruments; this one
+adds time on top and names which tool a number came from. Per RFC 0039 rule 6
+**nothing here gates anything, at any CI stage**.
+
+Internal instrument: workspace member, `publish = false`, plain binary.
+
+Profile note: the record declares `profile: "micro"`, and per-phase
+attribution is served **in-process** while the engine's phase-timing exposure
+is unshipped — an *implementation interim* per the RFC, named as such in every
+record's `instrument_access` field, not a different instrument.
+
+## Runs, points, and the run spec
+
+A **run** applies a workload to a fixture under stated conditions, measuring
+one SUT. Its **run spec** (Data / State / Workload / Environment / Protocol —
+one level per factor) is the record's natural key; flattened it is the
+**point name**:
+
+```
+m3-t8-n100k-btree-fresh-d50-warm
+^scenario ^data      ^state  ^delta ^warmth   (+ -divD off-default, -p<bytes> off-default, -s3)
+```
+
+`list` enumerates every runnable point (known scenarios x frozen fixtures x
+pre-tagged deltas x warmth regimes):
+
+```bash
+cargo run --release -p omnigraph-bench -- list --fixtures-root /path/to/fixtures
+```
+
+## Running (release only)
+
+A debug build refuses to run, record, or freeze — a debug-build wall-clock
+number must be impossible to write (rule 2). Storage-call counts would be
+build-profile-independent, but the record carries both, so the guard covers
+the record.
+
+```bash
+cargo run --release -p omnigraph-bench -- run --scenario m3 --warmth warm --out /tmp/bench-out
+cargo run --release -p omnigraph-bench -- run --scenario m5 --warmth warm --out /tmp/bench-out
+```
+
+Defaults are the small dev center (T=12 tables, N=10k rows/table, 5 measured
+reps, 1 discarded warm-up). The large center is reachable by flags
+(`--tables 140 --rows 100000`).
+
+Scenarios:
+
+| Id | Shape | Defaults |
+|---|---|---|
+| `m3` | Three-way diverged mixed merge (updates+deletes+inserts on both sides, disjoint rows, overlapping tables), delta sweep at fixed N | d ∈ {1, 50, 5000}, 4 diverged tables |
+| `m5` | Composite headline: every table diverged, small delta, one merge | d = 50, all T tables diverged |
+
+The delta split per side is updates-first (`ceil(d/3)` updates, then deletes,
+then inserts), so every d ≥ 1 carries at least one update per side and the
+merge can never classify onto the proven-pure-insert shortcut.
+
+Non-vacuous guards (every rep, warm-ups included): the outcome must be
+`Merged` (not `FastForward` / `AlreadyUpToDate`), the phase timings must be
+nonzero, and the post-merge row count of the first diverged table must equal
+the planned `N - deletes + inserts`.
+
+## Warmth regimes (rule 3: one per cell, declared)
+
+`--warmth` declares the cell's regime; the record carries regime, discarded
+warm-up count, and exactly what the regime did. Mixing regimes within a cell
+invalidates it — records from early development builds did exactly that (rep 1 partly cold)
+and read `"uncontrolled-v2"` after upgrade.
+
+| Regime | Mechanism here |
+|---|---|
+| `warm` (default) | `--warmup-reps` (default 1) full divergence+merge repetitions run and are discarded, then measurement |
+| `cold` | one **fresh process per measured repetition** (this binary re-execs itself; each process copies or rebuilds its own store); the parent folds the per-process rows into one record — one invocation, repetitions as rows |
+| `post-invalidation` | warm-up, then the engine handle is dropped and reopened (engine + Lance session caches invalidated), then measurement. The OS page cache stays warm: the engine exposes no finer invalidation door at this commit, and the record's `warmth.detail` says so |
+
+## Frozen fixtures: build, validate, refuse
+
+`fixture build` builds a base store, runs the **validation pass**, and only
+then freezes (RFC 0039: a fixture is validated once, before anything is ever
+measured against it; failing validation removes the partial fixture — it
+never freezes):
+
+- row counts per table equal the spec's N;
+- for `--index` builds: `ensure_indices` + `optimize`, then the id BTREE must
+  be `Indexed` on every table with no unindexed fragments (the condition the
+  indexed merge arms need);
+- nothing is fetched (generated data), recorded as such — a fetched artifact
+  would be digest-pinned here;
+- a SHA-256 content digest of the frozen `store/` goes into the
+  `fixture-manifest.json` **validation stamp**.
+
+`run --fixture <dir>` **refuses** a fixture whose manifest lacks the stamp,
+and re-digests the frozen store, refusing on mismatch (a mutated frozen store
+cannot be measured against). A stamp-less fixture is stamped in place with
+`fixture validate <dir>` (validates a copy, digests the untouched original);
+an already-stamped fixture is refused — delete the manifest's `validation`
+block (or rebuild) to force re-validation. Manifests below v3 are refused
+outright: fixtures are disposable, rebuild them. `fixture builder-version`
+prints the binary's builder version so scripts can compare it against a
+cached fixture's manifest before skipping a rebuild.
+
+```bash
+cargo run --release -p omnigraph-bench -- fixture build \
+    --fixtures-root /path/to/fixtures --tables 8 --rows 100000 --index
+cargo run --release -p omnigraph-bench -- fixture validate /path/to/fixtures/fx-t8-n4k-scalars-noindex
+cargo run --release -p omnigraph-bench -- run --scenario m3 \
+    --fixture /path/to/fixtures/fx-t8-n100k-scalars-btree-fresh \
+    --delta 50,5000 --warmth warm --out /tmp/bench-out
+```
+
+Fixture names derive from the tuple (`fx-t8-n100k-scalars-btree-fresh`);
+cohort tags are delta-namespaced (`d50_src_upd`, ...) so one frozen base
+serves the whole `--deltas` sweep; a delta outside the list is refused. The
+frozen bytes are never mutated: runs copy `store/` to a per-point tempdir.
+
+`scripts/generate_merge_bench_fixtures.py` (repo root) generates the
+branch-merge micro-benchmark's v1 fixtures — this crate's three, not the
+whole benchmark program's data: it builds the release binary and the
+fixtures under `target/bench/fixtures`, generation only, no measurements. It skips a cached
+fixture only when the manifest's builder version matches the binary's
+(`fixture builder-version`), deleting and rebuilding on mismatch.
+
+## The run record (schema v3, validated on write and read)
+
+One JSON file per point invocation:
+`<point_name>[_aa1|_aa2]_<invocation_id>.json` — the full point name keeps
+distinct points from colliding, the invocation id keeps re-runs of one point
+from colliding, and the file is opened `create_new` (a residual collision is
+a hard error, never a silent overwrite; no code path rewrites a record in
+place — RFC 0039: append-only until first cited). **One record = one
+invocation**; repetitions are rows (per-rep arrays) inside it. A record is
+identified uniquely by (spec, SUT, **invocation id**) — `invocation_id` is a
+caller-minted ULID generated at invocation start, so identity never rests on
+clock resolution; `invocation_unix_seconds` is persisted too but carries
+ordering only. Every record also carries the **session id** (one ULID per
+CLI invocation batch, RFC 0039) and the **point-name format version** (a
+name is decodable only with its format).
+
+The normative field list is `schema/run-record-v3.schema.json`, shipped with
+the crate: the harness refuses to **write** a record that fails it, `diff`
+refuses to **read** one. Top-level blocks:
+
+- **`run_spec`** — the five classes: `data` (provenance, T, N, column shape,
+  payload), `state` (F1–F5, the dataset-builder identity — `builder_version`
+  + `generation` parameters, recorded on every run, inline builds included —
+  and frozen-fixture provenance incl. the embedded validated manifest),
+  `workload` (scenario, merge kind, arrival, d, split, diverged tables),
+  `environment` (backend id, `s3_endpoint` when S3, and the **warmth
+  declaration**), `protocol` (instrument, attribution, reps, timer, rep
+  independence). The `profile` field is **derived** from the three
+  profile-deciding levels (arrival, provenance, attribution — RFC 0039:
+  decidable from a spec's levels alone), never asserted independently.
+- **`sut`** — the system under test, deliberately outside the spec: the
+  source commit (**embedded at build time** by `build.rs`, `-dirty` appended
+  when the build tree had uncommitted **tracked** changes — `git status -uno`,
+  so an untracked `.idea/` never marks a build dirty; a run-time git fallback
+  is labeled `unverified:`), build profile plus the embedded
+  `build_opt_level`, and **engine configuration as data** (every `OMNIGRAPH_*`
+  environment
+  variable at run time — a feature flag like `OMNIGRAPH_MERGE_LINEAGE` is a
+  record field, never a prose label; values of secret-looking names
+  (TOKEN/SECRET/PASSWORD/CREDENTIAL/KEY, case-insensitive) are stored
+  `<redacted>` — the name persists, the value never does).
+- **`machine`** — the auto-captured machine specification (cpu model, cores,
+  memory, storage class), **record-level identity beside the SUT** (RFC
+  0039: not a factor, auto-captured, so it sits outside the run spec; rule 4
+  still forbids silent cross-machine comparison).
+- **`results`** — wall-clock (p50/p95/min/max/mean + raw per-rep array +
+  the persisted **`tail_support`** marker: `supported` needs >= 20 reps for
+  p95, else `directional`, rule 3), per-phase totals (p50/max + raw
+  arrays), the non-vacuous row check, write-path counters, and
+  **`storage_calls`**: per-rep counts per RFC-031 operation class (get,
+  put, put_part, head, list, delete, copy, rename, and the multipart
+  operations — unobserved classes appear as zero), split into
+  `manifest_store` / `table_store` (Lance object stores, counted via the
+  engine's public `QueryIoProbes` wrapper seam through the `open_dataset`
+  chokepoint) and `control_plane` (the engine's public
+  `CountingStorageAdapter`). The counting wrapper forwards `rename_opts` to
+  the target store (counting one `rename`) instead of inheriting the
+  copy+delete default, so atomic renames stay atomic and land in the
+  `rename` class. RFC-031 counts at two layers; the layer observed here is
+  **logical operations** (`layer` field), and presence is stated per layer
+  for every conditional column (RFC 0039): `physical_attempts`, the
+  `concurrency_witness` (physical-layer, per-repetition span grain), the
+  per-layer `cumulative_request_time_*`, and the `latency_calibration` are
+  each explicitly `null` with the reason in their `_note` field — this seam
+  counts requests but neither times them nor observes the physical layer,
+  so the attempts x latency cross-check and elapsed reconciliation wait on
+  a seam that does (latency calibration is the next measurement to wire).
+  Counts cover the measured merge windows only and never gate anything
+  (rule 6).
+
+The build script re-embeds the SUT identity only when `.git/HEAD` or the git
+index changes, so the standard dev loop — edit a tracked file without
+staging, rebuild, run — re-links the binary with the **old** embedded commit
+and dirty flag. `source_commit` closes that window at run time: when git can
+still see the source tree and disagrees with the embedded values, every
+record's commit gets a `-stale-build` suffix (marked, never refused) and a
+one-line stderr warning says a rebuild clears it.
+
+v1/v2 records stay readable: `diff` upgrades them on load, labeling their
+warmth `"uncontrolled-v2"` and their machine/engine-config as not captured.
+
+## The A/A noise floor (rule 7), diff, and show
+
+```bash
+cargo run --release -p omnigraph-bench -- run --scenario m3 --fixture F --aa --out /tmp/floor
+cargo run --release -p omnigraph-bench -- diff DIR_A DIR_B --floor /tmp/floor/noise-floor.json
+cargo run --release -p omnigraph-bench -- diff DIR_A DIR_B --format md
+cargo run --release -p omnigraph-bench -- show /tmp/bench-out --format md
+```
+
+`--aa` runs every point twice at equal spec and SUT and writes
+`noise-floor.json` (wall-clock and per-phase pair deltas per point, plus the
+session id, the SUT commit, and the persisted default **claim margin** 2.0)
+beside the `_aa1`/`_aa2` records; an existing `noise-floor.json` in the out
+directory is refused before any measurement, never overwritten. `diff --floor` labels every wall or phase
+delta against three bands: below the floor reads **"no detected effect"** —
+never a small effect; between the floor and floor x margin is named the
+in-between band (not a claimable effect); above clears. `--margin` overrides
+the persisted default per invocation. A floor licenses only its own cell:
+`diff` prints a loud **extrapolation** warning when the floor's SUT commit or
+session differs from either compared record's.
+
+`diff` matches records by their full **point name** (the spec flattened —
+different specs never pair), prints both point names, wall-clock and
+per-phase deltas plus write-path and storage-call sums, reports points
+present in only one directory (both directions), and **warns loudly** when
+identities differ (rule 4: backend or machine spec; rule 2: build profile;
+rule 3: warmth), when any run-spec field differs, and when the two SUT
+engine configurations differ (a systems comparison, shown as data).
+Unsupported tails print the **directional** marker from the record.
+
+`show` renders one record (or every record of a directory) as tables:
+identity, wall-clock, the grouped phase view, write path, storage calls. The
+14 raw phases render under seven plain-language groups (setup and refresh /
+discover changes / table walk / validate changes / write merged data /
+publish new state / crash-safety bookkeeping), each group a row with total ms
+and its share of the wall-clock median, the raw phase names and µs indented
+beneath — grouping adds a layer, it never replaces the data. `TableWalk` is
+the general route's three-way row walk plus merged-row staging (one interval
+per table; zero on the insert-only fast route). `KeyedStage`/`KeyedCommit`
+are per-chunk sub-buckets of the write step (inside `PhysicalPublish` on the
+insert-only route, recorded bare on the general route), so the write group
+counts them once, never twice. Wall-clock the 14 phases do not cover prints
+as an explicit **not phase-attributed** row (on records written before the
+`TableWalk` phase existed, that remainder includes the then-uninstrumented
+walk), never silently normalized away. Both `diff` and `show` take `--format md` for
+GitHub-flavored markdown tables (paste-ready for PRs); the JSON record stays
+the single source of truth, the tables are views.
+
+## HTML report
+
+```bash
+cargo run --release -p omnigraph-bench -- report /tmp/bench-out --floor /tmp/bench-out/noise-floor.json
+```
+
+`report` renders every record of a directory (or one file) as a single
+**self-contained** HTML page (default `report.html` beside the records): no
+external requests of any kind, inline CSS and inline-SVG charts only, no
+JavaScript (collapsed sections are `<details>`), light theme with dark via
+`prefers-color-scheme`. Each record section leads with **metric cards**
+(median merge, p95, storage requests, biggest cost), then the seven grouped
+phase bars (share of wall-clock p50, one-line annotation, raw phases in a
+`<details>` fold — same grouping and unattributed-remainder rules as `show`),
+then the storage-call total and per-class split (with the S3 note: every
+request is one network round trip, so the count predicts cloud cost),
+write-path counters, and the full identity block collapsed — with the same
+honesty as the terminal views (full SUT commit incl. `-dirty`/`-stale-build`
+markers, directional tail badges). With `--floor`,
+A/A pairs in the directory (two records per point name) get a rule-7 delta
+section — below-floor deltas read "no detected effect". General two-directory
+diff pairing stays with `diff`; the report does not duplicate it.
+
+## Backend seam (MinIO later)
+
+Default backend is a fresh local tempdir per run (backend id
+`local-fs-tempdir` — the same local-FS backend the engine's own integration
+tests use; the engine has no whole-graph in-memory backend, the `memory://`
+adapter covers control objects only). `--root-uri s3://bucket/prefix`
+switches the entire store to any S3-compatible backend through the engine's
+normal `AWS_*` environment plumbing (`AWS_ENDPOINT_URL_S3`, ...), which is
+where a digest-pinned MinIO/RustFS slots in; the endpoint lands in the
+record's environment block. Nothing in this crate is MinIO-specific; a unique
+sub-prefix is appended per run.
+
+**S3 sub-prefixes accumulate.** Each run writes under a fresh
+`bench-<scenario>-d<delta>-<nanos>/` sub-prefix and the harness never deletes
+anything (deletion is an operator action). After a bench campaign, clean up
+with a command of this shape (operator-executed; `--dryrun` first):
+
+```bash
+aws s3 rm --recursive --dryrun s3://bucket/prefix/
+aws s3 rm --recursive s3://bucket/prefix/bench-m3-d50-1755600000000000000/
+```
+
+## Baseline records (v1/v2)
+
+Earlier baseline runs exist as v1/v2 records (`five_tuple`, uncontrolled
+warmth) from before this schema; `diff` still reads them, upgrades on load,
+and their per-rep arrays keep the warmth drift visible.
+
+## What benchmark v1 defers
+
+- `run --point <name>` (point names exist and `list` enumerates them; the
+  reverse parse is not wired), declarative case files, and the `Scenario`
+  trait for new scenario kinds.
+- Presentation exports beyond markdown (CSV) and the trend/progress view
+  (`diff`/`show --format md` exist).
+- State axes F1/F4 as real sweeps; scenarios M1/M2/M4, C family, D family.
+- The realistic profile (open-loop driver, on-time validity, quality floor,
+  cost) — rule 1 has no purchase on the micro profile's single-operation
+  workload.
+- Vector/blob column shapes, edge tables, topology; MinIO digest pinning and
+  any real-S3 run (operator-executed); S3-hosted fixture archives.
+- Branch cleanup between warm reps (cold reps are fully independent
+  processes; warm reps accumulate 2 branches each and deeper `__manifest`
+  journal history — the record's `rep_independence` note carries it).

--- a/crates/omnigraph-bench/build.rs
+++ b/crates/omnigraph-bench/build.rs
@@ -1,0 +1,57 @@
+//! Embeds the SUT identity at build time: the git commit (plus a dirty flag)
+//! and the cargo `OPT_LEVEL`. A run record's `source_commit` must describe
+//! the binary, and the binary can outlive the tree state it was built from —
+//! run-time `git rev-parse` describes the tree at run time, so it serves only
+//! as a fallback, labeled "unverified" (see `source_commit` in `main.rs`).
+//!
+//! Rerun window: the rerun-if-changed lines below REPLACE cargo's default
+//! rerun-on-any-source-change, so an unstaged edit to a tracked file (the
+//! standard dev loop: edit, build, run) re-links the binary with the OLD
+//! embedded commit and dirty flag — neither `.git/HEAD` nor the index moved.
+//! `source_commit` closes the window at run time: it re-runs the same two git
+//! commands and appends "-stale-build" when they disagree with the embedded
+//! values. The watched paths are resolved via `git rev-parse --git-path`: in
+//! a git worktree `.git` is a FILE pointing elsewhere, so the literal
+//! `../../.git/HEAD` would not exist and cargo would rerun this script on
+//! every build; the literals remain only as the no-git fallback.
+
+use std::process::Command;
+
+fn main() {
+    // Re-run when HEAD moves or the working tree's staged state changes.
+    // `--git-path` yields the real location (worktree-safe), relative to the
+    // package directory this script runs in — the same base cargo resolves
+    // rerun-if-changed paths against.
+    let head =
+        git(&["rev-parse", "--git-path", "HEAD"]).unwrap_or_else(|| "../../.git/HEAD".to_string());
+    let index = git(&["rev-parse", "--git-path", "index"])
+        .unwrap_or_else(|| "../../.git/index".to_string());
+    println!("cargo:rerun-if-changed={head}");
+    println!("cargo:rerun-if-changed={index}");
+    if let Some(commit) = git(&["rev-parse", "HEAD"]) {
+        println!("cargo:rustc-env=OMNIGRAPH_BENCH_GIT_COMMIT={commit}");
+        // `-uno`: tracked modifications only — an untracked `.idea/` must not
+        // mark every dev build dirty. An unreadable status is treated as
+        // dirty: the honest direction. `source_commit` in `main.rs` runs the
+        // same flags so the run-time staleness check compares like with like.
+        let dirty = git(&["status", "--porcelain", "-uno"]).is_none_or(|s| !s.is_empty());
+        println!(
+            "cargo:rustc-env=OMNIGRAPH_BENCH_GIT_DIRTY={}",
+            if dirty { "1" } else { "0" }
+        );
+    }
+    if let Ok(opt_level) = std::env::var("OPT_LEVEL") {
+        println!("cargo:rustc-env=OMNIGRAPH_BENCH_OPT_LEVEL={opt_level}");
+    }
+}
+
+/// Trimmed stdout of a git command run in the package directory, on success.
+fn git(args: &[&str]) -> Option<String> {
+    let out = Command::new("git").args(args).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    String::from_utf8(out.stdout)
+        .ok()
+        .map(|s| s.trim().to_string())
+}

--- a/crates/omnigraph-bench/schema/run-record-v3.schema.json
+++ b/crates/omnigraph-bench/schema/run-record-v3.schema.json
@@ -1,0 +1,386 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "omnigraph-bench/run-record-v3.schema.json",
+  "title": "omnigraph-bench run record, version 3",
+  "description": "The normative field list of a v3 run record (RFC 0039: 'the field list is normative, not illustrative: a record missing any field is invalid'). The harness validates every record against this file on write and diff validates on read. The in-crate validator interprets the subset of JSON Schema used here: type, properties, required, items, enum, minItems, additionalProperties (false only). Struct-derived objects are closed (additionalProperties false) so a struct field added without its schema counterpart fails validation; the deliberately open objects say why in their description.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "record_version",
+    "point_name",
+    "point_name_format",
+    "profile",
+    "instrument_access",
+    "invocation_id",
+    "session_id",
+    "invocation_unix_seconds",
+    "run_spec",
+    "sut",
+    "machine",
+    "results"
+  ],
+  "properties": {
+    "record_version": { "type": "integer", "enum": [3] },
+    "point_name": { "type": "string" },
+    "point_name_format": { "type": "integer", "enum": [1] },
+    "profile": { "type": "string", "enum": ["micro"] },
+    "instrument_access": { "type": "string" },
+    "label": { "type": "string" },
+    "invocation_id": { "type": "string" },
+    "session_id": { "type": "string" },
+    "invocation_unix_seconds": { "type": "integer" },
+    "run_spec": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["data", "state", "workload", "environment", "protocol"],
+      "properties": {
+        "data": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["provenance", "tables", "rows_per_table", "column_shape", "payload_bytes"],
+          "properties": {
+            "provenance": { "type": "string", "enum": ["synthetic", "corpus-derived"] },
+            "tables": { "type": "integer" },
+            "rows_per_table": { "type": "integer" },
+            "column_shape": { "type": "string" },
+            "payload_bytes": { "type": "integer" }
+          }
+        },
+        "state": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "fragmentation",
+            "index_existence",
+            "index_freshness",
+            "deletion_history",
+            "compaction_recency",
+            "builder_version",
+            "generation",
+            "base_load_commits"
+          ],
+          "properties": {
+            "fragmentation": { "type": "string" },
+            "index_existence": { "type": "string" },
+            "index_freshness": { "type": "string" },
+            "deletion_history": { "type": "string" },
+            "compaction_recency": { "type": "string" },
+            "builder_version": { "type": "integer" },
+            "generation": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["tables", "rows", "payload_bytes", "diverged_tables", "deltas"],
+              "properties": {
+                "tables": { "type": "integer" },
+                "rows": { "type": "integer" },
+                "payload_bytes": { "type": "integer" },
+                "diverged_tables": { "type": "integer" },
+                "deltas": { "type": "array", "items": { "type": "integer" }, "minItems": 1 }
+              }
+            },
+            "base_load_commits": { "type": "integer" },
+            "fixture_name": { "type": "string" },
+            "fixture_manifest": {
+              "type": "object",
+              "description": "The fixture's fixture-manifest.json embedded verbatim; deliberately open — its shape is owned by the fixture manifest version, which evolves independently of the record schema."
+            }
+          }
+        },
+        "workload": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "scenario",
+            "merge_kind",
+            "arrival",
+            "delta_rows_per_side",
+            "delta_split_per_side",
+            "diverged_tables"
+          ],
+          "properties": {
+            "scenario": { "type": "string", "enum": ["m3", "m5"] },
+            "merge_kind": { "type": "string" },
+            "arrival": {
+              "type": "string",
+              "enum": ["unscheduled single-shot", "scheduled steady", "scheduled bursty"]
+            },
+            "delta_rows_per_side": { "type": "integer" },
+            "delta_split_per_side": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["updates", "deletes", "inserts"],
+              "properties": {
+                "updates": { "type": "integer" },
+                "deletes": { "type": "integer" },
+                "inserts": { "type": "integer" }
+              }
+            },
+            "diverged_tables": { "type": "integer" }
+          }
+        },
+        "environment": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["backend", "root_uri_scheme", "warmth"],
+          "properties": {
+            "backend": { "type": "string" },
+            "root_uri_scheme": { "type": "string" },
+            "s3_endpoint": { "type": "string" },
+            "warmth": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["regime", "warmup_reps_discarded", "detail"],
+              "properties": {
+                "regime": {
+                  "type": "string",
+                  "enum": ["cold", "warm", "post-invalidation", "uncontrolled-v2"]
+                },
+                "warmup_reps_discarded": { "type": "integer" },
+                "detail": { "type": "string" }
+              }
+            }
+          }
+        },
+        "protocol": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["instrument", "attribution", "repetitions", "timer", "rep_independence"],
+          "properties": {
+            "instrument": { "type": "string" },
+            "attribution": { "type": "string", "enum": ["per-phase on", "off"] },
+            "repetitions": { "type": "integer" },
+            "timer": { "type": "string" },
+            "rep_independence": { "type": "string" }
+          }
+        }
+      }
+    },
+    "sut": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_commit", "build_profile", "build_opt_level", "engine_configuration"],
+      "properties": {
+        "source_commit": { "type": "string" },
+        "build_profile": { "type": "string", "enum": ["release"] },
+        "build_opt_level": { "type": "string" },
+        "engine_configuration": {
+          "type": "object",
+          "description": "Every OMNIGRAPH_* environment variable at run time, as a string map; deliberately open — the key set is whatever flags the engine grows."
+        }
+      }
+    },
+    "machine": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["os", "arch", "os_version", "cpu_model", "storage_class"],
+      "properties": {
+        "os": { "type": "string" },
+        "arch": { "type": "string" },
+        "os_version": { "type": "string" },
+        "cpu_model": { "type": "string" },
+        "physical_cores": { "type": "integer" },
+        "logical_cores": { "type": "integer" },
+        "memory_bytes": { "type": "integer" },
+        "storage_class": { "type": "string", "enum": ["ssd", "rotational", "unknown"] }
+      }
+    },
+    "results": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "wall_clock_ms",
+        "phases",
+        "merge_outcome",
+        "verified_rows_table0",
+        "fixture_build_seconds",
+        "write_path",
+        "storage_calls"
+      ],
+      "properties": {
+        "wall_clock_ms": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["p50", "p95", "min", "max", "mean", "tail_support", "reps"],
+          "properties": {
+            "p50": { "type": "number" },
+            "p95": { "type": "number" },
+            "min": { "type": "number" },
+            "max": { "type": "number" },
+            "mean": { "type": "number" },
+            "tail_support": { "type": "string", "enum": ["supported", "directional"] },
+            "reps": { "type": "array", "items": { "type": "number" }, "minItems": 1 }
+          }
+        },
+        "phases": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["phase", "total_us_p50", "total_us_max", "max_single_us", "per_rep_total_us"],
+            "properties": {
+              "phase": { "type": "string" },
+              "total_us_p50": { "type": "integer" },
+              "total_us_max": { "type": "integer" },
+              "max_single_us": { "type": "integer" },
+              "per_rep_total_us": { "type": "array", "items": { "type": "integer" } }
+            }
+          }
+        },
+        "merge_outcome": { "type": "string", "enum": ["Merged"] },
+        "verified_rows_table0": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["table_key", "expected", "actual"],
+          "properties": {
+            "table_key": { "type": "string" },
+            "expected": { "type": "integer" },
+            "actual": { "type": "integer" }
+          }
+        },
+        "fixture_build_seconds": { "type": "number" },
+        "write_path": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "stage_merge_insert_calls",
+            "stage_merge_insert_rows",
+            "stage_known_present_update_calls",
+            "stage_known_present_update_rows",
+            "stage_fenced_insert_calls",
+            "stage_fenced_insert_rows",
+            "strict_insert_preflight_calls"
+          ],
+          "properties": {
+            "stage_merge_insert_calls": { "type": "array", "items": { "type": "integer" } },
+            "stage_merge_insert_rows": { "type": "array", "items": { "type": "integer" } },
+            "stage_known_present_update_calls": { "type": "array", "items": { "type": "integer" } },
+            "stage_known_present_update_rows": { "type": "array", "items": { "type": "integer" } },
+            "stage_fenced_insert_calls": { "type": "array", "items": { "type": "integer" } },
+            "stage_fenced_insert_rows": { "type": "array", "items": { "type": "integer" } },
+            "strict_insert_preflight_calls": { "type": "array", "items": { "type": "integer" } }
+          }
+        },
+        "storage_calls": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "scope",
+            "layer",
+            "physical_attempts",
+            "physical_attempts_note",
+            "concurrency_witness",
+            "concurrency_witness_note",
+            "cumulative_request_time_logical_us",
+            "cumulative_request_time_physical_us",
+            "cumulative_request_time_note",
+            "latency_calibration",
+            "latency_calibration_note",
+            "manifest_store",
+            "table_store",
+            "control_plane"
+          ],
+          "properties": {
+            "scope": { "type": "string" },
+            "layer": { "type": "string", "enum": ["logical-operations", "physical-request-attempts"] },
+            "physical_attempts": {
+              "type": ["object", "null"],
+              "description": "Always null at the current seam; deliberately open — the shape belongs to the future seam that observes HTTP-level attempts, and closes when one populates it."
+            },
+            "physical_attempts_note": { "type": "string" },
+            "concurrency_witness": { "type": ["array", "null"], "items": { "type": "integer" } },
+            "concurrency_witness_note": { "type": "string" },
+            "cumulative_request_time_logical_us": { "type": ["array", "null"], "items": { "type": "integer" } },
+            "cumulative_request_time_physical_us": { "type": ["array", "null"], "items": { "type": "integer" } },
+            "cumulative_request_time_note": { "type": "string" },
+            "latency_calibration": {
+              "type": ["object", "null"],
+              "description": "Always null until a calibration is measured; deliberately open — the calibration's shape belongs to the measurement that produces it."
+            },
+            "latency_calibration_note": { "type": "string" },
+            "manifest_store": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "get",
+                  "put",
+                  "put_part",
+                  "head",
+                  "list",
+                  "delete",
+                  "copy",
+                  "rename",
+                  "put_multipart",
+                  "multipart_complete",
+                  "multipart_abort"
+                ],
+                "properties": {
+                  "get": { "type": "integer" },
+                  "put": { "type": "integer" },
+                  "put_part": { "type": "integer" },
+                  "head": { "type": "integer" },
+                  "list": { "type": "integer" },
+                  "delete": { "type": "integer" },
+                  "copy": { "type": "integer" },
+                  "rename": { "type": "integer" },
+                  "put_multipart": { "type": "integer" },
+                  "multipart_complete": { "type": "integer" },
+                  "multipart_abort": { "type": "integer" }
+                }
+              }
+            },
+            "table_store": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "get",
+                  "put",
+                  "put_part",
+                  "head",
+                  "list",
+                  "delete",
+                  "copy",
+                  "rename",
+                  "put_multipart",
+                  "multipart_complete",
+                  "multipart_abort"
+                ],
+                "properties": {
+                  "get": { "type": "integer" },
+                  "put": { "type": "integer" },
+                  "put_part": { "type": "integer" },
+                  "head": { "type": "integer" },
+                  "list": { "type": "integer" },
+                  "delete": { "type": "integer" },
+                  "copy": { "type": "integer" },
+                  "rename": { "type": "integer" },
+                  "put_multipart": { "type": "integer" },
+                  "multipart_complete": { "type": "integer" },
+                  "multipart_abort": { "type": "integer" }
+                }
+              }
+            },
+            "control_plane": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["read", "exists", "list", "mutation"],
+                "properties": {
+                  "read": { "type": "integer" },
+                  "exists": { "type": "integer" },
+                  "list": { "type": "integer" },
+                  "mutation": { "type": "integer" }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/omnigraph-bench/src/counting.rs
+++ b/crates/omnigraph-bench/src/counting.rs
@@ -1,0 +1,271 @@
+//! Per-operation-class object-store call counting for run records (RFC 0039:
+//! "the harness counts the run's storage calls per operation class, adopting
+//! RFC-031's operation vocabulary unchanged (get, put, put_part, head, list,
+//! delete, copy, rename, and the multipart operations), into the same record
+//! beside the timings").
+//!
+//! [`CallCounter`] is a [`WrappingObjectStore`] in the exact shape of the
+//! engine cost harness's `PrefixCounter` (`tests/helpers/cost.rs`): it is
+//! handed to the engine through the public `QueryIoProbes` task-local, the
+//! `open_dataset` chokepoint attaches it to every dataset opened under the
+//! probe scope, and every object-store request on those handles is counted.
+//! Counts are build-profile-independent (RFC 0039 rule 2). Per rule 6 they
+//! are a measurement column and never gate anything, at any CI stage.
+//!
+//! Unobserved classes still serialize as zero — a class is never omitted, so
+//! a reader can distinguish "no rename happened" from "rename was not
+//! counted".
+//!
+//! Completeness: the count covers every store opened inside the probe scope.
+//! The bench run opens the graph inside the scope, so cached handles reused by
+//! later repetitions still carry the wrapper. Non-Lance control-plane calls go
+//! through the engine's own public `CountingStorageAdapter` instead (wired in
+//! `run.rs`); the two are complementary, not overlapping.
+
+use std::fmt;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+use lance::io::WrappingObjectStore;
+use object_store::path::Path;
+use object_store::{
+    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult, RenameOptions, Result as OSResult,
+    UploadPart,
+};
+
+/// One take of the per-class call tally (calls since the previous take), in
+/// RFC-031's operation vocabulary. Every class always serializes, zero
+/// included.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct CallCounts {
+    pub get: u64,
+    pub put: u64,
+    pub put_part: u64,
+    pub head: u64,
+    pub list: u64,
+    pub delete: u64,
+    pub copy: u64,
+    pub rename: u64,
+    /// Multipart-upload initiations (`put_multipart_opts`).
+    pub put_multipart: u64,
+    pub multipart_complete: u64,
+    pub multipart_abort: u64,
+}
+
+#[derive(Debug, Default)]
+struct Tally {
+    get: AtomicU64,
+    put: AtomicU64,
+    put_part: AtomicU64,
+    head: AtomicU64,
+    list: AtomicU64,
+    delete: AtomicU64,
+    copy: AtomicU64,
+    rename: AtomicU64,
+    put_multipart: AtomicU64,
+    multipart_complete: AtomicU64,
+    multipart_abort: AtomicU64,
+}
+
+/// Shared per-class object-store call counter. Clone freely: every clone (and
+/// every store wrapped through [`WrappingObjectStore::wrap`]) feeds one tally.
+#[derive(Debug, Default, Clone)]
+pub struct CallCounter(Arc<Tally>);
+
+impl CallCounter {
+    /// Read-and-reset: the calls recorded since the previous `take`. The run
+    /// loop takes once immediately before each measured merge (discarding the
+    /// prepare/divergence calls) and once after (the merge's own counts).
+    pub fn take(&self) -> CallCounts {
+        CallCounts {
+            get: self.0.get.swap(0, Ordering::Relaxed),
+            put: self.0.put.swap(0, Ordering::Relaxed),
+            put_part: self.0.put_part.swap(0, Ordering::Relaxed),
+            head: self.0.head.swap(0, Ordering::Relaxed),
+            list: self.0.list.swap(0, Ordering::Relaxed),
+            delete: self.0.delete.swap(0, Ordering::Relaxed),
+            copy: self.0.copy.swap(0, Ordering::Relaxed),
+            rename: self.0.rename.swap(0, Ordering::Relaxed),
+            put_multipart: self.0.put_multipart.swap(0, Ordering::Relaxed),
+            multipart_complete: self.0.multipart_complete.swap(0, Ordering::Relaxed),
+            multipart_abort: self.0.multipart_abort.swap(0, Ordering::Relaxed),
+        }
+    }
+}
+
+impl WrappingObjectStore for CallCounter {
+    fn wrap(&self, _store_prefix: &str, target: Arc<dyn ObjectStore>) -> Arc<dyn ObjectStore> {
+        Arc::new(CountingStore {
+            target,
+            counter: self.clone(),
+        })
+    }
+}
+
+/// The wrapped `ObjectStore` recording each call into a [`CallCounter`].
+/// Implements the required core methods (object_store 0.13) — the convenience
+/// surface (`get`/`put`/`head`/`delete`/`rename`/...) is an extension-trait
+/// blanket impl routing through these core methods, so every request is still
+/// counted. `rename_opts` is a provided method whose default decomposes into
+/// copy-plus-delete; the wrapper overrides it (count one `rename`, forward to
+/// the target's own `rename_opts`) so an atomic backend rename stays atomic
+/// and lands in the `rename` class instead of masquerading as copy+delete.
+#[derive(Debug)]
+struct CountingStore {
+    target: Arc<dyn ObjectStore>,
+    counter: CallCounter,
+}
+
+impl fmt::Display for CountingStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CountingStore({})", self.target)
+    }
+}
+
+/// Counts `put_part` and the multipart completion/abort on a wrapped upload.
+#[derive(Debug)]
+struct CountingMultipart {
+    inner: Box<dyn MultipartUpload>,
+    counter: CallCounter,
+}
+
+#[async_trait]
+impl MultipartUpload for CountingMultipart {
+    fn put_part(&mut self, data: PutPayload) -> UploadPart {
+        self.counter.0.put_part.fetch_add(1, Ordering::Relaxed);
+        self.inner.put_part(data)
+    }
+
+    async fn complete(&mut self) -> OSResult<PutResult> {
+        self.counter
+            .0
+            .multipart_complete
+            .fetch_add(1, Ordering::Relaxed);
+        self.inner.complete().await
+    }
+
+    async fn abort(&mut self) -> OSResult<()> {
+        self.counter
+            .0
+            .multipart_abort
+            .fetch_add(1, Ordering::Relaxed);
+        self.inner.abort().await
+    }
+}
+
+#[async_trait]
+impl ObjectStore for CountingStore {
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> OSResult<PutResult> {
+        self.counter.0.put.fetch_add(1, Ordering::Relaxed);
+        self.target.put_opts(location, payload, opts).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOptions,
+    ) -> OSResult<Box<dyn MultipartUpload>> {
+        self.counter.0.put_multipart.fetch_add(1, Ordering::Relaxed);
+        let inner = self.target.put_multipart_opts(location, opts).await?;
+        Ok(Box::new(CountingMultipart {
+            inner,
+            counter: self.counter.clone(),
+        }))
+    }
+
+    async fn get_opts(&self, location: &Path, options: GetOptions) -> OSResult<GetResult> {
+        if options.head {
+            self.counter.0.head.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.counter.0.get.fetch_add(1, Ordering::Relaxed);
+        }
+        self.target.get_opts(location, options).await
+    }
+
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, OSResult<Path>>,
+    ) -> BoxStream<'static, OSResult<Path>> {
+        // Counted per stream invocation, not per deleted object.
+        self.counter.0.delete.fetch_add(1, Ordering::Relaxed);
+        self.target.delete_stream(locations)
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, OSResult<ObjectMeta>> {
+        self.counter.0.list.fetch_add(1, Ordering::Relaxed);
+        self.target.list(prefix)
+    }
+
+    fn list_with_offset(
+        &self,
+        prefix: Option<&Path>,
+        offset: &Path,
+    ) -> BoxStream<'static, OSResult<ObjectMeta>> {
+        self.counter.0.list.fetch_add(1, Ordering::Relaxed);
+        self.target.list_with_offset(prefix, offset)
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> OSResult<ListResult> {
+        self.counter.0.list.fetch_add(1, Ordering::Relaxed);
+        self.target.list_with_delimiter(prefix).await
+    }
+
+    async fn copy_opts(&self, from: &Path, to: &Path, options: CopyOptions) -> OSResult<()> {
+        self.counter.0.copy.fetch_add(1, Ordering::Relaxed);
+        self.target.copy_opts(from, to, options).await
+    }
+
+    async fn rename_opts(&self, from: &Path, to: &Path, options: RenameOptions) -> OSResult<()> {
+        // Forward to the target's own rename (atomic on local FS) instead of
+        // inheriting the copy-plus-delete default, so the rename class is
+        // observed rather than decomposed.
+        self.counter.0.rename.fetch_add(1, Ordering::Relaxed);
+        self.target.rename_opts(from, to, options).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn take_resets_the_tally() {
+        let counter = CallCounter::default();
+        counter.0.get.fetch_add(3, Ordering::Relaxed);
+        counter.0.put.fetch_add(1, Ordering::Relaxed);
+        counter.0.put_part.fetch_add(2, Ordering::Relaxed);
+        let first = counter.take();
+        assert_eq!(first.get, 3);
+        assert_eq!(first.put, 1);
+        assert_eq!(first.put_part, 2);
+        assert_eq!(counter.take(), CallCounts::default());
+    }
+
+    #[test]
+    fn unobserved_classes_serialize_as_zero() {
+        let json = serde_json::to_value(CallCounts::default()).unwrap();
+        for class in [
+            "get",
+            "put",
+            "put_part",
+            "head",
+            "list",
+            "delete",
+            "copy",
+            "rename",
+            "put_multipart",
+            "multipart_complete",
+            "multipart_abort",
+        ] {
+            assert_eq!(json[class], 0, "class {class} must appear even at zero");
+        }
+    }
+}

--- a/crates/omnigraph-bench/src/diff.rs
+++ b/crates/omnigraph-bench/src/diff.rs
@@ -1,0 +1,963 @@
+//! Diff and show modes: compare two run records (or two directories of them)
+//! point by point, or render one record (or directory) as tables — the
+//! before/after and status views the benchmark's records are read through.
+//!
+//! RFC 0039 conformance: records are matched by their full point name (the
+//! run spec flattened — cells under different specs never pair silently); v3
+//! records validate against the shipped schema on READ; v1/v2 records are
+//! upgraded on load and say so. Rule 4: differing backend, machine, or
+//! build-profile identities print a loud warning before any number. Rule 7:
+//! with `--floor noise-floor.json` (from `run --aa`), a delta below the
+//! session's A/A floor is labeled "no detected effect", never a small effect;
+//! a delta above the floor but inside the claim margin is named as the
+//! in-between band; a floor applied outside its own cell (different spec,
+//! SUT, or session) is marked as extrapolation. Output renders as plain text
+//! or GitHub-flavored markdown (`--format md`); the JSON record stays the
+//! single source of truth, the tables are views.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use crate::fixture::BenchResult;
+use crate::record::{FloorPoint, NoiseFloor, PhaseStats, RunRecord, short_commit, upgrade_v2, v2};
+use crate::schema;
+
+/// Output format for the diff/show tables.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum Format {
+    /// Aligned plain-text tables.
+    Text,
+    /// GitHub-flavored markdown tables (paste-ready for PRs and docs).
+    Md,
+}
+
+/// Per-column alignment for [`Out::table`]: numbers right, free text left.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Align {
+    Left,
+    Right,
+}
+
+/// Table/heading renderer for the two output formats.
+struct Out {
+    md: bool,
+}
+
+impl Out {
+    fn new(format: Format) -> Self {
+        Self {
+            md: format == Format::Md,
+        }
+    }
+
+    fn heading(&self, text: &str) {
+        if self.md {
+            println!("### {text}");
+            println!();
+        } else {
+            println!("== {text} ==");
+        }
+    }
+
+    fn warn(&self, text: &str) {
+        if self.md {
+            println!("> **WARNING** {text}");
+            println!();
+        } else {
+            println!("WARNING {text}");
+        }
+    }
+
+    fn note(&self, text: &str) {
+        if self.md {
+            println!("> note: {text}");
+            println!();
+        } else {
+            println!("note: {text}");
+        }
+    }
+
+    /// Render one table with the given per-column alignment (`aligns` and
+    /// `headers` are the same length).
+    fn table(&self, headers: &[&str], aligns: &[Align], rows: &[Vec<String>]) {
+        assert_eq!(headers.len(), aligns.len(), "one alignment per column");
+        if self.md {
+            println!("| {} |", headers.join(" | "));
+            let seps: Vec<&str> = aligns
+                .iter()
+                .map(|a| match a {
+                    Align::Left => ":--",
+                    Align::Right => "--:",
+                })
+                .collect();
+            println!("| {} |", seps.join(" | "));
+            for row in rows {
+                println!("| {} |", row.join(" | "));
+            }
+            println!();
+        } else {
+            let mut widths: Vec<usize> = headers.iter().map(|h| h.len()).collect();
+            for row in rows {
+                for (i, cell) in row.iter().enumerate() {
+                    widths[i] = widths[i].max(cell.len());
+                }
+            }
+            let render = |cells: Vec<String>| {
+                let mut line = String::new();
+                for (i, cell) in cells.into_iter().enumerate() {
+                    if i > 0 {
+                        line.push_str("  ");
+                    }
+                    match aligns[i] {
+                        Align::Left => line.push_str(&format!("{cell:<width$}", width = widths[i])),
+                        Align::Right => {
+                            line.push_str(&format!("{cell:>width$}", width = widths[i]))
+                        }
+                    }
+                }
+                // Left-aligned last columns pad to width; the terminal never
+                // needs trailing spaces.
+                line.trim_end().to_string()
+            };
+            println!(
+                "{}",
+                render(headers.iter().map(|h| h.to_string()).collect())
+            );
+            for row in rows {
+                println!("{}", render(row.clone()));
+            }
+        }
+    }
+
+    fn blank(&self) {
+        if !self.md {
+            println!();
+        }
+    }
+}
+
+pub(crate) fn load_record(path: &Path) -> BenchResult<RunRecord> {
+    let text =
+        std::fs::read_to_string(path).map_err(|e| format!("reading {}: {e}", path.display()))?;
+    let value: serde_json::Value =
+        serde_json::from_str(&text).map_err(|e| format!("parsing {}: {e}", path.display()))?;
+    match value.get("record_version").and_then(|v| v.as_u64()) {
+        Some(3) => {
+            schema::require_valid_v3(&value, &format!("refusing to read {}", path.display()))?;
+            Ok(serde_json::from_value(value)
+                .map_err(|e| format!("decoding {}: {e}", path.display()))?)
+        }
+        Some(1) | Some(2) => {
+            let old: v2::RunRecord = serde_json::from_value(value)
+                .map_err(|e| format!("decoding v1/v2 record {}: {e}", path.display()))?;
+            Ok(upgrade_v2(old))
+        }
+        other => Err(format!(
+            "{}: unsupported record_version {other:?} (this binary reads v1..=v3)",
+            path.display()
+        )
+        .into()),
+    }
+}
+
+pub(crate) fn load_floor(path: &Path) -> BenchResult<NoiseFloor> {
+    let text =
+        std::fs::read_to_string(path).map_err(|e| format!("reading {}: {e}", path.display()))?;
+    let floor: NoiseFloor =
+        serde_json::from_str(&text).map_err(|e| format!("parsing {}: {e}", path.display()))?;
+    Ok(floor)
+}
+
+fn records_in_dir(dir: &Path) -> BenchResult<BTreeMap<String, RunRecord>> {
+    let mut out = BTreeMap::new();
+    for path in record_paths(dir)? {
+        let record = load_record(&path)?;
+        let name = record.point_name.clone();
+        if out.insert(name.clone(), record).is_some() {
+            return Err(format!(
+                "{}: two records share point {name} — ambiguous diff (an A/A pair \
+                 belongs to `run --aa` + `--floor`, not to a diff directory)",
+                dir.display()
+            )
+            .into());
+        }
+    }
+    if out.is_empty() {
+        return Err(format!("{}: no .json run records found", dir.display()).into());
+    }
+    Ok(out)
+}
+
+/// The `.json` run-record files of a directory, sorted (`noise-floor.json`
+/// excluded).
+pub(crate) fn record_paths(dir: &Path) -> BenchResult<Vec<std::path::PathBuf>> {
+    let mut paths = Vec::new();
+    for entry in std::fs::read_dir(dir).map_err(|e| format!("reading {}: {e}", dir.display()))? {
+        let path = entry.map_err(|e| e.to_string())?.path();
+        let is_floor = path.file_name().is_some_and(|n| n == "noise-floor.json");
+        if path.extension().is_some_and(|ext| ext == "json") && !is_floor {
+            paths.push(path);
+        }
+    }
+    paths.sort();
+    Ok(paths)
+}
+
+/// Human-readable byte count for identity rows ("64.0 GiB"); "unknown" when
+/// the capture recorded nothing — never a Debug-formatted `Option`.
+pub(crate) fn fmt_bytes(bytes: Option<u64>) -> String {
+    const MIB: f64 = 1024.0 * 1024.0;
+    const GIB: f64 = MIB * 1024.0;
+    match bytes {
+        None => "unknown".to_string(),
+        Some(b) if b as f64 >= GIB => format!("{:.1} GiB", b as f64 / GIB),
+        Some(b) if b as f64 >= MIB => format!("{:.1} MiB", b as f64 / MIB),
+        Some(b) => format!("{b} B"),
+    }
+}
+
+/// Engine configuration as space-separated `KEY=value` pairs; "(none)" for
+/// the empty map (no flag set, recorded as such).
+fn fmt_engine_config(config: &BTreeMap<String, String>) -> String {
+    if config.is_empty() {
+        return "(none)".to_string();
+    }
+    config
+        .iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+pub(crate) fn fmt_delta_pct(a: f64, b: f64) -> String {
+    if a == 0.0 {
+        return "n/a".to_string();
+    }
+    format!("{:+.1}%", (b - a) / a * 100.0)
+}
+
+fn delta_pct_abs(a: f64, b: f64) -> Option<f64> {
+    if a == 0.0 {
+        None
+    } else {
+        Some(((b - a) / a * 100.0).abs())
+    }
+}
+
+/// Rule-7 label for a delta against its floor and claim margin: below the
+/// floor reads "no detected effect"; between floor and floor x margin is the
+/// explicit in-between band (not claimable, not "no effect"); above clears.
+pub(crate) fn floor_label(a: f64, b: f64, floor_pct: f64, margin: f64) -> String {
+    match delta_pct_abs(a, b) {
+        Some(pct) if pct <= floor_pct => {
+            format!("[below floor {floor_pct:.2}%: no detected effect]")
+        }
+        Some(pct) if pct <= floor_pct * margin => {
+            format!("[within margin x{margin}: not claimable]")
+        }
+        _ => String::new(),
+    }
+}
+
+/// Rule-4 (and rule-2/3) identity checks: identities that differ never
+/// compare silently. The table still prints — the warning makes the reader
+/// carry the caveat, and an unknown identity warns too.
+fn print_identity_warnings(a: &RunRecord, b: &RunRecord, out: &Out) {
+    let (ea, eb) = (&a.run_spec.environment, &b.run_spec.environment);
+    if ea.backend != eb.backend || ea.s3_endpoint != eb.s3_endpoint {
+        out.warn(&format!(
+            "(RFC 0039 rule 4): backend identities differ — A {} endpoint {} vs \
+             B {} endpoint {}; these numbers never compare silently.",
+            ea.backend,
+            ea.s3_endpoint.as_deref().unwrap_or("unset"),
+            eb.backend,
+            eb.s3_endpoint.as_deref().unwrap_or("unset")
+        ));
+    }
+    let (ma, mb) = (&a.machine, &b.machine);
+    if ma.cpu_model != mb.cpu_model
+        || ma.memory_bytes != mb.memory_bytes
+        || ma.os != mb.os
+        || ma.arch != mb.arch
+    {
+        out.warn(&format!(
+            "(RFC 0039 rule 4): machine specifications differ — A [{} {} {} mem {}] \
+             vs B [{} {} {} mem {}]; these numbers never compare silently.",
+            ma.os,
+            ma.arch,
+            ma.cpu_model,
+            fmt_bytes(ma.memory_bytes),
+            mb.os,
+            mb.arch,
+            mb.cpu_model,
+            fmt_bytes(mb.memory_bytes)
+        ));
+    }
+    if a.sut.build_profile != b.sut.build_profile {
+        out.warn(&format!(
+            "(RFC 0039 rule 2): build profiles differ ({} vs {}) — wall-clock across \
+             build profiles never compares.",
+            a.sut.build_profile, b.sut.build_profile
+        ));
+    }
+    if a.run_spec.environment.warmth.regime != b.run_spec.environment.warmth.regime {
+        out.warn(&format!(
+            "(RFC 0039 rule 3): warmth regimes differ ({} vs {}) — cells under \
+             different regimes do not compare.",
+            a.run_spec.environment.warmth.regime, b.run_spec.environment.warmth.regime
+        ));
+    }
+    if a.sut.engine_configuration != b.sut.engine_configuration {
+        out.note(&format!(
+            "SUT engine configurations differ (a systems comparison, as data): \
+             A {} vs B {}",
+            fmt_engine_config(&a.sut.engine_configuration),
+            fmt_engine_config(&b.sut.engine_configuration)
+        ));
+    }
+}
+
+/// Warn on ANY run-spec field mismatch (the machine spec is record-level
+/// identity, checked separately): records pair by point name, and the name is
+/// derived, so a spec field differing under an equal name is drift the reader
+/// must see.
+fn print_spec_mismatches(a: &RunRecord, b: &RunRecord, out: &Out) {
+    fn walk(a: &serde_json::Value, b: &serde_json::Value, path: &str, diffs: &mut Vec<String>) {
+        match (a, b) {
+            (serde_json::Value::Object(ma), serde_json::Value::Object(mb)) => {
+                for key in ma.keys().chain(mb.keys().filter(|k| !ma.contains_key(*k))) {
+                    let sub_path = format!("{path}.{key}");
+                    match (ma.get(key), mb.get(key)) {
+                        (Some(va), Some(vb)) => walk(va, vb, &sub_path, diffs),
+                        _ => diffs.push(format!("{sub_path} (present on one side only)")),
+                    }
+                }
+            }
+            _ if a != b => diffs.push(path.to_string()),
+            _ => {}
+        }
+    }
+    let (va, vb) = (
+        serde_json::to_value(&a.run_spec).expect("run spec serializes"),
+        serde_json::to_value(&b.run_spec).expect("run spec serializes"),
+    );
+    let mut diffs = Vec::new();
+    walk(&va, &vb, "run_spec", &mut diffs);
+    if !diffs.is_empty() {
+        out.warn(&format!(
+            "run-spec fields differ between A and B: {} — equal point names promise \
+             equal specs; treat the deltas below with that caveat.",
+            diffs.join(", ")
+        ));
+    }
+}
+
+/// Cell check for the floor (RFC 0039: a floor licenses comparisons at its
+/// own cell — same spec, same SUT, same session; anything else is stated
+/// extrapolation).
+fn print_floor_cell_warnings(floor: &NoiseFloor, a: &RunRecord, b: &RunRecord, out: &Out) {
+    for (r, side) in [(a, "A"), (b, "B")] {
+        if floor.source_commit != r.sut.source_commit {
+            out.warn(&format!(
+                "(RFC 0039 rule 7): the floor was measured on SUT {} but record {side} is \
+                 SUT {} — applying it here is extrapolation outside the floor's cell.",
+                floor.source_commit, r.sut.source_commit
+            ));
+        }
+        if floor.session_id != r.session_id {
+            out.warn(&format!(
+                "(RFC 0039 rule 7): the floor comes from session {} but record {side} is \
+                 from session {} — a floor is per session; this application is \
+                 extrapolation.",
+                floor.session_id, r.session_id
+            ));
+        }
+    }
+}
+
+/// The directional marker (rule 3) for the persisted tail-support fields of
+/// a compared pair: one unsupported side already makes the p95 row
+/// directional — it never prints as a clean percentile. The row carries the
+/// short marker; [`print_pair`] prints the explanation once as a note.
+fn tail_marker(a: &RunRecord, b: &RunRecord) -> &'static str {
+    if a.results.wall_clock_ms.tail_support == "supported"
+        && b.results.wall_clock_ms.tail_support == "supported"
+    {
+        ""
+    } else {
+        " [directional]"
+    }
+}
+
+pub(crate) fn storage_sums(r: &RunRecord) -> Option<crate::counting::CallCounts> {
+    let calls = r.results.storage_calls.as_ref()?;
+    let mut sum = crate::counting::CallCounts::default();
+    for c in calls.manifest_store.iter().chain(&calls.table_store) {
+        sum.get += c.get;
+        sum.put += c.put;
+        sum.put_part += c.put_part;
+        sum.head += c.head;
+        sum.list += c.list;
+        sum.delete += c.delete;
+        sum.copy += c.copy;
+        sum.rename += c.rename;
+        sum.put_multipart += c.put_multipart;
+        sum.multipart_complete += c.multipart_complete;
+        sum.multipart_abort += c.multipart_abort;
+    }
+    Some(sum)
+}
+
+fn print_write_path_and_storage(records: &[(&RunRecord, &str)], out: &Out) {
+    let mut wp_rows = Vec::new();
+    for (r, side) in records {
+        let wp = &r.results.write_path;
+        if !wp.stage_merge_insert_calls.is_empty() {
+            wp_rows.push(vec![
+                (*side).to_string(),
+                format!(
+                    "{}/{}",
+                    wp.stage_merge_insert_calls.iter().sum::<u64>(),
+                    wp.stage_merge_insert_rows.iter().sum::<u64>()
+                ),
+                format!(
+                    "{}/{}",
+                    wp.stage_known_present_update_calls.iter().sum::<u64>(),
+                    wp.stage_known_present_update_rows.iter().sum::<u64>()
+                ),
+                format!(
+                    "{}/{}",
+                    wp.stage_fenced_insert_calls.iter().sum::<u64>(),
+                    wp.stage_fenced_insert_rows.iter().sum::<u64>()
+                ),
+                wp.strict_insert_preflight_calls
+                    .iter()
+                    .sum::<u64>()
+                    .to_string(),
+            ]);
+        }
+    }
+    if !wp_rows.is_empty() {
+        out.table(
+            &[
+                "write-path (sum calls/rows)",
+                "merge_insert",
+                "known_present_update",
+                "fenced_insert",
+                "strict_preflight",
+            ],
+            &[
+                Align::Left,
+                Align::Right,
+                Align::Right,
+                Align::Right,
+                Align::Right,
+            ],
+            &wp_rows,
+        );
+    }
+    let mut sc_rows = Vec::new();
+    for (r, side) in records {
+        if let Some(sum) = storage_sums(r) {
+            let calls = r.results.storage_calls.as_ref().expect("summed above");
+            sc_rows.push(vec![
+                format!(
+                    "{side} ({}{})",
+                    calls.layer,
+                    if calls.physical_attempts.is_none() {
+                        "; physical absent"
+                    } else {
+                        ""
+                    }
+                ),
+                sum.get.to_string(),
+                sum.put.to_string(),
+                sum.put_part.to_string(),
+                sum.head.to_string(),
+                sum.list.to_string(),
+                sum.delete.to_string(),
+                sum.copy.to_string(),
+                sum.rename.to_string(),
+                sum.put_multipart.to_string(),
+            ]);
+        } else {
+            out.note(&format!(
+                "storage-calls {side}: not recorded (v1/v2 record)"
+            ));
+        }
+    }
+    if !sc_rows.is_empty() {
+        let mut aligns = vec![Align::Right; 10];
+        aligns[0] = Align::Left;
+        out.table(
+            &[
+                "storage-calls (merge windows, sum)",
+                "get",
+                "put",
+                "put_part",
+                "head",
+                "list",
+                "delete",
+                "copy",
+                "rename",
+                "put_multipart",
+            ],
+            &aligns,
+            &sc_rows,
+        );
+    }
+}
+
+/// The phase portion of the diff table: paired phases (both zero skipped),
+/// then phases present on only one side — a missing side is stated in the
+/// same style in both directions, never silently dropped.
+fn phase_rows(
+    a: &[PhaseStats],
+    b: &[PhaseStats],
+    label: impl Fn(&str, f64, f64) -> String,
+) -> Vec<Vec<String>> {
+    let mut rows = Vec::new();
+    for pa in a {
+        let Some(pb) = b.iter().find(|p| p.phase == pa.phase) else {
+            rows.push(vec![
+                format!("phase {} total_us p50", pa.phase),
+                "?".to_string(),
+                "(missing from B)".to_string(),
+                String::new(),
+                String::new(),
+                String::new(),
+            ]);
+            continue;
+        };
+        let (va, vb) = (pa.total_us_p50 as f64, pb.total_us_p50 as f64);
+        if va == 0.0 && vb == 0.0 {
+            continue;
+        }
+        rows.push(vec![
+            format!("phase {} total_us p50", pa.phase),
+            format!("{va:.0}"),
+            format!("{vb:.0}"),
+            format!("{:+.0}", vb - va),
+            fmt_delta_pct(va, vb),
+            label(&pa.phase, va, vb),
+        ]);
+    }
+    for pb in b {
+        if a.iter().all(|p| p.phase != pb.phase) {
+            rows.push(vec![
+                format!("phase {} total_us p50", pb.phase),
+                "(missing from A)".to_string(),
+                "?".to_string(),
+                String::new(),
+                String::new(),
+                String::new(),
+            ]);
+        }
+    }
+    rows
+}
+
+fn print_pair(
+    a: &RunRecord,
+    b: &RunRecord,
+    floor: Option<&NoiseFloor>,
+    margin_override: Option<f64>,
+    out: &Out,
+) {
+    out.heading(&format!(
+        "point A {} -> B {} (warmth {}) : A = {} @ {} -> B = {} @ {}",
+        a.point_name,
+        b.point_name,
+        a.run_spec.environment.warmth.regime,
+        a.label.as_deref().unwrap_or("unlabeled"),
+        short_commit(&a.sut.source_commit),
+        b.label.as_deref().unwrap_or("unlabeled"),
+        short_commit(&b.sut.source_commit),
+    ));
+    print_identity_warnings(a, b, out);
+    print_spec_mismatches(a, b, out);
+    let margin = margin_override
+        .or(floor.map(|f| f.default_margin))
+        .unwrap_or_else(crate::record::default_margin);
+    let floor_point: Option<&FloorPoint> = floor.and_then(|f| {
+        print_floor_cell_warnings(f, a, b, out);
+        let hit = f
+            .points
+            .get(&a.point_name)
+            .or_else(|| f.points.get(&b.point_name));
+        if hit.is_none() {
+            out.note(&format!(
+                "the noise floor has no entry for point {} — wall/phase deltas print \
+                 unlabeled; rerun `run --aa` on this point for a floor.",
+                a.point_name
+            ));
+        }
+        hit
+    });
+    if let Some(fp) = floor_point {
+        // The effective margin, with the floor file's persisted default
+        // beside it when a `--margin` override displaced it.
+        let margin_note = match (margin_override, floor) {
+            (Some(m), Some(f)) => format!(
+                "claim margin x{m} (floor file default x{})",
+                f.default_margin
+            ),
+            _ => format!("claim margin x{margin}"),
+        };
+        out.note(&format!(
+            "A/A noise floor for this point: {:.2}% ({:.2} ms on p50 {:.1}/{:.1} ms); \
+             {margin_note}",
+            fp.pct, fp.abs_delta_ms, fp.wall_p50_a_ms, fp.wall_p50_b_ms
+        ));
+    }
+    let marker = tail_marker(a, b);
+    if !marker.is_empty() {
+        out.note("directional p95 (rule 3): < 20 reps on at least one side — read as worst observed, not a tail.");
+    }
+    let mut rows = Vec::new();
+    for (name, va, vb, marker) in [
+        (
+            "wall_clock_ms p50",
+            a.results.wall_clock_ms.p50,
+            b.results.wall_clock_ms.p50,
+            "",
+        ),
+        (
+            "wall_clock_ms p95",
+            a.results.wall_clock_ms.p95,
+            b.results.wall_clock_ms.p95,
+            marker,
+        ),
+    ] {
+        let label = floor_point.map_or(String::new(), |fp| floor_label(va, vb, fp.pct, margin));
+        rows.push(vec![
+            format!("{name}{marker}"),
+            format!("{va:.2}"),
+            format!("{vb:.2}"),
+            format!("{:+.2}", vb - va),
+            fmt_delta_pct(va, vb),
+            label,
+        ]);
+    }
+    rows.extend(phase_rows(
+        &a.results.phases,
+        &b.results.phases,
+        |phase, va, vb| {
+            floor_point
+                .and_then(|fp| fp.phases.get(phase))
+                .map_or(String::new(), |phase_floor| {
+                    floor_label(va, vb, *phase_floor, margin)
+                })
+        },
+    ));
+    out.table(
+        &["metric", "A", "B", "delta", "delta%", "floor"],
+        &[
+            Align::Left,
+            Align::Right,
+            Align::Right,
+            Align::Right,
+            Align::Right,
+            Align::Left,
+        ],
+        &rows,
+    );
+    print_write_path_and_storage(&[(a, "A"), (b, "B")], out);
+    out.blank();
+}
+
+/// Render one record's identity and results as tables (the `show` view).
+fn print_record(r: &RunRecord, out: &Out) {
+    out.heading(&format!(
+        "record {} : {} @ {}",
+        r.point_name,
+        r.label.as_deref().unwrap_or("unlabeled"),
+        short_commit(&r.sut.source_commit),
+    ));
+    let identity = vec![
+        vec!["point_name".to_string(), r.point_name.clone()],
+        vec!["profile".to_string(), r.profile.clone()],
+        vec!["invocation_id".to_string(), r.invocation_id.clone()],
+        vec!["session_id".to_string(), r.session_id.clone()],
+        vec!["source_commit".to_string(), r.sut.source_commit.clone()],
+        vec![
+            "build".to_string(),
+            format!(
+                "{} (opt-level {})",
+                r.sut.build_profile, r.sut.build_opt_level
+            ),
+        ],
+        vec![
+            "backend".to_string(),
+            r.run_spec.environment.backend.clone(),
+        ],
+        vec![
+            "machine".to_string(),
+            format!(
+                "{} {} / {} / mem {}",
+                r.machine.os,
+                r.machine.arch,
+                r.machine.cpu_model,
+                fmt_bytes(r.machine.memory_bytes)
+            ),
+        ],
+        vec![
+            "warmth".to_string(),
+            r.run_spec.environment.warmth.regime.clone(),
+        ],
+        vec![
+            "repetitions".to_string(),
+            format!(
+                "{} ({})",
+                r.run_spec.protocol.repetitions, r.results.wall_clock_ms.tail_support
+            ),
+        ],
+    ];
+    out.table(
+        &["identity", "value"],
+        &[Align::Left, Align::Left],
+        &identity,
+    );
+    let w = &r.results.wall_clock_ms;
+    out.table(
+        &["wall_clock_ms", "p50", "p95", "min", "max", "mean"],
+        &[
+            Align::Left,
+            Align::Right,
+            Align::Right,
+            Align::Right,
+            Align::Right,
+            Align::Right,
+        ],
+        &[vec![
+            format!("{} reps", w.reps.len()),
+            format!("{:.2}", w.p50),
+            format!("{:.2}", w.p95),
+            format!("{:.2}", w.min),
+            format!("{:.2}", w.max),
+            format!("{:.2}", w.mean),
+        ]],
+    );
+    // Grouped phase view: plain-language group rows (total ms + share of
+    // the wall-clock median) with the raw phases indented beneath each —
+    // grouping adds a layer, the raw names and µs stay. The remainder the 14
+    // phases do not cover prints as its own explicit row, never normalized
+    // away (see groups.rs for the verified mapping and the remainder's
+    // mechanism).
+    if !r.results.phases.is_empty() {
+        let grouped = crate::groups::group_phases(&r.results.phases, w.p50);
+        let mut rows = Vec::new();
+        for group in &grouped.groups {
+            rows.push(vec![
+                group.name.to_string(),
+                format!("{:.1} ms", group.total_us as f64 / 1000.0),
+                String::new(),
+                String::new(),
+                format!("{:.1}%", group.share_pct),
+            ]);
+            for m in &group.members {
+                rows.push(vec![
+                    format!("  {}", m.name),
+                    format!("{} us", m.total_us_p50),
+                    format!("{} us", m.total_us_max),
+                    format!("{} us", m.max_single_us),
+                    String::new(),
+                ]);
+            }
+        }
+        if grouped.shows_unattributed() {
+            rows.push(vec![
+                crate::groups::UNATTRIBUTED_NAME.to_string(),
+                format!("{:.1} ms", grouped.unattributed_us as f64 / 1000.0),
+                String::new(),
+                String::new(),
+                format!("{:.1}%", grouped.unattributed_share_pct),
+            ]);
+        }
+        out.table(
+            &[
+                "merge phases (grouped)",
+                "total p50",
+                "total max",
+                "max single",
+                "share",
+            ],
+            &[
+                Align::Left,
+                Align::Right,
+                Align::Right,
+                Align::Right,
+                Align::Right,
+            ],
+            &rows,
+        );
+        if grouped.shows_unattributed() {
+            out.note(&format!(
+                "{}: {}",
+                crate::groups::UNATTRIBUTED_NAME,
+                crate::groups::UNATTRIBUTED_ANNOTATION
+            ));
+        }
+        if grouped.over_attributed {
+            out.note(crate::groups::OVER_ATTRIBUTION_NOTE);
+        }
+    }
+    print_write_path_and_storage(&[(r, "this run")], out);
+    out.blank();
+}
+
+/// Entry point for `show`: render one record file, or every record of a
+/// directory, as tables.
+pub fn run_show(path: &Path, format: Format) -> BenchResult<()> {
+    let out = Out::new(format);
+    if path.is_dir() {
+        let paths = record_paths(path)?;
+        if paths.is_empty() {
+            return Err(format!("{}: no .json run records found", path.display()).into());
+        }
+        for p in paths {
+            print_record(&load_record(&p)?, &out);
+        }
+    } else {
+        print_record(&load_record(path)?, &out);
+    }
+    Ok(())
+}
+
+/// Entry point: `a` and `b` are either two record files or two directories
+/// whose records are matched by their full point name.
+pub fn run_diff(
+    a: &Path,
+    b: &Path,
+    floor: Option<&Path>,
+    margin: Option<f64>,
+    format: Format,
+) -> BenchResult<()> {
+    if let Some(m) = margin {
+        if m < 1.0 {
+            return Err("--margin must be >= 1.0 (1.0 = the floor itself)".into());
+        }
+    }
+    let out = Out::new(format);
+    let floor = floor.map(load_floor).transpose()?;
+    match (a.is_dir(), b.is_dir()) {
+        (false, false) => {
+            let (ra, rb) = (load_record(a)?, load_record(b)?);
+            if ra.point_name != rb.point_name {
+                out.note(&format!(
+                    "comparing different points ({} vs {}) — deltas below cross points",
+                    ra.point_name, rb.point_name
+                ));
+            }
+            print_pair(&ra, &rb, floor.as_ref(), margin, &out);
+            Ok(())
+        }
+        (true, true) => {
+            let (mapa, mapb) = (records_in_dir(a)?, records_in_dir(b)?);
+            let mut matched = 0usize;
+            for (key, ra) in &mapa {
+                if let Some(rb) = mapb.get(key) {
+                    print_pair(ra, rb, floor.as_ref(), margin, &out);
+                    matched += 1;
+                } else {
+                    out.note(&format!("point {key} present only in {}", a.display()));
+                }
+            }
+            for key in mapb.keys().filter(|k| !mapa.contains_key(*k)) {
+                out.note(&format!("point {key} present only in {}", b.display()));
+            }
+            if matched == 0 {
+                return Err("no point name exists in both directories".into());
+            }
+            Ok(())
+        }
+        _ => Err("pass two record files or two directories, not a mix".into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn floor_labels_name_all_three_bands() {
+        // (a, b, floor_pct, margin, expected fragment; "" = clears the floor)
+        let cases: [(f64, f64, f64, f64, &str); 6] = [
+            (100.0, 100.5, 2.0, 2.0, "no detected effect"),
+            (100.0, 102.0, 2.0, 2.0, "no detected effect"),
+            (100.0, 103.0, 2.0, 2.0, "within margin"),
+            (100.0, 104.0, 2.0, 2.0, "within margin"),
+            (100.0, 110.0, 2.0, 2.0, ""),
+            (0.0, 50.0, 2.0, 2.0, ""), // zero baseline: n/a, never labeled
+        ];
+        for (a, b, floor_pct, margin, expected) in cases {
+            let label = floor_label(a, b, floor_pct, margin);
+            if expected.is_empty() {
+                assert!(
+                    label.is_empty(),
+                    "({a}, {b}): expected no label, got {label}"
+                );
+            } else {
+                assert!(
+                    label.contains(expected),
+                    "({a}, {b}): expected '{expected}' in '{label}'"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn margin_widens_the_unclaimable_band() {
+        // At margin x3 a 5% delta over a 2% floor is still inside the band.
+        assert!(floor_label(100.0, 105.0, 2.0, 3.0).contains("within margin"));
+        assert!(floor_label(100.0, 105.0, 2.0, 2.0).is_empty());
+    }
+
+    #[test]
+    fn fmt_bytes_uses_human_units_never_debug_forms() {
+        // (input, expected)
+        for (input, expected) in [
+            (None, "unknown"),
+            (Some(68_719_476_736), "64.0 GiB"),
+            (Some(17_179_869_184), "16.0 GiB"),
+            (Some(536_870_912), "512.0 MiB"),
+            (Some(1_610_612_736), "1.5 GiB"),
+            (Some(1024), "1024 B"),
+            (Some(0), "0 B"),
+        ] {
+            assert_eq!(fmt_bytes(input), expected, "input {input:?}");
+        }
+    }
+
+    fn phase(name: &str, p50: u64) -> PhaseStats {
+        PhaseStats {
+            phase: name.to_string(),
+            total_us_p50: p50,
+            total_us_max: p50,
+            max_single_us: p50,
+            per_rep_total_us: vec![p50],
+        }
+    }
+
+    #[test]
+    fn phase_rows_state_a_only_and_b_only_phases_in_both_directions() {
+        let a = [phase("Shared", 100), phase("OnlyA", 5)];
+        let b = [phase("Shared", 120), phase("OnlyB", 7)];
+        let rows = phase_rows(&a, &b, |_, _, _| String::new());
+        let row_for = |name: &str| {
+            rows.iter()
+                .find(|r| r[0].contains(name))
+                .unwrap_or_else(|| panic!("no row for {name}"))
+        };
+        assert_eq!(row_for("Shared")[1], "100");
+        assert_eq!(row_for("Shared")[2], "120");
+        assert_eq!(row_for("OnlyA")[2], "(missing from B)");
+        assert_eq!(row_for("OnlyB")[1], "(missing from A)");
+        // Both-zero pairs are skipped, one-sided phases never are.
+        let a = [phase("Zero", 0)];
+        let b = [phase("Zero", 0), phase("OnlyB", 0)];
+        let rows = phase_rows(&a, &b, |_, _, _| String::new());
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0][0].contains("OnlyB"));
+    }
+}

--- a/crates/omnigraph-bench/src/diff.rs
+++ b/crates/omnigraph-bench/src/diff.rs
@@ -379,6 +379,21 @@ fn print_floor_cell_warnings(floor: &NoiseFloor, a: &RunRecord, b: &RunRecord, o
 /// a compared pair: one unsupported side already makes the p95 row
 /// directional — it never prints as a clean percentile. The row carries the
 /// short marker; [`print_pair`] prints the explanation once as a note.
+/// The floor entry applicable to a compared pair. A noise floor is per point
+/// (per cell, RFC 0039 rule 7), so a cross-point comparison gets NO floor:
+/// a "no detected effect"/"not claimable" label minted from either side's
+/// cell would be an unsupported claim for the pair.
+fn floor_entry_for_pair<'f>(
+    f: &'f NoiseFloor,
+    a: &RunRecord,
+    b: &RunRecord,
+) -> Option<&'f FloorPoint> {
+    if a.point_name != b.point_name {
+        return None;
+    }
+    f.points.get(&a.point_name)
+}
+
 fn tail_marker(a: &RunRecord, b: &RunRecord) -> &'static str {
     if a.results.wall_clock_ms.tail_support == "supported"
         && b.results.wall_clock_ms.tail_support == "supported"
@@ -581,16 +596,20 @@ fn print_pair(
         .unwrap_or_else(crate::record::default_margin);
     let floor_point: Option<&FloorPoint> = floor.and_then(|f| {
         print_floor_cell_warnings(f, a, b, out);
-        let hit = f
-            .points
-            .get(&a.point_name)
-            .or_else(|| f.points.get(&b.point_name));
+        let hit = floor_entry_for_pair(f, a, b);
         if hit.is_none() {
-            out.note(&format!(
-                "the noise floor has no entry for point {} — wall/phase deltas print \
-                 unlabeled; rerun `run --aa` on this point for a floor.",
-                a.point_name
-            ));
+            if a.point_name == b.point_name {
+                out.note(&format!(
+                    "the noise floor has no entry for point {} — wall/phase deltas print \
+                     unlabeled; rerun `run --aa` on this point for a floor.",
+                    a.point_name
+                ));
+            } else {
+                out.note(
+                    "cross-point comparison: a noise floor is per point (per cell, RFC 0039 \
+                     rule 7), so no floor applies — wall/phase deltas print unlabeled.",
+                );
+            }
         }
         hit
     });

--- a/crates/omnigraph-bench/src/fixture.rs
+++ b/crates/omnigraph-bench/src/fixture.rs
@@ -1,0 +1,979 @@
+//! Fixture builder for the branch-control micro-benchmark (RFC 0039 micro
+//! profile, Data + State classes).
+//!
+//! Builds a fresh multi-table store at chosen content axes (T tables, N rows
+//! per table, all scalar columns), then diverges a source/target branch pair
+//! with a planned mixed delta (updates + deletes + inserts on both sides,
+//! disjoint row sets) so `branch_merge` takes the general three-way
+//! RewriteMerged route — never the fast-forward or proven-pure-insert
+//! shortcuts, and never a genuine row conflict.
+//!
+//! The planned mutation sets are baked into the base data as a `cohort`
+//! column, so one GQ mutation per (side, table, kind) diverges thousands of
+//! rows in one commit instead of one commit per row. Cohort values are
+//! delta-namespaced (`d50_src_upd`, `d5000_tgt_del`, ..., `keep`): a base
+//! store carries disjoint pre-tagged row sets for EVERY delta in its
+//! [`BaseProfile::deltas`] list, which is what lets one frozen fixture serve
+//! a whole delta sweep.
+//!
+//! Frozen fixtures (`fixture build` subcommand): the built store is kept in
+//! `<fixtures-root>/<derived-name>/store/` beside a `fixture-manifest.json`
+//! recording the full Data+State tuple, engine commit, and build metadata.
+//! `run --fixture <dir>` copies the store to a per-run tempdir and runs
+//! against the copy, so the frozen bytes are never mutated.
+
+use std::error::Error;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use omnigraph::db::Omnigraph;
+use omnigraph::loader::LoadMode;
+use omnigraph_compiler::ir::ParamMap;
+use omnigraph_compiler::query::ast::Literal;
+use sha2::{Digest, Sha256};
+
+/// The engine's keyed-write cap per table per transaction
+/// (`KEYED_WRITE_MAX_ROWS` / `KEYED_WRITE_MAX_BYTES` in the engine).
+const KEYED_WRITE_MAX_ROWS: usize = 8192;
+const KEYED_WRITE_MAX_BYTES: usize = 32 * 1024 * 1024;
+
+/// Serialized-JSONL bytes one base row carries beyond its payload column
+/// (type, name, cohort, val, JSON syntax) — a deliberate overestimate so the
+/// derived chunk size errs small.
+const ROW_OVERHEAD_BYTES: usize = 160;
+
+/// Rows per table per `load` call, derived from the payload size: the chunk's
+/// byte total stays at half the engine's 32 MiB keyed-write cap, and the row
+/// count at half the 8,192-row cap, whichever binds first. Loads are issued
+/// per table (one table per `load` call), so the chunk bound is also the
+/// bound on any single in-memory chunk string — a 32 KiB payload at T=140
+/// can breach neither the cap nor memory.
+pub fn load_chunk_rows(payload_bytes: usize) -> usize {
+    let row_bytes = payload_bytes + ROW_OVERHEAD_BYTES;
+    (KEYED_WRITE_MAX_BYTES / 2 / row_bytes).clamp(1, KEYED_WRITE_MAX_ROWS / 2)
+}
+
+/// Bumped when the builder's baked base content changes shape (cohort scheme,
+/// row naming, chunking) so a stale frozen fixture is detectable.
+/// v2: per-table load chunking with payload-derived chunk rows.
+pub const BUILDER_VERSION: u32 = 2;
+
+pub const MANIFEST_FILE: &str = "fixture-manifest.json";
+pub const STORE_SUBDIR: &str = "store";
+
+pub type BenchResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+
+/// The Data(+divergence-shape) axes one base store is built from. A store
+/// built from a profile can serve any single-delta run whose delta is in
+/// `deltas` and whose diverged-table count equals `diverged_tables` (both are
+/// baked into the cohort tags).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct BaseProfile {
+    /// T — node-table count (v0 approximates "T node/edge types" as T node
+    /// types; edges are deferred).
+    pub tables: usize,
+    /// N — rows per table in the base load.
+    pub rows: usize,
+    /// Bytes of filler in the scalar `payload` string column per row.
+    pub payload_bytes: usize,
+    /// How many tables any delta touches, on BOTH sides (overlapping-table
+    /// divergence). Baked into which tables carry tagged cohorts.
+    pub diverged_tables: usize,
+    /// Every delta (rows per side) this base is pre-tagged for, ascending.
+    pub deltas: Vec<usize>,
+}
+
+impl BaseProfile {
+    pub fn new(
+        tables: usize,
+        rows: usize,
+        payload_bytes: usize,
+        diverged_tables: usize,
+        mut deltas: Vec<usize>,
+    ) -> BenchResult<Self> {
+        if tables == 0 || rows == 0 {
+            return Err("tables and rows must both be >= 1".into());
+        }
+        if diverged_tables == 0 || diverged_tables > tables {
+            return Err(format!(
+                "diverged_tables must be between 1 and tables (T = {tables}), got {diverged_tables}"
+            )
+            .into());
+        }
+        deltas.sort_unstable();
+        deltas.dedup();
+        if deltas.is_empty() || deltas[0] == 0 {
+            return Err("deltas must be a non-empty list of values >= 1".into());
+        }
+        let profile = Self {
+            tables,
+            rows,
+            payload_bytes,
+            diverged_tables,
+            deltas,
+        };
+        // Every delta's four tagged sets live side by side in the base rows;
+        // the busiest table must still fit them all.
+        for k in 0..profile.diverged_tables {
+            let tagged = profile.tagged_rows(k);
+            if tagged > profile.rows {
+                return Err(format!(
+                    "table {k}: the delta list needs {tagged} pre-tagged rows but N = {} — raise rows or trim deltas",
+                    profile.rows
+                )
+                .into());
+            }
+        }
+        Ok(profile)
+    }
+
+    /// Per-side operation counts for `delta` on diverged table `k`.
+    fn table_plan(&self, delta: usize, k: usize) -> TablePlan {
+        let side_split = split_delta(delta);
+        let per_table = |split: KindSplit| KindSplit {
+            updates: share(split.updates, self.diverged_tables, k),
+            deletes: share(split.deletes, self.diverged_tables, k),
+            inserts: share(split.inserts, self.diverged_tables, k),
+        };
+        TablePlan {
+            src: per_table(side_split),
+            tgt: per_table(side_split),
+        }
+    }
+
+    /// Cohort segments of diverged table `k`: `(end_row_exclusive, cohort)`
+    /// in layout order. Rows past the last end are cohort `keep`.
+    fn cohort_segments(&self, k: usize) -> Vec<(usize, String)> {
+        let mut segments = Vec::with_capacity(self.deltas.len() * 4);
+        let mut end = 0usize;
+        for &delta in &self.deltas {
+            let tp = self.table_plan(delta, k);
+            for (count, side_kind) in [
+                (tp.src.updates, "src_upd"),
+                (tp.src.deletes, "src_del"),
+                (tp.tgt.updates, "tgt_upd"),
+                (tp.tgt.deletes, "tgt_del"),
+            ] {
+                if count > 0 {
+                    end += count;
+                    segments.push((end, format!("d{delta}_{side_kind}")));
+                }
+            }
+        }
+        segments
+    }
+
+    /// Total pre-tagged (non-`keep`) rows of diverged table `k`.
+    fn tagged_rows(&self, k: usize) -> usize {
+        self.cohort_segments(k).last().map_or(0, |(end, _)| *end)
+    }
+}
+
+/// Per-side operation counts for one delta of d rows.
+#[derive(Debug, Clone, Copy, Default, serde::Serialize, serde::Deserialize)]
+pub struct KindSplit {
+    pub updates: usize,
+    pub deletes: usize,
+    pub inserts: usize,
+}
+
+impl std::fmt::Display for KindSplit {
+    /// Compact progress-line form: `1667u/1667d/1666i`.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}u/{}d/{}i", self.updates, self.deletes, self.inserts)
+    }
+}
+
+/// Split d operations into updates/deletes/inserts, updates first so every
+/// d >= 1 keeps at least one update per side — an update-bearing divergence
+/// can never be classified onto the proven-pure-insert shortcut.
+pub fn split_delta(d: usize) -> KindSplit {
+    assert!(d >= 1, "delta must be >= 1");
+    let updates = d.div_ceil(3).max(1);
+    let rest = d - updates;
+    let deletes = rest.div_ceil(2);
+    let inserts = rest - deletes;
+    KindSplit {
+        updates,
+        deletes,
+        inserts,
+    }
+}
+
+/// `idx`'s share when `total` items are dealt round-robin over `parts` bins.
+fn share(total: usize, parts: usize, idx: usize) -> usize {
+    total / parts + usize::from(idx < total % parts)
+}
+
+/// One diverged table's planned per-side operation counts.
+#[derive(Debug, Clone, Copy)]
+pub struct TablePlan {
+    pub src: KindSplit,
+    pub tgt: KindSplit,
+}
+
+/// The divergence plan for ONE run: a base profile plus the chosen delta.
+#[derive(Debug, Clone)]
+pub struct FixturePlan {
+    pub profile: BaseProfile,
+    /// d — delta rows per side, one of `profile.deltas`.
+    pub delta: usize,
+    /// One entry per diverged table (tables `0..diverged_tables`).
+    pub table_plans: Vec<TablePlan>,
+    /// Per-side totals (the d split).
+    pub side_split: KindSplit,
+}
+
+impl FixturePlan {
+    pub fn new(profile: BaseProfile, delta: usize) -> BenchResult<Self> {
+        if !profile.deltas.contains(&delta) {
+            return Err(format!(
+                "delta {delta} is not pre-tagged in this base (supported deltas: {:?})",
+                profile.deltas
+            )
+            .into());
+        }
+        let table_plans: Vec<TablePlan> = (0..profile.diverged_tables)
+            .map(|k| profile.table_plan(delta, k))
+            .collect();
+        let side_split = split_delta(delta);
+        Ok(Self {
+            profile,
+            delta,
+            table_plans,
+            side_split,
+        })
+    }
+
+    /// Expected row count of diverged table `k` on the target branch after a
+    /// clean three-way merge (deletes from both sides applied, inserts from
+    /// both sides landed).
+    pub fn expected_rows_after_merge(&self, k: usize) -> usize {
+        let tp = &self.table_plans[k];
+        self.profile.rows - tp.src.deletes - tp.tgt.deletes + tp.src.inserts + tp.tgt.inserts
+    }
+}
+
+pub fn type_name(k: usize) -> String {
+    format!("BenchT{k:03}")
+}
+
+pub fn table_key(k: usize) -> String {
+    format!("node:{}", type_name(k))
+}
+
+/// Generate the `.pg` schema: T node types, all scalar columns.
+pub fn schema_source(tables: usize) -> String {
+    let mut out = String::new();
+    for k in 0..tables {
+        writeln!(
+            out,
+            "node {} {{\n    name: String @key\n    cohort: String?\n    val: I32?\n    payload: String?\n}}\n",
+            type_name(k)
+        )
+        .expect("writing to String cannot fail");
+    }
+    out
+}
+
+/// Generate the `.gq` mutation-query source for the diverged tables: one
+/// cohort-filtered bulk update and one cohort-filtered bulk delete per table.
+pub fn mutation_queries(diverged_tables: usize) -> String {
+    let mut out = String::new();
+    for k in 0..diverged_tables {
+        let ty = type_name(k);
+        writeln!(
+            out,
+            "query upd_{k}($v: I32, $c: String) {{\n    update {ty} set {{ val: $v }} where cohort = $c\n}}\n"
+        )
+        .expect("writing to String cannot fail");
+        writeln!(
+            out,
+            "query del_{k}($c: String) {{\n    delete {ty} where cohort = $c\n}}\n"
+        )
+        .expect("writing to String cannot fail");
+    }
+    out
+}
+
+/// Which cohort base row `j` carries, given the table's precomputed cohort
+/// segments. Rows are partitioned front-to-back into the planned mutation
+/// sets of every supported delta; all sets are disjoint by construction, so
+/// any single-delta merge is conflict-free.
+fn cohort_at(segments: &[(usize, String)], j: usize) -> &str {
+    for (end, cohort) in segments {
+        if j < *end {
+            return cohort;
+        }
+    }
+    "keep"
+}
+
+fn jsonl_node_row(ty: &str, name: &str, cohort: &str, val: usize, payload: &str) -> String {
+    serde_json::json!({
+        "type": ty,
+        "data": { "name": name, "cohort": cohort, "val": val as i64, "payload": payload }
+    })
+    .to_string()
+}
+
+/// Bulk-load the base content onto `main`: N rows into each of T tables, one
+/// table per `load` call, in chunks of [`load_chunk_rows`] rows per commit
+/// (bounded under the engine's keyed-write cap at any payload size). Returns
+/// the number of load commits performed.
+pub async fn load_base(db: &Omnigraph, profile: &BaseProfile) -> BenchResult<usize> {
+    let payload = "x".repeat(profile.payload_bytes);
+    let chunk_rows = load_chunk_rows(profile.payload_bytes);
+    let segments_per_table: Vec<Vec<(usize, String)>> = (0..profile.diverged_tables)
+        .map(|k| profile.cohort_segments(k))
+        .collect();
+    let mut commits = 0usize;
+    for k in 0..profile.tables {
+        let ty = type_name(k);
+        let segments = segments_per_table.get(k);
+        let mut start = 0usize;
+        while start < profile.rows {
+            let end = (start + chunk_rows).min(profile.rows);
+            let mut chunk = String::new();
+            for j in start..end {
+                let cohort = segments.map_or("keep", |segments| cohort_at(segments, j));
+                let name = format!("t{k:03}_r{j:07}");
+                chunk.push_str(&jsonl_node_row(&ty, &name, cohort, j, &payload));
+                chunk.push('\n');
+            }
+            db.load("main", &chunk, LoadMode::Append).await?;
+            commits += 1;
+            start = end;
+        }
+    }
+    Ok(commits)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Side {
+    Source,
+    Target,
+}
+
+impl Side {
+    fn tag(self) -> &'static str {
+        match self {
+            Side::Source => "src",
+            Side::Target => "tgt",
+        }
+    }
+}
+
+fn string_param(map: &mut ParamMap, key: &str, value: &str) {
+    map.insert(key.to_string(), Literal::String(value.to_string()));
+}
+
+/// Apply one side's planned delta on `branch` (already forked from main):
+/// per diverged table one bulk cohort update and one bulk cohort delete, then
+/// the side's new rows in one (chunked) load. `rep` uniquifies insert keys
+/// across repetitions.
+pub async fn diverge(
+    db: &Omnigraph,
+    branch: &str,
+    side: Side,
+    plan: &FixturePlan,
+    queries: &str,
+    rep: usize,
+) -> BenchResult<()> {
+    let tag = side.tag();
+    let d = plan.delta;
+    for (k, tp) in plan.table_plans.iter().enumerate() {
+        let split = match side {
+            Side::Source => tp.src,
+            Side::Target => tp.tgt,
+        };
+        if split.updates > 0 {
+            let mut params = ParamMap::new();
+            params.insert("v".to_string(), Literal::Integer(1_000_000 + rep as i64));
+            string_param(&mut params, "c", &format!("d{d}_{tag}_upd"));
+            db.mutate(branch, queries, &format!("upd_{k}"), &params)
+                .await?;
+        }
+        if split.deletes > 0 {
+            let mut params = ParamMap::new();
+            string_param(&mut params, "c", &format!("d{d}_{tag}_del"));
+            db.mutate(branch, queries, &format!("del_{k}"), &params)
+                .await?;
+        }
+    }
+    // Inserts: one table per load call, chunk rows derived from the payload
+    // size (same keyed-write-cap bound as the base load).
+    let payload = "y".repeat(plan.profile.payload_bytes);
+    let chunk_rows = load_chunk_rows(plan.profile.payload_bytes);
+    for (k, tp) in plan.table_plans.iter().enumerate() {
+        let inserts = match side {
+            Side::Source => tp.src.inserts,
+            Side::Target => tp.tgt.inserts,
+        };
+        let ty = type_name(k);
+        let mut start = 0usize;
+        while start < inserts {
+            let end = (start + chunk_rows).min(inserts);
+            let mut chunk = String::new();
+            for j in start..end {
+                let name = format!("{tag}{rep:03}_t{k:03}_n{j:07}");
+                chunk.push_str(&jsonl_node_row(&ty, &name, "new", j, &payload));
+                chunk.push('\n');
+            }
+            db.load(branch, &chunk, LoadMode::Append).await?;
+            start = end;
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Frozen fixtures
+// ---------------------------------------------------------------------------
+
+/// `fixture-manifest.json`: full provenance of one frozen base store. A run
+/// against the fixture embeds this whole manifest in its record's state
+/// group, so the record stays reproducible from itself alone.
+///
+/// Manifest v2 added the [`ValidationStamp`] (RFC 0039: "a fixture is
+/// validated once, before anything is ever measured against it"; a fixture
+/// that fails validation never freezes, and `run --fixture` refuses a
+/// manifest without the stamp); v3 added the machine-readable
+/// `state.index_level`. Manifests below v3 are refused by [`load_manifest`]
+/// (fixtures are disposable — rebuild); `fixture validate` stamps a v3
+/// manifest whose stamp was deleted to force re-validation.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct FixtureManifest {
+    pub manifest_version: u32,
+    /// Derived name, also the fixture's directory name.
+    pub fixture_name: String,
+    /// [`BUILDER_VERSION`] at build time.
+    pub builder_version: u32,
+    pub built_unix_seconds: u64,
+    /// `git rev-parse HEAD` of the engine tree the builder was built from.
+    pub engine_commit: String,
+    pub build_seconds: f64,
+    pub profile: BaseProfile,
+    pub column_shape: String,
+    pub state: FixtureState,
+    /// The validation stamp; absent only on v1 manifests, which `run` refuses.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub validation: Option<ValidationStamp>,
+}
+
+/// Result of the fixture validation pass, stamped into the manifest at build
+/// (or by `fixture validate` for pre-stamp fixtures). `run --fixture`
+/// re-digests the frozen store and refuses on mismatch, so the stamp is
+/// load-bearing, not decorative.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ValidationStamp {
+    pub validated_unix_seconds: u64,
+    /// The checks that ran, in order (row counts, index coverage, digest, ...).
+    pub checks: Vec<String>,
+    /// Observed row count per table key (each must equal the spec's N).
+    pub row_counts: std::collections::BTreeMap<String, usize>,
+    pub store_files: u64,
+    pub store_bytes: u64,
+    /// SHA-256 over the store directory (sorted relative paths + contents).
+    pub content_digest_sha256: String,
+}
+
+/// Machine-readable F2/F3 level of a fixture (F2 = index existence, F3 =
+/// index freshness). The prose fields of [`FixtureState`] carry the detail;
+/// this enum is what code branches on.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum IndexLevel {
+    /// No declared indexes (F2 low end).
+    #[default]
+    None,
+    /// Declared key indexes built and freshly optimized (F2/F3 high end).
+    BtreeFresh,
+}
+
+/// F1–F5 state axes of the frozen store, in the run-record vocabulary.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct FixtureState {
+    pub fragmentation: String,
+    pub index_existence: String,
+    pub index_freshness: String,
+    pub deletion_history: String,
+    pub compaction_recency: String,
+    /// Machine-readable F2/F3 level; the prose fields above are detail only,
+    /// never gated on. Defaults (pre-v3 manifests) to `None`; those manifests
+    /// are refused by the manifest-version floor in `load_manifest`, so the
+    /// default never reaches a run.
+    #[serde(default)]
+    pub index_level: IndexLevel,
+    pub base_load_commits: usize,
+}
+
+/// Derived directory name for a profile, e.g. `fx-t8-n100k-scalars-btree-fresh`.
+/// A non-default diverged-table count (anything but the historical
+/// `min(4, T)` m3 shape) is part of the tuple and gets a `-div<D>` suffix so
+/// e.g. an all-diverged base cannot collide with the diverged-4 base of the
+/// same T/N.
+pub fn derived_fixture_name(profile: &BaseProfile, index: bool) -> String {
+    let rows = if profile.rows.is_multiple_of(1000) {
+        format!("{}k", profile.rows / 1000)
+    } else {
+        profile.rows.to_string()
+    };
+    let div = if profile.diverged_tables == profile.tables.min(4) {
+        String::new()
+    } else {
+        format!("-div{}", profile.diverged_tables)
+    };
+    format!(
+        "fx-t{}-n{}-scalars-{}{div}",
+        profile.tables,
+        rows,
+        if index { "btree-fresh" } else { "noindex" }
+    )
+}
+
+pub fn store_dir(fixture_dir: &Path) -> PathBuf {
+    fixture_dir.join(STORE_SUBDIR)
+}
+
+pub fn manifest_path(fixture_dir: &Path) -> PathBuf {
+    fixture_dir.join(MANIFEST_FILE)
+}
+
+pub fn load_manifest(fixture_dir: &Path) -> BenchResult<FixtureManifest> {
+    let path = manifest_path(fixture_dir);
+    let text =
+        std::fs::read_to_string(&path).map_err(|e| format!("reading {}: {e}", path.display()))?;
+    let manifest: FixtureManifest =
+        serde_json::from_str(&text).map_err(|e| format!("parsing {}: {e}", path.display()))?;
+    if manifest.builder_version != BUILDER_VERSION {
+        return Err(format!(
+            "fixture {} was built by builder v{}, this binary is v{BUILDER_VERSION} — rebuild the fixture",
+            manifest.fixture_name, manifest.builder_version
+        )
+        .into());
+    }
+    // Pre-v3 manifests predate `state.index_level`; builder v2 coexisted with
+    // manifest v2, so the builder-version check above does not catch them.
+    if manifest.manifest_version < MANIFEST_VERSION {
+        return Err(format!(
+            "fixture {} has manifest v{}, this binary reads only v{MANIFEST_VERSION} — \
+             fixtures are disposable; rebuild it",
+            manifest.fixture_name, manifest.manifest_version
+        )
+        .into());
+    }
+    if manifest.manifest_version > MANIFEST_VERSION {
+        return Err(format!(
+            "fixture {} has manifest v{}, this binary reads up to v{MANIFEST_VERSION}",
+            manifest.fixture_name, manifest.manifest_version
+        )
+        .into());
+    }
+    if !store_dir(fixture_dir).is_dir() {
+        return Err(format!(
+            "fixture {} has no {STORE_SUBDIR}/ directory",
+            fixture_dir.display()
+        )
+        .into());
+    }
+    Ok(manifest)
+}
+
+/// Current manifest version (2 = validation stamp present; 3 = machine-
+/// readable `state.index_level`), and the only version `load_manifest`
+/// accepts.
+pub const MANIFEST_VERSION: u32 = 3;
+
+/// The state tag a fixture name / point name carries for its F2/F3 level.
+pub fn state_tag(level: IndexLevel) -> &'static str {
+    match level {
+        IndexLevel::BtreeFresh => "btree-fresh",
+        IndexLevel::None => "noindex",
+    }
+}
+
+/// Write the manifest atomically: a temp file in the fixture directory, then
+/// a rename over the final path. A crash mid-write can leave a stray temp
+/// file, never a torn `fixture-manifest.json`.
+pub fn write_manifest_atomic(fixture_dir: &Path, manifest: &FixtureManifest) -> BenchResult<()> {
+    let path = manifest_path(fixture_dir);
+    let tmp = fixture_dir.join(format!("{MANIFEST_FILE}.tmp"));
+    std::fs::write(&tmp, serde_json::to_string_pretty(manifest)?)
+        .map_err(|e| format!("writing {}: {e}", tmp.display()))?;
+    std::fs::rename(&tmp, &path)
+        .map_err(|e| format!("renaming {} over {}: {e}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+/// Load a fixture manifest and enforce the run-side contract: the manifest
+/// must carry a validation stamp, and the frozen store must re-digest to the
+/// stamped digest (RFC 0039: run records may reference only validated
+/// fixtures; a mutated frozen store cannot be measured against).
+pub fn load_validated(dir: &Path) -> BenchResult<FixtureManifest> {
+    let manifest = load_manifest(dir)?;
+    let Some(stamp) = manifest.validation.as_ref() else {
+        return Err(format!(
+            "fixture {} has no validation stamp (RFC 0039: run records may reference \
+             only validated fixtures) — rebuild it, or stamp it with \
+             `fixture validate {}`",
+            manifest.fixture_name,
+            dir.display()
+        )
+        .into());
+    };
+    let (_, _, digest) = digest_store_dir(&store_dir(dir))?;
+    if digest != stamp.content_digest_sha256 {
+        return Err(format!(
+            "fixture {}: frozen store digest mismatch (manifest {}, on-store {digest}) — \
+             the store was modified after validation; rebuild or re-validate",
+            manifest.fixture_name, stamp.content_digest_sha256
+        )
+        .into());
+    }
+    Ok(manifest)
+}
+
+/// Digest a per-run copy of the frozen store against the manifest's stamp.
+/// Runs once per copy (each point copies afresh): the entry check in `run`
+/// covers the moment the fixture is loaded, this one covers the bytes each
+/// point actually opens.
+pub fn verify_copy_digest(copy_root: &Path, manifest: &FixtureManifest) -> BenchResult<()> {
+    let stamp = manifest
+        .validation
+        .as_ref()
+        .ok_or("fixture manifest lost its validation stamp between load and copy")?;
+    let (_, _, digest) = digest_store_dir(copy_root)?;
+    if digest != stamp.content_digest_sha256 {
+        return Err(format!(
+            "fixture {}: per-run store copy digests {digest}, manifest stamps {} — \
+             the frozen store changed after this run started (or the copy is unfaithful); \
+             refusing to measure against it",
+            manifest.fixture_name, stamp.content_digest_sha256
+        )
+        .into());
+    }
+    Ok(())
+}
+
+/// SHA-256 content digest of a store directory: every regular file in sorted
+/// relative-path order, hashing `relpath \0 len \0 bytes`. Returns
+/// (files, bytes, hex digest). Identical trees digest identically on any
+/// machine — the hashed relative path is component-joined with '/' so the
+/// platform separator never enters the digest (a unix tree keeps its
+/// historical digest byte for byte). Non-UTF-8 path components hash their
+/// lossy replacement, so two names differing only in invalid bytes could
+/// collide — accepted for generated fixture trees, which are ASCII. A mutated
+/// frozen store cannot pass `run --fixture`.
+pub fn digest_store_dir(store: &Path) -> BenchResult<(u64, u64, String)> {
+    fn walk(dir: &Path, files: &mut Vec<PathBuf>) -> BenchResult<()> {
+        for entry in
+            std::fs::read_dir(dir).map_err(|e| format!("reading {}: {e}", dir.display()))?
+        {
+            let entry = entry?;
+            // DirEntry::file_type never follows symlinks (same refusal as
+            // copy_dir_recursive): a symlink must fail the digest, not be
+            // silently hashed as whatever it points at.
+            let file_type = entry.file_type()?;
+            let path = entry.path();
+            if file_type.is_dir() {
+                walk(&path, files)?;
+            } else if file_type.is_file() {
+                files.push(path);
+            } else {
+                return Err(format!(
+                    "unsupported entry (symlink?) in fixture store: {}",
+                    path.display()
+                )
+                .into());
+            }
+        }
+        Ok(())
+    }
+    let mut files = Vec::new();
+    walk(store, &mut files)?;
+    files.sort();
+    let mut hasher = Sha256::new();
+    let mut total_bytes = 0u64;
+    for path in &files {
+        let rel = path
+            .strip_prefix(store)
+            .expect("walked path is under the store root");
+        // '/'-joined components: on unix this reproduces the path string
+        // exactly (frozen digests stay valid); on Windows it replaces the
+        // '\\' separator without touching separator bytes inside a name.
+        let rel_portable = rel
+            .components()
+            .map(|c| c.as_os_str().to_string_lossy())
+            .collect::<Vec<_>>()
+            .join("/");
+        let bytes = std::fs::read(path).map_err(|e| format!("reading {}: {e}", path.display()))?;
+        hasher.update(rel_portable.as_bytes());
+        hasher.update([0]);
+        hasher.update((bytes.len() as u64).to_le_bytes());
+        hasher.update([0]);
+        hasher.update(&bytes);
+        total_bytes += bytes.len() as u64;
+    }
+    let digest = hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<String>();
+    Ok((files.len() as u64, total_bytes, digest))
+}
+
+/// Recursive copy of `src` into `dst` (created). Returns (files, bytes).
+pub fn copy_dir_recursive(src: &Path, dst: &Path) -> BenchResult<(u64, u64)> {
+    std::fs::create_dir_all(dst)?;
+    let mut files = 0u64;
+    let mut bytes = 0u64;
+    for entry in std::fs::read_dir(src).map_err(|e| format!("reading {}: {e}", src.display()))? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            let (f, b) = copy_dir_recursive(&from, &to)?;
+            files += f;
+            bytes += b;
+        } else if file_type.is_file() {
+            bytes += std::fs::copy(&from, &to)
+                .map_err(|e| format!("copying {}: {e}", from.display()))?;
+            files += 1;
+        } else {
+            return Err(format!(
+                "unsupported entry (symlink?) in fixture store: {}",
+                from.display()
+            )
+            .into());
+        }
+    }
+    Ok((files, bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn multi_delta_cohorts_are_disjoint_and_fit() {
+        let profile = BaseProfile::new(8, 4000, 64, 4, vec![1, 50, 5000]).unwrap();
+        // Busiest table's tagged rows must fit N and lay out without overlap.
+        for k in 0..profile.diverged_tables {
+            let segments = profile.cohort_segments(k);
+            let mut prev = 0usize;
+            for (end, cohort) in &segments {
+                assert!(*end > prev, "segment {cohort} is empty or out of order");
+                prev = *end;
+            }
+            assert!(prev <= profile.rows);
+        }
+        // A per-delta plan's tagged counts match the segments carrying its tag.
+        let plan = FixturePlan::new(profile.clone(), 50).unwrap();
+        let tp = plan.table_plans[0];
+        let segments = profile.cohort_segments(0);
+        let seg_len = |cohort: &str| {
+            let mut prev = 0usize;
+            for (end, c) in &segments {
+                if c == cohort {
+                    return end - prev;
+                }
+                prev = *end;
+            }
+            0
+        };
+        assert_eq!(seg_len("d50_src_upd"), tp.src.updates);
+        assert_eq!(seg_len("d50_src_del"), tp.src.deletes);
+        assert_eq!(seg_len("d50_tgt_upd"), tp.tgt.updates);
+        assert_eq!(seg_len("d50_tgt_del"), tp.tgt.deletes);
+    }
+
+    #[test]
+    fn unsupported_delta_is_refused() {
+        let profile = BaseProfile::new(2, 1000, 8, 2, vec![1, 50]).unwrap();
+        assert!(FixturePlan::new(profile, 7).is_err());
+    }
+
+    #[test]
+    fn out_of_bounds_diverged_tables_is_a_hard_error() {
+        for (tables, diverged) in [(8, 0), (8, 9), (1, 2)] {
+            let err = BaseProfile::new(tables, 1000, 8, diverged, vec![1])
+                .expect_err("out-of-bounds diverged_tables must be refused, never clamped");
+            let msg = err.to_string();
+            assert!(
+                msg.contains("diverged_tables must be between 1 and tables"),
+                "error must name the bound, got: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn chunk_rows_stay_under_the_keyed_write_cap() {
+        // (payload_bytes, expectation on the derived chunk)
+        for payload in [0usize, 64, 4096, 32 * 1024, 10 * 1024 * 1024] {
+            let rows = load_chunk_rows(payload);
+            assert!(
+                rows >= 1,
+                "payload {payload}: chunk must hold at least one row"
+            );
+            assert!(
+                rows <= KEYED_WRITE_MAX_ROWS / 2,
+                "payload {payload}: {rows} rows exceeds half the row cap"
+            );
+            assert!(
+                rows * (payload + ROW_OVERHEAD_BYTES) <= KEYED_WRITE_MAX_BYTES,
+                "payload {payload}: {rows} rows breach the 32 MiB keyed-write cap"
+            );
+        }
+        // The historical default shape keeps its historical chunk size.
+        assert_eq!(load_chunk_rows(64), 4096);
+    }
+
+    fn test_manifest(name: &str, stamp: Option<ValidationStamp>) -> FixtureManifest {
+        FixtureManifest {
+            manifest_version: MANIFEST_VERSION,
+            fixture_name: name.to_string(),
+            builder_version: BUILDER_VERSION,
+            built_unix_seconds: 0,
+            engine_commit: "test".to_string(),
+            build_seconds: 0.0,
+            profile: BaseProfile::new(1, 10, 8, 1, vec![1]).unwrap(),
+            column_shape: "test".to_string(),
+            state: FixtureState {
+                fragmentation: "test".to_string(),
+                index_existence: "none declared (F2 low end)".to_string(),
+                index_freshness: "n/a".to_string(),
+                deletion_history: "none".to_string(),
+                compaction_recency: "never".to_string(),
+                index_level: IndexLevel::None,
+                base_load_commits: 1,
+            },
+            validation: stamp,
+        }
+    }
+
+    /// Builder v2 coexisted with manifest v2, so the version floor (not the
+    /// builder-version check) must refuse pre-v3 manifests.
+    #[test]
+    fn pre_v3_manifests_are_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let fixture_dir = dir.path();
+        std::fs::create_dir_all(store_dir(fixture_dir)).unwrap();
+        let mut manifest = test_manifest("fx-old", None);
+        manifest.manifest_version = 2;
+        write_manifest_atomic(fixture_dir, &manifest).unwrap();
+        let err = load_manifest(fixture_dir).expect_err("a v2 manifest must be refused");
+        assert!(err.to_string().contains("manifest v2"), "got: {err}");
+        assert!(err.to_string().contains("rebuild"), "got: {err}");
+    }
+
+    #[test]
+    fn run_side_contract_refuses_unstamped_and_mutated_fixtures() {
+        let dir = tempfile::tempdir().unwrap();
+        let fixture_dir = dir.path();
+        let store = store_dir(fixture_dir);
+        std::fs::create_dir_all(&store).unwrap();
+        std::fs::write(store.join("data.bin"), b"frozen bytes").unwrap();
+
+        // Unstamped: refused with the stamp instruction.
+        write_manifest_atomic(fixture_dir, &test_manifest("fx-test", None)).unwrap();
+        let err = load_validated(fixture_dir).expect_err("unstamped fixture must be refused");
+        assert!(err.to_string().contains("no validation stamp"));
+
+        // Stamped and untouched: accepted.
+        let (files, bytes, digest) = digest_store_dir(&store).unwrap();
+        let stamp = ValidationStamp {
+            validated_unix_seconds: 0,
+            checks: vec!["test".to_string()],
+            row_counts: std::collections::BTreeMap::new(),
+            store_files: files,
+            store_bytes: bytes,
+            content_digest_sha256: digest,
+        };
+        write_manifest_atomic(fixture_dir, &test_manifest("fx-test", Some(stamp))).unwrap();
+        load_validated(fixture_dir).expect("stamped, unmodified fixture must load");
+
+        // Mutated after stamping: refused with the digest mismatch.
+        std::fs::write(store.join("data.bin"), b"tampered bytes").unwrap();
+        let err = load_validated(fixture_dir).expect_err("mutated store must be refused");
+        assert!(err.to_string().contains("digest mismatch"));
+    }
+
+    #[test]
+    fn derived_names_match_convention() {
+        let p = BaseProfile::new(8, 100_000, 64, 4, vec![1, 50, 5000]).unwrap();
+        assert_eq!(
+            derived_fixture_name(&p, true),
+            "fx-t8-n100k-scalars-btree-fresh"
+        );
+        let p = BaseProfile::new(8, 4000, 64, 4, vec![1, 50, 5000]).unwrap();
+        assert_eq!(derived_fixture_name(&p, false), "fx-t8-n4k-scalars-noindex");
+        // Non-default diverged count is part of the name (all-diverged bases
+        // must not collide with the diverged-4 base of the same T/N).
+        let p = BaseProfile::new(8, 4000, 64, 8, vec![24]).unwrap();
+        assert_eq!(
+            derived_fixture_name(&p, false),
+            "fx-t8-n4k-scalars-noindex-div8"
+        );
+        let p = BaseProfile::new(140, 4000, 64, 140, vec![420]).unwrap();
+        assert_eq!(
+            derived_fixture_name(&p, false),
+            "fx-t140-n4k-scalars-noindex-div140"
+        );
+    }
+
+    #[test]
+    fn store_digest_is_deterministic_and_content_sensitive() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("data");
+        std::fs::create_dir_all(&sub).unwrap();
+        std::fs::write(dir.path().join("a.txt"), b"alpha").unwrap();
+        std::fs::write(sub.join("b.bin"), b"beta").unwrap();
+        let (files, bytes, first) = digest_store_dir(dir.path()).unwrap();
+        assert_eq!(files, 2);
+        assert_eq!(bytes, 9);
+        let (_, _, second) = digest_store_dir(dir.path()).unwrap();
+        assert_eq!(first, second, "same tree must digest identically");
+        std::fs::write(sub.join("b.bin"), b"BETA").unwrap();
+        let (_, _, third) = digest_store_dir(dir.path()).unwrap();
+        assert_ne!(first, third, "a mutated store must change the digest");
+    }
+
+    /// Pins the digest formula (`relpath \0 len \0 bytes`, '/'-separated
+    /// relative paths): frozen fixtures stamped before the separator
+    /// normalization must keep digesting to the same value.
+    #[test]
+    fn digest_formula_is_stable_for_slash_separated_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("data");
+        std::fs::create_dir_all(&sub).unwrap();
+        std::fs::write(dir.path().join("a.txt"), b"alpha").unwrap();
+        std::fs::write(sub.join("b.bin"), b"beta").unwrap();
+        let mut hasher = Sha256::new();
+        for (rel, contents) in [("a.txt", b"alpha" as &[u8]), ("data/b.bin", b"beta")] {
+            hasher.update(rel.as_bytes());
+            hasher.update([0]);
+            hasher.update((contents.len() as u64).to_le_bytes());
+            hasher.update([0]);
+            hasher.update(contents);
+        }
+        let expected = hasher
+            .finalize()
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect::<String>();
+        let (_, _, actual) = digest_store_dir(dir.path()).unwrap();
+        assert_eq!(actual, expected, "digest formula drifted");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn digest_refuses_symlinks_without_following_them() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("a.txt"), b"alpha").unwrap();
+        std::os::unix::fs::symlink(dir.path().join("a.txt"), dir.path().join("link")).unwrap();
+        let err = digest_store_dir(dir.path()).expect_err("a symlink must fail the digest");
+        assert!(err.to_string().contains("symlink"));
+    }
+}

--- a/crates/omnigraph-bench/src/fixture_cmd.rs
+++ b/crates/omnigraph-bench/src/fixture_cmd.rs
@@ -1,0 +1,349 @@
+//! The `fixture` subcommands: build + validate + freeze a base store, or
+//! stamp an existing pre-stamp fixture after validating a copy.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use clap::Args;
+use omnigraph::IndexCoverage;
+use omnigraph::db::{Omnigraph, ReadTarget};
+
+use crate::fixture::{
+    self, BaseProfile, BenchResult, FixtureManifest, IndexLevel, ValidationStamp,
+};
+use crate::{refuse_debug_build, source_commit, unix_now};
+
+#[derive(Debug, Args)]
+pub struct FixtureBuildArgs {
+    /// Directory that holds frozen fixtures (created if absent). The fixture
+    /// itself lands in `<fixtures-root>/<derived-name>/`.
+    #[arg(long)]
+    fixtures_root: PathBuf,
+    /// T — node-table count.
+    #[arg(long, default_value_t = 8)]
+    tables: usize,
+    /// N — base rows per table.
+    #[arg(long, default_value_t = 100_000)]
+    rows: usize,
+    /// Filler bytes in the scalar payload column per row.
+    #[arg(long, default_value_t = 64)]
+    payload_bytes: usize,
+    /// Deltas (rows per side) to pre-tag cohorts for, comma-separated.
+    /// Default: the m3 sweep 1,50,5000.
+    #[arg(long, value_delimiter = ',')]
+    deltas: Vec<usize>,
+    /// Tables any delta touches on both sides. Default: min(4, T) — the m3
+    /// shape.
+    #[arg(long)]
+    diverged_tables: Option<usize>,
+    /// High end of the index axes (F2 = index existence, F3 = index
+    /// freshness): build the engine's declared key indexes (BTREE on the
+    /// physical row-key column `id`, plus the FTS the `name @key` String
+    /// implies) via `ensure_indices`, then run `optimize` so coverage is
+    /// fresh, then verify coverage before freezing.
+    #[arg(long)]
+    index: bool,
+}
+
+pub async fn fixture_build(args: FixtureBuildArgs) -> BenchResult<()> {
+    refuse_debug_build("freezing a fixture")?;
+    let deltas = if args.deltas.is_empty() {
+        vec![1, 50, 5000]
+    } else {
+        args.deltas.clone()
+    };
+    let diverged = args.diverged_tables.unwrap_or(args.tables.min(4));
+    let profile = BaseProfile::new(args.tables, args.rows, args.payload_bytes, diverged, deltas)?;
+    let name = fixture::derived_fixture_name(&profile, args.index);
+    let fixture_dir = args.fixtures_root.join(&name);
+    std::fs::create_dir_all(&args.fixtures_root)
+        .map_err(|e| format!("creating {}: {e}", args.fixtures_root.display()))?;
+    // `create_dir` (not exists + create_dir_all): claiming the directory IS
+    // the existence check, so a concurrent builder cannot slip between them.
+    match std::fs::create_dir(&fixture_dir) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            return Err(format!(
+                "fixture directory {} already exists — delete it first to rebuild",
+                fixture_dir.display()
+            )
+            .into());
+        }
+        Err(e) => return Err(format!("creating {}: {e}", fixture_dir.display()).into()),
+    }
+    // A fixture that fails to build or validate never freezes: on any error
+    // the partial directory is removed so no unstamped store lingers.
+    let result = fixture_build_inner(&args, &profile, &name, &fixture_dir).await;
+    if result.is_err() {
+        let _ = std::fs::remove_dir_all(&fixture_dir);
+    }
+    result
+}
+
+async fn fixture_build_inner(
+    args: &FixtureBuildArgs,
+    profile: &BaseProfile,
+    name: &str,
+    fixture_dir: &Path,
+) -> BenchResult<()> {
+    let store = fixture::store_dir(fixture_dir);
+    std::fs::create_dir_all(&store)?;
+    let root = store
+        .to_str()
+        .ok_or("fixture store path is not UTF-8")?
+        .to_string();
+
+    let started = Instant::now();
+    println!(
+        "[fixture {name}] building: T={} N={} payload={}B diverged={} deltas={:?} index={}",
+        profile.tables,
+        profile.rows,
+        profile.payload_bytes,
+        profile.diverged_tables,
+        profile.deltas,
+        args.index
+    );
+    let schema_source = fixture::schema_source(profile.tables);
+    let db = Omnigraph::init(&root, &schema_source).await?;
+    let base_load_commits = fixture::load_base(&db, profile).await?;
+    println!(
+        "[fixture {name}] base loaded: {base_load_commits} commits, {:.1}s",
+        started.elapsed().as_secs_f64()
+    );
+
+    let state = if args.index {
+        let pending = db.ensure_indices().await?;
+        if !pending.is_empty() {
+            return Err(format!(
+                "ensure_indices left {} declared index(es) pending — an indexed fixture \
+                 must freeze with every declared index materialized: {pending:?}",
+                pending.len()
+            )
+            .into());
+        }
+        println!(
+            "[fixture {name}] ensure_indices done, {:.1}s",
+            started.elapsed().as_secs_f64()
+        );
+        let stats = db.optimize().await?;
+        println!(
+            "[fixture {name}] optimize done ({} tables), {:.1}s",
+            stats.len(),
+            started.elapsed().as_secs_f64()
+        );
+        let fts_on_name = verify_index_state(&db, profile.tables).await?;
+        println!(
+            "[fixture {name}] verified: id BTREE Indexed on all {} tables, no unindexed \
+             fragments, fts(name)={fts_on_name}",
+            profile.tables
+        );
+        fixture::FixtureState {
+            fragmentation: "bulk load in payload-bounded chunks, then optimize compaction \
+                            (F1: compacted at freeze)"
+                .to_string(),
+            index_existence: format!(
+                "BTREE on 'id' (physical row-key for name @key) on all {} node tables via \
+                 ensure_indices{}; declared via the engine's key-column index path, not a \
+                 .pg annotation",
+                profile.tables,
+                if fts_on_name {
+                    ", plus the engine-implied FTS on 'name' (@key String)"
+                } else {
+                    ""
+                }
+            ),
+            index_freshness: "fresh (F3): optimize run after index build; verified at freeze — \
+                              id BTREE coverage Indexed on every table, no unindexed fragments"
+                .to_string(),
+            deletion_history: "none before freeze (F4 stub)".to_string(),
+            compaction_recency: "optimize (compaction + reindex) run immediately before freeze \
+                                 (F5: recent)"
+                .to_string(),
+            index_level: IndexLevel::BtreeFresh,
+            base_load_commits,
+        }
+    } else {
+        fixture::FixtureState {
+            fragmentation: "fresh bulk load in payload-bounded chunks, no aging (F1 stub)"
+                .to_string(),
+            index_existence: "none declared (F2 low end)".to_string(),
+            index_freshness: "n/a — no indexes (F3 stub)".to_string(),
+            deletion_history: "none before freeze (F4 stub)".to_string(),
+            compaction_recency: "optimize never run (F5 stub)".to_string(),
+            index_level: IndexLevel::None,
+            base_load_commits,
+        }
+    };
+
+    // Validation pass (RFC 0039: "a fixture is validated once, before
+    // anything is ever measured against it"): row counts per table against
+    // the spec, then a content digest of the built store into the stamp.
+    // The index-coverage check above is part of the same pass for --index
+    // builds. This builder fetches nothing, so there are no artifact digests
+    // to pin — recorded as such rather than skipped silently.
+    let row_counts = validate_row_counts(&db, profile).await?;
+    println!(
+        "[fixture {name}] validated: {} tables x {} rows",
+        profile.tables, profile.rows
+    );
+    drop(db);
+    let (store_files, store_bytes, content_digest_sha256) = fixture::digest_store_dir(&store)?;
+    let mut checks = vec!["row counts per table equal the spec's N".to_string()];
+    if args.index {
+        checks.push(
+            "declared indexes present and covering (id BTREE Indexed, no unindexed fragments)"
+                .to_string(),
+        );
+    }
+    checks.push("no fetched artifacts (generated data; nothing to digest-pin)".to_string());
+    checks.push("content digest of the built store recorded".to_string());
+    let validation = ValidationStamp {
+        validated_unix_seconds: unix_now(),
+        checks,
+        row_counts,
+        store_files,
+        store_bytes,
+        content_digest_sha256,
+    };
+
+    let build_seconds = started.elapsed().as_secs_f64();
+    let manifest = FixtureManifest {
+        manifest_version: fixture::MANIFEST_VERSION,
+        fixture_name: name.to_string(),
+        builder_version: fixture::BUILDER_VERSION,
+        built_unix_seconds: unix_now(),
+        engine_commit: source_commit(),
+        build_seconds,
+        profile: profile.clone(),
+        column_shape: "scalars-only (String key, String cohort, I32, String payload)".to_string(),
+        state,
+        validation: Some(validation),
+    };
+    fixture::write_manifest_atomic(fixture_dir, &manifest)?;
+    println!(
+        "[fixture {name}] validated + frozen at {} in {:.1}s",
+        fixture_dir.display(),
+        build_seconds
+    );
+    Ok(())
+}
+
+/// Row counts per table must equal the spec's N. Returns the observed map
+/// for the validation stamp.
+async fn validate_row_counts(
+    db: &Omnigraph,
+    profile: &BaseProfile,
+) -> BenchResult<BTreeMap<String, usize>> {
+    let snapshot = db.snapshot_of(ReadTarget::branch("main")).await?;
+    let mut counts = BTreeMap::new();
+    for k in 0..profile.tables {
+        let table_key = fixture::table_key(k);
+        let actual = snapshot.open(&table_key).await?.count_rows(None).await?;
+        if actual != profile.rows {
+            return Err(format!(
+                "validation failed: {table_key} holds {actual} rows, spec says {} — \
+                 this fixture never freezes",
+                profile.rows
+            )
+            .into());
+        }
+        counts.insert(table_key, actual);
+    }
+    Ok(counts)
+}
+
+/// F2/F3 verification (index existence and freshness): the id BTREE must
+/// exist with full fragment coverage on every node table (the condition the
+/// indexed merge arms need). Returns whether the engine-implied FTS on `name`
+/// is present everywhere.
+async fn verify_index_state(db: &Omnigraph, tables: usize) -> BenchResult<bool> {
+    let snapshot = db.snapshot_of(ReadTarget::branch("main")).await?;
+    let mut fts_on_name = true;
+    for k in 0..tables {
+        let table_key = fixture::table_key(k);
+        let table = snapshot.open(&table_key).await?;
+        if !table.has_btree_index("id").await? {
+            return Err(format!("{table_key}: no BTREE on 'id' after ensure_indices").into());
+        }
+        match table.index_coverage("id").await? {
+            IndexCoverage::Indexed => {}
+            IndexCoverage::Degraded { reason } => {
+                return Err(format!(
+                    "{table_key}: id BTREE coverage degraded after optimize: {reason}"
+                )
+                .into());
+            }
+        }
+        if table.has_unindexed_fragments().await? {
+            return Err(format!("{table_key}: unindexed fragments remain after optimize").into());
+        }
+        fts_on_name &= table.has_fts_index("name").await?;
+    }
+    Ok(fts_on_name)
+}
+
+/// Stamp an existing stamp-less fixture: validate a copy of the frozen
+/// store, digest the untouched original, write the stamp into its manifest
+/// (atomically: temp file + rename, never an in-place overwrite). An
+/// already-stamped fixture is refused — a stamp is minted once, and silently
+/// re-stamping would move `validated_unix_seconds` under a frozen store.
+pub async fn fixture_validate(dir: PathBuf) -> BenchResult<()> {
+    refuse_debug_build("stamping a fixture")?;
+    let mut manifest = fixture::load_manifest(&dir)?;
+    if let Some(stamp) = &manifest.validation {
+        return Err(format!(
+            "fixture {} is already stamped (validated_unix_seconds {}) — to force \
+             re-validation, delete the manifest's `validation` block (or rebuild the \
+             fixture) and rerun `fixture validate`",
+            manifest.fixture_name, stamp.validated_unix_seconds
+        )
+        .into());
+    }
+    let store = fixture::store_dir(&dir);
+    // Open a copy: the engine's open path may write (recovery sweep), and the
+    // frozen bytes must stay exactly what the digest stamps.
+    let scratch = tempfile::tempdir()?;
+    let (files, bytes) = fixture::copy_dir_recursive(&store, scratch.path())?;
+    println!(
+        "[fixture {}] validating a copy: {} files, {:.1} MiB",
+        manifest.fixture_name,
+        files,
+        bytes as f64 / (1024.0 * 1024.0)
+    );
+    let root = scratch
+        .path()
+        .to_str()
+        .ok_or("scratch path is not UTF-8")?
+        .to_string();
+    let db = Omnigraph::open(&root).await?;
+    let row_counts = validate_row_counts(&db, &manifest.profile).await?;
+    let mut checks = vec!["row counts per table equal the spec's N".to_string()];
+    if manifest.state.index_level == IndexLevel::BtreeFresh {
+        verify_index_state(&db, manifest.profile.tables).await?;
+        checks.push(
+            "declared indexes present and covering (id BTREE Indexed, no unindexed fragments)"
+                .to_string(),
+        );
+    }
+    drop(db);
+    checks.push("no fetched artifacts (generated data; nothing to digest-pin)".to_string());
+    checks.push("content digest of the frozen store recorded".to_string());
+    let (store_files, store_bytes, content_digest_sha256) = fixture::digest_store_dir(&store)?;
+    manifest.validation = Some(ValidationStamp {
+        validated_unix_seconds: unix_now(),
+        checks,
+        row_counts,
+        store_files,
+        store_bytes,
+        content_digest_sha256,
+    });
+    manifest.manifest_version = fixture::MANIFEST_VERSION;
+    fixture::write_manifest_atomic(&dir, &manifest)?;
+    println!(
+        "[fixture {}] validated + stamped (manifest v{})",
+        manifest.fixture_name,
+        fixture::MANIFEST_VERSION
+    );
+    Ok(())
+}

--- a/crates/omnigraph-bench/src/groups.rs
+++ b/crates/omnigraph-bench/src/groups.rs
@@ -1,0 +1,367 @@
+//! Plain-language grouping of the 14 `MergeTimingPhase` buckets for the
+//! reader-facing views (`show` and `report`). Grouping adds a layer, never
+//! hides data: every view renders the raw phases (exact names, total/max µs)
+//! beneath their group.
+//!
+//! The mapping and every annotation are verified against the engine source
+//! (`crates/omnigraph/src/exec/merge.rs`, the `record_merge_timing` call
+//! sites):
+//!
+//! - `TableWalk` is the general route's per-table three-way ordered walk
+//!   plus merged-row staging (`stage_streaming_table_merge`), one interval
+//!   per table, disjoint from the keyed publish loop by construction. The
+//!   proven insert-only route bypasses the walk, so it reads zero there.
+//!   Records written before the phase existed carry no `TableWalk` entry —
+//!   their walk time stays in the unattributed remainder, honestly.
+//! - `KeyedStage`/`KeyedCommit` are per-chunk sub-intervals recorded inside
+//!   `commit_keyed_stream_chunks`, which BOTH publish routes share. On the
+//!   proven-insert route that loop runs inside the span recorded as
+//!   `PhysicalPublish` (`publish_proven_pure_insert_adopt` — the only
+//!   `PhysicalPublish` record site), so summing all three would double-count.
+//!   On the general rewrite route no `PhysicalPublish` interval is recorded
+//!   and the two sub-buckets are the only physical-write timings. The write
+//!   group therefore totals `max(PhysicalPublish, KeyedStage + KeyedCommit)`:
+//!   the parent when it exists, the bare sub-buckets when it does not, never
+//!   both. (A per-table mix of routes would undercount here and surface as
+//!   unattributed time — the honest direction.)
+//! - Shares are computed against the wall-clock median, not the phase sum, so
+//!   the "biggest cost" headline and the unattributed remainder agree.
+
+use std::collections::BTreeSet;
+
+use crate::record::PhaseStats;
+
+/// One plain-language group over raw phase names.
+struct PhaseGroup {
+    name: &'static str,
+    annotation: &'static str,
+    members: &'static [&'static str],
+}
+
+const WRITE_GROUP_NAME: &str = "write merged data";
+
+/// The seven groups, in phase-model order (rendering sorts by time).
+const GROUPS: [PhaseGroup; 7] = [
+    PhaseGroup {
+        name: "setup and refresh",
+        annotation: "resolve refs and the base snapshot, take the merge lock, point the \
+                     engine at the target; restore and refresh the handle afterwards",
+        members: &["OuterPrepare", "OuterRestoreRefresh"],
+    },
+    PhaseGroup {
+        name: "discover changes",
+        annotation: "prove the insert-only fast route from the source table's history \
+                     since the fork and plan its write chunks; zero when the merge takes \
+                     the general three-way route",
+        members: &["ProvenInsertHistory", "ProvenInsertPlanScan"],
+    },
+    PhaseGroup {
+        name: "table walk",
+        annotation: "the three-way row walk over base, source, and target plus \
+                     merged-row staging — grows with full table size, not delta size; \
+                     zero on the insert-only fast route",
+        members: &["TableWalk"],
+    },
+    PhaseGroup {
+        name: "validate changes",
+        annotation: "declared constraints evaluated over the merge delta against the \
+                     committed target through its indexes — scales with the delta, not \
+                     the table",
+        members: &["CandidateValidation", "FinalRevalidation"],
+    },
+    PhaseGroup {
+        name: WRITE_GROUP_NAME,
+        annotation: "stage and commit the bounded keyed Lance transactions that write \
+                     merged rows onto the target; KeyedStage/KeyedCommit are the \
+                     per-chunk sub-steps (inside PhysicalPublish on the insert-only \
+                     route, bare on the general route — counted once, never twice)",
+        members: &["PhysicalPublish", "KeyedStage", "KeyedCommit"],
+    },
+    PhaseGroup {
+        name: "publish new state",
+        annotation: "the one __manifest compare-and-swap that makes every merged table \
+                     version and the lineage commit visible together",
+        members: &["ManifestPublish"],
+    },
+    PhaseGroup {
+        name: "crash-safety bookkeeping",
+        annotation: "arm the recovery sidecar before the first durable effect, confirm \
+                     it after every effect lands, delete it after publish",
+        members: &["RecoveryArm", "RecoveryConfirm", "RecoveryCleanup"],
+    },
+];
+
+/// The name and annotation of the explicit remainder bar. Rendered only when
+/// the remainder share clears [`UNATTRIBUTED_MIN_SHARE_PCT`] — and never
+/// silently normalized away below it.
+pub const UNATTRIBUTED_NAME: &str = "not phase-attributed";
+pub const UNATTRIBUTED_ANNOTATION: &str = "wall-clock outside all 14 phases (on records written before the TableWalk phase \
+     existed, this includes the three-way row walk, which those binaries did not \
+     instrument)";
+pub const UNATTRIBUTED_MIN_SHARE_PCT: f64 = 5.0;
+
+/// Footnote rendered when the group totals sum past the wall-clock median
+/// (shares then exceed 100%): the math prints as computed, never silently
+/// capped, and this line explains why it can happen.
+pub const OVER_ATTRIBUTION_NOTE: &str =
+    "phase p50s are per-phase medians and need not sum under the wall-clock median";
+
+/// One raw phase as shown inside its group's unfolded detail.
+pub struct MemberReading {
+    pub name: String,
+    pub total_us_p50: u64,
+    pub total_us_max: u64,
+    pub max_single_us: u64,
+}
+
+pub struct GroupReading {
+    pub name: &'static str,
+    pub annotation: &'static str,
+    /// Group total in µs (p50 phase totals; the write group's containment
+    /// rule is documented on the module).
+    pub total_us: u64,
+    /// Share of the wall-clock median (percent). 0 when the wall is 0.
+    pub share_pct: f64,
+    pub members: Vec<MemberReading>,
+}
+
+pub struct GroupedPhases {
+    /// The seven groups (plus a catch-all for phases outside the known
+    /// mapping, so a future 14th phase can never vanish), sorted descending
+    /// by total.
+    pub groups: Vec<GroupReading>,
+    pub unattributed_us: u64,
+    pub unattributed_share_pct: f64,
+    /// Whether the group totals sum past the wall-clock median — possible
+    /// because each phase's p50 is taken independently across reps. Rendering
+    /// prints the shares as computed plus [`OVER_ATTRIBUTION_NOTE`].
+    pub over_attributed: bool,
+}
+
+impl GroupedPhases {
+    /// Whether the remainder is material enough to render its explicit bar.
+    pub fn shows_unattributed(&self) -> bool {
+        self.unattributed_share_pct > UNATTRIBUTED_MIN_SHARE_PCT
+    }
+
+    /// The headline "biggest cost": the largest group, or the unattributed
+    /// remainder when it is shown and larger — the two never disagree with
+    /// the bars below them.
+    pub fn biggest_cost(&self) -> (&'static str, f64) {
+        let top = self
+            .groups
+            .first()
+            .map(|g| (g.name, g.share_pct))
+            .unwrap_or((UNATTRIBUTED_NAME, 0.0));
+        if self.shows_unattributed() && self.unattributed_share_pct > top.1 {
+            (UNATTRIBUTED_NAME, self.unattributed_share_pct)
+        } else {
+            top
+        }
+    }
+}
+
+fn member(p: &PhaseStats) -> MemberReading {
+    MemberReading {
+        name: p.phase.clone(),
+        total_us_p50: p.total_us_p50,
+        total_us_max: p.total_us_max,
+        max_single_us: p.max_single_us,
+    }
+}
+
+/// Group a record's phases against its wall-clock median (ms).
+pub fn group_phases(phases: &[PhaseStats], wall_p50_ms: f64) -> GroupedPhases {
+    let wall_us = wall_p50_ms * 1000.0;
+    let share = |us: u64| {
+        if wall_us > 0.0 {
+            us as f64 / wall_us * 100.0
+        } else {
+            0.0
+        }
+    };
+    let find = |name: &str| phases.iter().find(|p| p.phase == name);
+    let mut grouped_names: BTreeSet<&str> = BTreeSet::new();
+    let mut groups: Vec<GroupReading> = Vec::with_capacity(GROUPS.len() + 1);
+    for group in &GROUPS {
+        let members: Vec<MemberReading> = group
+            .members
+            .iter()
+            .inspect(|name| {
+                grouped_names.insert(name);
+            })
+            .filter_map(|name| find(name))
+            .map(member)
+            .collect();
+        let total_us = if group.name == WRITE_GROUP_NAME {
+            // Containment rule: parent when recorded, bare sub-buckets when
+            // not — see the module doc.
+            let physical = find("PhysicalPublish").map_or(0, |p| p.total_us_p50);
+            let keyed = find("KeyedStage").map_or(0, |p| p.total_us_p50)
+                + find("KeyedCommit").map_or(0, |p| p.total_us_p50);
+            physical.max(keyed)
+        } else {
+            members.iter().map(|m| m.total_us_p50).sum()
+        };
+        groups.push(GroupReading {
+            name: group.name,
+            annotation: group.annotation,
+            total_us,
+            share_pct: share(total_us),
+            members,
+        });
+    }
+    let leftovers: Vec<MemberReading> = phases
+        .iter()
+        .filter(|p| !grouped_names.contains(p.phase.as_str()))
+        .map(member)
+        .collect();
+    if !leftovers.is_empty() {
+        let total_us = leftovers.iter().map(|m| m.total_us_p50).sum();
+        groups.push(GroupReading {
+            name: "other instrumented phases",
+            annotation: "phases outside this view's grouping — the grouping is stale; \
+                         update it (groups.rs) for the new phase list",
+            total_us,
+            share_pct: share(total_us),
+            members: leftovers,
+        });
+    }
+    groups.sort_by_key(|g| std::cmp::Reverse(g.total_us));
+    let attributed_us: u64 = groups.iter().map(|g| g.total_us).sum();
+    let unattributed_us = (wall_us - attributed_us as f64).max(0.0) as u64;
+    let over_attributed = wall_us > 0.0 && attributed_us as f64 > wall_us;
+    GroupedPhases {
+        groups,
+        over_attributed,
+        unattributed_us,
+        unattributed_share_pct: share(unattributed_us),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn phase(name: &str, p50: u64) -> PhaseStats {
+        PhaseStats {
+            phase: name.to_string(),
+            total_us_p50: p50,
+            total_us_max: p50 + 1,
+            max_single_us: p50,
+            per_rep_total_us: vec![p50],
+        }
+    }
+
+    fn group<'a>(grouped: &'a GroupedPhases, name: &str) -> &'a GroupReading {
+        grouped
+            .groups
+            .iter()
+            .find(|g| g.name == name)
+            .unwrap_or_else(|| panic!("no group {name}"))
+    }
+
+    #[test]
+    fn write_group_never_double_counts_the_keyed_sub_buckets() {
+        // Proven route: PhysicalPublish wraps the sub-buckets — parent wins.
+        let phases = [
+            phase("PhysicalPublish", 50_000),
+            phase("KeyedStage", 30_000),
+            phase("KeyedCommit", 10_000),
+        ];
+        let grouped = group_phases(&phases, 100.0);
+        let write = group(&grouped, "write merged data");
+        assert_eq!(write.total_us, 50_000, "parent covers its sub-buckets");
+        assert_eq!(write.members.len(), 3, "the fold still lists all three");
+
+        // General route: no PhysicalPublish interval — the bare sub-buckets
+        // are the write time and must not fall into unattributed.
+        let phases = [
+            phase("PhysicalPublish", 0),
+            phase("KeyedStage", 30_000),
+            phase("KeyedCommit", 10_000),
+        ];
+        let grouped = group_phases(&phases, 100.0);
+        assert_eq!(group(&grouped, "write merged data").total_us, 40_000);
+    }
+
+    #[test]
+    fn shares_are_against_wall_clock_and_remainder_is_explicit() {
+        // 100 ms wall, 20 ms in phases: 78% unattributed, never normalized.
+        let phases = [
+            phase("OuterPrepare", 15_000),
+            phase("ManifestPublish", 5_000),
+        ];
+        let grouped = group_phases(&phases, 100.0);
+        assert!((group(&grouped, "setup and refresh").share_pct - 15.0).abs() < 1e-9);
+        assert_eq!(grouped.unattributed_us, 80_000);
+        assert!((grouped.unattributed_share_pct - 80.0).abs() < 1e-9);
+        assert!(grouped.shows_unattributed());
+        assert_eq!(grouped.biggest_cost().0, UNATTRIBUTED_NAME);
+
+        // Phases covering the wall: no unattributed bar, biggest cost is the
+        // top group.
+        let phases = [
+            phase("OuterPrepare", 97_000),
+            phase("ManifestPublish", 3_000),
+        ];
+        let grouped = group_phases(&phases, 100.0);
+        assert!(!grouped.shows_unattributed());
+        assert_eq!(grouped.biggest_cost().0, "setup and refresh");
+        // Groups sorted descending by time.
+        assert_eq!(grouped.groups[0].name, "setup and refresh");
+    }
+
+    #[test]
+    fn table_walk_is_its_own_group_and_collapses_the_remainder() {
+        // A general-route record from a TableWalk-aware binary: the walk is
+        // the named majority and the phases now cover the wall.
+        let phases = [
+            phase("TableWalk", 82_000),
+            phase("OuterPrepare", 10_000),
+            phase("KeyedStage", 8_000),
+        ];
+        let grouped = group_phases(&phases, 100.0);
+        assert_eq!(group(&grouped, "table walk").total_us, 82_000);
+        assert_eq!(grouped.groups[0].name, "table walk");
+        assert!(!grouped.shows_unattributed());
+        assert_eq!(grouped.biggest_cost().0, "table walk");
+        // A pre-TableWalk record (no such phase) keeps its walk time in the
+        // explicit remainder instead.
+        let grouped = group_phases(&phases[1..], 100.0);
+        assert_eq!(group(&grouped, "table walk").total_us, 0);
+        assert!(grouped.shows_unattributed());
+    }
+
+    #[test]
+    fn unknown_phases_never_vanish() {
+        let phases = [phase("SomeFuturePhase", 9_000)];
+        let grouped = group_phases(&phases, 10.0);
+        let other = group(&grouped, "other instrumented phases");
+        assert_eq!(other.total_us, 9_000);
+        assert_eq!(other.members[0].name, "SomeFuturePhase");
+    }
+
+    #[test]
+    fn zero_wall_clock_never_divides() {
+        let grouped = group_phases(&[phase("OuterPrepare", 100)], 0.0);
+        assert_eq!(grouped.unattributed_us, 0);
+        assert_eq!(group(&grouped, "setup and refresh").share_pct, 0.0);
+        assert!(!grouped.over_attributed);
+    }
+
+    #[test]
+    fn over_attribution_prints_as_computed_and_is_flagged() {
+        // Per-phase medians summing past the wall median: shares stay as
+        // computed (here 120%), never silently capped; the flag drives the
+        // footnote.
+        let grouped = group_phases(&[phase("OuterPrepare", 120_000)], 100.0);
+        assert!(grouped.over_attributed);
+        assert!((group(&grouped, "setup and refresh").share_pct - 120.0).abs() < 1e-9);
+        assert_eq!(grouped.unattributed_us, 0);
+        assert!(!grouped.shows_unattributed());
+        // Fully-attributed records never carry the flag.
+        let grouped = group_phases(&[phase("OuterPrepare", 90_000)], 100.0);
+        assert!(!grouped.over_attributed);
+    }
+}

--- a/crates/omnigraph-bench/src/list.rs
+++ b/crates/omnigraph-bench/src/list.rs
@@ -1,0 +1,102 @@
+//! The `list` subcommand: enumerate the runnable benchmark points (known
+//! scenarios x frozen fixtures x their pre-tagged deltas x the three warmth
+//! regimes). The point name is the run spec flattened (RFC 0039), so this
+//! list is also the naming reference.
+
+use std::path::PathBuf;
+
+use clap::Args;
+
+use crate::fixture::{self, BenchResult};
+use crate::record;
+
+#[derive(Debug, Args)]
+pub struct ListArgs {
+    /// Directory holding frozen fixtures; omit to list only the points
+    /// runnable without a fixture (inline base build).
+    #[arg(long)]
+    fixtures_root: Option<PathBuf>,
+}
+
+pub fn list_points(args: ListArgs) -> BenchResult<()> {
+    const WARMTHS: [&str; 3] = ["warm", "cold", "post-invalidation"];
+    let mut any = false;
+    if let Some(root) = &args.fixtures_root {
+        let mut dirs: Vec<PathBuf> = std::fs::read_dir(root)
+            .map_err(|e| format!("reading {}: {e}", root.display()))?
+            .filter_map(|entry| entry.ok().map(|e| e.path()))
+            .filter(|p| p.is_dir())
+            .collect();
+        dirs.sort();
+        for dir in dirs {
+            let manifest = match fixture::load_manifest(&dir) {
+                Ok(m) => m,
+                Err(e) => {
+                    println!("(skipping {}: {e})", dir.display());
+                    continue;
+                }
+            };
+            let stamped = manifest.validation.is_some();
+            let tag = fixture::state_tag(manifest.state.index_level);
+            let p = &manifest.profile;
+            let non_default_diverged =
+                (p.diverged_tables != p.tables.min(4)).then_some(p.diverged_tables);
+            let mut scenarios = vec!["m3"];
+            if p.diverged_tables == p.tables {
+                scenarios.push("m5");
+            }
+            for scenario in scenarios {
+                for &delta in &p.deltas {
+                    for warmth in WARMTHS {
+                        let name = record::point_name(
+                            scenario,
+                            p.tables,
+                            p.rows,
+                            p.payload_bytes,
+                            tag,
+                            non_default_diverged,
+                            delta,
+                            warmth,
+                            false,
+                        );
+                        println!(
+                            "{name}  [fixture {}{}]",
+                            manifest.fixture_name,
+                            if stamped {
+                                ""
+                            } else {
+                                ", UNSTAMPED — run refuses it; stamp with `fixture validate`"
+                            }
+                        );
+                        any = true;
+                    }
+                }
+            }
+        }
+    }
+    if !any {
+        println!(
+            "(no frozen-fixture points{})",
+            if args.fixtures_root.is_some() {
+                ""
+            } else {
+                " — pass --fixtures-root to enumerate them"
+            }
+        );
+    }
+    println!();
+    println!("inline points (no fixture; base built per run):");
+    for warmth in WARMTHS {
+        println!(
+            "  {}",
+            record::point_name("m3", 12, 10_000, 64, "noindex", None, 50, warmth, false)
+        );
+    }
+    println!("  (m3 sweeps d=1,50,5000 by default; m5 runs d=50 with every table diverged)");
+    println!();
+    println!(
+        "run a point: omnigraph-bench run --scenario <m3|m5> [--fixture <dir>] \
+         --delta <d> --warmth <regime> --out <dir>"
+    );
+    Ok(())
+}

--- a/crates/omnigraph-bench/src/machine.rs
+++ b/crates/omnigraph-bench/src/machine.rs
@@ -1,0 +1,148 @@
+//! Machine-specification auto-capture (RFC 0039 Environment class: "machine
+//! specification: processor, cores, memory, storage class (auto-captured)").
+//!
+//! Rule 4 makes the machine spec part of every number's identity, so capture
+//! must be automatic, never typed by hand. Fields that cannot be determined on
+//! this platform are recorded as an honest `"unknown"` / absent rather than
+//! guessed: an unknown identity still blocks a silent comparison, a guessed
+//! one manufactures a false match.
+
+use std::process::Command;
+
+use crate::record::MachineSpec;
+
+/// Run a command and return trimmed stdout on success. `sysctl`/`diskutil`
+/// live in `/usr/sbin`, which is not always on a build tool's PATH, so a bare
+/// name is retried under `/usr/sbin` and `/usr/bin` before giving up.
+fn cmd_out(program: &str, args: &[&str]) -> Option<String> {
+    let candidates = [
+        program.to_string(),
+        format!("/usr/sbin/{program}"),
+        format!("/usr/bin/{program}"),
+    ];
+    for candidate in &candidates {
+        let Ok(out) = Command::new(candidate).args(args).output() else {
+            continue;
+        };
+        if !out.status.success() {
+            continue;
+        }
+        let Ok(text) = String::from_utf8(out.stdout) else {
+            continue;
+        };
+        let trimmed = text.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+    None
+}
+
+fn sysctl(name: &str) -> Option<String> {
+    cmd_out("sysctl", &["-n", name])
+}
+
+/// First `/proc/cpuinfo`-style value for `key` ("key<tab>: value").
+#[cfg(target_os = "linux")]
+fn proc_value(path: &str, key: &str) -> Option<String> {
+    let text = std::fs::read_to_string(path).ok()?;
+    text.lines()
+        .find(|line| line.starts_with(key))
+        .and_then(|line| line.split(':').nth(1))
+        .map(|v| v.trim().to_string())
+}
+
+fn capture_macos() -> MachineSpec {
+    // `diskutil info /` reports "Solid State: Yes|No" for the boot volume.
+    let storage_class = cmd_out("diskutil", &["info", "/"])
+        .and_then(|text| {
+            text.lines()
+                .find(|line| line.contains("Solid State"))
+                .map(|line| line.contains("Yes"))
+        })
+        .map(|ssd| if ssd { "ssd" } else { "rotational" })
+        .unwrap_or("unknown")
+        .to_string();
+    MachineSpec {
+        os: std::env::consts::OS.to_string(),
+        arch: std::env::consts::ARCH.to_string(),
+        os_version: cmd_out("sw_vers", &["-productVersion"]).unwrap_or_else(|| "unknown".into()),
+        cpu_model: sysctl("machdep.cpu.brand_string").unwrap_or_else(|| "unknown".into()),
+        physical_cores: sysctl("hw.physicalcpu").and_then(|v| v.parse().ok()),
+        // In-process fallback: sandboxed environments deny the sysctl
+        // syscall; available_parallelism needs no privilege.
+        logical_cores: sysctl("hw.logicalcpu")
+            .and_then(|v| v.parse().ok())
+            .or_else(|| {
+                std::thread::available_parallelism()
+                    .ok()
+                    .map(|n| n.get() as u64)
+            }),
+        memory_bytes: sysctl("hw.memsize").and_then(|v| v.parse().ok()),
+        storage_class,
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn capture_linux() -> MachineSpec {
+    // MemTotal is reported in kB.
+    let memory_bytes = proc_value("/proc/meminfo", "MemTotal")
+        .and_then(|v| {
+            v.split_whitespace()
+                .next()
+                .and_then(|kb| kb.parse::<u64>().ok())
+        })
+        .map(|kb| kb * 1024);
+    MachineSpec {
+        os: std::env::consts::OS.to_string(),
+        arch: std::env::consts::ARCH.to_string(),
+        os_version: cmd_out("uname", &["-r"]).unwrap_or_else(|| "unknown".into()),
+        cpu_model: proc_value("/proc/cpuinfo", "model name").unwrap_or_else(|| "unknown".into()),
+        physical_cores: None,
+        logical_cores: std::thread::available_parallelism()
+            .ok()
+            .map(|n| n.get() as u64),
+        memory_bytes,
+        storage_class: "unknown".to_string(),
+    }
+}
+
+fn capture_fallback() -> MachineSpec {
+    MachineSpec {
+        os: std::env::consts::OS.to_string(),
+        arch: std::env::consts::ARCH.to_string(),
+        os_version: "unknown".to_string(),
+        cpu_model: "unknown".to_string(),
+        physical_cores: None,
+        logical_cores: std::thread::available_parallelism()
+            .ok()
+            .map(|n| n.get() as u64),
+        memory_bytes: None,
+        storage_class: "unknown".to_string(),
+    }
+}
+
+/// Auto-capture this machine's specification.
+pub fn capture() -> MachineSpec {
+    match std::env::consts::OS {
+        "macos" => capture_macos(),
+        #[cfg(target_os = "linux")]
+        "linux" => capture_linux(),
+        _ => capture_fallback(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capture_names_the_platform() {
+        let spec = capture();
+        assert_eq!(spec.os, std::env::consts::OS);
+        assert_eq!(spec.arch, std::env::consts::ARCH);
+        // Fields are honest: either a real value or the explicit unknown.
+        assert!(!spec.cpu_model.is_empty());
+        assert!(!spec.storage_class.is_empty());
+    }
+}

--- a/crates/omnigraph-bench/src/main.rs
+++ b/crates/omnigraph-bench/src/main.rs
@@ -1,0 +1,324 @@
+//! omnigraph-bench — the branch-control micro-benchmark under RFC 0039 (the
+//! end-to-end benchmark), benchmark v1.
+//!
+//! Measures `branch_merge` wall-clock, the 14-phase `MergeTimingPhase`
+//! breakdown, and per-repetition storage-call counts on a parameterized
+//! multi-table fixture, and writes one schema-validated JSON run record per
+//! point (run spec + SUT block + machine spec + declared warmth). `diff`
+//! compares two records (or directories) matched by their full point name,
+//! warns on identity mismatches (rule 4), and labels deltas against the
+//! session's A/A noise floor and claim margin (rule 7). `show` renders one
+//! record (or directory) as tables. `fixture build` validates and freezes a
+//! base store; `run --fixture` refuses an unvalidated or modified fixture.
+//! `list` enumerates the runnable points. See this crate's README for the run
+//! protocol and the deferrals.
+
+// The merge future is deep and the run body executes under the probe
+// task-local scope; the engine's own cost tests raise the same limit.
+#![recursion_limit = "512"]
+
+mod counting;
+mod diff;
+mod fixture;
+mod fixture_cmd;
+mod groups;
+mod list;
+mod machine;
+mod record;
+mod report;
+mod run;
+mod schema;
+
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use clap::{Parser, Subcommand};
+
+use fixture::BenchResult;
+use fixture_cmd::FixtureBuildArgs;
+use list::ListArgs;
+use run::RunArgs;
+
+#[derive(Parser)]
+#[command(
+    name = "omnigraph-bench",
+    about = "Branch-control micro-benchmark (RFC 0039 micro profile): merge wall-clock, phase \
+             attribution, storage-call counts (release builds only)"
+)]
+struct Cli {
+    #[command(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Subcommand)]
+enum Cmd {
+    /// Acquire a base store (build inline, or copy a validated frozen
+    /// fixture), run a merge scenario under one declared warmth regime, write
+    /// one schema-validated run record per point.
+    Run(Box<RunArgs>),
+    /// Compare two run records (files) or two run directories matched by
+    /// point name; prints per-phase absolute + percent deltas, warns on
+    /// identity mismatches, labels deltas against the floor and margin.
+    Diff {
+        a: PathBuf,
+        b: PathBuf,
+        /// noise-floor.json from `run --aa`; deltas below the floor read
+        /// "no detected effect" (RFC 0039 rule 7).
+        #[arg(long)]
+        floor: Option<PathBuf>,
+        /// Claim margin (rule 7): an effect must exceed floor x margin to be
+        /// claimable. Overrides the floor file's persisted default (2.0).
+        #[arg(long)]
+        margin: Option<f64>,
+        /// Output format: aligned text, or GitHub-flavored markdown tables.
+        #[arg(long, value_enum, default_value_t = diff::Format::Text)]
+        format: diff::Format,
+    },
+    /// Render run records (a file or a directory) as one self-contained HTML
+    /// page: overview, per-record phase and storage-call charts (inline SVG,
+    /// no external requests, no JavaScript), full identity, and — with
+    /// --floor — rule-7-labeled A/A pair deltas.
+    Report(report::ReportArgs),
+    /// Render one run record (or every record of a directory) as tables:
+    /// identity, wall-clock, phases, write path, storage calls.
+    Show {
+        path: PathBuf,
+        /// Output format: aligned text, or GitHub-flavored markdown tables.
+        #[arg(long, value_enum, default_value_t = diff::Format::Text)]
+        format: diff::Format,
+    },
+    /// Frozen base-store fixtures (build + validate once, run many).
+    Fixture {
+        #[command(subcommand)]
+        cmd: FixtureCmd,
+    },
+    /// Enumerate the runnable benchmark points (known scenarios x frozen
+    /// fixtures x pre-tagged deltas x warmth regimes).
+    List(ListArgs),
+}
+
+#[derive(Subcommand)]
+enum FixtureCmd {
+    /// Build a frozen base store from Data+State parameters into
+    /// `<fixtures-root>/<derived-name>/`, run the validation pass, and stamp
+    /// `fixture-manifest.json`. A fixture that fails validation never
+    /// freezes.
+    Build(Box<FixtureBuildArgs>),
+    /// Run the validation pass on an existing stamp-less fixture (e.g. the
+    /// manifest's stamp was deleted to force re-validation) and stamp its
+    /// manifest in place. The frozen store is validated on a copy and
+    /// digested untouched. An already-stamped fixture is refused.
+    Validate { dir: PathBuf },
+    /// Print this binary's fixture builder version (an integer): the value a
+    /// frozen fixture's manifest must match for `run --fixture` to accept it.
+    /// Scripts compare it against a cached fixture's manifest before skipping
+    /// a rebuild.
+    BuilderVersion,
+}
+
+fn main() -> std::process::ExitCode {
+    let cli = Cli::parse();
+    // The session id (RFC 0039): one harness invocation batch = one CLI run
+    // here; minted once and persisted in every record this batch writes.
+    let session_id = ulid::Ulid::new().to_string();
+    let result = match cli.cmd {
+        Cmd::Run(args) => on_big_stack(move || run::run(*args, session_id)),
+        Cmd::Diff {
+            a,
+            b,
+            floor,
+            margin,
+            format,
+        } => diff::run_diff(&a, &b, floor.as_deref(), margin, format),
+        Cmd::Report(args) => report::run_report(args),
+        Cmd::Show { path, format } => diff::run_show(&path, format),
+        Cmd::Fixture {
+            cmd: FixtureCmd::Build(args),
+        } => on_big_stack(move || fixture_cmd::fixture_build(*args)),
+        Cmd::Fixture {
+            cmd: FixtureCmd::Validate { dir },
+        } => on_big_stack(move || fixture_cmd::fixture_validate(dir)),
+        Cmd::Fixture {
+            cmd: FixtureCmd::BuilderVersion,
+        } => {
+            println!("{}", fixture::BUILDER_VERSION);
+            Ok(())
+        }
+        Cmd::List(args) => list::list_points(args),
+    };
+    match result {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("error: {err}");
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+
+/// Run an async body on a dedicated 64 MiB-stack thread with a
+/// current-thread runtime — the same shape the engine's merge cost tests use
+/// (the merge future is deep, and the timing task-local must stay on the
+/// merge's own task).
+fn on_big_stack<Fut>(make: impl FnOnce() -> Fut + Send + 'static) -> BenchResult<()>
+where
+    Fut: std::future::Future<Output = BenchResult<()>>,
+{
+    std::thread::Builder::new()
+        .stack_size(64 * 1024 * 1024)
+        .spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::new(e) })?
+                .block_on(make())
+        })?
+        .join()
+        .map_err(|_| "bench thread panicked")?
+}
+
+/// Debug-build guard (RFC 0039 rule 2): a debug-build number must be
+/// impossible to record, and a debug-built fixture must be impossible to
+/// freeze or stamp (its provenance would lie beside release runs). The guard
+/// reads `cfg!(debug_assertions)` — an approximation of "release"; the
+/// record's `build_opt_level` carries the hard datum.
+pub fn refuse_debug_build(what: &str) -> BenchResult<()> {
+    if cfg!(debug_assertions) {
+        return Err(format!(
+            "this is a debug build; {what} from it is refused (rebuild with --release)"
+        )
+        .into());
+    }
+    Ok(())
+}
+
+pub fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_secs()
+}
+
+/// The SUT commit for records and manifests. Primary source: the commit
+/// embedded at BUILD time by `build.rs` ("-dirty" appended when the build
+/// tree had uncommitted tracked changes) — the value describes the binary,
+/// and cold child processes report the same embedded value by construction.
+/// The build script's rerun triggers watch `.git/HEAD` and the index only, so
+/// an unstaged tracked edit re-links with the OLD embedded values; when
+/// run-time git disagrees with them, "-stale-build" is appended (the record
+/// still writes, marked) and a one-line warning goes to stderr. Fallback when
+/// the build embedded nothing (git unavailable at build time): run-time
+/// `git rev-parse`, labeled "unverified" because the tree may have moved
+/// since the build; "unknown" when neither source is available.
+pub fn source_commit() -> String {
+    if let Some(commit) = option_env!("OMNIGRAPH_BENCH_GIT_COMMIT") {
+        let embedded_dirty = matches!(option_env!("OMNIGRAPH_BENCH_GIT_DIRTY"), Some("1"));
+        let value = compose_source_commit(commit, embedded_dirty, runtime_git_state().as_ref());
+        if value.ends_with(STALE_BUILD_SUFFIX) {
+            // Once per process: every record of a batch carries the marker,
+            // one warning explains it.
+            static STALE_WARNING: std::sync::Once = std::sync::Once::new();
+            STALE_WARNING.call_once(|| {
+                eprintln!(
+                    "warning: the tree no longer matches the commit embedded in this binary \
+                     (an unstaged edit does not re-trigger the build script) — records are \
+                     marked '{STALE_BUILD_SUFFIX}'; rebuild to clear it"
+                );
+            });
+        }
+        return value;
+    }
+    std::process::Command::new("git")
+        .args(["-C", env!("CARGO_MANIFEST_DIR"), "rev-parse", "HEAD"])
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .and_then(|out| String::from_utf8(out.stdout).ok())
+        .map(|s| format!("unverified:{}", s.trim()))
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Marker appended to `source_commit` when run-time git contradicts the
+/// build-time embedding (see [`source_commit`]).
+const STALE_BUILD_SUFFIX: &str = "-stale-build";
+
+/// Compose the SUT commit string from the embedded values and the run-time
+/// git state (`None` when git is unavailable at run time — the embedded value
+/// then stands unchecked, exactly as on a machine without the source tree).
+fn compose_source_commit(
+    embedded_commit: &str,
+    embedded_dirty: bool,
+    runtime: Option<&(String, bool)>,
+) -> String {
+    let mut value = if embedded_dirty {
+        format!("{embedded_commit}-dirty")
+    } else {
+        embedded_commit.to_string()
+    };
+    if let Some((runtime_commit, runtime_dirty)) = runtime {
+        if runtime_commit != embedded_commit || *runtime_dirty != embedded_dirty {
+            value.push_str(STALE_BUILD_SUFFIX);
+        }
+    }
+    value
+}
+
+/// Run-time (commit, dirty) of the source tree the binary was built in, when
+/// git can still see it. The dirty probe uses the same `-uno` flags as
+/// `build.rs` so the comparison is like with like.
+fn runtime_git_state() -> Option<(String, bool)> {
+    let git = |args: &[&str]| -> Option<String> {
+        let out = std::process::Command::new("git")
+            .args(["-C", env!("CARGO_MANIFEST_DIR")])
+            .args(args)
+            .output()
+            .ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        String::from_utf8(out.stdout)
+            .ok()
+            .map(|s| s.trim().to_string())
+    };
+    let commit = git(&["rev-parse", "HEAD"])?;
+    // A failed status deliberately reads as dirty — the honest direction,
+    // and the same policy `build.rs` applies to the embedded flag.
+    let dirty = git(&["status", "--porcelain", "-uno"]).is_none_or(|s| !s.is_empty());
+    Some((commit, dirty))
+}
+
+/// The `OPT_LEVEL` cargo compiled this binary with, embedded by `build.rs`.
+pub fn build_opt_level() -> String {
+    option_env!("OMNIGRAPH_BENCH_OPT_LEVEL")
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stale_build_suffix_marks_any_runtime_disagreement() {
+        let rt = |commit: &str, dirty: bool| Some((commit.to_string(), dirty));
+        // (embedded commit, embedded dirty, runtime state, expected)
+        let cases = [
+            ("abc", false, rt("abc", false), "abc"),
+            ("abc", true, rt("abc", true), "abc-dirty"),
+            // Unstaged-edit window: same commit, dirty flipped at run time.
+            ("abc", false, rt("abc", true), "abc-stale-build"),
+            ("abc", true, rt("abc", false), "abc-dirty-stale-build"),
+            // HEAD moved without touching the index (e.g. soft reset).
+            ("abc", false, rt("def", false), "abc-stale-build"),
+            // No git at run time: the embedded value stands unchecked.
+            ("abc", false, None, "abc"),
+            ("abc", true, None, "abc-dirty"),
+        ];
+        for (commit, dirty, runtime, expected) in cases {
+            assert_eq!(
+                compose_source_commit(commit, dirty, runtime.as_ref()),
+                expected,
+                "embedded ({commit}, dirty={dirty})"
+            );
+        }
+    }
+}

--- a/crates/omnigraph-bench/src/record.rs
+++ b/crates/omnigraph-bench/src/record.rs
@@ -1,0 +1,1117 @@
+//! Run-record schema v3 (one JSON file per run) and small stat helpers.
+//!
+//! v3 aligns the record with RFC 0039 (the end-to-end benchmark):
+//!
+//! - the five-class factorization is named `run_spec` (fixture + workload +
+//!   conditions) and doubles as the natural key; its serialized form is the
+//!   [`RunRecord::point_name`];
+//! - the **SUT block** ([`SutBlock`]) sits deliberately OUTSIDE the run spec
+//!   (RFC 0039: "the spec describes the experiment, the SUT is the subject"):
+//!   source commit, build profile, and the engine configuration captured as
+//!   data (every `OMNIGRAPH_*` environment variable), never as prose labels;
+//! - the auto-captured [`MachineSpec`] is record-level identity beside the
+//!   SUT (rule 4), outside the run spec; the Environment class carries the
+//!   declared [`WarmthDeclaration`] (one regime per cell, rule 3);
+//! - the record declares its [`RunRecord::profile`] ("micro") and names the
+//!   in-process phase readout as an implementation interim, per the RFC's
+//!   profile definition;
+//! - `results.storage_calls` records per-repetition object-store call counts
+//!   per class (get / put / list / ...) beside the timings.
+//!
+//! The normative field list is the JSON Schema shipped with this crate
+//! (`schema/run-record-v3.schema.json`, see `schema.rs`): records validate on
+//! write (the harness refuses to emit an invalid record) and on read (`diff`
+//! refuses to consume one). v1/v2 records remain readable through
+//! [`v2::RunRecord`] + [`upgrade_v2`]; `diff` upgrades them on load.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::counting::CallCounts;
+use crate::fixture::{BaseProfile, KindSplit};
+
+/// v3: run_spec + SUT block + machine spec + warmth declaration + profile +
+/// per-run storage-call counts (breaking rename of v2's `five_tuple`; v2 stays
+/// readable through [`v2`]).
+pub const RECORD_VERSION: u32 = 3;
+
+/// Version of the point-name serialization format (RFC 0039: a name is
+/// decodable only with its format, so the format version is a persisted field
+/// of every record). Format 1 is [`point_name`]'s layout.
+pub const POINT_NAME_FORMAT: u32 = 1;
+
+/// The profile every record of this harness declares (RFC 0039: canonical
+/// region of the run-spec space, named so it can be invoked without reciting
+/// levels). This binary implements the micro profile only.
+pub const PROFILE_MICRO: &str = "micro";
+
+/// How the micro profile's per-phase attribution is served while the engine's
+/// phase-timing exposure is unshipped (RFC 0039: "the harness's in-process
+/// access is an implementation interim, not a different instrument").
+pub const INSTRUMENT_ACCESS_INTERIM: &str = "in-process (implementation interim per RFC 0039: the public-surface phase-timing \
+     exposure is unshipped; wall-clock and phases are read via \
+     MergeWriteProbes::merge_timing_snapshot on the merge future)";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunRecord {
+    pub record_version: u32,
+    /// The run spec flattened into one string — the natural key a series over
+    /// time shares (e.g. `m3-t8-n100k-btree-fresh-d50-warm`).
+    pub point_name: String,
+    /// The point-name format version ([`POINT_NAME_FORMAT`]): a name is
+    /// decodable only with its format (RFC 0039).
+    pub point_name_format: u32,
+    /// "micro" (the realistic profile is not implemented by this binary).
+    pub profile: String,
+    /// How the instrument reaches its measurements (the in-process interim).
+    pub instrument_access: String,
+    /// Optional operator label ("baseline-main", "after-O3", ...).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    /// Caller-minted unique id generated when the invocation starts (a
+    /// ULID here). One record holds one invocation, its repetitions as rows
+    /// inside it; (spec, SUT, invocation id) identifies one record uniquely
+    /// (RFC 0039) — identity never rests on clock resolution.
+    pub invocation_id: String,
+    /// The session id (RFC 0039: one harness invocation batch on one machine)
+    /// — a ULID minted once per CLI run and persisted in every record the
+    /// batch produces. "unknown" only on upgraded v1/v2 records.
+    #[serde(default = "unknown_string")]
+    pub session_id: String,
+    /// Seconds since UNIX epoch when this invocation started (UTC).
+    /// Persisted for ordering only; identity is the invocation id.
+    pub invocation_unix_seconds: u64,
+    pub run_spec: RunSpec,
+    pub sut: SutBlock,
+    /// Auto-captured machine specification — record-level identity beside the
+    /// SUT (RFC 0039 rule 4), deliberately outside the run spec: two runs of
+    /// one spec on two machines are the same experiment on different
+    /// hardware, and the identity warning (not the pairing key) carries that.
+    pub machine: MachineSpec,
+    pub results: RunResults,
+}
+
+impl RunRecord {
+    /// The scenario id ("m3" | "m5"), owned by the workload axes (single
+    /// owner; upgraded v1/v2 records fold their top-level copy in here).
+    pub fn scenario(&self) -> &str {
+        &self.run_spec.workload.scenario
+    }
+}
+
+/// The five-class run spec: fixture (Data + State) + workload + conditions
+/// (Environment + Protocol). Equal specs are directly comparable and form one
+/// series over time; the SUT is deliberately not in here.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunSpec {
+    pub data: DataAxes,
+    pub state: StateAxes,
+    pub workload: WorkloadAxes,
+    pub environment: EnvironmentAxes,
+    pub protocol: ProtocolAxes,
+}
+
+/// The system under test: what the run measures, outside the spec.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SutBlock {
+    /// The commit the binary was built from, embedded at build time
+    /// ("-dirty" appended when the build tree had uncommitted changes;
+    /// "unverified:<sha>" when the build embedded nothing and the value came
+    /// from run-time git; "unknown" when neither source was available).
+    pub source_commit: String,
+    /// "release" on v3-written records — an approximation derived from the
+    /// debug-assertions guard (`cfg!(debug_assertions)` off), not from cargo's
+    /// profile name; `build_opt_level` carries the hard datum. Upgraded v1/v2
+    /// records carry whatever their protocol block recorded.
+    pub build_profile: String,
+    /// The `OPT_LEVEL` cargo compiled this binary with, embedded at build
+    /// time ("unknown" on records that predate the field).
+    #[serde(default = "unknown_string")]
+    pub build_opt_level: String,
+    /// Engine configuration as data: every `OMNIGRAPH_*` environment variable
+    /// set at run time (feature flags and enabled techniques, e.g.
+    /// `OMNIGRAPH_MERGE_LINEAGE`). Empty map = no flag set, recorded as such.
+    pub engine_configuration: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DataAxes {
+    /// Data provenance factor ("synthetic" | "corpus-derived") — one of the
+    /// three levels the profile is decided from (RFC 0039: a profile is
+    /// decidable from a spec's levels alone). This builder generates, so
+    /// every record here reads "synthetic"; the serde default covers v1/v2
+    /// records, which were synthetic by construction.
+    #[serde(default = "synthetic")]
+    pub provenance: String,
+    /// T — node-table count.
+    pub tables: usize,
+    /// N — base rows per table.
+    pub rows_per_table: usize,
+    pub column_shape: String,
+    pub payload_bytes: usize,
+}
+
+fn synthetic() -> String {
+    "synthetic".to_string()
+}
+
+/// The micro profile's three deciding levels (RFC 0039 profile definition).
+pub const ARRIVAL_UNSCHEDULED_SINGLE_SHOT: &str = "unscheduled single-shot";
+pub const PROVENANCE_SYNTHETIC: &str = "synthetic";
+pub const ATTRIBUTION_PER_PHASE_ON: &str = "per-phase on";
+
+/// Decide the profile from the spec's levels (RFC 0039: decidable from a
+/// spec's levels alone, never asserted independently). `None` = the spec
+/// falls in neither profile's region (a valid run, named by its full spec).
+pub fn derive_profile(spec: &RunSpec) -> Option<&'static str> {
+    if spec.workload.arrival == ARRIVAL_UNSCHEDULED_SINGLE_SHOT
+        && spec.data.provenance == PROVENANCE_SYNTHETIC
+        && spec.protocol.attribution == ATTRIBUTION_PER_PHASE_ON
+    {
+        return Some(PROFILE_MICRO);
+    }
+    None
+}
+
+/// F1–F5 fixture-state axes. Fresh-only levels name their stub explicitly so
+/// a later real sweep is a value change, not a schema change.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StateAxes {
+    pub fragmentation: String,
+    pub index_existence: String,
+    pub index_freshness: String,
+    pub deletion_history: String,
+    pub compaction_recency: String,
+    /// The dataset builder's version (RFC 0039: the builder's identity is
+    /// persisted with every run) — recorded unconditionally on v3 writes,
+    /// fixture and inline alike; absent only on upgraded v1/v2 records.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub builder_version: Option<u32>,
+    /// The builder's generation parameters (the base profile) — with
+    /// `builder_version` these fully determine the generated bytes, so an
+    /// inline record stays rebuildable without a fixture directory. Absent
+    /// only on upgraded v1/v2 records.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub generation: Option<BaseProfile>,
+    /// Commits on main after the base load (load chunks + init).
+    pub base_load_commits: usize,
+    /// Frozen-fixture provenance: the fixture's directory name, when the run
+    /// used `--fixture` instead of building its base inline.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fixture_name: Option<String>,
+    /// The fixture's full `fixture-manifest.json` (validation stamp included),
+    /// embedded verbatim so the record stays self-describing without the
+    /// fixture directory.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fixture_manifest: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkloadAxes {
+    pub scenario: String,
+    pub merge_kind: String,
+    /// Arrival factor ("unscheduled single-shot" here; scheduled arrivals
+    /// belong to the realistic profile) — profile-deciding level. The serde
+    /// default covers v1/v2 records, which were single-shot by construction.
+    #[serde(default = "unscheduled_single_shot")]
+    pub arrival: String,
+    /// d — delta rows per side.
+    pub delta_rows_per_side: usize,
+    pub delta_split_per_side: KindSplit,
+    pub diverged_tables: usize,
+}
+
+fn unscheduled_single_shot() -> String {
+    ARRIVAL_UNSCHEDULED_SINGLE_SHOT.to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnvironmentAxes {
+    /// Backend id — load-bearing (repo rule: never generic "disk").
+    /// "local-fs-tempdir" for the default `file://`-semantics run;
+    /// "s3-compatible" when `--root-uri s3://...` points at MinIO/RustFS/S3.
+    pub backend: String,
+    pub root_uri_scheme: String,
+    /// `AWS_ENDPOINT_URL_S3` at run time, when the backend is S3-compatible —
+    /// part of the backend identity (rule 4).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub s3_endpoint: Option<String>,
+    /// The declared warmth regime of this cell (rule 3: exactly one).
+    pub warmth: WarmthDeclaration,
+}
+
+/// Auto-captured machine identity. Unknown fields say "unknown"/absent rather
+/// than guessing; an unknown identity still blocks a silent comparison.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MachineSpec {
+    pub os: String,
+    pub arch: String,
+    pub os_version: String,
+    pub cpu_model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub physical_cores: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub logical_cores: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory_bytes: Option<u64>,
+    /// "ssd" | "rotational" | "unknown".
+    pub storage_class: String,
+}
+
+/// One warmth regime per cell (RFC 0039 rule 3: mixing regimes within a cell
+/// invalidates it).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WarmthDeclaration {
+    /// "cold" | "warm" | "post-invalidation" ("uncontrolled-v2" only on
+    /// records upgraded from v1/v2, which mixed rep 1's cold caches into the
+    /// warm cell).
+    pub regime: String,
+    /// Warm-up repetitions run and discarded before measurement (0 for cold).
+    pub warmup_reps_discarded: usize,
+    /// Exactly what the regime did in this harness (which caches are fresh).
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProtocolAxes {
+    pub instrument: String,
+    /// Attribution factor ("per-phase on" | "off") — profile-deciding level.
+    /// The serde default covers v1/v2 records, which always recorded phases.
+    #[serde(default = "per_phase_on")]
+    pub attribution: String,
+    /// Measured repetitions (warm-ups excluded; see the warmth declaration).
+    pub repetitions: usize,
+    pub timer: String,
+    /// Repetition-independence note (regime-dependent: cold repetitions are
+    /// fully independent processes; warm ones accumulate branches + journal
+    /// history within the run).
+    pub rep_independence: String,
+}
+
+fn per_phase_on() -> String {
+    ATTRIBUTION_PER_PHASE_ON.to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunResults {
+    pub wall_clock_ms: WallClockStats,
+    /// Per merge phase, aggregated over repetitions (see field docs).
+    pub phases: Vec<PhaseStats>,
+    /// Engine outcome of every measured merge (must be "Merged").
+    pub merge_outcome: String,
+    /// Non-vacuous proof: expected vs observed row count on the first
+    /// diverged table of the target branch after the last measured merge.
+    pub verified_rows_table0: RowCheck,
+    /// Fixture build time (base load + per-rep divergence), for ops planning
+    /// only — never a benchmark number.
+    pub fixture_build_seconds: f64,
+    /// Which constructive write primitives each measured merge staged
+    /// (`MergeWriteProbes` counters, one entry per rep). Route evidence: a
+    /// merge that stages known-present rows through the update primitive
+    /// shows nonzero `stage_known_present_update_*`; one that stages
+    /// everything through `stage_merge_insert_*` shows zeros there.
+    #[serde(default)]
+    pub write_path: WritePathCounters,
+    /// Per-repetition object-store call counts per class, measured-merge only
+    /// (RFC 0039: every run records counts beside timings). Absent only on
+    /// records upgraded from v1/v2.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub storage_calls: Option<StorageCalls>,
+}
+
+/// Per-repetition storage-call counts of the measured merges, split by store
+/// class the way the engine's cost harness splits them.
+///
+/// RFC 0039 counts at RFC-031's two layers: logical operations AND physical
+/// request attempts. The per-class vectors here are the layer named in
+/// `layer`; an unobservable layer is explicitly `null` with its reason in the
+/// note field — the rationale ships in the record itself (`run.rs` builds
+/// the note strings), so the record is the canonical home, not this comment.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct StorageCalls {
+    /// Exactly what the counts cover (probe scope, merge-only windows).
+    pub scope: String,
+    /// The counting layer of the per-class vectors below
+    /// ("logical-operations" at the `WrappingObjectStore` seam).
+    pub layer: String,
+    /// RFC-031's physical-request-attempt layer, when observable; `null`
+    /// means not observable at this seam, reason in `physical_attempts_note`.
+    pub physical_attempts: Option<PhysicalAttempts>,
+    /// Why `physical_attempts` is absent, when it is (the canonical rationale
+    /// string, written per record).
+    pub physical_attempts_note: String,
+    /// The concurrency witness (RFC 0039: the highest number of storage
+    /// requests simultaneously in flight per measured span) — a physical-layer
+    /// measurement at per-repetition span grain (one entry per rep), when
+    /// captured; `null` means not captured at this seam, reason in
+    /// `concurrency_witness_note`. Without it, elapsed-vs-cumulative
+    /// reconciliation is unavailable, never assumed serial.
+    #[serde(default)]
+    pub concurrency_witness: Option<Vec<u64>>,
+    /// Why `concurrency_witness` is absent, when it is.
+    #[serde(default)]
+    pub concurrency_witness_note: String,
+    /// Observed cumulative request time at the logical layer (µs, sum of
+    /// request durations, one entry per rep), where captured; `null` = this
+    /// seam counts requests but does not time them (see the note).
+    #[serde(default)]
+    pub cumulative_request_time_logical_us: Option<Vec<u64>>,
+    /// Observed cumulative request time at the physical layer, where
+    /// captured; `null` = the physical layer is not observable at this seam.
+    #[serde(default)]
+    pub cumulative_request_time_physical_us: Option<Vec<u64>>,
+    /// Per-layer presence statement for the request-timing columns.
+    #[serde(default)]
+    pub cumulative_request_time_note: String,
+    /// The latency calibration (the backend's measured per-request latency,
+    /// the second operand of the attempts x latency prediction), where
+    /// captured; `null` = not yet measured by this harness (see the note).
+    #[serde(default)]
+    pub latency_calibration: Option<serde_json::Value>,
+    /// Why `latency_calibration` is absent, when it is.
+    #[serde(default)]
+    pub latency_calibration_note: String,
+    /// Calls on the `__manifest` registry's object store, one entry per rep.
+    pub manifest_store: Vec<CallCounts>,
+    /// Calls on the data-table object stores, one entry per rep.
+    pub table_store: Vec<CallCounts>,
+    /// Non-Lance control-plane calls (the engine `StorageAdapter`), one entry
+    /// per rep.
+    pub control_plane: Vec<ControlCalls>,
+}
+
+/// The physical-request-attempt layer, per store class, one entry per rep.
+/// Unpopulated at the current seam; the slot exists so a future seam that
+/// observes HTTP-level attempts lands as a value change, not a schema change.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PhysicalAttempts {
+    pub manifest_store: Vec<CallCounts>,
+    pub table_store: Vec<CallCounts>,
+}
+
+/// One rep's control-plane (`StorageAdapter`) call deltas, from the engine's
+/// public `CountingStorageAdapter`.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct ControlCalls {
+    /// `read_text` + `read_text_if_exists` + `read_text_versioned`.
+    pub read: u64,
+    pub exists: u64,
+    pub list: u64,
+    /// All mutating calls (`write_text*`, `rename`, `delete*`, CAS writes).
+    pub mutation: u64,
+}
+
+/// Per-rep write-path counters snapshotted from the merge's
+/// `MergeWriteProbes` after each measured merge. All vectors are in
+/// execution order and empty on records that predate them (v1).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct WritePathCounters {
+    pub stage_merge_insert_calls: Vec<u64>,
+    pub stage_merge_insert_rows: Vec<u64>,
+    pub stage_known_present_update_calls: Vec<u64>,
+    pub stage_known_present_update_rows: Vec<u64>,
+    pub stage_fenced_insert_calls: Vec<u64>,
+    pub stage_fenced_insert_rows: Vec<u64>,
+    pub strict_insert_preflight_calls: Vec<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WallClockStats {
+    pub p50: f64,
+    /// Nearest-rank p95; with < 20 reps this equals the max — read it as
+    /// "worst observed", not a distribution tail (RFC-031's sample rule).
+    pub p95: f64,
+    pub min: f64,
+    pub max: f64,
+    pub mean: f64,
+    /// Whether the sample count supports the reported tail (rule 3: p95
+    /// needs 20+ samples, p99 would need 100+): "supported" | "directional".
+    /// Derived from the rep count via [`tail_support`]; `diff` prints the
+    /// directional label on unsupported tails.
+    #[serde(default = "unknown_string")]
+    pub tail_support: String,
+    /// Raw per-repetition values, in execution order.
+    pub reps: Vec<f64>,
+}
+
+/// The tail-support marker for a cell of `reps` measured repetitions.
+pub fn tail_support(reps: usize) -> &'static str {
+    if reps >= 20 {
+        "supported"
+    } else {
+        "directional"
+    }
+}
+
+fn unknown_string() -> String {
+    "unknown".to_string()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PhaseStats {
+    pub phase: String,
+    /// Nearest-rank p50 of the per-rep phase totals (µs).
+    pub total_us_p50: u64,
+    /// Largest per-rep phase total (µs).
+    pub total_us_max: u64,
+    /// Largest single recorded interval across all reps (µs) — for
+    /// per-table phases this is the slowest single table.
+    pub max_single_us: u64,
+    /// Raw per-repetition totals (µs), in execution order.
+    pub per_rep_total_us: Vec<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RowCheck {
+    pub table_key: String,
+    pub expected: usize,
+    pub actual: usize,
+}
+
+// ---------------------------------------------------------------------------
+// The A/A noise floor (rule 7)
+// ---------------------------------------------------------------------------
+
+/// The session's measured noise floor: the delta between two runs with equal
+/// spec and equal SUT (`run --aa`). `diff --floor` consumes it; a delta below
+/// the floor reads "no detected effect", never a small effect. A floor
+/// licenses comparisons at its own cell (same spec, same SUT, same session,
+/// RFC 0039); `diff` marks any other application as extrapolation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NoiseFloor {
+    pub floor_version: u32,
+    pub created_unix_seconds: u64,
+    /// The session the A/A pair ran in.
+    #[serde(default = "unknown_string")]
+    pub session_id: String,
+    /// SUT commit both floor runs shared (a floor is per session + SUT).
+    pub source_commit: String,
+    /// The persisted claim margin (rule 7: a protocol-level default, never an
+    /// after-the-fact choice): an effect must exceed floor x margin to be
+    /// claimed. `diff --margin` overrides per invocation; the floor note then
+    /// prints the effective margin with this default beside it.
+    #[serde(default = "default_margin")]
+    pub default_margin: f64,
+    /// Per point: the A/A pair's wall-clock p50s and their relative delta.
+    pub points: BTreeMap<String, FloorPoint>,
+}
+
+/// v2: session id + persisted default margin.
+pub const FLOOR_VERSION: u32 = 2;
+
+/// The protocol-level default claim margin (rule 7): an effect clears the
+/// floor when it exceeds floor x this factor.
+pub fn default_margin() -> f64 {
+    2.0
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FloorPoint {
+    pub wall_p50_a_ms: f64,
+    pub wall_p50_b_ms: f64,
+    pub abs_delta_ms: f64,
+    /// |A − B| as a percentage of the pair mean — the floor a claimed effect
+    /// on this point must clearly exceed.
+    pub pct: f64,
+    /// Per-phase floors (same formula over phase total_us p50), for phases
+    /// with a nonzero pair mean.
+    #[serde(default)]
+    pub phases: BTreeMap<String, f64>,
+}
+
+/// |a − b| as a percentage of the pair mean (0 when both are 0).
+pub fn pair_delta_pct(a: f64, b: f64) -> f64 {
+    let mean = (a + b) / 2.0;
+    if mean == 0.0 {
+        0.0
+    } else {
+        ((a - b).abs() / mean) * 100.0
+    }
+}
+
+/// First nine characters of a commit string, cut on a char boundary (a byte
+/// slice would panic on multibyte input — commits are operator-influenced
+/// strings on upgraded records, not guaranteed hex).
+pub fn short_commit(commit: &str) -> &str {
+    commit
+        .char_indices()
+        .nth(9)
+        .map_or(commit, |(i, _)| &commit[..i])
+}
+
+// ---------------------------------------------------------------------------
+// Point names
+// ---------------------------------------------------------------------------
+
+/// Derive the point name: the run spec flattened into one string (RFC 0039's
+/// natural key, e.g. `m3-t8-n100k-btree-fresh-d50-warm`). Payload bytes join
+/// only off the default so historical names stay stable; the S3 backend joins
+/// as a suffix (the local backend is the default and stays out of the name —
+/// the record's environment block always carries the full identity).
+#[allow(clippy::too_many_arguments)]
+pub fn point_name(
+    scenario: &str,
+    tables: usize,
+    rows: usize,
+    payload_bytes: usize,
+    state_tag: &str,
+    non_default_diverged: Option<usize>,
+    delta: usize,
+    warmth: &str,
+    s3_backend: bool,
+) -> String {
+    let rows_fmt = if rows.is_multiple_of(1000) {
+        format!("{}k", rows / 1000)
+    } else {
+        rows.to_string()
+    };
+    let payload = if payload_bytes == 64 {
+        String::new()
+    } else {
+        format!("-p{payload_bytes}")
+    };
+    let div = non_default_diverged.map_or(String::new(), |d| format!("-div{d}"));
+    let backend = if s3_backend { "-s3" } else { "" };
+    format!("{scenario}-t{tables}-n{rows_fmt}{payload}-{state_tag}{div}-d{delta}-{warmth}{backend}")
+}
+
+// ---------------------------------------------------------------------------
+// v1/v2 legacy records (read path only)
+// ---------------------------------------------------------------------------
+
+/// The v1/v2 record shapes, kept verbatim so `diff` can still read every
+/// record written before the v3 rename. Never written.
+pub mod v2 {
+    use serde::{Deserialize, Serialize};
+
+    use super::{DataAxes, RowCheck, StateAxes, WallClockStats, WorkloadAxes, WritePathCounters};
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct RunRecord {
+        pub record_version: u32,
+        pub scenario: String,
+        #[serde(default)]
+        pub label: Option<String>,
+        pub created_unix_seconds: u64,
+        pub source_commit: String,
+        pub five_tuple: FiveTuple,
+        pub results: RunResults,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct FiveTuple {
+        pub data: DataAxes,
+        pub state: StateAxes,
+        pub workload: WorkloadAxes,
+        pub environment: EnvironmentAxes,
+        pub protocol: ProtocolAxes,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct EnvironmentAxes {
+        pub backend: String,
+        pub root_uri_scheme: String,
+        pub host_os: String,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct ProtocolAxes {
+        pub instrument: String,
+        pub repetitions: usize,
+        pub build_profile: String,
+        pub timer: String,
+        pub rep_independence: String,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct RunResults {
+        pub wall_clock_ms: WallClockStats,
+        pub phases: Vec<super::PhaseStats>,
+        pub merge_outcome: String,
+        pub verified_rows_table0: RowCheck,
+        pub fixture_build_seconds: f64,
+        #[serde(default)]
+        pub write_path: WritePathCounters,
+    }
+}
+
+/// Upgrade a v1/v2 record to the v3 shape for diffing. The upgrade is honest
+/// about what v2 did not control or capture: warmth reads
+/// `"uncontrolled-v2"` (v0 mixed rep 1's cold caches into the cell), the
+/// machine spec is unknown beyond os-arch, the engine configuration is empty
+/// (v2's gap: flags lived in prose labels), and storage calls are absent.
+pub fn upgrade_v2(old: v2::RunRecord) -> RunRecord {
+    let (os, arch) = old
+        .five_tuple
+        .environment
+        .host_os
+        .split_once('-')
+        .map(|(os, arch)| (os.to_string(), arch.to_string()))
+        .unwrap_or_else(|| (old.five_tuple.environment.host_os.clone(), "unknown".into()));
+    let state_tag = if old.five_tuple.state.index_existence.starts_with("BTREE") {
+        "btree-fresh"
+    } else {
+        "noindex"
+    };
+    let default_div = old.five_tuple.data.tables.min(4);
+    let non_default_diverged = (old.five_tuple.workload.diverged_tables != default_div)
+        .then_some(old.five_tuple.workload.diverged_tables);
+    let name = point_name(
+        &old.scenario,
+        old.five_tuple.data.tables,
+        old.five_tuple.data.rows_per_table,
+        old.five_tuple.data.payload_bytes,
+        state_tag,
+        non_default_diverged,
+        old.five_tuple.workload.delta_rows_per_side,
+        "uncontrolled-v2",
+        old.five_tuple.environment.backend == "s3-compatible",
+    );
+    let mut wall_clock_ms = old.results.wall_clock_ms;
+    wall_clock_ms.tail_support = tail_support(wall_clock_ms.reps.len()).to_string();
+    RunRecord {
+        record_version: old.record_version,
+        point_name: name,
+        point_name_format: POINT_NAME_FORMAT,
+        profile: PROFILE_MICRO.to_string(),
+        instrument_access: INSTRUMENT_ACCESS_INTERIM.to_string(),
+        // v2 records predate the caller-minted id. The upgrade derives a
+        // DETERMINISTIC id from the record's own content so re-reading the
+        // same file never mints a new identity.
+        invocation_id: format!(
+            "v2-upgrade:{}:{}:d{}:{}",
+            short_commit(&old.source_commit),
+            old.scenario,
+            old.five_tuple.workload.delta_rows_per_side,
+            old.created_unix_seconds
+        ),
+        session_id: "unknown (v2 record: sessions were not minted)".to_string(),
+        label: old.label,
+        // v2 stamped record-assembly time; the closest thing to an
+        // invocation timestamp the old record carries.
+        invocation_unix_seconds: old.created_unix_seconds,
+        run_spec: RunSpec {
+            data: old.five_tuple.data,
+            state: old.five_tuple.state,
+            workload: old.five_tuple.workload,
+            environment: EnvironmentAxes {
+                backend: old.five_tuple.environment.backend,
+                root_uri_scheme: old.five_tuple.environment.root_uri_scheme,
+                s3_endpoint: None,
+                warmth: WarmthDeclaration {
+                    regime: "uncontrolled-v2".to_string(),
+                    warmup_reps_discarded: 0,
+                    detail: "v0/v2 record: rep 1 ran with partly cold caches and was mixed \
+                             into the cell (the regime mixing RFC 0039 rule 3 forbids); \
+                             per-rep arrays keep the drift visible"
+                        .to_string(),
+                },
+            },
+            protocol: ProtocolAxes {
+                instrument: old.five_tuple.protocol.instrument,
+                // v1/v2 always recorded the per-phase attribution.
+                attribution: ATTRIBUTION_PER_PHASE_ON.to_string(),
+                repetitions: old.five_tuple.protocol.repetitions,
+                timer: old.five_tuple.protocol.timer,
+                rep_independence: old.five_tuple.protocol.rep_independence,
+            },
+        },
+        sut: SutBlock {
+            source_commit: old.source_commit,
+            build_profile: old.five_tuple.protocol.build_profile,
+            build_opt_level: "unknown (v2 record: opt-level was not captured)".to_string(),
+            engine_configuration: BTreeMap::new(),
+        },
+        machine: MachineSpec {
+            os,
+            arch,
+            os_version: "unknown".to_string(),
+            cpu_model: "unknown (v2 record: machine spec was not captured)".to_string(),
+            physical_cores: None,
+            logical_cores: None,
+            memory_bytes: None,
+            storage_class: "unknown".to_string(),
+        },
+        results: RunResults {
+            wall_clock_ms,
+            phases: old.results.phases,
+            merge_outcome: old.results.merge_outcome,
+            verified_rows_table0: old.results.verified_rows_table0,
+            fixture_build_seconds: old.results.fixture_build_seconds,
+            write_path: old.results.write_path,
+            storage_calls: None,
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Stat helpers
+// ---------------------------------------------------------------------------
+
+/// Nearest-rank percentile over an unsorted sample (q in 0..=100).
+pub fn percentile_f64(values: &[f64], q: usize) -> f64 {
+    assert!(!values.is_empty());
+    let mut sorted = values.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).expect("timings are finite"));
+    let rank = (q * sorted.len()).div_ceil(100).max(1);
+    sorted[rank - 1]
+}
+
+pub fn percentile_u64(values: &[u64], q: usize) -> u64 {
+    assert!(!values.is_empty());
+    let mut sorted = values.to_vec();
+    sorted.sort_unstable();
+    let rank = (q * sorted.len()).div_ceil(100).max(1);
+    sorted[rank - 1]
+}
+
+/// Test-only builders shared across the crate's unit tests.
+#[cfg(test)]
+pub mod testkit {
+    use super::*;
+
+    /// A complete, schema-valid v3 run record with the given wall-clock reps.
+    pub fn sample_record(point_name: &str, wall_reps: &[f64]) -> RunRecord {
+        let phases = vec![PhaseStats {
+            phase: "OuterPrepare".to_string(),
+            total_us_p50: percentile_u64(&vec![100; wall_reps.len()], 50),
+            total_us_max: 100,
+            max_single_us: 100,
+            per_rep_total_us: vec![100; wall_reps.len()],
+        }];
+        let call_counts = vec![CallCounts::default(); wall_reps.len()];
+        RunRecord {
+            record_version: RECORD_VERSION,
+            point_name: point_name.to_string(),
+            point_name_format: POINT_NAME_FORMAT,
+            profile: PROFILE_MICRO.to_string(),
+            instrument_access: INSTRUMENT_ACCESS_INTERIM.to_string(),
+            label: Some("test".to_string()),
+            invocation_id: format!("test-{point_name}-{}", wall_reps.len()),
+            session_id: "test-session".to_string(),
+            invocation_unix_seconds: 1,
+            run_spec: RunSpec {
+                data: DataAxes {
+                    provenance: PROVENANCE_SYNTHETIC.to_string(),
+                    tables: 2,
+                    rows_per_table: 100,
+                    column_shape: "scalars-only".to_string(),
+                    payload_bytes: 64,
+                },
+                state: StateAxes {
+                    fragmentation: "fresh".to_string(),
+                    index_existence: "none declared (F2 low end)".to_string(),
+                    index_freshness: "n/a".to_string(),
+                    deletion_history: "none".to_string(),
+                    compaction_recency: "never".to_string(),
+                    builder_version: Some(crate::fixture::BUILDER_VERSION),
+                    generation: Some(
+                        crate::fixture::BaseProfile::new(2, 100, 64, 2, vec![1]).unwrap(),
+                    ),
+                    base_load_commits: 2,
+                    fixture_name: None,
+                    fixture_manifest: None,
+                },
+                workload: WorkloadAxes {
+                    scenario: "m3".to_string(),
+                    merge_kind: "diverged mixed three-way".to_string(),
+                    arrival: ARRIVAL_UNSCHEDULED_SINGLE_SHOT.to_string(),
+                    delta_rows_per_side: 1,
+                    delta_split_per_side: KindSplit {
+                        updates: 1,
+                        deletes: 0,
+                        inserts: 0,
+                    },
+                    diverged_tables: 2,
+                },
+                environment: EnvironmentAxes {
+                    backend: "local-fs-tempdir".to_string(),
+                    root_uri_scheme: "file".to_string(),
+                    s3_endpoint: None,
+                    warmth: WarmthDeclaration {
+                        regime: "warm".to_string(),
+                        warmup_reps_discarded: 1,
+                        detail: "test".to_string(),
+                    },
+                },
+                protocol: ProtocolAxes {
+                    instrument: "test".to_string(),
+                    attribution: ATTRIBUTION_PER_PHASE_ON.to_string(),
+                    repetitions: wall_reps.len(),
+                    timer: "test".to_string(),
+                    rep_independence: "test".to_string(),
+                },
+            },
+            sut: SutBlock {
+                source_commit: "deadbeefdeadbeef".to_string(),
+                build_profile: "release".to_string(),
+                build_opt_level: "3".to_string(),
+                engine_configuration: BTreeMap::new(),
+            },
+            machine: MachineSpec {
+                os: "testos".to_string(),
+                arch: "testarch".to_string(),
+                os_version: "1".to_string(),
+                cpu_model: "test cpu".to_string(),
+                physical_cores: Some(4),
+                logical_cores: Some(8),
+                memory_bytes: Some(1024),
+                storage_class: "ssd".to_string(),
+            },
+            results: RunResults {
+                wall_clock_ms: WallClockStats {
+                    p50: percentile_f64(wall_reps, 50),
+                    p95: percentile_f64(wall_reps, 95),
+                    min: wall_reps.iter().copied().fold(f64::INFINITY, f64::min),
+                    max: wall_reps.iter().copied().fold(0.0, f64::max),
+                    mean: wall_reps.iter().sum::<f64>() / wall_reps.len() as f64,
+                    tail_support: tail_support(wall_reps.len()).to_string(),
+                    reps: wall_reps.to_vec(),
+                },
+                phases,
+                merge_outcome: "Merged".to_string(),
+                verified_rows_table0: RowCheck {
+                    table_key: "node:BenchT000".to_string(),
+                    expected: 100,
+                    actual: 100,
+                },
+                fixture_build_seconds: 0.1,
+                write_path: WritePathCounters {
+                    stage_merge_insert_calls: vec![1; wall_reps.len()],
+                    stage_merge_insert_rows: vec![1; wall_reps.len()],
+                    stage_known_present_update_calls: vec![0; wall_reps.len()],
+                    stage_known_present_update_rows: vec![0; wall_reps.len()],
+                    stage_fenced_insert_calls: vec![0; wall_reps.len()],
+                    stage_fenced_insert_rows: vec![0; wall_reps.len()],
+                    strict_insert_preflight_calls: vec![0; wall_reps.len()],
+                },
+                storage_calls: Some(StorageCalls {
+                    scope: "test".to_string(),
+                    layer: "logical-operations".to_string(),
+                    physical_attempts: None,
+                    physical_attempts_note: "test".to_string(),
+                    concurrency_witness: None,
+                    concurrency_witness_note: "test".to_string(),
+                    cumulative_request_time_logical_us: None,
+                    cumulative_request_time_physical_us: None,
+                    cumulative_request_time_note: "test".to_string(),
+                    latency_calibration: None,
+                    latency_calibration_note: "test".to_string(),
+                    manifest_store: call_counts.clone(),
+                    table_store: call_counts,
+                    control_plane: vec![ControlCalls::default(); wall_reps.len()],
+                }),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nearest_rank_percentiles() {
+        let v = [5.0, 1.0, 3.0, 2.0, 4.0];
+        assert_eq!(percentile_f64(&v, 50), 3.0);
+        assert_eq!(percentile_f64(&v, 95), 5.0);
+        assert_eq!(percentile_u64(&[7], 50), 7);
+    }
+
+    #[test]
+    fn point_names_flatten_the_spec() {
+        assert_eq!(
+            point_name("m3", 8, 100_000, 64, "btree-fresh", None, 50, "warm", false),
+            "m3-t8-n100k-btree-fresh-d50-warm"
+        );
+        assert_eq!(
+            point_name(
+                "m5",
+                140,
+                4000,
+                64,
+                "noindex",
+                Some(140),
+                420,
+                "cold",
+                false
+            ),
+            "m5-t140-n4k-noindex-div140-d420-cold"
+        );
+        assert_eq!(
+            point_name(
+                "m3",
+                8,
+                4000,
+                128,
+                "noindex",
+                None,
+                1,
+                "post-invalidation",
+                true
+            ),
+            "m3-t8-n4k-p128-noindex-d1-post-invalidation-s3"
+        );
+    }
+
+    #[test]
+    fn short_commit_cuts_on_char_boundaries() {
+        // (input, expected): multibyte input must truncate, never panic.
+        for (input, expected) in [
+            ("cafebabecafebabe", "cafebabec"),
+            ("short", "short"),
+            ("", ""),
+            ("héllo-wörld-commit", "héllo-wör"),
+            ("ééééééééééé", "ééééééééé"),
+        ] {
+            assert_eq!(short_commit(input), expected, "input {input}");
+        }
+    }
+
+    #[test]
+    fn pair_delta_pct_is_symmetric_and_zero_safe() {
+        assert_eq!(pair_delta_pct(0.0, 0.0), 0.0);
+        assert!((pair_delta_pct(100.0, 110.0) - pair_delta_pct(110.0, 100.0)).abs() < 1e-12);
+        assert!((pair_delta_pct(100.0, 110.0) - 9.523_809_523_809_524).abs() < 1e-9);
+    }
+
+    #[test]
+    fn tail_support_thresholds() {
+        // (reps, expected marker): p95 needs >= 20 samples (rule 3).
+        for (reps, expected) in [
+            (1, "directional"),
+            (5, "directional"),
+            (19, "directional"),
+            (20, "supported"),
+            (100, "supported"),
+        ] {
+            assert_eq!(tail_support(reps), expected, "reps = {reps}");
+        }
+    }
+
+    fn v2_record(scenario: &str, backend: &str, indexed: bool, reps: usize) -> v2::RunRecord {
+        v2::RunRecord {
+            record_version: 2,
+            scenario: scenario.to_string(),
+            label: None,
+            created_unix_seconds: 42,
+            source_commit: "cafebabecafebabe".to_string(),
+            five_tuple: v2::FiveTuple {
+                data: DataAxes {
+                    provenance: PROVENANCE_SYNTHETIC.to_string(),
+                    tables: 8,
+                    rows_per_table: 100_000,
+                    column_shape: "scalars-only".to_string(),
+                    payload_bytes: 64,
+                },
+                state: StateAxes {
+                    fragmentation: "fresh".to_string(),
+                    index_existence: if indexed {
+                        "BTREE on 'id'".to_string()
+                    } else {
+                        "none declared".to_string()
+                    },
+                    index_freshness: "n/a".to_string(),
+                    deletion_history: "none".to_string(),
+                    compaction_recency: "never".to_string(),
+                    builder_version: None,
+                    generation: None,
+                    base_load_commits: 25,
+                    fixture_name: None,
+                    fixture_manifest: None,
+                },
+                workload: WorkloadAxes {
+                    scenario: scenario.to_string(),
+                    merge_kind: "diverged mixed three-way".to_string(),
+                    arrival: ARRIVAL_UNSCHEDULED_SINGLE_SHOT.to_string(),
+                    delta_rows_per_side: 50,
+                    delta_split_per_side: KindSplit {
+                        updates: 17,
+                        deletes: 17,
+                        inserts: 16,
+                    },
+                    diverged_tables: 4,
+                },
+                environment: v2::EnvironmentAxes {
+                    backend: backend.to_string(),
+                    root_uri_scheme: "file".to_string(),
+                    host_os: "macos-aarch64".to_string(),
+                },
+                protocol: v2::ProtocolAxes {
+                    instrument: "test".to_string(),
+                    repetitions: reps,
+                    build_profile: "release".to_string(),
+                    timer: "test".to_string(),
+                    rep_independence: "test".to_string(),
+                },
+            },
+            results: v2::RunResults {
+                wall_clock_ms: WallClockStats {
+                    p50: 10.0,
+                    p95: 12.0,
+                    min: 9.0,
+                    max: 12.0,
+                    mean: 10.3,
+                    tail_support: "unknown".to_string(),
+                    reps: vec![10.0; reps],
+                },
+                phases: vec![],
+                merge_outcome: "Merged".to_string(),
+                verified_rows_table0: RowCheck {
+                    table_key: "node:BenchT000".to_string(),
+                    expected: 1,
+                    actual: 1,
+                },
+                fixture_build_seconds: 1.0,
+                write_path: WritePathCounters::default(),
+            },
+        }
+    }
+
+    #[test]
+    fn upgrade_v2_is_honest_about_what_v2_did_not_capture() {
+        // (scenario, backend, indexed, reps, expected point name, expected tail marker)
+        for (scenario, backend, indexed, reps, want_name, want_tail) in [
+            (
+                "m3",
+                "local-fs-tempdir",
+                false,
+                5,
+                "m3-t8-n100k-noindex-d50-uncontrolled-v2",
+                "directional",
+            ),
+            (
+                "m5",
+                "s3-compatible",
+                true,
+                25,
+                "m5-t8-n100k-btree-fresh-d50-uncontrolled-v2-s3",
+                "supported",
+            ),
+        ] {
+            let up = upgrade_v2(v2_record(scenario, backend, indexed, reps));
+            assert_eq!(up.point_name, want_name);
+            assert_eq!(up.point_name_format, POINT_NAME_FORMAT);
+            assert_eq!(up.scenario(), scenario);
+            // v2 records sit in the micro region: derivable from the levels.
+            assert_eq!(derive_profile(&up.run_spec), Some(PROFILE_MICRO));
+            assert!(up.session_id.contains("v2 record"));
+            assert_eq!(up.run_spec.environment.warmth.regime, "uncontrolled-v2");
+            assert_eq!(up.results.wall_clock_ms.tail_support, want_tail);
+            assert!(up.machine.cpu_model.contains("not captured"));
+            assert_eq!(up.machine.os, "macos");
+            assert_eq!(up.machine.arch, "aarch64");
+            assert!(up.sut.build_opt_level.contains("v2 record"));
+            assert!(up.sut.engine_configuration.is_empty());
+            assert!(up.results.storage_calls.is_none());
+            assert!(up.run_spec.state.builder_version.is_none());
+            assert!(up.run_spec.state.generation.is_none());
+            // Re-reading the same file never mints a new identity.
+            assert_eq!(
+                up.invocation_id,
+                upgrade_v2(v2_record(scenario, backend, indexed, reps)).invocation_id
+            );
+        }
+    }
+}

--- a/crates/omnigraph-bench/src/report.rs
+++ b/crates/omnigraph-bench/src/report.rs
@@ -1,0 +1,1044 @@
+//! The `report` subcommand: render run records as one self-contained HTML
+//! page — the shareable view of the same records `show` prints as tables.
+//!
+//! Self-containment is a hard constraint: no external requests of any kind
+//! (no CDN scripts, no web fonts, no remote images). All CSS is inline, the
+//! charts are inline SVG generated here, and there is no JavaScript —
+//! collapsed sections use `<details>`, so the page reads fully with JS
+//! disabled. Identity is stated with the same honesty as the terminal view:
+//! the full SUT commit (dirty/stale markers included), session, machine,
+//! warmth, directional tail labels, and rule-7 floor labels on any delta.
+//! Every interpolated free-form string passes through [`esc`]. The JSON
+//! record stays the single source of truth; this page is a view.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use clap::Args;
+
+use crate::counting::CallCounts;
+use crate::diff::{floor_label, fmt_bytes, fmt_delta_pct, load_floor, load_record, record_paths};
+use crate::fixture::BenchResult;
+use crate::record::{ControlCalls, NoiseFloor, RunRecord, short_commit};
+
+#[derive(Debug, Args)]
+pub struct ReportArgs {
+    /// Run-record file, or directory of run records.
+    path: PathBuf,
+    /// noise-floor.json from `run --aa`; labels the A/A pair deltas per
+    /// RFC 0039 rule 7 (below the floor reads "no detected effect").
+    #[arg(long)]
+    floor: Option<PathBuf>,
+    /// Output HTML file (default: report.html beside the records).
+    #[arg(long)]
+    out: Option<PathBuf>,
+}
+
+pub fn run_report(args: ReportArgs) -> BenchResult<()> {
+    let (dir, paths) = if args.path.is_dir() {
+        (args.path.clone(), record_paths(&args.path)?)
+    } else {
+        let parent = args
+            .path
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or(Path::new("."))
+            .to_path_buf();
+        (parent, vec![args.path.clone()])
+    };
+    if paths.is_empty() {
+        return Err(format!("{}: no .json run records found", args.path.display()).into());
+    }
+    let mut records = Vec::with_capacity(paths.len());
+    for path in &paths {
+        let file_name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| path.display().to_string());
+        records.push((file_name, load_record(path)?));
+    }
+    let floor = args.floor.as_deref().map(load_floor).transpose()?;
+    let html = render_report(&records, floor.as_ref(), crate::unix_now());
+    let out = args.out.unwrap_or_else(|| dir.join("report.html"));
+    std::fs::write(&out, html).map_err(|e| format!("writing {}: {e}", out.display()))?;
+    println!("report written: {}", out.display());
+    Ok(())
+}
+
+/// HTML-escape every free-form string before interpolation (labels, notes,
+/// commits, phase names — anything not generated here is untrusted markup).
+fn esc(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// `1234567` -> `1,234,567` (tabular figures need readable magnitudes).
+fn fmt_thousands(n: u64) -> String {
+    let digits = n.to_string();
+    let mut out = String::with_capacity(digits.len() + digits.len() / 3);
+    for (i, c) in digits.chars().enumerate() {
+        if i > 0 && (digits.len() - i).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// UTC timestamp for the page header, from seconds since the UNIX epoch
+/// (civil-from-days, so the crate needs no calendar dependency).
+fn fmt_utc(secs: u64) -> String {
+    let days = (secs / 86_400) as i64;
+    let secs_of_day = secs % 86_400;
+    // Howard Hinnant's civil_from_days.
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097);
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    format!(
+        "{y:04}-{m:02}-{d:02} {:02}:{:02}:{:02} UTC",
+        secs_of_day / 3600,
+        (secs_of_day % 3600) / 60,
+        secs_of_day % 60
+    )
+}
+
+fn sum_counts(counts: &[CallCounts]) -> CallCounts {
+    counts.iter().fold(CallCounts::default(), |mut acc, c| {
+        acc.get += c.get;
+        acc.put += c.put;
+        acc.put_part += c.put_part;
+        acc.head += c.head;
+        acc.list += c.list;
+        acc.delete += c.delete;
+        acc.copy += c.copy;
+        acc.rename += c.rename;
+        acc.put_multipart += c.put_multipart;
+        acc.multipart_complete += c.multipart_complete;
+        acc.multipart_abort += c.multipart_abort;
+        acc
+    })
+}
+
+/// The 11 RFC-031 operation classes of one summed tally, in vocabulary order.
+fn class_values(c: &CallCounts) -> [(&'static str, u64); 11] {
+    [
+        ("get", c.get),
+        ("put", c.put),
+        ("put_part", c.put_part),
+        ("head", c.head),
+        ("list", c.list),
+        ("delete", c.delete),
+        ("copy", c.copy),
+        ("rename", c.rename),
+        ("put_multipart", c.put_multipart),
+        ("multipart_complete", c.multipart_complete),
+        ("multipart_abort", c.multipart_abort),
+    ]
+}
+
+fn total_calls(c: &CallCounts) -> u64 {
+    class_values(c).iter().map(|(_, v)| *v).sum()
+}
+
+/// Horizontal SVG bar chart: one row per (label, value, annotation). Colors
+/// come from the page's CSS variables so the chart follows the theme.
+fn svg_bars(rows: &[(String, u64, String)]) -> String {
+    if rows.is_empty() {
+        return String::new();
+    }
+    const LABEL_W: u64 = 200;
+    const BAR_MAX_W: u64 = 380;
+    const ROW_H: u64 = 22;
+    let peak = rows.iter().map(|(_, v, _)| *v).max().unwrap_or(0).max(1);
+    let height = rows.len() as u64 * ROW_H + 6;
+    // Inline SVG in HTML needs no xmlns, and the namespace URI would trip
+    // the self-containment guard on external URLs.
+    let mut svg = format!(
+        "<svg viewBox=\"0 0 720 {height}\" width=\"720\" height=\"{height}\" role=\"img\">\n"
+    );
+    for (i, (label, value, annotation)) in rows.iter().enumerate() {
+        let y = i as u64 * ROW_H + 4;
+        let w = (value * BAR_MAX_W) / peak;
+        // A nonzero value always draws a visible sliver.
+        let w = if *value > 0 { w.max(2) } else { 0 };
+        svg.push_str(&format!(
+            "<text x=\"{}\" y=\"{}\" text-anchor=\"end\" class=\"bl\">{}</text>\
+             <rect x=\"{}\" y=\"{y}\" width=\"{w}\" height=\"14\" rx=\"2\" class=\"bar\"/>\
+             <text x=\"{}\" y=\"{}\" class=\"bv\">{}{}</text>\n",
+            LABEL_W - 8,
+            y + 11,
+            esc(label),
+            LABEL_W,
+            LABEL_W + w + 6,
+            y + 11,
+            fmt_thousands(*value),
+            esc(annotation),
+        ));
+    }
+    svg.push_str("</svg>\n");
+    svg
+}
+
+/// One grouped-phase bar: name + value/share, a CSS track whose fill width IS
+/// the share of wall-clock (bars and shares can never disagree), and the
+/// one-line annotation. The unattributed remainder renders in the muted fill.
+fn phase_group_bar(
+    out: &mut String,
+    name: &str,
+    total_us: u64,
+    share_pct: f64,
+    annotation: &str,
+    unattributed: bool,
+) {
+    let fill = if unattributed { "fill un" } else { "fill" };
+    out.push_str(&format!(
+        "<div class=\"grp\">\n<div class=\"grp-head\"><span>{}</span>\
+         <span class=\"grp-val\">{:.1} ms · {:.1}%</span></div>\n\
+         <div class=\"track\"><div class=\"{fill}\" style=\"width:{:.1}%\"></div></div>\n\
+         <p class=\"muted\">{}</p>\n</div>\n",
+        esc(name),
+        total_us as f64 / 1000.0,
+        share_pct,
+        share_pct.min(100.0),
+        esc(annotation),
+    ));
+}
+
+fn identity_rows(file_name: &str, r: &RunRecord) -> Vec<(String, String)> {
+    let m = &r.machine;
+    let w = &r.run_spec.environment.warmth;
+    let engine_config = if r.sut.engine_configuration.is_empty() {
+        "(none)".to_string()
+    } else {
+        r.sut
+            .engine_configuration
+            .iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect::<Vec<_>>()
+            .join(" ")
+    };
+    vec![
+        ("record file".into(), file_name.to_string()),
+        ("point_name".into(), r.point_name.clone()),
+        ("profile".into(), r.profile.clone()),
+        (
+            "label".into(),
+            r.label.clone().unwrap_or("unlabeled".into()),
+        ),
+        ("invocation_id".into(), r.invocation_id.clone()),
+        ("session_id".into(), r.session_id.clone()),
+        ("source_commit".into(), r.sut.source_commit.clone()),
+        (
+            "build".into(),
+            format!(
+                "{} (opt-level {})",
+                r.sut.build_profile, r.sut.build_opt_level
+            ),
+        ),
+        ("engine configuration".into(), engine_config),
+        ("backend".into(), r.run_spec.environment.backend.clone()),
+        (
+            "s3_endpoint".into(),
+            r.run_spec
+                .environment
+                .s3_endpoint
+                .clone()
+                .unwrap_or("unset".into()),
+        ),
+        (
+            "warmth".into(),
+            format!(
+                "{} ({} warm-up(s) discarded)",
+                w.regime, w.warmup_reps_discarded
+            ),
+        ),
+        ("warmth detail".into(), w.detail.clone()),
+        (
+            "machine".into(),
+            format!(
+                "{} {} ({}) / {} / mem {} / storage {}",
+                m.os,
+                m.arch,
+                m.os_version,
+                m.cpu_model,
+                fmt_bytes(m.memory_bytes),
+                m.storage_class
+            ),
+        ),
+        (
+            "repetitions".into(),
+            format!(
+                "{} ({})",
+                r.run_spec.protocol.repetitions, r.results.wall_clock_ms.tail_support
+            ),
+        ),
+        (
+            "rep independence".into(),
+            r.run_spec.protocol.rep_independence.clone(),
+        ),
+        ("instrument".into(), r.run_spec.protocol.instrument.clone()),
+        ("timer".into(), r.run_spec.protocol.timer.clone()),
+        (
+            "storage-call scope".into(),
+            r.results
+                .storage_calls
+                .as_ref()
+                .map_or("not recorded (v1/v2 record)".into(), |sc| sc.scope.clone()),
+        ),
+    ]
+}
+
+/// The `-dirty` / `-stale-build` / `unverified:` markers stay visible: the
+/// commit prints whole, plus a badge when any marker is present.
+fn commit_html(commit: &str) -> String {
+    let mut badges = String::new();
+    for marker in ["-dirty", "-stale-build"] {
+        if commit.contains(marker) {
+            badges.push_str(&format!(
+                " <span class=\"badge\">{}</span>",
+                esc(marker.trim_start_matches('-'))
+            ));
+        }
+    }
+    if commit.starts_with("unverified:") {
+        badges.push_str(" <span class=\"badge\">unverified</span>");
+    }
+    format!("<code>{}</code>{badges}", esc(commit))
+}
+
+fn per_record_section(out: &mut String, file_name: &str, r: &RunRecord) {
+    let w = &r.results.wall_clock_ms;
+    let directional = if w.tail_support == "supported" {
+        ""
+    } else {
+        " <span class=\"badge\">directional</span>"
+    };
+    out.push_str(&format!(
+        "<section id=\"r-{}\">\n<h2>{}</h2>\n<p class=\"muted\">{} @ {} · warmth {} · \
+         {} reps{directional}</p>\n",
+        esc(&r.invocation_id),
+        esc(&r.point_name),
+        esc(r.label.as_deref().unwrap_or("unlabeled")),
+        commit_html(&r.sut.source_commit),
+        esc(&r.run_spec.environment.warmth.regime),
+        r.run_spec.protocol.repetitions,
+    ));
+
+    // Headline first: the answer as metric cards before any table.
+    let grouped = crate::groups::group_phases(&r.results.phases, w.p50);
+    let storage_total = r.results.storage_calls.as_ref().map(|sc| {
+        total_calls(&sum_counts(&sc.table_store)) + total_calls(&sum_counts(&sc.manifest_store))
+    });
+    let (cost_name, cost_share) = grouped.biggest_cost();
+    out.push_str("<div class=\"cards\">\n");
+    out.push_str(&format!(
+        "<div class=\"card\"><div class=\"v\">{:.1} ms</div>\
+         <div class=\"l\">median merge (p50)</div></div>\n",
+        w.p50
+    ));
+    out.push_str(&format!(
+        "<div class=\"card\"><div class=\"v\">{:.1} ms{directional}</div>\
+         <div class=\"l\">p95</div></div>\n",
+        w.p95
+    ));
+    out.push_str(&format!(
+        "<div class=\"card\"><div class=\"v\">{}</div>\
+         <div class=\"l\">storage requests</div></div>\n",
+        storage_total.map_or("n/a".to_string(), fmt_thousands)
+    ));
+    out.push_str(&format!(
+        "<div class=\"card\"><div class=\"v\">{} {:.0}%</div>\
+         <div class=\"l\">biggest cost</div></div>\n",
+        esc(cost_name),
+        cost_share
+    ));
+    out.push_str("</div>\n");
+
+    // Wall-clock stats.
+    out.push_str(
+        "<table><thead><tr><th>wall_clock_ms</th><th class=\"num\">p50</th>\
+         <th class=\"num\">p95</th><th class=\"num\">min</th><th class=\"num\">max</th>\
+         <th class=\"num\">mean</th></tr></thead><tbody>\n",
+    );
+    out.push_str(&format!(
+        "<tr><td>{} reps{directional}</td><td class=\"num\">{:.2}</td>\
+         <td class=\"num\">{:.2}</td><td class=\"num\">{:.2}</td>\
+         <td class=\"num\">{:.2}</td><td class=\"num\">{:.2}</td></tr>\n</tbody></table>\n",
+        w.reps.len(),
+        w.p50,
+        w.p95,
+        w.min,
+        w.max,
+        w.mean,
+    ));
+
+    // Grouped phase attribution (sorted descending; shares against the
+    // wall-clock median, so these bars agree with the "biggest cost" card and
+    // the explicit remainder). Each group unfolds to its raw phases — exact
+    // names, total/max µs — so nothing is hidden, just layered.
+    if !r.results.phases.is_empty() {
+        out.push_str("<h3>where the merge time goes (share of wall-clock p50)</h3>\n");
+        for group in &grouped.groups {
+            phase_group_bar(
+                out,
+                group.name,
+                group.total_us,
+                group.share_pct,
+                group.annotation,
+                false,
+            );
+            if !group.members.is_empty() {
+                out.push_str(
+                    "<details><summary>raw phases</summary>\n<table><thead><tr><th>phase</th>\
+                     <th class=\"num\">total_us p50</th><th class=\"num\">total_us max</th>\
+                     <th class=\"num\">max_single_us</th></tr></thead><tbody>\n",
+                );
+                for m in &group.members {
+                    out.push_str(&format!(
+                        "<tr><td>{}</td><td class=\"num\">{}</td><td class=\"num\">{}</td>\
+                         <td class=\"num\">{}</td></tr>\n",
+                        esc(&m.name),
+                        fmt_thousands(m.total_us_p50),
+                        fmt_thousands(m.total_us_max),
+                        fmt_thousands(m.max_single_us),
+                    ));
+                }
+                out.push_str("</tbody></table>\n</details>\n");
+            }
+        }
+        if grouped.shows_unattributed() {
+            phase_group_bar(
+                out,
+                crate::groups::UNATTRIBUTED_NAME,
+                grouped.unattributed_us,
+                grouped.unattributed_share_pct,
+                crate::groups::UNATTRIBUTED_ANNOTATION,
+                true,
+            );
+        }
+        if grouped.over_attributed {
+            out.push_str(&format!(
+                "<p class=\"muted\">{}</p>\n",
+                esc(crate::groups::OVER_ATTRIBUTION_NOTE)
+            ));
+        }
+    }
+
+    // Storage calls, split by store class the way the record splits them.
+    if let Some(sc) = &r.results.storage_calls {
+        let table = sum_counts(&sc.table_store);
+        let manifest = sum_counts(&sc.manifest_store);
+        out.push_str(&format!(
+            "<h3>storage calls ({}, merge windows, sum over reps)</h3>\n",
+            esc(&sc.layer)
+        ));
+        out.push_str(&format!(
+            "<p><strong>{} requests total</strong> — {} on the table stores, {} on the \
+             __manifest store.</p>\n<p class=\"muted\">On S3 every request is one network \
+             round trip, so this count predicts cloud latency and request cost.</p>\n",
+            fmt_thousands(total_calls(&table) + total_calls(&manifest)),
+            fmt_thousands(total_calls(&table)),
+            fmt_thousands(total_calls(&manifest)),
+        ));
+        out.push_str(
+            "<table><thead><tr><th>class</th><th class=\"num\">table stores</th>\
+             <th class=\"num\">__manifest store</th></tr></thead><tbody>\n",
+        );
+        for ((class, t), (_, m)) in class_values(&table).iter().zip(class_values(&manifest)) {
+            out.push_str(&format!(
+                "<tr><td>{class}</td><td class=\"num\">{}</td><td class=\"num\">{}</td></tr>\n",
+                fmt_thousands(*t),
+                fmt_thousands(m)
+            ));
+        }
+        out.push_str("</tbody></table>\n");
+        let bars: Vec<(String, u64, String)> = class_values(&table)
+            .iter()
+            .zip(class_values(&manifest))
+            .filter(|((_, t), (_, m))| *t + m > 0)
+            .map(|((class, t), (_, m))| ((*class).to_string(), *t + m, String::new()))
+            .collect();
+        out.push_str(&svg_bars(&bars));
+        let control = sc
+            .control_plane
+            .iter()
+            .fold(ControlCalls::default(), |mut acc, c| {
+                acc.read += c.read;
+                acc.exists += c.exists;
+                acc.list += c.list;
+                acc.mutation += c.mutation;
+                acc
+            });
+        out.push_str(&format!(
+            "<p class=\"muted\">control plane (engine StorageAdapter): read {} · exists {} · \
+             list {} · mutation {}</p>\n",
+            fmt_thousands(control.read),
+            fmt_thousands(control.exists),
+            fmt_thousands(control.list),
+            fmt_thousands(control.mutation)
+        ));
+    } else {
+        out.push_str("<p class=\"muted\">storage calls: not recorded (v1/v2 record)</p>\n");
+    }
+
+    // Write-path counters.
+    let wp = &r.results.write_path;
+    if !wp.stage_merge_insert_calls.is_empty() {
+        out.push_str(
+            "<h3>write path (sum calls/rows)</h3>\n<table><thead><tr>\
+             <th class=\"num\">merge_insert</th><th class=\"num\">known_present_update</th>\
+             <th class=\"num\">fenced_insert</th><th class=\"num\">strict_preflight</th>\
+             </tr></thead><tbody>\n",
+        );
+        out.push_str(&format!(
+            "<tr><td class=\"num\">{}/{}</td><td class=\"num\">{}/{}</td>\
+             <td class=\"num\">{}/{}</td><td class=\"num\">{}</td></tr>\n</tbody></table>\n",
+            wp.stage_merge_insert_calls.iter().sum::<u64>(),
+            wp.stage_merge_insert_rows.iter().sum::<u64>(),
+            wp.stage_known_present_update_calls.iter().sum::<u64>(),
+            wp.stage_known_present_update_rows.iter().sum::<u64>(),
+            wp.stage_fenced_insert_calls.iter().sum::<u64>(),
+            wp.stage_fenced_insert_rows.iter().sum::<u64>(),
+            wp.strict_insert_preflight_calls.iter().sum::<u64>(),
+        ));
+    }
+
+    // Full identity, collapsed.
+    out.push_str("<details><summary>full identity</summary>\n<table><tbody>\n");
+    for (key, value) in identity_rows(file_name, r) {
+        out.push_str(&format!(
+            "<tr><td>{}</td><td>{}</td></tr>\n",
+            esc(&key),
+            esc(&value)
+        ));
+    }
+    out.push_str("</tbody></table>\n</details>\n</section>\n");
+}
+
+/// The rule-7 delta section for the A/A pairs a records directory holds (two
+/// records sharing one point name). Below-floor deltas read "no detected
+/// effect", never a small effect. Pairing is by point name, so a before/after
+/// pair can land here — differing identities (SUT, machine, backend) are then
+/// badged loudly (rule 4), never presented as a silent A/A comparison;
+/// anything else about pairing belongs to `diff`.
+fn pair_sections(out: &mut String, records: &[(String, RunRecord)], floor: &NoiseFloor) {
+    let mut by_point: BTreeMap<&str, Vec<&RunRecord>> = BTreeMap::new();
+    for (_, r) in records {
+        by_point.entry(&r.point_name).or_default().push(r);
+    }
+    // Named, not silent: a point with 3+ records cannot pair.
+    let unpaired: Vec<(&str, usize)> = by_point
+        .iter()
+        .filter(|(_, rs)| rs.len() > 2)
+        .map(|(point, rs)| (*point, rs.len()))
+        .collect();
+    let pairs: Vec<(&str, &RunRecord, &RunRecord)> = by_point
+        .iter()
+        .filter(|(_, rs)| rs.len() == 2)
+        .map(|(point, rs)| {
+            let (a, b) = (rs[0], rs[1]);
+            if a.invocation_unix_seconds <= b.invocation_unix_seconds {
+                (*point, a, b)
+            } else {
+                (*point, b, a)
+            }
+        })
+        .collect();
+    if pairs.is_empty() && unpaired.is_empty() {
+        return;
+    }
+    out.push_str(
+        "<section>\n<h2>A/A pair deltas (rule 7)</h2>\n<p class=\"muted\">Two records per \
+         point at equal spec and SUT; deltas are labeled against the session's noise floor \
+         and claim margin.</p>\n",
+    );
+    for (point, count) in unpaired {
+        out.push_str(&format!(
+            "<p class=\"muted\">{}: {count} records share this point — pairing needs \
+             exactly two, not rendered</p>\n",
+            esc(point)
+        ));
+    }
+    for (point, a, b) in pairs {
+        // Identity checks mirror diff.rs's rule-4 warnings: a same-point pair
+        // with a differing identity is a before/after comparison, badged as
+        // such rather than presented as A/A.
+        if a.sut.source_commit != b.sut.source_commit {
+            out.push_str("<p><span class=\"badge\">not an A/A pair: SUT differs</span></p>\n");
+        }
+        let (ma, mb) = (&a.machine, &b.machine);
+        if ma.cpu_model != mb.cpu_model
+            || ma.memory_bytes != mb.memory_bytes
+            || ma.os != mb.os
+            || ma.arch != mb.arch
+        {
+            out.push_str(
+                "<p><span class=\"badge\">not an A/A pair: machine specifications differ \
+                 (rule 4)</span></p>\n",
+            );
+        }
+        let (ea, eb) = (&a.run_spec.environment, &b.run_spec.environment);
+        if ea.backend != eb.backend || ea.s3_endpoint != eb.s3_endpoint {
+            out.push_str(
+                "<p><span class=\"badge\">not an A/A pair: backend identities differ \
+                 (rule 4)</span></p>\n",
+            );
+        }
+        // The floor licenses only its own cell — checked against BOTH sides.
+        for (side, r) in [("A", a), ("B", b)] {
+            if floor.source_commit != r.sut.source_commit || floor.session_id != r.session_id {
+                out.push_str(&format!(
+                    "<p class=\"badge\">extrapolation: the floor's SUT commit or session \
+                     differs from record {side}'s — a floor licenses only its own cell</p>\n",
+                ));
+            }
+        }
+        let Some(fp) = floor.points.get(point) else {
+            out.push_str(&format!(
+                "<p class=\"muted\">{}: no floor entry — deltas not shown; rerun \
+                 `run --aa` on this point</p>\n",
+                esc(point)
+            ));
+            continue;
+        };
+        let margin = floor.default_margin;
+        out.push_str(&format!(
+            "<h3>{}</h3>\n<p class=\"muted\">floor {:.2}% · claim margin x{margin}</p>\n",
+            esc(point),
+            fp.pct
+        ));
+        // The commits stay visible in the header even when equal.
+        out.push_str(&format!(
+            "<table><thead><tr><th>metric</th><th class=\"num\">A @ {}</th>\
+             <th class=\"num\">B @ {}</th><th class=\"num\">delta%</th><th>floor</th>\
+             </tr></thead><tbody>\n",
+            esc(short_commit(&a.sut.source_commit)),
+            esc(short_commit(&b.sut.source_commit)),
+        ));
+        let (pa, pb) = (a.results.wall_clock_ms.p50, b.results.wall_clock_ms.p50);
+        out.push_str(&format!(
+            "<tr><td>wall_clock_ms p50</td><td class=\"num\">{pa:.2}</td>\
+             <td class=\"num\">{pb:.2}</td><td class=\"num\">{}</td><td>{}</td></tr>\n",
+            fmt_delta_pct(pa, pb),
+            esc(&floor_label(pa, pb, fp.pct, margin)),
+        ));
+        for phase_a in &a.results.phases {
+            let Some(phase_b) = b.results.phases.iter().find(|p| p.phase == phase_a.phase) else {
+                continue;
+            };
+            let (va, vb) = (phase_a.total_us_p50 as f64, phase_b.total_us_p50 as f64);
+            if va == 0.0 && vb == 0.0 {
+                continue;
+            }
+            let label = fp
+                .phases
+                .get(&phase_a.phase)
+                .map_or(String::new(), |phase_floor| {
+                    floor_label(va, vb, *phase_floor, margin)
+                });
+            out.push_str(&format!(
+                "<tr><td>phase {} total_us p50</td><td class=\"num\">{va:.0}</td>\
+                 <td class=\"num\">{vb:.0}</td><td class=\"num\">{}</td><td>{}</td></tr>\n",
+                esc(&phase_a.phase),
+                fmt_delta_pct(va, vb),
+                esc(&label),
+            ));
+        }
+        out.push_str("</tbody></table>\n");
+    }
+    out.push_str("</section>\n");
+}
+
+const STYLE: &str = "\
+:root { --bg: #ffffff; --fg: #1a1f27; --muted: #667085; --accent: #2563eb; \
+--card: #f6f8fa; --border: #e2e6ea; }
+@media (prefers-color-scheme: dark) {
+  :root { --bg: #0f1216; --fg: #e6e8eb; --muted: #98a1ab; --accent: #6b9aef; \
+--card: #161b21; --border: #2a313a; }
+}
+* { box-sizing: border-box; }
+body { margin: 0 auto; max-width: 60rem; padding: 2.5rem 1.5rem 4rem; \
+background: var(--bg); color: var(--fg); line-height: 1.55; \
+font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif; }
+h1 { font-size: 1.6rem; margin: 0 0 0.25rem; }
+h1 .product { color: var(--accent); }
+h2 { font-size: 1.15rem; margin: 2.5rem 0 0.5rem; border-top: 1px solid var(--border); \
+padding-top: 1.5rem; }
+h3 { font-size: 0.95rem; margin: 1.25rem 0 0.4rem; }
+.muted { color: var(--muted); font-size: 0.85rem; margin: 0.15rem 0 0.75rem; }
+code { font-size: 0.85em; background: var(--card); padding: 0.1em 0.35em; \
+border-radius: 4px; }
+.badge { display: inline-block; font-size: 0.7rem; font-weight: 600; \
+color: var(--bg); background: var(--accent); border-radius: 4px; \
+padding: 0.05rem 0.4rem; vertical-align: middle; }
+table { border-collapse: collapse; font-size: 0.85rem; \
+font-variant-numeric: tabular-nums; margin: 0.5rem 0 1rem; }
+th, td { text-align: left; padding: 0.3rem 0.9rem 0.3rem 0; \
+border-bottom: 1px solid var(--border); vertical-align: top; }
+th { color: var(--muted); font-weight: 600; }
+th.num, td.num { text-align: right; }
+details { margin: 1rem 0; }
+summary { cursor: pointer; color: var(--muted); font-size: 0.85rem; }
+.cards { display: flex; flex-wrap: wrap; gap: 0.75rem; margin: 0.75rem 0 1rem; }
+.card { border: 1px solid var(--border); background: var(--card); border-radius: 8px; \
+padding: 0.55rem 0.9rem; min-width: 8.5rem; }
+.card .v { font-size: 1.2rem; font-weight: 600; font-variant-numeric: tabular-nums; }
+.card .l { color: var(--muted); font-size: 0.72rem; }
+.grp { margin: 0.65rem 0 0; }
+.grp-head { display: flex; justify-content: space-between; gap: 1rem; \
+font-size: 0.9rem; }
+.grp-val { color: var(--muted); font-variant-numeric: tabular-nums; \
+white-space: nowrap; }
+.track { height: 8px; background: var(--card); border: 1px solid var(--border); \
+border-radius: 4px; overflow: hidden; margin: 0.25rem 0; }
+.fill { height: 100%; background: var(--accent); }
+.fill.un { background: var(--muted); }
+.grp .muted { margin: 0.1rem 0 0.2rem; }
+.grp + details { margin: 0 0 0.6rem; }
+svg { max-width: 100%; height: auto; }
+svg .bl { font-size: 12px; fill: var(--fg); }
+svg .bv { font-size: 12px; fill: var(--muted); }
+svg .bar { fill: var(--accent); }
+footer { margin-top: 3rem; border-top: 1px solid var(--border); \
+padding-top: 1rem; color: var(--muted); font-size: 0.8rem; }
+";
+
+/// Render the whole page. Pure (records + floor + timestamp in, HTML out) so
+/// the tests exercise it without touching the filesystem.
+fn render_report(
+    records: &[(String, RunRecord)],
+    floor: Option<&NoiseFloor>,
+    generated_unix_seconds: u64,
+) -> String {
+    let mut sessions: Vec<&str> = records.iter().map(|(_, r)| r.session_id.as_str()).collect();
+    sessions.sort_unstable();
+    sessions.dedup();
+    let mut commits: Vec<&str> = records
+        .iter()
+        .map(|(_, r)| r.sut.source_commit.as_str())
+        .collect();
+    commits.sort_unstable();
+    commits.dedup();
+
+    let mut out = String::with_capacity(64 * 1024);
+    out.push_str(&format!(
+        "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n\
+         <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n\
+         <title>omnigraph-bench report</title>\n<style>\n{STYLE}</style>\n</head>\n<body>\n\
+         <header>\n<h1><span class=\"product\">omnigraph-bench</span> run report</h1>\n\
+         <p class=\"muted\">generated {} · {} record(s) · session(s): {} · SUT: {}</p>\n\
+         </header>\n",
+        fmt_utc(generated_unix_seconds),
+        records.len(),
+        esc(&sessions.join(", ")),
+        commits
+            .iter()
+            .map(|c| commit_html(c))
+            .collect::<Vec<_>>()
+            .join(", "),
+    ));
+
+    // Overview: one row per record.
+    out.push_str(
+        "<section>\n<h2>overview</h2>\n<table><thead><tr><th>point</th><th>label</th>\
+         <th class=\"num\">reps</th><th class=\"num\">p50 ms</th><th class=\"num\">p95 ms</th>\
+         <th class=\"num\">storage calls</th></tr></thead><tbody>\n",
+    );
+    for (_, r) in records {
+        let w = &r.results.wall_clock_ms;
+        let directional = if w.tail_support == "supported" {
+            ""
+        } else {
+            " <span class=\"badge\">directional</span>"
+        };
+        let calls = r
+            .results
+            .storage_calls
+            .as_ref()
+            .map(|sc| {
+                fmt_thousands(
+                    total_calls(&sum_counts(&sc.table_store))
+                        + total_calls(&sum_counts(&sc.manifest_store)),
+                )
+            })
+            .unwrap_or("n/a".into());
+        out.push_str(&format!(
+            "<tr><td><a href=\"#r-{}\">{}</a></td><td>{}</td><td class=\"num\">{}</td>\
+             <td class=\"num\">{:.2}</td><td class=\"num\">{:.2}{directional}</td>\
+             <td class=\"num\">{calls}</td></tr>\n",
+            esc(&r.invocation_id),
+            esc(&r.point_name),
+            esc(r.label.as_deref().unwrap_or("unlabeled")),
+            r.run_spec.protocol.repetitions,
+            w.p50,
+            w.p95,
+        ));
+    }
+    out.push_str("</tbody></table>\n</section>\n");
+
+    if let Some(floor) = floor {
+        pair_sections(&mut out, records, floor);
+    }
+
+    for (file_name, r) in records {
+        per_record_section(&mut out, file_name, r);
+    }
+
+    // Footer: versions + record filenames.
+    let mut builder_versions: Vec<String> = records
+        .iter()
+        .filter_map(|(_, r)| r.run_spec.state.builder_version)
+        .map(|v| v.to_string())
+        .collect();
+    builder_versions.sort_unstable();
+    builder_versions.dedup();
+    out.push_str(&format!(
+        "<footer>\nrecord schema v{} · builder v{} · records: {}\n</footer>\n</body>\n</html>\n",
+        crate::record::RECORD_VERSION,
+        if builder_versions.is_empty() {
+            "unknown".to_string()
+        } else {
+            builder_versions.join(", ")
+        },
+        esc(&records
+            .iter()
+            .map(|(f, _)| f.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")),
+    ));
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::record::testkit::sample_record;
+
+    #[test]
+    fn utc_formatting_is_civil() {
+        // (unix seconds, expected)
+        for (secs, expected) in [
+            (0, "1970-01-01 00:00:00 UTC"),
+            (951_782_400, "2000-02-29 00:00:00 UTC"),
+            (1_755_600_000, "2025-08-19 10:40:00 UTC"),
+        ] {
+            assert_eq!(fmt_utc(secs), expected);
+        }
+    }
+
+    #[test]
+    fn thousands_grouping() {
+        for (n, expected) in [
+            (0, "0"),
+            (999, "999"),
+            (1_000, "1,000"),
+            (1_234_567, "1,234,567"),
+        ] {
+            assert_eq!(fmt_thousands(n), expected);
+        }
+    }
+
+    #[test]
+    fn report_names_points_phases_and_identity() {
+        let records = vec![
+            (
+                "a.json".to_string(),
+                sample_record("m3-t2-n100-noindex-d1-warm", &[10.0, 11.0]),
+            ),
+            (
+                "b.json".to_string(),
+                sample_record("m3-t2-n100-noindex-d50-warm", &[20.0]),
+            ),
+        ];
+        let html = render_report(&records, None, 0);
+        assert!(html.contains("omnigraph-bench"));
+        assert!(html.contains("m3-t2-n100-noindex-d1-warm"));
+        assert!(html.contains("m3-t2-n100-noindex-d50-warm"));
+        assert!(html.contains("OuterPrepare"));
+        assert!(html.contains("a.json") && html.contains("b.json"));
+        // Directional tails and the SUT commit stay visible.
+        assert!(html.contains("directional"));
+        assert!(html.contains("deadbeefdeadbeef"));
+        // Headline cards precede the tables.
+        assert!(html.contains("median merge (p50)"));
+        assert!(html.contains("biggest cost"));
+        // The S3 cost annotation rides with the storage split.
+        assert!(html.contains("one network round trip"));
+        // Self-containment: no external fetches of any kind.
+        for needle in ["http://", "https://", "<script", "@import", "url("] {
+            assert!(
+                !html.contains(needle),
+                "self-contained page must not contain '{needle}'"
+            );
+        }
+    }
+
+    #[test]
+    fn phases_render_grouped_with_explicit_unattributed_remainder() {
+        // sample_record: wall p50 10 ms, phases 100 µs — the remainder is
+        // material and must render as its own bar, never normalized away.
+        let record = sample_record("m3-t2-n100-noindex-d1-warm", &[10.0]);
+        let html = render_report(&[("a.json".to_string(), record)], None, 0);
+        for group in [
+            "setup and refresh",
+            "discover changes",
+            "table walk",
+            "validate changes",
+            "write merged data",
+            "publish new state",
+            "crash-safety bookkeeping",
+        ] {
+            assert!(html.contains(group), "missing group '{group}'");
+        }
+        assert!(html.contains(crate::groups::UNATTRIBUTED_NAME));
+        assert!(html.contains("three-way row walk"));
+        // The raw phase stays visible inside the fold.
+        assert!(html.contains("OuterPrepare"));
+
+        // Sub-bucket exclusion, visible in the rendered totals: PhysicalPublish
+        // 5 ms wrapping KeyedStage 3 ms + KeyedCommit 1 ms on a 5 ms wall —
+        // the write group reads 5.0 ms (parent only) and fully explains the
+        // wall, so no unattributed bar renders.
+        let mut record = sample_record("m3-t2-n100-noindex-d1-warm", &[5.0]);
+        record.results.phases = ["PhysicalPublish", "KeyedStage", "KeyedCommit"]
+            .iter()
+            .zip([5_000_u64, 3_000, 1_000])
+            .map(|(name, us)| crate::record::PhaseStats {
+                phase: (*name).to_string(),
+                total_us_p50: us,
+                total_us_max: us,
+                max_single_us: us,
+                per_rep_total_us: vec![us],
+            })
+            .collect();
+        let html = render_report(&[("a.json".to_string(), record)], None, 0);
+        assert!(html.contains("5.0 ms · 100.0%"), "parent-only write total");
+        assert!(!html.contains("9.0 ms"), "sub-buckets must not sum on top");
+        assert!(!html.contains(crate::groups::UNATTRIBUTED_NAME));
+        // The sub-buckets stay visible as raw phases in the fold.
+        assert!(html.contains("KeyedStage") && html.contains("KeyedCommit"));
+    }
+
+    #[test]
+    fn free_form_strings_are_escaped() {
+        let mut record = sample_record("m3-t2-n100-noindex-d1-warm", &[10.0]);
+        record.label = Some("<script>alert(1)</script>".to_string());
+        record.results.phases[0].phase = "Phase<&>\"quote".to_string();
+        let html = render_report(&[("x.json".to_string(), record)], None, 0);
+        assert!(!html.contains("<script>alert"));
+        assert!(html.contains("&lt;script&gt;alert(1)&lt;/script&gt;"));
+        assert!(html.contains("Phase&lt;&amp;&gt;&quot;quote"));
+    }
+
+    #[test]
+    fn aa_pairs_get_rule_7_labels() {
+        let a = sample_record("m3-t2-n100-noindex-d1-warm", &[100.0]);
+        let b = sample_record("m3-t2-n100-noindex-d1-warm", &[100.5]);
+        let floor = NoiseFloor {
+            floor_version: crate::record::FLOOR_VERSION,
+            created_unix_seconds: 0,
+            session_id: a.session_id.clone(),
+            source_commit: a.sut.source_commit.clone(),
+            default_margin: 2.0,
+            points: [(
+                a.point_name.clone(),
+                crate::record::FloorPoint {
+                    wall_p50_a_ms: 100.0,
+                    wall_p50_b_ms: 100.5,
+                    abs_delta_ms: 0.5,
+                    pct: 2.0,
+                    phases: BTreeMap::new(),
+                },
+            )]
+            .into(),
+        };
+        let html = render_report(
+            &[("a.json".to_string(), a), ("b.json".to_string(), b)],
+            Some(&floor),
+            0,
+        );
+        assert!(html.contains("A/A pair deltas"));
+        assert!(html.contains("no detected effect"));
+        // Commits stay visible in the pair table header even when equal.
+        assert!(html.contains("A @ deadbeefd") && html.contains("B @ deadbeefd"));
+        assert!(!html.contains("not an A/A pair"));
+    }
+
+    fn empty_floor(session_id: &str, source_commit: &str) -> NoiseFloor {
+        NoiseFloor {
+            floor_version: crate::record::FLOOR_VERSION,
+            created_unix_seconds: 0,
+            session_id: session_id.to_string(),
+            source_commit: source_commit.to_string(),
+            default_margin: 2.0,
+            points: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn same_point_pairs_with_differing_identity_are_badged_not_aa() {
+        let point = "m3-t2-n100-noindex-d1-warm";
+        let a = sample_record(point, &[100.0]);
+        let mut b = sample_record(point, &[100.5]);
+        b.sut.source_commit = "0123456789abcdef".to_string();
+        b.machine.cpu_model = "other cpu".to_string();
+        let floor = empty_floor(&a.session_id, &a.sut.source_commit);
+        let html = render_report(
+            &[("a.json".to_string(), a), ("b.json".to_string(), b)],
+            Some(&floor),
+            0,
+        );
+        assert!(html.contains("not an A/A pair: SUT differs"));
+        assert!(html.contains("machine specifications differ"));
+        // The floor cell check covers BOTH sides: B's SUT differs from the
+        // floor's, A's does not.
+        assert!(html.contains("differs from record B"));
+        assert!(!html.contains("differs from record A"));
+    }
+
+    #[test]
+    fn points_with_more_than_two_records_are_named_not_silently_dropped() {
+        let point = "m3-t2-n100-noindex-d1-warm";
+        let records: Vec<(String, RunRecord)> = (0..3)
+            .map(|i| {
+                (
+                    format!("r{i}.json"),
+                    sample_record(point, &[100.0 + i as f64]),
+                )
+            })
+            .collect();
+        let floor = empty_floor("test-session", "deadbeefdeadbeef");
+        let html = render_report(&records, Some(&floor), 0);
+        assert!(html.contains("3 records share this point"));
+    }
+
+    #[test]
+    fn over_attributed_records_carry_the_footnote() {
+        // Wall p50 0.05 ms vs a 100 µs phase median: shares exceed 100% and
+        // the footnote renders instead of a silent cap.
+        let record = sample_record("m3-t2-n100-noindex-d1-warm", &[0.05]);
+        let html = render_report(&[("a.json".to_string(), record)], None, 0);
+        assert!(html.contains(crate::groups::OVER_ATTRIBUTION_NOTE));
+        // A fully-attributed record renders no footnote.
+        let record = sample_record("m3-t2-n100-noindex-d1-warm", &[10.0]);
+        let html = render_report(&[("a.json".to_string(), record)], None, 0);
+        assert!(!html.contains(crate::groups::OVER_ATTRIBUTION_NOTE));
+    }
+}

--- a/crates/omnigraph-bench/src/run.rs
+++ b/crates/omnigraph-bench/src/run.rs
@@ -1,0 +1,1284 @@
+//! The `run` subcommand: acquire a base store (inline build or a validated
+//! frozen fixture copy), run one merge scenario per point under one declared
+//! warmth regime, and write one schema-validated run record per point.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use clap::{Args, ValueEnum};
+use lance::io::WrappingObjectStore;
+use omnigraph::db::{MergeOutcome, Omnigraph, ReadTarget};
+use omnigraph::instrumentation::{
+    CountingStorageAdapter, MergeWriteProbes, QueryIoProbes, StorageReadCounts,
+    with_merge_write_probes, with_query_io_probes,
+};
+use omnigraph::storage::storage_for_uri;
+
+use crate::counting::CallCounter;
+use crate::fixture::{self, BaseProfile, BenchResult, FixtureManifest, FixturePlan, Side};
+use crate::record::{
+    ARRIVAL_UNSCHEDULED_SINGLE_SHOT, ATTRIBUTION_PER_PHASE_ON, ControlCalls, DataAxes,
+    EnvironmentAxes, FLOOR_VERSION, FloorPoint, NoiseFloor, POINT_NAME_FORMAT,
+    PROVENANCE_SYNTHETIC, PhaseStats, ProtocolAxes, RECORD_VERSION, RowCheck, RunRecord,
+    RunResults, RunSpec, StateAxes, StorageCalls, SutBlock, WallClockStats, WarmthDeclaration,
+    WorkloadAxes, WritePathCounters, default_margin, derive_profile, pair_delta_pct,
+    percentile_f64, percentile_u64, tail_support,
+};
+use crate::{refuse_debug_build, schema, source_commit, unix_now};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum Scenario {
+    /// Three-way diverged mixed merge, delta sweep at fixed N.
+    M3,
+    /// Composite headline: every table diverged, small delta, one merge.
+    M5,
+}
+
+impl Scenario {
+    pub fn id(self) -> &'static str {
+        match self {
+            Scenario::M3 => "m3",
+            Scenario::M5 => "m5",
+        }
+    }
+}
+
+/// The declared warmth regime (RFC 0039 Environment class; rule 3 requires
+/// exactly one per cell, declared in the record).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum Warmth {
+    /// Fresh process per measured repetition (spawned by this binary).
+    Cold,
+    /// Discarded warm-up repetition(s), then measurement.
+    Warm,
+    /// Warm-up, then the engine handle is dropped and reopened (engine +
+    /// Lance session caches invalidated), then measurement.
+    PostInvalidation,
+}
+
+impl Warmth {
+    pub fn id(self) -> &'static str {
+        match self {
+            Warmth::Cold => "cold",
+            Warmth::Warm => "warm",
+            Warmth::PostInvalidation => "post-invalidation",
+        }
+    }
+}
+
+#[derive(Debug, Args)]
+pub struct RunArgs {
+    /// Scenario to run.
+    #[arg(long, value_enum)]
+    scenario: Scenario,
+    /// T — node-table count (default 12; large center: 140).
+    /// Incompatible with --fixture (the fixture pins the Data axes).
+    #[arg(long)]
+    tables: Option<usize>,
+    /// N — base rows per table (default 10000; center: 100000).
+    /// Incompatible with --fixture.
+    #[arg(long)]
+    rows: Option<usize>,
+    /// d values to sweep, comma-separated (delta rows per side).
+    /// Defaults: m3 = 1,50,5000; m5 = 50.
+    #[arg(long, value_delimiter = ',')]
+    delta: Vec<usize>,
+    /// Tables the delta touches on both sides. Defaults: m3 = min(4, T);
+    /// m5 = T (m5 diverges every table; any other value is refused).
+    /// Incompatible with --fixture.
+    #[arg(long)]
+    diverged_tables: Option<usize>,
+    /// Measured merges per point (warm-ups are extra; see --warmup-reps).
+    #[arg(long, default_value_t = 5)]
+    reps: usize,
+    /// Warmth regime, declared per cell (RFC 0039 rule 3).
+    #[arg(long, value_enum, default_value_t = Warmth::Warm)]
+    warmth: Warmth,
+    /// Warm-up repetitions run and discarded before measurement (warm and
+    /// post-invalidation regimes; cold has none).
+    #[arg(long, default_value_t = 1)]
+    warmup_reps: usize,
+    /// Run every point twice at equal spec and SUT (the A/A pair) and write
+    /// a noise-floor.json beside the records for `diff --floor` (rule 7).
+    #[arg(long)]
+    aa: bool,
+    /// Filler bytes in the scalar payload column per row (default 64).
+    /// Incompatible with --fixture.
+    #[arg(long)]
+    payload_bytes: Option<usize>,
+    /// Directory for run-record JSON files (created if absent).
+    #[arg(long)]
+    out: PathBuf,
+    /// Store root. Absent: a fresh local tempdir per run
+    /// (backend "local-fs-tempdir"). `s3://bucket/prefix`: an S3-compatible
+    /// backend (MinIO/RustFS via AWS_* env; see README) — a unique sub-prefix
+    /// is appended per run.
+    #[arg(long)]
+    root_uri: Option<String>,
+    /// Frozen fixture directory (from `fixture build`). Must carry a
+    /// validation stamp; the frozen store is re-digested and refused on
+    /// mismatch (again per per-point copy). The store is copied to a fresh
+    /// per-point tempdir and the run opens the copy; Data+State axes come
+    /// from the fixture's manifest.
+    #[arg(long)]
+    fixture: Option<PathBuf>,
+    /// Free-form label stored in the record ("baseline-main", "after-O3").
+    #[arg(long)]
+    label: Option<String>,
+    /// Internal: run exactly one cold measured repetition with this index
+    /// (spawned by the cold parent; not for direct use).
+    #[arg(long, hide = true)]
+    internal_cold_rep: Option<usize>,
+}
+
+/// Engine configuration as data (RFC 0039 SUT block): every `OMNIGRAPH_*`
+/// environment variable set at run time. An empty map means no flag was set,
+/// recorded as such — never inferred from a prose label. Values of
+/// secret-looking variables are stored redacted ([`is_secret_config_name`]):
+/// records and reports are shareable artifacts, and the server's bearer-token
+/// variables (`OMNIGRAPH_SERVER_BEARER_TOKEN*`) live in this namespace.
+fn engine_configuration() -> BTreeMap<String, String> {
+    std::env::vars()
+        .filter(|(key, _)| key.starts_with("OMNIGRAPH_"))
+        .map(|(key, value)| {
+            let value = if is_secret_config_name(&key) {
+                "<redacted>".to_string()
+            } else {
+                value
+            };
+            (key, value)
+        })
+        .collect()
+}
+
+/// Whether a configuration variable's NAME marks its value as a secret: the
+/// name persists, the value never does. Case-insensitive substring match —
+/// KEY also covers plausible future credential-style flags.
+fn is_secret_config_name(name: &str) -> bool {
+    let upper = name.to_uppercase();
+    ["TOKEN", "SECRET", "PASSWORD", "CREDENTIAL", "KEY"]
+        .iter()
+        .any(|marker| upper.contains(marker))
+}
+
+pub async fn run(args: RunArgs, session_id: String) -> BenchResult<()> {
+    refuse_debug_build("recording benchmark numbers")?;
+    if args.reps == 0 {
+        return Err("--reps must be >= 1".into());
+    }
+    if args.warmth != Warmth::Cold && args.warmup_reps == 0 {
+        return Err(
+            "the warm and post-invalidation regimes need --warmup-reps >= 1 \
+                    (0 warm-ups would mix rep 1's cold caches into the cell — the regime \
+                    mixing RFC 0039 rule 3 forbids); use --warmth cold for cold numbers"
+                .into(),
+        );
+    }
+    if args.internal_cold_rep.is_some() && (args.warmth != Warmth::Cold || args.reps != 1) {
+        return Err("--internal-cold-rep is the cold parent's internal seam \
+                    (requires --warmth cold --reps 1)"
+            .into());
+    }
+    if args.scenario == Scenario::M5 && args.fixture.is_none() {
+        let tables = args.tables.unwrap_or(12);
+        if let Some(diverged) = args.diverged_tables {
+            if diverged != tables {
+                return Err(format!(
+                    "m5 diverges every table: --diverged-tables {diverged} contradicts \
+                     --tables {tables}; drop --diverged-tables or make them equal"
+                )
+                .into());
+            }
+        }
+    }
+    let fixture = match &args.fixture {
+        Some(dir) => {
+            if args.root_uri.is_some() {
+                return Err("--fixture and --root-uri are mutually exclusive (frozen \
+                            fixtures are local-copy only in this version)"
+                    .into());
+            }
+            if args.tables.is_some()
+                || args.rows.is_some()
+                || args.payload_bytes.is_some()
+                || args.diverged_tables.is_some()
+            {
+                return Err("--fixture pins the Data axes; drop --tables/--rows/\
+                            --payload-bytes/--diverged-tables"
+                    .into());
+            }
+            let manifest = fixture::load_validated(dir)?;
+            if args.scenario == Scenario::M5
+                && manifest.profile.diverged_tables != manifest.profile.tables
+            {
+                return Err(format!(
+                    "m5 diverges every table, but fixture {} was built with diverged_tables = {} of {}",
+                    manifest.fixture_name,
+                    manifest.profile.diverged_tables,
+                    manifest.profile.tables
+                )
+                .into());
+            }
+            Some((dir.clone(), manifest))
+        }
+        None => None,
+    };
+    let deltas = if args.delta.is_empty() {
+        match args.scenario {
+            Scenario::M3 => vec![1, 50, 5000],
+            Scenario::M5 => vec![50],
+        }
+    } else {
+        args.delta.clone()
+    };
+    std::fs::create_dir_all(&args.out)?;
+    let floor_path = args.out.join("noise-floor.json");
+    // Checked before any measurement: a floor is per session, and overwriting
+    // an existing one would silently retarget every diff that reads it.
+    if args.aa && floor_path.exists() {
+        return Err(format!(
+            "{} already exists — refusing to overwrite a noise floor; point --out at \
+             a fresh directory or delete the file first",
+            floor_path.display()
+        )
+        .into());
+    }
+
+    let mut floor_points: BTreeMap<String, FloorPoint> = BTreeMap::new();
+    let mut floor_commit = String::new();
+    for delta in deltas {
+        let plan = match &fixture {
+            Some((_, manifest)) => FixturePlan::new(manifest.profile.clone(), delta)?,
+            None => {
+                let tables = args.tables.unwrap_or(12);
+                let rows = args.rows.unwrap_or(10_000);
+                let payload_bytes = args.payload_bytes.unwrap_or(64);
+                let diverged_default = match args.scenario {
+                    Scenario::M3 => tables.min(4),
+                    Scenario::M5 => tables,
+                };
+                let diverged = args.diverged_tables.unwrap_or(diverged_default);
+                let profile = BaseProfile::new(tables, rows, payload_bytes, diverged, vec![delta])?;
+                FixturePlan::new(profile, delta)?
+            }
+        };
+        if args.aa {
+            let rec_a = run_point(&args, &plan, fixture.as_ref(), &session_id).await?;
+            write_record(&args.out, &rec_a, "_aa1")?;
+            let rec_b = run_point(&args, &plan, fixture.as_ref(), &session_id).await?;
+            write_record(&args.out, &rec_b, "_aa2")?;
+            floor_commit = rec_a.sut.source_commit.clone();
+            floor_points.insert(rec_a.point_name.clone(), floor_point(&rec_a, &rec_b));
+        } else {
+            let record = run_point(&args, &plan, fixture.as_ref(), &session_id).await?;
+            write_record(&args.out, &record, "")?;
+        }
+    }
+    if args.aa {
+        let floor = NoiseFloor {
+            floor_version: FLOOR_VERSION,
+            created_unix_seconds: unix_now(),
+            session_id,
+            source_commit: floor_commit,
+            default_margin: default_margin(),
+            points: floor_points,
+        };
+        // Temp + rename in the same directory (the fixture-manifest pattern):
+        // a crash mid-write can leave a stray temp file, never a torn floor.
+        // The pre-run existence check refused an existing floor; the rename
+        // still makes any race a replace, not interleaved bytes.
+        let tmp = args.out.join("noise-floor.json.tmp");
+        std::fs::write(&tmp, serde_json::to_string_pretty(&floor)?)
+            .map_err(|e| format!("writing {}: {e}", tmp.display()))?;
+        std::fs::rename(&tmp, &floor_path).map_err(|e| {
+            format!(
+                "renaming {} over {}: {e}",
+                tmp.display(),
+                floor_path.display()
+            )
+        })?;
+        println!("noise floor written: {}", floor_path.display());
+    }
+    Ok(())
+}
+
+/// One point: dispatches the cold parent (fresh process per rep) or the
+/// in-process warm / post-invalidation / cold-child run. Stamps the
+/// caller-minted invocation id (a ULID — identity never rests on clock
+/// resolution) and the invocation timestamp (ordering only) at entry — one
+/// record = one invocation, and (spec, SUT, invocation id) is the record's
+/// unique key (RFC 0039).
+async fn run_point(
+    args: &RunArgs,
+    plan: &FixturePlan,
+    fixture: Option<&(PathBuf, FixtureManifest)>,
+    session_id: &str,
+) -> BenchResult<RunRecord> {
+    let invocation_id = ulid::Ulid::new().to_string();
+    let invoked = unix_now();
+    if args.warmth == Warmth::Cold && args.internal_cold_rep.is_none() {
+        run_cold(args, plan, fixture, invocation_id, session_id, invoked).await
+    } else {
+        run_one(args, plan, fixture, invocation_id, session_id, invoked).await
+    }
+}
+
+/// Validate against the shipped schema, then write
+/// `<point_name><suffix>_<invocation_id>.json` — the full point name keeps
+/// distinct points from colliding, the invocation id keeps re-runs of one
+/// point from colliding. `create_new` makes any residual collision a hard
+/// error instead of a silent overwrite, and no code path rewrites an existing
+/// record (RFC 0039: append-only until first cited). The harness refuses to
+/// emit an invalid record (validation on WRITE).
+fn write_record(out: &Path, record: &RunRecord, suffix: &str) -> BenchResult<PathBuf> {
+    let value = serde_json::to_value(record)?;
+    schema::require_valid_v3(&value, "refusing to write an invalid run record")?;
+    let path = out.join(format!(
+        "{}{suffix}_{}.json",
+        record.point_name, record.invocation_id
+    ));
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .map_err(|e| format!("creating {} (refusing to overwrite): {e}", path.display()))?;
+    use std::io::Write as _;
+    file.write_all(serde_json::to_string_pretty(&value)?.as_bytes())?;
+    println!("run record written: {}", path.display());
+    Ok(path)
+}
+
+/// The A/A pair's floor entry for one point (rule 7): wall-clock p50 delta as
+/// a percentage of the pair mean, plus per-phase floors where a phase has a
+/// nonzero pair mean.
+fn floor_point(a: &RunRecord, b: &RunRecord) -> FloorPoint {
+    let (pa, pb) = (a.results.wall_clock_ms.p50, b.results.wall_clock_ms.p50);
+    let mut phases = BTreeMap::new();
+    for phase_a in &a.results.phases {
+        let Some(phase_b) = b.results.phases.iter().find(|p| p.phase == phase_a.phase) else {
+            continue;
+        };
+        let (fa, fb) = (phase_a.total_us_p50 as f64, phase_b.total_us_p50 as f64);
+        if fa + fb > 0.0 {
+            phases.insert(phase_a.phase.clone(), pair_delta_pct(fa, fb));
+        }
+    }
+    FloorPoint {
+        wall_p50_a_ms: pa,
+        wall_p50_b_ms: pb,
+        abs_delta_ms: (pa - pb).abs(),
+        pct: pair_delta_pct(pa, pb),
+        phases,
+    }
+}
+
+/// The store root for one run, plus the tempdir guard that must outlive it.
+fn run_root(
+    args: &RunArgs,
+    delta: usize,
+) -> BenchResult<(String, String, Option<tempfile::TempDir>)> {
+    match &args.root_uri {
+        Some(uri) if uri.starts_with("s3://") => {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock after epoch")
+                .as_nanos();
+            let root = format!(
+                "{}/bench-{}-d{}-{}",
+                uri.trim_end_matches('/'),
+                args.scenario.id(),
+                delta,
+                nanos
+            );
+            Ok((root, "s3-compatible".to_string(), None))
+        }
+        Some(other) => Err(format!(
+            "--root-uri must be an s3:// URI (got '{other}'); omit it for the local tempdir backend"
+        )
+        .into()),
+        None => {
+            let dir = tempfile::tempdir()?;
+            let root = dir
+                .path()
+                .to_str()
+                .ok_or("tempdir path is not UTF-8")?
+                .to_string();
+            Ok((root, "local-fs-tempdir".to_string(), Some(dir)))
+        }
+    }
+}
+
+/// Open the store with the engine's public counting decorator on the
+/// control-plane `StorageAdapter`, returning the handle plus the counter.
+async fn open_counting(root: &str) -> BenchResult<(Omnigraph, Arc<StorageReadCounts>)> {
+    let inner = storage_for_uri(root)?;
+    let (adapter, counts) = CountingStorageAdapter::new(inner);
+    Ok((Omnigraph::open_with_storage(root, adapter).await?, counts))
+}
+
+/// One rep's control-plane call tallies (cumulative; subtract for deltas).
+#[derive(Debug, Clone, Copy, Default)]
+struct ControlSnapshot {
+    read: u64,
+    exists: u64,
+    list: u64,
+    mutation: u64,
+}
+
+fn control_snapshot(counts: &StorageReadCounts) -> ControlSnapshot {
+    ControlSnapshot {
+        read: counts.read_text() + counts.read_text_if_exists() + counts.read_text_versioned(),
+        exists: counts.exists(),
+        list: counts.list_dir(),
+        mutation: counts.mutation_calls(),
+    }
+}
+
+fn control_delta(before: ControlSnapshot, after: ControlSnapshot) -> ControlCalls {
+    ControlCalls {
+        read: after.read - before.read,
+        exists: after.exists - before.exists,
+        list: after.list - before.list,
+        mutation: after.mutation - before.mutation,
+    }
+}
+
+/// The state tag a point name carries for this run's F2/F3 level.
+fn run_state_tag(fixture: Option<&(PathBuf, FixtureManifest)>) -> &'static str {
+    match fixture {
+        Some((_, manifest)) => fixture::state_tag(manifest.state.index_level),
+        None => fixture::state_tag(fixture::IndexLevel::None),
+    }
+}
+
+fn derive_point_name(
+    args: &RunArgs,
+    plan: &FixturePlan,
+    fixture: Option<&(PathBuf, FixtureManifest)>,
+    backend_is_s3: bool,
+) -> String {
+    let p = &plan.profile;
+    let non_default_diverged = (p.diverged_tables != p.tables.min(4)).then_some(p.diverged_tables);
+    crate::record::point_name(
+        args.scenario.id(),
+        p.tables,
+        p.rows,
+        p.payload_bytes,
+        run_state_tag(fixture),
+        non_default_diverged,
+        plan.delta,
+        args.warmth.id(),
+        backend_is_s3,
+    )
+}
+
+async fn run_one(
+    args: &RunArgs,
+    plan: &FixturePlan,
+    fixture: Option<&(PathBuf, FixtureManifest)>,
+    invocation_id: String,
+    session_id: &str,
+    invoked: u64,
+) -> BenchResult<RunRecord> {
+    let warmup = match args.warmth {
+        Warmth::Cold => 0,
+        _ => args.warmup_reps,
+    };
+    let (root, backend, _tempdir_guard) = run_root(args, plan.delta)?;
+    let manifest_counter = CallCounter::default();
+    let table_counter = CallCounter::default();
+    let probes = QueryIoProbes {
+        manifest_wrapper: Some(Arc::new(manifest_counter.clone()) as Arc<dyn WrappingObjectStore>),
+        table_wrapper: Some(Arc::new(table_counter.clone()) as Arc<dyn WrappingObjectStore>),
+        ..Default::default()
+    };
+    // The whole run body executes under the probe scope so every dataset the
+    // engine opens (and every cached handle reused later) carries the
+    // counting wrapper — the completeness condition for per-run counts.
+    with_query_io_probes(
+        probes,
+        run_one_body(
+            args,
+            plan,
+            fixture,
+            root,
+            backend,
+            warmup,
+            invocation_id,
+            session_id,
+            invoked,
+            manifest_counter,
+            table_counter,
+        ),
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_one_body(
+    args: &RunArgs,
+    plan: &FixturePlan,
+    fixture: Option<&(PathBuf, FixtureManifest)>,
+    root: String,
+    backend: String,
+    warmup: usize,
+    invocation_id: String,
+    session_id: &str,
+    invoked: u64,
+    manifest_counter: CallCounter,
+    table_counter: CallCounter,
+) -> BenchResult<RunRecord> {
+    let p = &plan.profile;
+    println!(
+        "[{} d={}] base: T={} N={} diverged={} split/side={}",
+        args.scenario.id(),
+        plan.delta,
+        p.tables,
+        p.rows,
+        p.diverged_tables,
+        plan.side_split,
+    );
+    println!(
+        "[{} d={}] env: backend={} warmth={}{}",
+        args.scenario.id(),
+        plan.delta,
+        backend,
+        args.warmth.id(),
+        fixture.map_or(String::new(), |(_, m)| format!(
+            " fixture={}",
+            m.fixture_name
+        )),
+    );
+
+    let build_started = Instant::now();
+    let queries = fixture::mutation_queries(p.diverged_tables);
+    let (mut db, mut control_counts, base_load_commits) = match fixture {
+        Some((dir, manifest)) => {
+            let (files, bytes) =
+                fixture::copy_dir_recursive(&fixture::store_dir(dir), Path::new(&root))?;
+            // Re-verify per copy: the entry check in `run` covered the load
+            // moment; this covers the bytes this point actually opens.
+            fixture::verify_copy_digest(Path::new(&root), manifest)?;
+            println!(
+                "[{} d={}] fixture copied + digest-verified: {} files, {:.1} MiB, {:.1}s",
+                args.scenario.id(),
+                plan.delta,
+                files,
+                bytes as f64 / (1024.0 * 1024.0),
+                build_started.elapsed().as_secs_f64()
+            );
+            let (db, counts) = open_counting(&root).await?;
+            (db, counts, manifest.state.base_load_commits)
+        }
+        None => {
+            let schema_source = fixture::schema_source(p.tables);
+            let db = Omnigraph::init(&root, &schema_source).await?;
+            let commits = fixture::load_base(&db, p).await?;
+            println!(
+                "[{} d={}] base loaded: {} commits, {:.1}s",
+                args.scenario.id(),
+                plan.delta,
+                commits,
+                build_started.elapsed().as_secs_f64()
+            );
+            drop(db);
+            let (db, counts) = open_counting(&root).await?;
+            (db, counts, commits)
+        }
+    };
+
+    let mut wall_ms: Vec<f64> = Vec::with_capacity(args.reps);
+    let mut phase_names: Vec<String> = Vec::new();
+    let mut phase_totals: Vec<Vec<u64>> = Vec::new();
+    let mut phase_max_single: Vec<u64> = Vec::new();
+    let mut write_path = WritePathCounters::default();
+    let mut storage_manifest: Vec<crate::counting::CallCounts> = Vec::with_capacity(args.reps);
+    let mut storage_table: Vec<crate::counting::CallCounts> = Vec::with_capacity(args.reps);
+    let mut storage_control: Vec<ControlCalls> = Vec::with_capacity(args.reps);
+    let mut fixture_seconds = build_started.elapsed().as_secs_f64();
+    let mut last_target = String::new();
+
+    let rep_base = args.internal_cold_rep.unwrap_or(0);
+    let total_reps = warmup + args.reps;
+    for i in 0..total_reps {
+        let measured = i >= warmup;
+        if args.warmth == Warmth::PostInvalidation && i == warmup {
+            // The regime's invalidation step: drop the engine handle and
+            // reopen (engine + Lance session caches fresh; OS page cache
+            // stays warm — the engine exposes no finer invalidation door).
+            drop(db);
+            let (fresh_db, fresh_counts) = open_counting(&root).await?;
+            db = fresh_db;
+            control_counts = fresh_counts;
+            println!(
+                "[{} d={}] caches invalidated: engine handle reopened after {warmup} warm-up rep(s)",
+                args.scenario.id(),
+                plan.delta
+            );
+        }
+        let rep = rep_base + i;
+        let src = format!("bench_src_d{}_{rep}", plan.delta);
+        let tgt = format!("bench_tgt_d{}_{rep}", plan.delta);
+        let diverge_started = Instant::now();
+        db.branch_create_from(ReadTarget::branch("main"), &src)
+            .await?;
+        db.branch_create_from(ReadTarget::branch("main"), &tgt)
+            .await?;
+        fixture::diverge(&db, &src, Side::Source, plan, &queries, rep).await?;
+        fixture::diverge(&db, &tgt, Side::Target, plan, &queries, rep).await?;
+        fixture_seconds += diverge_started.elapsed().as_secs_f64();
+
+        // Reset the storage-call tallies so each measured window covers the
+        // merge only (divergence/prepare calls are deliberately excluded).
+        let _ = manifest_counter.take();
+        let _ = table_counter.take();
+        let control_before = control_snapshot(&control_counts);
+
+        let probes = MergeWriteProbes::default();
+        let merge_started = Instant::now();
+        let outcome = with_merge_write_probes(probes.clone(), db.branch_merge(&src, &tgt)).await?;
+        let elapsed = merge_started.elapsed();
+
+        // Non-vacuous checks (every rep, warm-ups included): the measured
+        // merge must be the general three-way route with real work behind it.
+        if !matches!(outcome, MergeOutcome::Merged) {
+            return Err(format!(
+                "rep {rep}: merge outcome was {outcome:?}, expected Merged (three-way); \
+                 the fixture short-circuited and this run is vacuous"
+            )
+            .into());
+        }
+        let readings = probes.merge_timing_snapshot();
+        if readings.iter().map(|r| r.total_us).sum::<u64>() == 0 {
+            return Err(format!(
+                "rep {rep}: every merge phase reads 0 µs — the timing probes saw no work; \
+                 refusing to record a vacuous run"
+            )
+            .into());
+        }
+        println!(
+            "[{} d={}] rep {rep}{}: merge {:?} in {:.1} ms",
+            args.scenario.id(),
+            plan.delta,
+            if measured {
+                ""
+            } else {
+                " (warm-up, discarded)"
+            },
+            outcome,
+            duration_ms(elapsed)
+        );
+        last_target = tgt;
+        if !measured {
+            continue;
+        }
+        if phase_names.is_empty() {
+            phase_names = readings.iter().map(|r| r.phase.to_string()).collect();
+            phase_totals = vec![Vec::with_capacity(args.reps); readings.len()];
+            phase_max_single = vec![0; readings.len()];
+        }
+        for (i, reading) in readings.iter().enumerate() {
+            phase_totals[i].push(reading.total_us);
+            phase_max_single[i] = phase_max_single[i].max(reading.max_us);
+        }
+        write_path
+            .stage_merge_insert_calls
+            .push(probes.stage_merge_insert_calls());
+        write_path
+            .stage_merge_insert_rows
+            .push(probes.stage_merge_insert_rows());
+        write_path
+            .stage_known_present_update_calls
+            .push(probes.stage_known_present_update_calls());
+        write_path
+            .stage_known_present_update_rows
+            .push(probes.stage_known_present_update_rows());
+        write_path
+            .stage_fenced_insert_calls
+            .push(probes.stage_fenced_insert_calls());
+        write_path
+            .stage_fenced_insert_rows
+            .push(probes.stage_fenced_insert_rows());
+        write_path
+            .strict_insert_preflight_calls
+            .push(probes.strict_insert_preflight_calls());
+        storage_manifest.push(manifest_counter.take());
+        storage_table.push(table_counter.take());
+        storage_control.push(control_delta(
+            control_before,
+            control_snapshot(&control_counts),
+        ));
+        wall_ms.push(duration_ms(elapsed));
+    }
+
+    // Non-vacuous row check on the first diverged table of the last target.
+    let table_key = fixture::table_key(0);
+    let expected = plan.expected_rows_after_merge(0);
+    let actual = db
+        .snapshot_of(ReadTarget::branch(&last_target))
+        .await?
+        .open(&table_key)
+        .await?
+        .count_rows(None)
+        .await?;
+    if actual != expected {
+        return Err(format!(
+            "post-merge row count on {table_key} is {actual}, expected {expected}; \
+             the merge did not apply the planned delta — refusing to record"
+        )
+        .into());
+    }
+
+    let phases: Vec<PhaseStats> = phase_names
+        .iter()
+        .zip(&phase_totals)
+        .zip(&phase_max_single)
+        .map(|((name, totals), max_single)| PhaseStats {
+            phase: name.clone(),
+            total_us_p50: percentile_u64(totals, 50),
+            total_us_max: *totals.iter().max().expect("reps >= 1"),
+            max_single_us: *max_single,
+            per_rep_total_us: totals.clone(),
+        })
+        .collect();
+    let results = RunResults {
+        wall_clock_ms: wall_stats(&wall_ms),
+        phases,
+        merge_outcome: "Merged".to_string(),
+        verified_rows_table0: RowCheck {
+            table_key,
+            expected,
+            actual,
+        },
+        fixture_build_seconds: fixture_seconds,
+        write_path,
+        storage_calls: Some(StorageCalls {
+            scope: "object-store calls of the measured merges only (tallies reset before each \
+                    merge; divergence and prepare excluded), split by store class; complete for \
+                    every dataset opened under this run's probe scope (the whole run body). \
+                    control_plane counts the engine StorageAdapter (non-Lance control objects); \
+                    delete counted per delete-stream invocation, not per object."
+                .to_string(),
+            layer: "logical-operations".to_string(),
+            physical_attempts: None,
+            physical_attempts_note: "physical request attempts (RFC-031's second layer: \
+                                     retries, multipart fan-out) are not observable at the \
+                                     WrappingObjectStore seam — retries happen inside the \
+                                     object_store backend client below this wrapper. Recorded \
+                                     as explicitly absent, never assumed equal to the logical \
+                                     counts."
+                .to_string(),
+            concurrency_witness: None,
+            concurrency_witness_note: "the concurrency witness is defined at the physical \
+                                       request layer, which is not observable at this seam; \
+                                       recorded as absent — no measured span is assumed \
+                                       serial, so elapsed-vs-cumulative reconciliation is \
+                                       unavailable here, never assumed."
+                .to_string(),
+            cumulative_request_time_logical_us: None,
+            cumulative_request_time_physical_us: None,
+            cumulative_request_time_note: "this seam counts requests but does not time them; \
+                                           per-layer request durations are recorded as absent \
+                                           at both layers."
+                .to_string(),
+            latency_calibration: None,
+            latency_calibration_note: "no backend latency calibration measured yet — the \
+                                       attempts x per-request-latency cross-check waits on \
+                                       it; the next measurement to wire."
+                .to_string(),
+            manifest_store: storage_manifest,
+            table_store: storage_table,
+            control_plane: storage_control,
+        }),
+    };
+    print_summary(args.scenario.id(), plan.delta, &results);
+
+    let state = match fixture {
+        Some((_, manifest)) => StateAxes {
+            fragmentation: manifest.state.fragmentation.clone(),
+            index_existence: manifest.state.index_existence.clone(),
+            index_freshness: manifest.state.index_freshness.clone(),
+            deletion_history: manifest.state.deletion_history.clone(),
+            compaction_recency: manifest.state.compaction_recency.clone(),
+            builder_version: Some(manifest.builder_version),
+            generation: Some(manifest.profile.clone()),
+            base_load_commits,
+            fixture_name: Some(manifest.fixture_name.clone()),
+            fixture_manifest: Some(serde_json::to_value(manifest)?),
+        },
+        None => StateAxes {
+            fragmentation: "fresh bulk load, no aging (stub for F1)".to_string(),
+            index_existence: "none declared (F2 low end)".to_string(),
+            index_freshness: "n/a — no indexes (stub for F3)".to_string(),
+            deletion_history: "none before the measured merges (stub for F4)".to_string(),
+            compaction_recency: "optimize never run (stub for F5)".to_string(),
+            builder_version: Some(fixture::BUILDER_VERSION),
+            generation: Some(p.clone()),
+            base_load_commits,
+            fixture_name: None,
+            fixture_manifest: None,
+        },
+    };
+
+    let warmth = WarmthDeclaration {
+        regime: args.warmth.id().to_string(),
+        warmup_reps_discarded: warmup,
+        detail: match args.warmth {
+            Warmth::Warm => format!(
+                "{warmup} warm-up repetition(s) ran the full divergence + merge and were \
+                 discarded; measurement started with engine, Lance-session, and OS caches warm"
+            ),
+            Warmth::PostInvalidation => format!(
+                "{warmup} warm-up repetition(s), then the engine handle was dropped and \
+                 reopened (engine + Lance session caches invalidated) before measurement; \
+                 the OS page cache stays warm — the engine exposes no finer \
+                 cache-invalidation door at this commit"
+            ),
+            Warmth::Cold => "fresh process per measured repetition; the store is copied or \
+                             built fresh in that process (note: the copy itself leaves the OS \
+                             page cache warm for the store files)"
+                .to_string(),
+        },
+    };
+    let rep_independence = match args.warmth {
+        Warmth::Cold => "single measured repetition in its own fresh process on a fresh store \
+                         copy (fully independent; the cold parent aggregates per-process \
+                         records into one cell)"
+            .to_string(),
+        _ => "each rep merges a fresh branch pair off an unchanged main, but branches and \
+              __manifest journal history accumulate across reps within the run"
+            .to_string(),
+    };
+    let backend_is_s3 = backend == "s3-compatible";
+
+    let run_spec = RunSpec {
+        data: DataAxes {
+            provenance: PROVENANCE_SYNTHETIC.to_string(),
+            tables: p.tables,
+            rows_per_table: p.rows,
+            column_shape: "scalars-only (String key, String cohort, I32, String payload)"
+                .to_string(),
+            payload_bytes: p.payload_bytes,
+        },
+        state,
+        workload: WorkloadAxes {
+            scenario: args.scenario.id().to_string(),
+            merge_kind: "diverged mixed three-way (updates+deletes+inserts, both sides, \
+                         disjoint rows)"
+                .to_string(),
+            arrival: ARRIVAL_UNSCHEDULED_SINGLE_SHOT.to_string(),
+            delta_rows_per_side: plan.delta,
+            delta_split_per_side: plan.side_split,
+            diverged_tables: p.diverged_tables,
+        },
+        environment: EnvironmentAxes {
+            backend,
+            root_uri_scheme: if args.root_uri.is_some() {
+                "s3"
+            } else {
+                "file"
+            }
+            .to_string(),
+            s3_endpoint: if backend_is_s3 {
+                std::env::var("AWS_ENDPOINT_URL_S3").ok()
+            } else {
+                None
+            },
+            warmth,
+        },
+        protocol: ProtocolAxes {
+            instrument: "in-process wall-clock + MergeTimingPhase snapshot \
+                         (MergeWriteProbes::merge_timing_snapshot) + per-class \
+                         storage-call counts (QueryIoProbes wrappers + \
+                         CountingStorageAdapter)"
+                .to_string(),
+            attribution: ATTRIBUTION_PER_PHASE_ON.to_string(),
+            repetitions: args.reps,
+            timer: "std::time::Instant around branch_merge only (fixture build excluded)"
+                .to_string(),
+            rep_independence,
+        },
+    };
+    // RFC 0039: the profile is decidable from the spec's levels alone — so it
+    // is derived from them, never asserted independently.
+    let profile = derive_profile(&run_spec)
+        .expect("this harness always runs single-shot + synthetic + per-phase on: the micro region")
+        .to_string();
+
+    Ok(RunRecord {
+        record_version: RECORD_VERSION,
+        point_name: derive_point_name(args, plan, fixture, backend_is_s3),
+        point_name_format: POINT_NAME_FORMAT,
+        profile,
+        instrument_access: crate::record::INSTRUMENT_ACCESS_INTERIM.to_string(),
+        label: args.label.clone(),
+        invocation_id,
+        session_id: session_id.to_string(),
+        invocation_unix_seconds: invoked,
+        run_spec,
+        sut: SutBlock {
+            source_commit: source_commit(),
+            build_profile: "release".to_string(),
+            build_opt_level: crate::build_opt_level(),
+            engine_configuration: engine_configuration(),
+        },
+        machine: crate::machine::capture(),
+        results,
+    })
+}
+
+fn wall_stats(wall_ms: &[f64]) -> WallClockStats {
+    WallClockStats {
+        p50: percentile_f64(wall_ms, 50),
+        p95: percentile_f64(wall_ms, 95),
+        min: wall_ms.iter().copied().fold(f64::INFINITY, f64::min),
+        max: wall_ms.iter().copied().fold(0.0, f64::max),
+        mean: wall_ms.iter().sum::<f64>() / wall_ms.len() as f64,
+        tail_support: tail_support(wall_ms.len()).to_string(),
+        reps: wall_ms.to_vec(),
+    }
+}
+
+/// The cold regime's parent: one fresh process per measured repetition (the
+/// RFC's cold definition), aggregated into one cell/record. Each child copies
+/// or rebuilds its own store, runs exactly one measured merge with no
+/// warm-ups, and writes a schema-valid single-rep record the parent folds in.
+async fn run_cold(
+    args: &RunArgs,
+    plan: &FixturePlan,
+    fixture: Option<&(PathBuf, FixtureManifest)>,
+    invocation_id: String,
+    session_id: &str,
+    invoked: u64,
+) -> BenchResult<RunRecord> {
+    if fixture.is_none() {
+        println!(
+            "[{} d={}] note: cold without --fixture rebuilds the base store once per \
+             repetition process — freeze a fixture for faster cold runs",
+            args.scenario.id(),
+            plan.delta
+        );
+    }
+    let scratch = tempfile::tempdir()?;
+    let exe = std::env::current_exe()?;
+    let mut children: Vec<RunRecord> = Vec::with_capacity(args.reps);
+    for rep in 0..args.reps {
+        let out_dir = scratch.path().join(format!("rep{rep}"));
+        std::fs::create_dir_all(&out_dir)?;
+        let mut cmd = std::process::Command::new(&exe);
+        cmd.arg("run")
+            .arg("--scenario")
+            .arg(args.scenario.id())
+            .arg("--delta")
+            .arg(plan.delta.to_string())
+            .arg("--reps")
+            .arg("1")
+            .arg("--warmth")
+            .arg("cold")
+            .arg("--internal-cold-rep")
+            .arg(rep.to_string())
+            .arg("--out")
+            .arg(&out_dir);
+        if let Some((dir, _)) = fixture {
+            cmd.arg("--fixture").arg(dir);
+        } else {
+            if let Some(t) = args.tables {
+                cmd.arg("--tables").arg(t.to_string());
+            }
+            if let Some(r) = args.rows {
+                cmd.arg("--rows").arg(r.to_string());
+            }
+            if let Some(pb) = args.payload_bytes {
+                cmd.arg("--payload-bytes").arg(pb.to_string());
+            }
+            if let Some(d) = args.diverged_tables {
+                cmd.arg("--diverged-tables").arg(d.to_string());
+            }
+        }
+        if let Some(uri) = &args.root_uri {
+            cmd.arg("--root-uri").arg(uri);
+        }
+        if let Some(label) = &args.label {
+            cmd.arg("--label").arg(label);
+        }
+        println!(
+            "[{} d={}] cold rep {rep}: spawning fresh process",
+            args.scenario.id(),
+            plan.delta
+        );
+        let status = cmd.status()?;
+        if !status.success() {
+            return Err(format!("cold rep {rep}: child process failed with {status}").into());
+        }
+        // The child names its record `<point>_<its own invocation id>.json`,
+        // so the parent discovers it: the child's out dir holds exactly one
+        // record.
+        let record_path = sole_record_in(&out_dir)?;
+        let text = std::fs::read_to_string(&record_path)
+            .map_err(|e| format!("reading cold child record {}: {e}", record_path.display()))?;
+        let value: serde_json::Value = serde_json::from_str(&text)?;
+        schema::require_valid_v3(&value, "cold child produced an invalid record")?;
+        children.push(serde_json::from_value(value)?);
+    }
+    merge_cold_records(args, children, invocation_id, session_id, invoked)
+}
+
+/// The single `.json` record a cold child's private out dir holds.
+fn sole_record_in(dir: &Path) -> BenchResult<PathBuf> {
+    let mut records: Vec<PathBuf> = std::fs::read_dir(dir)
+        .map_err(|e| format!("reading {}: {e}", dir.display()))?
+        .filter_map(|entry| entry.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|ext| ext == "json"))
+        .collect();
+    match records.len() {
+        1 => Ok(records.remove(0)),
+        n => Err(format!(
+            "cold child out dir {} holds {n} .json records, expected exactly 1",
+            dir.display()
+        )
+        .into()),
+    }
+}
+
+/// Fold the cold children's single-rep records into one cell. Wall-clock,
+/// phase, write-path, and storage-call vectors concatenate in rep order;
+/// aggregates are recomputed over the combined sample.
+fn merge_cold_records(
+    args: &RunArgs,
+    children: Vec<RunRecord>,
+    invocation_id: String,
+    session_id: &str,
+    invoked: u64,
+) -> BenchResult<RunRecord> {
+    let mut iter = children.into_iter();
+    let mut merged = iter.next().ok_or("cold run produced no child records")?;
+    for child in iter {
+        if child.point_name != merged.point_name {
+            return Err("cold children disagree on the point name — mixed binaries?".into());
+        }
+        if child.results.phases.len() != merged.results.phases.len() {
+            return Err("cold children disagree on the phase list — mixed binaries?".into());
+        }
+        merged
+            .results
+            .wall_clock_ms
+            .reps
+            .extend(child.results.wall_clock_ms.reps);
+        for (into, from) in merged.results.phases.iter_mut().zip(child.results.phases) {
+            if into.phase != from.phase {
+                return Err("cold children disagree on phase order — mixed binaries?".into());
+            }
+            into.per_rep_total_us.extend(from.per_rep_total_us);
+            into.max_single_us = into.max_single_us.max(from.max_single_us);
+        }
+        let (wp_into, wp_from) = (&mut merged.results.write_path, child.results.write_path);
+        wp_into
+            .stage_merge_insert_calls
+            .extend(wp_from.stage_merge_insert_calls);
+        wp_into
+            .stage_merge_insert_rows
+            .extend(wp_from.stage_merge_insert_rows);
+        wp_into
+            .stage_known_present_update_calls
+            .extend(wp_from.stage_known_present_update_calls);
+        wp_into
+            .stage_known_present_update_rows
+            .extend(wp_from.stage_known_present_update_rows);
+        wp_into
+            .stage_fenced_insert_calls
+            .extend(wp_from.stage_fenced_insert_calls);
+        wp_into
+            .stage_fenced_insert_rows
+            .extend(wp_from.stage_fenced_insert_rows);
+        wp_into
+            .strict_insert_preflight_calls
+            .extend(wp_from.strict_insert_preflight_calls);
+        if let (Some(sc_into), Some(sc_from)) = (
+            merged.results.storage_calls.as_mut(),
+            child.results.storage_calls,
+        ) {
+            sc_into.manifest_store.extend(sc_from.manifest_store);
+            sc_into.table_store.extend(sc_from.table_store);
+            sc_into.control_plane.extend(sc_from.control_plane);
+        }
+        merged.results.verified_rows_table0 = child.results.verified_rows_table0;
+        merged.results.fixture_build_seconds += child.results.fixture_build_seconds;
+        if child.sut.source_commit != merged.sut.source_commit {
+            return Err("cold children report different SUT commits".into());
+        }
+    }
+    let reps = std::mem::take(&mut merged.results.wall_clock_ms.reps);
+    merged.results.wall_clock_ms = wall_stats(&reps);
+    for phase in &mut merged.results.phases {
+        phase.total_us_p50 = percentile_u64(&phase.per_rep_total_us, 50);
+        phase.total_us_max = *phase
+            .per_rep_total_us
+            .iter()
+            .max()
+            .expect("at least one rep");
+    }
+    if let Some(sc) = merged.results.storage_calls.as_mut() {
+        sc.scope = format!(
+            "{} (aggregated across {} fresh cold processes)",
+            sc.scope, args.reps
+        );
+    }
+    merged.run_spec.protocol.repetitions = args.reps;
+    // The cell's invocation is the parent command; children were its rows.
+    // The parent-minted id carries identity, the timestamp only ordering, and
+    // the parent's session is the batch every child ran inside.
+    merged.invocation_id = invocation_id;
+    merged.session_id = session_id.to_string();
+    merged.invocation_unix_seconds = invoked;
+    print_summary(
+        merged.scenario(),
+        merged.run_spec.workload.delta_rows_per_side,
+        &merged.results,
+    );
+    Ok(merged)
+}
+
+fn duration_ms(d: Duration) -> f64 {
+    d.as_secs_f64() * 1000.0
+}
+
+fn print_summary(scenario: &str, delta: usize, results: &RunResults) {
+    let top = results
+        .phases
+        .iter()
+        .max_by_key(|p| p.total_us_p50)
+        .expect("a recorded run holds at least one phase (the vacuous-run guard refused zero)");
+    println!(
+        "[{scenario} d={delta}] wall-clock p50 {:.1} ms, p95 {:.1} ms; top phase {} ({} µs p50)",
+        results.wall_clock_ms.p50, results.wall_clock_ms.p95, top.phase, top.total_us_p50
+    );
+    if let Some(calls) = &results.storage_calls {
+        let sum = |v: &[crate::counting::CallCounts]| {
+            v.iter()
+                .fold(crate::counting::CallCounts::default(), |mut acc, c| {
+                    acc.get += c.get;
+                    acc.head += c.head;
+                    acc.put += c.put;
+                    acc.list += c.list;
+                    acc.copy += c.copy;
+                    acc.delete += c.delete;
+                    acc
+                })
+        };
+        let (m, t) = (sum(&calls.manifest_store), sum(&calls.table_store));
+        println!(
+            "[{scenario} d={delta}] storage calls (sum over reps): table get {} / put {} / \
+             list {}, __manifest get {} / put {} / list {}",
+            t.get + t.head,
+            t.put,
+            t.list,
+            m.get + m.head,
+            m.put,
+            m.list
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::record::testkit::sample_record;
+
+    fn cold_args(reps: usize) -> RunArgs {
+        RunArgs {
+            scenario: Scenario::M3,
+            tables: None,
+            rows: None,
+            delta: vec![],
+            diverged_tables: None,
+            reps,
+            warmth: Warmth::Cold,
+            warmup_reps: 0,
+            aa: false,
+            payload_bytes: None,
+            out: PathBuf::from("unused"),
+            root_uri: None,
+            fixture: None,
+            label: None,
+            internal_cold_rep: None,
+        }
+    }
+
+    #[test]
+    fn secret_config_names_are_detected_case_insensitively() {
+        // (name, is secret): the NAME persists either way, only the value is
+        // replaced.
+        for (name, secret) in [
+            ("OMNIGRAPH_SERVER_BEARER_TOKEN", true),
+            ("OMNIGRAPH_SERVER_BEARER_TOKENS_JSON", true),
+            ("OMNIGRAPH_SERVER_BEARER_TOKENS_AWS_SECRET", true),
+            ("omnigraph_api_key", true),
+            ("OMNIGRAPH_DB_PASSWORD", true),
+            ("OMNIGRAPH_CREDENTIAL_PATH", true),
+            ("OMNIGRAPH_MERGE_LINEAGE", false),
+            ("OMNIGRAPH_QUERY_TIMEOUT_MS", false),
+        ] {
+            assert_eq!(is_secret_config_name(name), secret, "name {name}");
+        }
+    }
+
+    #[test]
+    fn cold_fold_concatenates_reps_and_recomputes_aggregates() {
+        let point = "m3-t2-n100-noindex-d1-cold";
+        let children = vec![
+            sample_record(point, &[10.0]),
+            sample_record(point, &[30.0]),
+            sample_record(point, &[20.0]),
+        ];
+        let merged = merge_cold_records(
+            &cold_args(3),
+            children,
+            "parent-invocation".to_string(),
+            "parent-session",
+            7,
+        )
+        .unwrap();
+        assert_eq!(merged.results.wall_clock_ms.reps, vec![10.0, 30.0, 20.0]);
+        assert_eq!(merged.results.wall_clock_ms.p50, 20.0);
+        assert_eq!(merged.results.wall_clock_ms.max, 30.0);
+        assert_eq!(merged.results.wall_clock_ms.tail_support, "directional");
+        assert_eq!(merged.run_spec.protocol.repetitions, 3);
+        assert_eq!(merged.invocation_id, "parent-invocation");
+        assert_eq!(merged.session_id, "parent-session");
+        assert_eq!(merged.invocation_unix_seconds, 7);
+        // Phase vectors concatenated in rep order.
+        assert_eq!(merged.results.phases[0].per_rep_total_us.len(), 3);
+        // Storage-call vectors concatenated too.
+        let sc = merged.results.storage_calls.as_ref().unwrap();
+        assert_eq!(sc.manifest_store.len(), 3);
+        assert!(sc.scope.contains("3 fresh cold processes"));
+        // Write-path vectors concatenated.
+        assert_eq!(merged.results.write_path.stage_merge_insert_calls.len(), 3);
+    }
+
+    #[test]
+    fn cold_fold_refuses_mixed_binaries() {
+        let point = "m3-t2-n100-noindex-d1-cold";
+        let a = sample_record(point, &[10.0]);
+        let mut b = sample_record(point, &[20.0]);
+        b.results.phases[0].phase = "SomethingElse".to_string();
+        let err = merge_cold_records(&cold_args(2), vec![a, b], "id".to_string(), "s", 0)
+            .expect_err("disagreeing phase lists must be refused");
+        assert!(err.to_string().contains("phase order"));
+
+        let a = sample_record(point, &[10.0]);
+        let mut b = sample_record(point, &[20.0]);
+        b.sut.source_commit = "different".to_string();
+        let err = merge_cold_records(&cold_args(2), vec![a, b], "id".to_string(), "s", 0)
+            .expect_err("disagreeing SUT commits must be refused");
+        assert!(err.to_string().contains("different SUT commits"));
+
+        let a = sample_record(point, &[10.0]);
+        let b = sample_record("m3-t2-n100-noindex-d1-warm", &[20.0]);
+        let err = merge_cold_records(&cold_args(2), vec![a, b], "id".to_string(), "s", 0)
+            .expect_err("disagreeing point names must be refused");
+        assert!(err.to_string().contains("point name"));
+    }
+}

--- a/crates/omnigraph-bench/src/run.rs
+++ b/crates/omnigraph-bench/src/run.rs
@@ -412,6 +412,41 @@ fn run_root(
 
 /// Open the store with the engine's public counting decorator on the
 /// control-plane `StorageAdapter`, returning the handle plus the counter.
+/// Non-vacuous row check, run for EVERY repetition (warm-ups included — the
+/// README's guard contract): the merged target must hold exactly the planned
+/// row count on the first diverged table, or the repetition (and with it the
+/// whole run) is refused. Callers place this AFTER the measured window's
+/// storage counters are captured: the verification reads must never ride a
+/// merge window's tallies (they are wiped by the next rep's pre-merge reset).
+async fn verify_merged_rows(
+    db: &Omnigraph,
+    target: &str,
+    plan: &FixturePlan,
+    rep: usize,
+) -> BenchResult<RowCheck> {
+    let table_key = fixture::table_key(0);
+    let expected = plan.expected_rows_after_merge(0);
+    let actual = db
+        .snapshot_of(ReadTarget::branch(target))
+        .await?
+        .open(&table_key)
+        .await?
+        .count_rows(None)
+        .await?;
+    if actual != expected {
+        return Err(format!(
+            "rep {rep}: post-merge row count on {table_key} is {actual}, expected {expected}; \
+             the merge did not apply the planned delta — refusing to record"
+        )
+        .into());
+    }
+    Ok(RowCheck {
+        table_key,
+        expected,
+        actual,
+    })
+}
+
 async fn open_counting(root: &str) -> BenchResult<(Omnigraph, Arc<StorageReadCounts>)> {
     let inner = storage_for_uri(root)?;
     let (adapter, counts) = CountingStorageAdapter::new(inner);
@@ -598,7 +633,9 @@ async fn run_one_body(
     let mut storage_table: Vec<crate::counting::CallCounts> = Vec::with_capacity(args.reps);
     let mut storage_control: Vec<ControlCalls> = Vec::with_capacity(args.reps);
     let mut fixture_seconds = build_started.elapsed().as_secs_f64();
-    let mut last_target = String::new();
+    // Every rep is row-checked in the loop; the record persists the last
+    // measured rep's check (all reps passed, or the run refused above).
+    let mut row_check: Option<RowCheck> = None;
 
     let rep_base = args.internal_cold_rep.unwrap_or(0);
     let total_reps = warmup + args.reps;
@@ -670,8 +707,10 @@ async fn run_one_body(
             outcome,
             duration_ms(elapsed)
         );
-        last_target = tgt;
         if !measured {
+            // Warm-up reps get the same row check; its reads are wiped by the
+            // next rep's pre-merge counter reset, so no tally is polluted.
+            let _ = verify_merged_rows(&db, &tgt, plan, rep).await?;
             continue;
         }
         if phase_names.is_empty() {
@@ -711,24 +750,10 @@ async fn run_one_body(
             control_snapshot(&control_counts),
         ));
         wall_ms.push(duration_ms(elapsed));
-    }
-
-    // Non-vacuous row check on the first diverged table of the last target.
-    let table_key = fixture::table_key(0);
-    let expected = plan.expected_rows_after_merge(0);
-    let actual = db
-        .snapshot_of(ReadTarget::branch(&last_target))
-        .await?
-        .open(&table_key)
-        .await?
-        .count_rows(None)
-        .await?;
-    if actual != expected {
-        return Err(format!(
-            "post-merge row count on {table_key} is {actual}, expected {expected}; \
-             the merge did not apply the planned delta — refusing to record"
-        )
-        .into());
+        // Measured reps run the row check HERE, after the merge window's
+        // counters were captured above, so the verification reads never ride
+        // a measured tally (and are wiped by the next rep's reset).
+        row_check = Some(verify_merged_rows(&db, &tgt, plan, rep).await?);
     }
 
     let phases: Vec<PhaseStats> = phase_names
@@ -747,11 +772,8 @@ async fn run_one_body(
         wall_clock_ms: wall_stats(&wall_ms),
         phases,
         merge_outcome: "Merged".to_string(),
-        verified_rows_table0: RowCheck {
-            table_key,
-            expected,
-            actual,
-        },
+        verified_rows_table0: row_check
+            .ok_or("no measured repetition ran; nothing to record (reps must be >= 1)")?,
         fixture_build_seconds: fixture_seconds,
         write_path,
         storage_calls: Some(StorageCalls {

--- a/crates/omnigraph-bench/src/schema.rs
+++ b/crates/omnigraph-bench/src/schema.rs
@@ -1,0 +1,285 @@
+//! The versioned record-schema artifact and its validator.
+//!
+//! `schema/run-record-v3.schema.json` is the single normative definition of
+//! the v3 run record (RFC 0039: "the field list is normative" — here made
+//! executable). The harness validates every record against it on WRITE
+//! (refusing to emit an invalid record) and `diff` validates on READ
+//! (refusing to consume one), so the structs in `record.rs` are a derivation
+//! of the schema, never a second truth.
+//!
+//! The validator interprets the subset of JSON Schema the artifact uses —
+//! `type`, `properties`, `required`, `items`, `enum`, `minItems`,
+//! `additionalProperties: false` — rather than pulling a full JSON Schema
+//! engine into the workspace for an internal instrument. Anything the schema
+//! file says that this subset cannot express would be silently unenforced, so
+//! the subset is a deliberate boundary: extend the validator before extending
+//! the schema vocabulary.
+
+use serde_json::Value;
+
+use crate::fixture::BenchResult;
+
+/// The v3 schema artifact, embedded so the binary and the file cannot drift.
+pub const RUN_RECORD_V3_SCHEMA: &str = include_str!("../schema/run-record-v3.schema.json");
+
+/// Validate a v3 run-record instance against the shipped schema. Returns
+/// every violation, not just the first.
+pub fn validate_run_record_v3(instance: &Value) -> Result<(), Vec<String>> {
+    let schema: Value =
+        serde_json::from_str(RUN_RECORD_V3_SCHEMA).expect("embedded schema is valid JSON");
+    let mut errors = Vec::new();
+    validate(&schema, instance, "$", &mut errors);
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
+}
+
+/// Convenience wrapper turning violations into one refusal error.
+pub fn require_valid_v3(instance: &Value, context: &str) -> BenchResult<()> {
+    validate_run_record_v3(instance).map_err(|errors| {
+        format!(
+            "{context}: record violates schema/run-record-v3.schema.json:\n  {}",
+            errors.join("\n  ")
+        )
+        .into()
+    })
+}
+
+fn type_name(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(n) => {
+            if n.is_u64() || n.is_i64() {
+                "integer"
+            } else {
+                "number"
+            }
+        }
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+fn matches_type(instance: &Value, wanted: &str) -> bool {
+    match wanted {
+        // Every integer is a number.
+        "number" => matches!(instance, Value::Number(_)),
+        other => type_name(instance) == other,
+    }
+}
+
+fn validate(schema: &Value, instance: &Value, path: &str, errors: &mut Vec<String>) {
+    let Some(schema_obj) = schema.as_object() else {
+        return;
+    };
+
+    if let Some(wanted) = schema_obj.get("type") {
+        let ok = match wanted {
+            Value::String(t) => matches_type(instance, t),
+            Value::Array(ts) => ts
+                .iter()
+                .filter_map(|t| t.as_str())
+                .any(|t| matches_type(instance, t)),
+            _ => true,
+        };
+        if !ok {
+            errors.push(format!(
+                "{path}: expected type {wanted}, found {}",
+                type_name(instance)
+            ));
+            return; // Structural checks below assume the right type.
+        }
+    }
+
+    if let Some(allowed) = schema_obj.get("enum").and_then(Value::as_array) {
+        if !allowed.contains(instance) {
+            errors.push(format!(
+                "{path}: value {instance} is not one of {allowed:?}"
+            ));
+        }
+    }
+
+    if let Some(required) = schema_obj.get("required").and_then(Value::as_array) {
+        if let Some(map) = instance.as_object() {
+            for key in required.iter().filter_map(Value::as_str) {
+                if !map.contains_key(key) {
+                    errors.push(format!("{path}: missing required field '{key}'"));
+                }
+            }
+        }
+    }
+
+    if let Some(props) = schema_obj.get("properties").and_then(Value::as_object) {
+        if let Some(map) = instance.as_object() {
+            for (key, subschema) in props {
+                if let Some(value) = map.get(key) {
+                    validate(subschema, value, &format!("{path}.{key}"), errors);
+                }
+            }
+        }
+    }
+
+    // Closed objects (struct-derived): an instance key the schema does not
+    // name is drift — a struct field added without its schema counterpart.
+    if schema_obj.get("additionalProperties") == Some(&Value::Bool(false)) {
+        if let Some(map) = instance.as_object() {
+            let props = schema_obj.get("properties").and_then(Value::as_object);
+            for key in map.keys() {
+                if props.is_none_or(|p| !p.contains_key(key)) {
+                    errors.push(format!(
+                        "{path}: unknown field '{key}' (the object is closed: \
+                         additionalProperties false)"
+                    ));
+                }
+            }
+        }
+    }
+
+    if let Some(items) = schema_obj.get("items") {
+        if let Some(array) = instance.as_array() {
+            for (i, value) in array.iter().enumerate() {
+                validate(items, value, &format!("{path}[{i}]"), errors);
+            }
+        }
+    }
+
+    if let Some(min) = schema_obj.get("minItems").and_then(Value::as_u64) {
+        if let Some(array) = instance.as_array() {
+            if (array.len() as u64) < min {
+                errors.push(format!(
+                    "{path}: array has {} item(s), schema requires at least {min}",
+                    array.len()
+                ));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn schema_artifact_parses() {
+        let schema: Value = serde_json::from_str(RUN_RECORD_V3_SCHEMA).unwrap();
+        assert_eq!(schema["properties"]["record_version"]["enum"][0], json!(3));
+    }
+
+    #[test]
+    fn missing_required_field_is_reported_with_its_path() {
+        let errors = validate_run_record_v3(&json!({ "record_version": 3 })).unwrap_err();
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("missing required field 'run_spec'"))
+        );
+        assert!(errors.iter().any(|e| e.contains("'point_name'")));
+    }
+
+    #[test]
+    fn wrong_type_and_bad_enum_are_reported() {
+        let errors =
+            validate_run_record_v3(&json!({ "record_version": 2, "point_name": 7 })).unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("$.record_version")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("$.point_name") && e.contains("expected type"))
+        );
+    }
+
+    /// Drift guard, direction schema -> validator: every keyword the shipped
+    /// schema uses must be one the mini-validator interprets. A keyword the
+    /// validator ignores is a constraint silently unenforced — the deliberate
+    /// boundary the module doc states, here made a failing test.
+    #[test]
+    fn every_schema_keyword_is_interpreted_by_the_validator() {
+        /// Keywords `validate` interprets.
+        const INTERPRETED: [&str; 7] = [
+            "type",
+            "properties",
+            "required",
+            "items",
+            "enum",
+            "minItems",
+            "additionalProperties",
+        ];
+        /// Pure annotations: no validation semantics to enforce.
+        const ANNOTATIONS: [&str; 4] = ["$schema", "$id", "title", "description"];
+        fn walk_schema(schema: &Value, path: &str, violations: &mut Vec<String>) {
+            let Some(obj) = schema.as_object() else {
+                return;
+            };
+            for (key, value) in obj {
+                match key.as_str() {
+                    // The values under `properties` are named subschemas.
+                    "properties" => {
+                        if let Some(props) = value.as_object() {
+                            for (name, sub) in props {
+                                walk_schema(sub, &format!("{path}.{name}"), violations);
+                            }
+                        }
+                    }
+                    // The value of `items` is itself a schema.
+                    "items" => walk_schema(value, &format!("{path}[]"), violations),
+                    k if INTERPRETED.contains(&k) || ANNOTATIONS.contains(&k) => {}
+                    other => violations.push(format!(
+                        "{path}: keyword '{other}' is not interpreted by the mini-validator; \
+                         extend `validate` in schema.rs before using it"
+                    )),
+                }
+            }
+        }
+        let schema: Value = serde_json::from_str(RUN_RECORD_V3_SCHEMA).unwrap();
+        let mut violations = Vec::new();
+        walk_schema(&schema, "$", &mut violations);
+        assert!(violations.is_empty(), "{}", violations.join("\n"));
+    }
+
+    /// Drift guard, direction structs -> schema: a full in-memory `RunRecord`
+    /// must validate against the shipped schema and survive a serialize +
+    /// deserialize round trip unchanged. Catches a struct field added without
+    /// its schema counterpart (the closed objects' `additionalProperties:
+    /// false` refuses the unknown key) and a schema field removed from the
+    /// structs (through the required lists).
+    #[test]
+    fn golden_record_validates_and_round_trips() {
+        let record =
+            crate::record::testkit::sample_record("m3-t2-n100-noindex-d1-warm", &[10.0, 11.0]);
+        let value = serde_json::to_value(&record).unwrap();
+        require_valid_v3(&value, "golden record").unwrap();
+        let reread: crate::record::RunRecord = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(
+            serde_json::to_value(&reread).unwrap(),
+            value,
+            "a validated record must round-trip byte-identically"
+        );
+    }
+
+    /// The closed objects refuse unknown keys at every depth; the
+    /// deliberately open objects (embedded manifest, engine configuration)
+    /// still accept anything.
+    #[test]
+    fn closed_objects_refuse_unknown_keys_and_open_objects_accept_them() {
+        let record = crate::record::testkit::sample_record("m3-t2-n100-noindex-d1-warm", &[10.0]);
+        let mut value = serde_json::to_value(&record).unwrap();
+        value["stray_top_level"] = json!(1);
+        value["run_spec"]["data"]["stray_nested"] = json!("x");
+        let errors = validate_run_record_v3(&value).unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("'stray_top_level'")));
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("$.run_spec.data") && e.contains("'stray_nested'"))
+        );
+
+        let mut value = serde_json::to_value(&record).unwrap();
+        value["sut"]["engine_configuration"]["OMNIGRAPH_ANYTHING"] = json!("on");
+        require_valid_v3(&value, "open engine configuration").unwrap();
+    }
+}

--- a/crates/omnigraph/benches/scenarios/rfc023.rs
+++ b/crates/omnigraph/benches/scenarios/rfc023.rs
@@ -830,6 +830,8 @@ fn merge_phase_metrics(probes: &MergeWriteProbes) -> serde_json::Value {
         "outer_prepare": probes.outer_prepare_us(),
         "proven_insert_history": probes.proven_insert_history_us(),
         "proven_insert_plan_scan": probes.proven_insert_plan_scan_us(),
+        "table_walk_total": probes.table_walk_total_us(),
+        "table_walk_max": probes.table_walk_max_us(),
         "candidate_validation": probes.candidate_validation_us(),
         "final_revalidation": probes.final_revalidation_us(),
         "recovery_arm": probes.recovery_arm_us(),

--- a/crates/omnigraph/src/exec/merge.rs
+++ b/crates/omnigraph/src/exec/merge.rs
@@ -3899,22 +3899,33 @@ impl Omnigraph {
                     {
                         candidates.insert(table_key.clone(), candidate);
                     }
-                } else if let Some(staged) = stage_streaming_table_merge(
-                    self,
-                    table_key,
-                    catalog,
-                    base_snapshot,
-                    source_snapshot,
-                    target_snapshot,
-                    &mut conflicts,
-                    &empty_external_preflight,
-                )
-                .await?
-                {
-                    candidates.insert(
-                        table_key.clone(),
-                        CandidateTableState::RewriteMerged(staged),
+                } else {
+                    // One TableWalk interval per scalar table: the three-way
+                    // ordered walk plus merged-row staging, ending before
+                    // validation and before the keyed publish loop
+                    // (KeyedStage/KeyedCommit stay disjoint).
+                    let table_walk_start = std::time::Instant::now();
+                    let staged = stage_streaming_table_merge(
+                        self,
+                        table_key,
+                        catalog,
+                        base_snapshot,
+                        source_snapshot,
+                        target_snapshot,
+                        &mut conflicts,
+                        &empty_external_preflight,
+                    )
+                    .await?;
+                    crate::instrumentation::record_merge_timing(
+                        crate::instrumentation::MergeTimingPhase::TableWalk,
+                        table_walk_start.elapsed(),
                     );
+                    if let Some(staged) = staged {
+                        candidates.insert(
+                            table_key.clone(),
+                            CandidateTableState::RewriteMerged(staged),
+                        );
+                    }
                 }
                 continue;
             }
@@ -4098,7 +4109,12 @@ impl Omnigraph {
                 continue;
             }
 
-            if let Some(staged) = stage_streaming_table_merge(
+            // One TableWalk interval per blob-bearing table (the scalar pass
+            // above records its own): the three-way ordered walk plus
+            // merged-row staging, ending before validation and before the
+            // keyed publish loop (KeyedStage/KeyedCommit stay disjoint).
+            let table_walk_start = std::time::Instant::now();
+            let staged = stage_streaming_table_merge(
                 self,
                 table_key,
                 catalog,
@@ -4108,8 +4124,12 @@ impl Omnigraph {
                 &mut conflicts,
                 &external_preflight,
             )
-            .await?
-            {
+            .await?;
+            crate::instrumentation::record_merge_timing(
+                crate::instrumentation::MergeTimingPhase::TableWalk,
+                table_walk_start.elapsed(),
+            );
+            if let Some(staged) = staged {
                 candidates.insert(
                     table_key.clone(),
                     CandidateTableState::RewriteMerged(staged),

--- a/crates/omnigraph/src/instrumentation.rs
+++ b/crates/omnigraph/src/instrumentation.rs
@@ -213,6 +213,11 @@ pub(crate) enum MergeTimingPhase {
     OuterPrepare,
     ProvenInsertHistory,
     ProvenInsertPlanScan,
+    /// The general route's per-table three-way ordered walk (base, source,
+    /// and target cursors) plus merged-row staging into the temp table — one
+    /// interval per table, disjoint from the keyed publish loop. The proven
+    /// insert-only route bypasses the walk and records nothing here.
+    TableWalk,
     CandidateValidation,
     FinalRevalidation,
     RecoveryArm,
@@ -226,11 +231,61 @@ pub(crate) enum MergeTimingPhase {
 }
 
 impl MergeTimingPhase {
-    const COUNT: usize = 13;
+    const COUNT: usize = 14;
 
     const fn index(self) -> usize {
         self as usize
     }
+
+    /// Every phase, in recording (index) order. Kept next to `COUNT` so adding
+    /// a phase updates both or fails the exhaustiveness of `name`.
+    const ALL: [MergeTimingPhase; MergeTimingPhase::COUNT] = [
+        MergeTimingPhase::OuterPrepare,
+        MergeTimingPhase::ProvenInsertHistory,
+        MergeTimingPhase::ProvenInsertPlanScan,
+        MergeTimingPhase::TableWalk,
+        MergeTimingPhase::CandidateValidation,
+        MergeTimingPhase::FinalRevalidation,
+        MergeTimingPhase::RecoveryArm,
+        MergeTimingPhase::PhysicalPublish,
+        MergeTimingPhase::KeyedStage,
+        MergeTimingPhase::KeyedCommit,
+        MergeTimingPhase::RecoveryConfirm,
+        MergeTimingPhase::ManifestPublish,
+        MergeTimingPhase::RecoveryCleanup,
+        MergeTimingPhase::OuterRestoreRefresh,
+    ];
+
+    /// Stable diagnostic name (the variant name) for out-of-crate readouts.
+    const fn name(self) -> &'static str {
+        match self {
+            MergeTimingPhase::OuterPrepare => "OuterPrepare",
+            MergeTimingPhase::ProvenInsertHistory => "ProvenInsertHistory",
+            MergeTimingPhase::ProvenInsertPlanScan => "ProvenInsertPlanScan",
+            MergeTimingPhase::TableWalk => "TableWalk",
+            MergeTimingPhase::CandidateValidation => "CandidateValidation",
+            MergeTimingPhase::FinalRevalidation => "FinalRevalidation",
+            MergeTimingPhase::RecoveryArm => "RecoveryArm",
+            MergeTimingPhase::PhysicalPublish => "PhysicalPublish",
+            MergeTimingPhase::KeyedStage => "KeyedStage",
+            MergeTimingPhase::KeyedCommit => "KeyedCommit",
+            MergeTimingPhase::RecoveryConfirm => "RecoveryConfirm",
+            MergeTimingPhase::ManifestPublish => "ManifestPublish",
+            MergeTimingPhase::RecoveryCleanup => "RecoveryCleanup",
+            MergeTimingPhase::OuterRestoreRefresh => "OuterRestoreRefresh",
+        }
+    }
+}
+
+/// One diagnostic merge phase's accumulated elapsed time, in microseconds, as
+/// returned by [`MergeWriteProbes::merge_timing_snapshot`]. `total_us` sums
+/// every recorded interval; `max_us` is the largest single interval (per-table
+/// phases record one interval per table).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MergeTimingReading {
+    pub phase: &'static str,
+    pub total_us: u64,
+    pub max_us: u64,
 }
 
 #[derive(Clone, Default)]
@@ -381,6 +436,12 @@ impl MergeWriteProbes {
     pub fn proven_insert_plan_scan_us(&self) -> u64 {
         self.merge_timing_total_us(MergeTimingPhase::ProvenInsertPlanScan)
     }
+    pub fn table_walk_total_us(&self) -> u64 {
+        self.merge_timing_total_us(MergeTimingPhase::TableWalk)
+    }
+    pub fn table_walk_max_us(&self) -> u64 {
+        self.merge_timing_max_us(MergeTimingPhase::TableWalk)
+    }
     pub fn candidate_validation_us(&self) -> u64 {
         self.merge_timing_total_us(MergeTimingPhase::CandidateValidation)
     }
@@ -416,6 +477,22 @@ impl MergeWriteProbes {
     }
     pub fn outer_restore_refresh_us(&self) -> u64 {
         self.merge_timing_total_us(MergeTimingPhase::OuterRestoreRefresh)
+    }
+
+    /// Snapshot every diagnostic merge-timing phase (name, total, max in
+    /// microseconds), in recording order. The out-of-crate readout door for
+    /// benchmarks that install probes via [`with_merge_write_probes`]; the
+    /// per-phase accessors above remain the in-crate test surface. Purely
+    /// observational — reads the same relaxed counters the accessors read.
+    pub fn merge_timing_snapshot(&self) -> Vec<MergeTimingReading> {
+        MergeTimingPhase::ALL
+            .into_iter()
+            .map(|phase| MergeTimingReading {
+                phase: phase.name(),
+                total_us: self.merge_timing_total_us(phase),
+                max_us: self.merge_timing_max_us(phase),
+            })
+            .collect()
     }
 }
 
@@ -781,5 +858,20 @@ impl StorageAdapter for CountingStorageAdapter {
     async fn delete_prefix(&self, prefix_uri: &str) -> Result<()> {
         self.counts.mutation_calls.fetch_add(1, Ordering::Relaxed);
         self.inner.delete_prefix(prefix_uri).await
+    }
+}
+
+#[cfg(test)]
+mod merge_timing_phase_tests {
+    use super::*;
+
+    /// `ALL` must list every phase in recording (index) order: the snapshot
+    /// readout iterates `ALL` and pairs each entry with the counter at its
+    /// index, so a reordered or missing entry would silently misattribute.
+    #[test]
+    fn all_lists_every_phase_in_index_order() {
+        for (i, phase) in MergeTimingPhase::ALL.into_iter().enumerate() {
+            assert_eq!(phase.index(), i);
+        }
     }
 }

--- a/scripts/generate_merge_bench_fixtures.py
+++ b/scripts/generate_merge_bench_fixtures.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Generate the branch-merge micro-benchmark v1 fixtures, nothing else.
+
+This script is the source of truth for the branch-merge micro-benchmark's
+fixture data (RFC 0039 micro profile) - three fixtures, one slice of the
+benchmark program, not its whole dataset. It builds them synthetically and
+deterministically (same builder version and parameters produce the same
+bytes), validates and freezes each, and stops. It runs no measurements: measuring is a separate,
+deliberate act against these fixtures (see the crate README for the run
+commands, or `omnigraph-bench list`).
+
+Everything lands under <target>/bench/fixtures (gitignored; <target> honors
+CARGO_TARGET_DIR); nothing outside this repository is read or written. A
+cached fixture is kept only when its manifest's builder version matches the
+binary's (`omnigraph-bench fixture builder-version`); a stale one is deleted
+and rebuilt — the fixtures directory is disposable build output.
+
+Usage: python3 scripts/generate_merge_bench_fixtures.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run(args: list[str | Path], cwd: Path | None = None) -> None:
+    print(f"$ {' '.join(str(a) for a in args)}", flush=True)
+    subprocess.run([str(a) for a in args], check=True, cwd=cwd)
+
+
+def main() -> int:
+    root = Path(
+        subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    )
+    target = Path(os.environ.get("CARGO_TARGET_DIR", root / "target"))
+    exe = ".exe" if sys.platform == "win32" else ""
+    bench = target / "release" / f"omnigraph-bench{exe}"
+    fixtures = target / "bench" / "fixtures"
+
+    print("== building omnigraph-bench (release) ==")
+    # cwd, not --manifest-path: cargo finds the repo's .cargo/config.toml by
+    # walking up from cwd only, so the build runs from the repo root no
+    # matter where this script was invoked.
+    run(["cargo", "build", "--release", "-p", "omnigraph-bench"], cwd=root)
+
+    # Capture stdout only; the subprocess's stderr passes through so a
+    # failure explains itself.
+    builder_version = int(
+        subprocess.run(
+            [str(bench), "fixture", "builder-version"],
+            check=True,
+            stdout=subprocess.PIPE,
+            text=True,
+        ).stdout.strip()
+    )
+
+    fixtures.mkdir(parents=True, exist_ok=True)
+
+    def cached_builder_version(fixture_dir: Path) -> int | None:
+        """The builder version stamped in a cached fixture's manifest, or
+        None when the manifest is missing/unreadable (a partial build)."""
+        try:
+            manifest = json.loads(
+                (fixture_dir / "fixture-manifest.json").read_text()
+            )
+            return int(manifest["builder_version"])
+        except (OSError, ValueError, KeyError):
+            return None
+
+    def build_fixture(name: str, *args: str) -> None:
+        fixture_dir = fixtures / name
+        if fixture_dir.is_dir():
+            cached = cached_builder_version(fixture_dir)
+            if cached == builder_version:
+                print(f"== fixture {name} exists (builder v{cached}), keeping ==")
+                return
+            print(f"== fixture {name} is stale (manifest builder "
+                  f"{'v' + str(cached) if cached is not None else 'unreadable'}, "
+                  f"binary v{builder_version}): deleting and rebuilding — the "
+                  f"fixtures directory is disposable build output ==")
+            shutil.rmtree(fixture_dir)
+        print(f"== building fixture {name} ==")
+        run([bench, "fixture", "build", "--fixtures-root", fixtures, *args])
+        # The expected name is hand-derived here; the binary derives its own.
+        # A silent desync would freeze a fixture this script then reports
+        # missing, so verify the build landed where this script expects.
+        if not fixture_dir.is_dir():
+            sys.exit(f"error: fixture build did not produce {fixture_dir} — "
+                     f"this script's fixture name is out of sync with the "
+                     f"binary's derived name")
+
+    # The merge-bench v1 fixtures: three, covering the initial-workload section
+    # of RFC 0039 (small unindexed, large indexed, many-table).
+    build_fixture("fx-t8-n4k-scalars-noindex", "--tables", "8", "--rows", "4000")
+    build_fixture("fx-t8-n100k-scalars-btree-fresh",
+                  "--tables", "8", "--rows", "100000", "--index")
+    build_fixture("fx-t140-n4k-scalars-noindex",
+                  "--tables", "140", "--rows", "4000")
+
+    print("\n== merge-bench v1 fixtures ready ==")
+    run([bench, "list", "--fixtures-root", fixtures])
+    print(f"\nfixtures root: {fixtures}")
+    print("run a point (example):")
+    print(f"  {bench} run --scenario m3 "
+          f"--fixture {fixtures / 'fx-t8-n4k-scalars-noindex'} "
+          f"--warmth warm --reps 5 --out <records-dir>")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What & why

Adds `omnigraph-bench`, the harness for the end-to-end benchmark (RFC 0039). It owns the general machinery: frozen validated fixtures, append-only schema-validated run records, an A/A noise floor with rule-7 claim labeling, and terminal plus self-contained HTML reporting. Branch merge is the first workload wired through it, measuring wall-clock with 14-phase attribution and storage-call counts per run.

First result from the harness: on the large fixture (8 tables, 100k rows, delta 5000) the three-way row walk is ~90% of merge wall-clock, and merge cost tracks table size, not delta size. The walk had no phase bucket before; the new `TableWalk` phase records it directly.

## Backing issue / RFC

- [x] Is an RFC PR, or implements a **merged** RFC: docs/rfcs/0039-end-to-end-benchmark.md (RFC PR #535; this PR lands after it merges)

## Checklist

- [x] Change is focused (one logical change: the harness plus the minimal engine seam it reads)
- [x] Tests added/updated for behavior changes (48 unit tests in the crate; engine drift guards extended for the 14th phase)
- [x] Public docs updated if user-facing surface changed (crate README, AGENTS.md crate list and topic map; internal instrument, no public API surface)
- [x] Reviewed against docs/dev/invariants.md — no Hard Invariant weakened, no deny-list item hit (engine change is one observational enum variant plus two timing spans, no-op unless a probe is installed)

## Local verification

- `cargo fmt --all --check` — clean
- `cargo clippy -p omnigraph-bench --all-targets -- -D warnings` — clean
- `cargo clippy -p omnigraph-engine --lib -- -D warnings` — clean
- `cargo check -p omnigraph-engine --benches` — clean
- `cargo test -p omnigraph-bench` — 48 passed, 0 failed
- `bash scripts/check-agents-md.sh` — OK (78 links, 72 docs)
- `python3 scripts/generate_merge_bench_fixtures.py` — builds the release binary and the three v1 fixtures end to end

## Notes for reviewers

- Engine footprint: `MergeTimingPhase::TableWalk` plus two recording spans around `stage_streaming_table_merge`. Production pays one unset task-local check.
- Rule 6: nothing here gates anything, at any CI stage. Workspace member, `publish = false`.
- Records carry explicit identity (embedded SUT commit with dirty and stale-build detection, session and invocation ULIDs, machine spec, declared warmth). Env values with secret-looking names are redacted in records and reports.
- Fixtures are generated, never fetched: `scripts/generate_merge_bench_fixtures.py` is the dataset source of truth (deterministic per builder version, SHA-256 validation stamp; runs refuse unvalidated or modified fixtures).
- Deferrals are listed in the README ("What benchmark v1 defers"): S3/MinIO backend seam, realistic profile, remaining scenarios.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the RFC 0039 end-to-end benchmark harness, with validated fixtures, append-only run records, A/A noise-floor comparisons, reporting, and branch-merge timing and storage instrumentation.
- Introduces the `omnigraph-bench` workspace crate and fixture-generation tooling.
- Adds schema-validated benchmark records, terminal/HTML reports, and per-point A/A comparison support.
- Adds `TableWalk` timing around the general three-way merge workload.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/omnigraph-bench/src/run.rs | Orchestrates benchmark repetitions, validates every merged repetition, and produces records only after successful checks. |
| crates/omnigraph-bench/src/diff.rs | Compares records and now correctly withholds point-specific noise-floor labels from cross-point comparisons. |
| crates/omnigraph-bench/src/record.rs | Defines benchmark identity, specification, result, and noise-floor record structures. |
| crates/omnigraph-bench/src/report.rs | Produces self-contained benchmark reports from validated run records. |
| crates/omnigraph/src/exec/merge.rs | Adds observational timing spans around the general three-way table walk without changing merge semantics. |
| crates/omnigraph/src/instrumentation.rs | Extends merge timing instrumentation with the TableWalk phase used by the benchmark harness. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    F[Validated fixture] --> R[Benchmark repetitions]
    R --> M[Branch merge]
    M --> T[Wall-clock and phase timings]
    M --> S[Storage-call counters]
    T --> V[Per-repetition row validation]
    S --> V
    V --> J[Schema-validated run record]
    J --> D[Diff and A/A noise-floor labels]
    J --> P[Terminal and HTML reports]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(bench): row-check every repetition, ..."](https://github.com/modernrelay/omnigraph/commit/dc091b55fa9e575caa7fb2ef7054b0db100521e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54915763)</sub>

**Context used:**

- Knowledge Base — [Branching and merge](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/branching-and-merge.md)

<!-- /greptile_comment -->