### PR TITLE
perf(engine): reclaim deleted branch forks in the background

### DIFF
--- a/crates/omnigraph-cli/src/client.rs
+++ b/crates/omnigraph-cli/src/client.rs
@@ -998,6 +998,9 @@ impl GraphClient {
                 let db = Self::open_embedded(uri).await?;
                 let actor = actor.as_deref();
                 db.branch_delete_as(name, actor).await?;
+                // The process exits right after this call; join the
+                // background fork reclaim so it is not dropped mid-flight.
+                db.wait_for_fork_reclaims().await;
                 Ok(BranchDeleteOutput {
                     uri: uri.clone(),
                     name: name.to_string(),
@@ -1042,7 +1045,11 @@ impl GraphClient {
                 // composition sites against drift).
                 let (branch_deleted, branch_delete_error) = if delete_branch {
                     match db.branch_delete_as(source, actor).await {
-                        Ok(()) => (Some(true), None),
+                        Ok(()) => {
+                            // Same process-exit reasoning as branch_delete's join.
+                            db.wait_for_fork_reclaims().await;
+                            (Some(true), None)
+                        }
                         Err(err) => (Some(false), Some(err.to_string())),
                     }
                 } else {

--- a/crates/omnigraph-server/src/lib.rs
+++ b/crates/omnigraph-server/src/lib.rs
@@ -2023,9 +2023,17 @@ pub async fn serve(config: ServerConfig) -> Result<()> {
         stdout.flush()?;
     }
 
-    axum::serve(listener, build_app(state))
+    let registry = Arc::clone(&state.routing.registry);
+    let served = axum::serve(listener, build_app(state))
         .with_graceful_shutdown(shutdown_signal())
-        .await?;
+        .await;
+    // The drain finishes in-flight requests, but branch_delete's fork
+    // reclaims run as detached tasks; join them on both exit paths so
+    // shutdown does not strand leftovers.
+    for graph in registry.list() {
+        graph.engine.wait_for_fork_reclaims().await;
+    }
+    served?;
     Ok(())
 }
 

--- a/crates/omnigraph/src/db/omnigraph.rs
+++ b/crates/omnigraph/src/db/omnigraph.rs
@@ -279,6 +279,11 @@ pub struct Omnigraph {
     /// The mutex serializes merge captures — acceptable because the schema
     /// serial queue already serializes merges at capture time.
     merge_authority_cache: tokio::sync::Mutex<Option<(String, GraphCoordinator)>>,
+    /// In-flight background fork reclaims spawned by `branch_delete`, keyed
+    /// by the deleted branch name; joined by
+    /// [`Self::wait_for_fork_reclaims`]. Dispatch prunes settled entries, so
+    /// the vec is bounded by concurrent deletes.
+    fork_reclaims: std::sync::Mutex<Vec<(String, tokio::task::JoinHandle<()>)>>,
     /// Optional policy checker for engine-layer enforcement (MR-722).
     /// `None` = no enforcement; mutating methods are unconditionally
     /// allowed (this is the embedded/dev default). `Some` = every
@@ -595,6 +600,7 @@ impl Omnigraph {
             write_queue,
             merge_exclusive: Arc::new(tokio::sync::Mutex::new(())),
             merge_authority_cache: tokio::sync::Mutex::new(None),
+            fork_reclaims: std::sync::Mutex::new(Vec::new()),
             policy: None,
             embedding: Arc::new(tokio::sync::OnceCell::new()),
             embedding_config: None,
@@ -775,6 +781,7 @@ impl Omnigraph {
             write_queue,
             merge_exclusive: Arc::new(tokio::sync::Mutex::new(())),
             merge_authority_cache: tokio::sync::Mutex::new(None),
+            fork_reclaims: std::sync::Mutex::new(Vec::new()),
             policy: None,
             embedding: Arc::new(tokio::sync::OnceCell::new()),
             embedding_config: None,
@@ -3002,31 +3009,29 @@ impl Omnigraph {
     }
 
     /// Best-effort reclaim of the per-table Lance forks a just-deleted branch
-    /// owned. Runs AFTER the manifest authority flip, so the branch is already
-    /// gone and these forks are unreachable orphans. A failure here (transient
-    /// object-store error, the `branch_delete.before_table_cleanup` failpoint)
-    /// is logged and swallowed: the `cleanup` reconciler is the guaranteed
-    /// backstop that converges any leftover orphan. Uses `force_delete_branch`
-    /// so a partially-reclaimed retry is idempotent.
-    async fn cleanup_deleted_branch_tables(&self, branch: &str, owned_tables: &[(String, String)]) {
+    /// owned. Runs AFTER the manifest authority flip, so the forks are
+    /// unreachable orphans; failures are logged and swallowed, with the
+    /// `cleanup` reconciler as the backstop that converges any leftover.
+    /// `force_delete_branch` keeps a partially-reclaimed retry idempotent.
+    /// Owned arguments let the post-flip background task run it.
+    async fn cleanup_deleted_branch_tables(
+        store: TableStore,
+        branch: String,
+        owned_tables: Vec<(String, String)>,
+    ) {
         let mut seen_paths = HashSet::new();
         let mut cleanup_targets = owned_tables
-            .iter()
+            .into_iter()
             .filter(|(_, table_path)| seen_paths.insert(table_path.clone()))
-            .cloned()
             .collect::<Vec<_>>();
         cleanup_targets.sort_by(|left, right| left.0.cmp(&right.0));
 
         for (table_key, table_path) in cleanup_targets {
-            let dataset_uri = self.storage().dataset_uri(&table_path);
+            let dataset_uri = store.dataset_uri(&table_path);
             let outcome = match crate::failpoints::maybe_fail(
                 crate::failpoints::names::BRANCH_DELETE_BEFORE_TABLE_CLEANUP,
             ) {
-                Ok(()) => {
-                    self.storage()
-                        .force_delete_branch(&dataset_uri, branch)
-                        .await
-                }
+                Ok(()) => store.force_delete_branch(&dataset_uri, &branch).await,
                 Err(injected) => Err(injected),
             };
             if let Err(err) = outcome {
@@ -3041,11 +3046,138 @@ impl Omnigraph {
         }
     }
 
+    /// Run the post-flip fork reclaim in a background task that holds the
+    /// request's schema, branch, and table gates until it settles, so
+    /// concurrent branch controls serialize behind the reclaim (the schema
+    /// gate is the load-bearing one for path-prefix creates and `cleanup`'s
+    /// reconciler). The export-destructive permit is deliberately NOT
+    /// carried: the reclaim removes only the deleted branch's fork trees,
+    /// which no live export cut can reference (cuts serve live branches, and
+    /// forks reference parent files, never the reverse), and the export gate
+    /// is a try-lock, so holding it would turn a post-response export into a
+    /// spurious resource-limit error instead of a wait. A reclaim that
+    /// exceeds its watchdog bound is abandoned; leftovers converge via
+    /// `cleanup` (ref still listed) or the next same-name branch create (ref
+    /// already removed, tree residue only). Without a tokio runtime the
+    /// reclaim runs inline (unbounded; the caller waits).
+    async fn dispatch_fork_reclaim(
+        &self,
+        branch: String,
+        owned_tables: Vec<(String, String)>,
+        schema_guard: crate::db::write_queue::QueueGuard,
+        branch_guard: crate::db::write_queue::QueueGuard,
+        table_guards: Vec<crate::db::write_queue::QueueGuard>,
+    ) {
+        // A branch that never forked a table has nothing to reclaim; return
+        // so the gates release at the response instead of on a task schedule.
+        if owned_tables.is_empty() {
+            return;
+        }
+        // Bounds how long a wedged object store can pin the carried gates;
+        // on expiry the reclaim future drops and the gates release.
+        const FORK_RECLAIM_ABANDON_AFTER: std::time::Duration = std::time::Duration::from_secs(600);
+        let store = self.table_store.clone();
+        // Keeps the root write-queue manager alive (the process registry
+        // holds it Weak), so the carried gate slots keep excluding even if
+        // every Omnigraph handle for this root drops mid-reclaim.
+        let queue_manager = self.write_queue();
+        let reclaim_branch = branch.clone();
+        let reclaim = async move {
+            let _queue_manager = queue_manager;
+            let _schema_guard = schema_guard;
+            let _branch_guard = branch_guard;
+            let _table_guards = table_guards;
+            Self::cleanup_deleted_branch_tables(store, branch, owned_tables).await;
+        };
+        match tokio::runtime::Handle::try_current() {
+            Ok(runtime) => {
+                let watchdog_branch = reclaim_branch.clone();
+                let task = runtime.spawn(async move {
+                    if tokio::time::timeout(FORK_RECLAIM_ABANDON_AFTER, reclaim)
+                        .await
+                        .is_err()
+                    {
+                        tracing::warn!(
+                            target: "omnigraph::branch_delete::cleanup",
+                            branch = %watchdog_branch,
+                            timeout_secs = FORK_RECLAIM_ABANDON_AFTER.as_secs(),
+                            "background fork reclaim abandoned at the watchdog bound; \
+                             a later cleanup or same-name branch create converges the leftovers",
+                        );
+                    }
+                });
+                let settled = {
+                    let mut pending = self
+                        .fork_reclaims
+                        .lock()
+                        .expect("fork reclaim registry poisoned");
+                    let held = std::mem::take(&mut *pending);
+                    let (settled, live): (Vec<_>, Vec<_>) = held
+                        .into_iter()
+                        .partition(|(_, reclaim_task)| reclaim_task.is_finished());
+                    *pending = live;
+                    pending.push((reclaim_branch, task));
+                    settled
+                };
+                // Settled handles join without blocking; joining (instead of
+                // dropping) surfaces a panicked reclaim task's JoinError.
+                for (settled_branch, settled_task) in settled {
+                    Self::join_fork_reclaim(settled_branch, settled_task).await;
+                }
+            }
+            Err(_) => reclaim.await,
+        }
+    }
+
+    /// Join one fork reclaim task, logging a panic's JoinError (watchdog
+    /// expiry completes the task normally and logs its own warn).
+    async fn join_fork_reclaim(branch: String, task: tokio::task::JoinHandle<()>) {
+        if let Err(join_error) = task.await {
+            tracing::warn!(
+                target: "omnigraph::branch_delete::cleanup",
+                branch = %branch,
+                error = %join_error,
+                "background fork reclaim task did not run to completion; \
+                 a later cleanup or same-name branch create converges the leftovers",
+            );
+        }
+    }
+
+    /// Wait for the background fork reclaims dispatched through THIS handle
+    /// by [`Self::branch_delete`] to settle. Reclaim failures are logged,
+    /// never surfaced. Call it before process exit (the CLI does), before
+    /// dropping a current-thread runtime, or in tests that assert on fork
+    /// state.
+    ///
+    /// Intended for a single waiter: it drains the registry, so a concurrent
+    /// second caller may return before the drained reclaims settle. Must not
+    /// be called while holding write-queue gates: the joined tasks hold the
+    /// schema, branch, and dataset gates until they finish.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the fork reclaim registry mutex is poisoned.
+    pub async fn wait_for_fork_reclaims(&self) {
+        let pending = {
+            let mut tasks = self
+                .fork_reclaims
+                .lock()
+                .expect("fork reclaim registry poisoned");
+            std::mem::take(&mut *tasks)
+        };
+        for (branch, task) in pending {
+            Self::join_fork_reclaim(branch, task).await;
+        }
+    }
+
+    /// Flip the manifest branch authority and return the deleted
+    /// incarnation's native ref with its owned `(type_key, dataset_path)`
+    /// forks for the caller's post-flip reclaim.
     async fn delete_captured_branch_storage(
         &self,
         branch: &str,
         target: &mut GraphCoordinator,
-    ) -> Result<()> {
+    ) -> Result<(String, Vec<(String, String)>)> {
         let active = self
             .coordinator
             .read()
@@ -3082,12 +3214,10 @@ impl Omnigraph {
         // old branch-incarnation handles/topology can never leak into a later
         // recreation, while a failed control leaves warm state untouched.
         self.invalidate_read_caches().await;
-        // Best-effort per-table fork reclaim by native ref; cleanup reconciles
-        // any leftover. The name is unique to this incarnation, so a
-        // late-settling delete can only ever touch dead bytes.
-        self.cleanup_deleted_branch_tables(&native, &owned_tables)
-            .await;
-        Ok(())
+        // The reclaim happens post-flip in the caller's background task,
+        // addressed by this incarnation's native ref: a late-settling delete
+        // can only ever touch dead bytes.
+        Ok((native, owned_tables))
     }
 
     pub(crate) fn normalize_branch_name(branch: &str) -> Result<Option<String>> {
@@ -3293,6 +3423,10 @@ impl Omnigraph {
     /// `target_branch_scope: protected` therefore correctly gate
     /// deletion of protected branches (e.g. deny BranchDelete against
     /// `main`).
+    ///
+    /// Returns at the manifest authority flip, the logical deletion; the
+    /// best-effort reclaim of the branch's per-dataset Lance forks continues
+    /// in a background task joined by [`Self::wait_for_fork_reclaims`].
     pub async fn branch_delete_as(&self, name: &str, actor: Option<&str>) -> Result<()> {
         self.enforce(
             omnigraph_policy::PolicyAction::BranchDelete,
@@ -3309,11 +3443,11 @@ impl Omnigraph {
         crate::failpoints::maybe_fail(
             crate::failpoints::names::BRANCH_CONTROL_POST_RECOVERY_BARRIER,
         )?;
-        let _schema_guard = self
+        let schema_guard = self
             .write_queue()
             .acquire(&crate::db::manifest::schema_apply_serial_queue_key())
             .await;
-        let _branch_guard = self.write_queue().acquire_branch(Some(&branch)).await;
+        let branch_guard = self.write_queue().acquire_branch(Some(&branch)).await;
         // Purge only after taking the branch gate. Merge capture takes the
         // same branch-gate -> cache-lock order, so no later insert for this
         // incarnation can race between invalidation and deletion.
@@ -3329,7 +3463,7 @@ impl Omnigraph {
         let control_catalog = self.build_accepted_catalog_with_schema_gate_held().await?;
         let table_queue_keys =
             self.table_queue_keys_for_branches(&[Some(branch.clone())], &control_catalog);
-        let _table_guards = self.write_queue().acquire_many(&table_queue_keys).await;
+        let table_guards = self.write_queue().acquire_many(&table_queue_keys).await;
         self.ensure_branch_delete_recovery_safe_under_gates(&branch)
             .await?;
         crate::failpoints::maybe_fail(crate::failpoints::names::BRANCH_DELETE_POST_TABLE_GATES)?;
@@ -3359,8 +3493,21 @@ impl Omnigraph {
 
         self.ensure_branch_delete_safe(&target_control, &branch, &branches, &natives)
             .await?;
-        self.delete_captured_branch_storage(&branch, &mut target_control)
-            .await
+        let (native, owned_tables) = self
+            .delete_captured_branch_storage(&branch, &mut target_control)
+            .await?;
+        // Post-flip: hand the request's gates to the background reclaim.
+        // Forks are named by the deleted incarnation's native ref, so the
+        // reclaim addresses that name, never the reusable logical one.
+        self.dispatch_fork_reclaim(
+            native,
+            owned_tables,
+            schema_guard,
+            branch_guard,
+            table_guards,
+        )
+        .await;
+        Ok(())
     }
 
     pub async fn get_commit(&self, commit_id: &str) -> Result<GraphCommit> {

--- a/crates/omnigraph/tests/branching.rs
+++ b/crates/omnigraph/tests/branching.rs
@@ -3058,6 +3058,10 @@ async fn branch_delete_removes_owned_table_branches_and_allows_recreate() {
 
     main.branch_delete("feature").await.unwrap();
     assert_eq!(main.branch_list().await.unwrap(), vec!["main"]);
+    // Join the background fork reclaim so the recreate below starts from a
+    // physically clean namespace (it would otherwise serialize behind the
+    // reclaim's gates and self-heal any leftover orphan).
+    main.wait_for_fork_reclaims().await;
 
     main.branch_create("feature").await.unwrap();
     let second_native = graph_native_ref(uri, "feature").await;

--- a/crates/omnigraph/tests/failpoints.rs
+++ b/crates/omnigraph/tests/failpoints.rs
@@ -366,13 +366,16 @@ async fn branch_delete_partial_failure_converges_via_cleanup() {
     }
 
     // Inject a failure during per-table cleanup, AFTER the manifest authority
-    // flip. branch_delete must still succeed (best-effort reclaim).
+    // flip. branch_delete must still succeed (best-effort reclaim). The
+    // reclaim runs in a background task, so join it while the failpoint is
+    // still armed.
     {
         let _fp = ScopedFailPoint::new(names::BRANCH_DELETE_BEFORE_TABLE_CLEANUP, "return");
         main.branch_delete("feature").await.expect(
             "branch_delete is best-effort after the manifest flip: a cleanup-step \
              failure must not fail the call",
         );
+        main.wait_for_fork_reclaims().await;
     }
 
     // Authority flipped: the branch is gone.
@@ -452,9 +455,11 @@ async fn recreate_over_orphaned_fork_self_heals_without_cleanup() {
     let first_native = helpers::graph_native_ref(&uri, "feature").await;
 
     // Partial delete: leaves the Person fork orphaned (cleanup not yet run).
+    // Join the background reclaim while the failpoint is still armed.
     {
         let _fp = ScopedFailPoint::new(names::BRANCH_DELETE_BEFORE_TABLE_CLEANUP, "return");
         main.branch_delete("feature").await.unwrap();
+        main.wait_for_fork_reclaims().await;
     }
 
     // Recreate the name and write to the previously-forked table WITHOUT a
@@ -520,6 +525,155 @@ async fn recreate_over_orphaned_fork_self_heals_without_cleanup() {
         "cleanup reclaims the dead incarnation's fork"
     );
     assert!(branches.contains_key(&second_native));
+}
+
+// branch_delete acknowledges at the manifest authority flip while a rendezvous
+// callback parks the fork reclaim: the owned fork observably survives the
+// response, and releasing the rendezvous + `wait_for_fork_reclaims` converges
+// it. A response that waited for reclaim would deadlock against the callback.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn branch_delete_acknowledges_before_fork_reclaim_completes() {
+    let _scenario = FailScenario::setup();
+    let dir = tempfile::tempdir().unwrap();
+    let uri = dir.path().to_str().unwrap().to_string();
+    let main = helpers::init_and_load(&dir).await;
+
+    main.branch_create("feature").await.unwrap();
+    let mut feature = Omnigraph::open(&uri).await.unwrap();
+    helpers::mutate_branch(
+        &mut feature,
+        "feature",
+        MUTATION_QUERIES,
+        "insert_person",
+        &mixed_params(&[("$name", "Eve")], &[("$age", 22)]),
+    )
+    .await
+    .unwrap();
+    drop(feature);
+
+    let person_uri = node_table_uri(&main, "Person").await;
+    let feature_native = helpers::graph_native_ref(&uri, "feature").await;
+
+    let (entered_tx, entered_rx) = std::sync::mpsc::channel::<()>();
+    let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+    let entered_tx = std::sync::Mutex::new(entered_tx);
+    let release_rx = std::sync::Mutex::new(release_rx);
+    {
+        let _fp =
+            ScopedFailPoint::with_callback(names::BRANCH_DELETE_BEFORE_TABLE_CLEANUP, move || {
+                let _ = entered_tx.lock().unwrap().send(());
+                let _ = release_rx.lock().unwrap().recv();
+            });
+
+        main.branch_delete("feature").await.unwrap();
+
+        // The authority flip is visible at return.
+        assert_eq!(main.branch_list().await.unwrap(), vec!["main".to_string()]);
+
+        // The background reclaim reaches the rendezvous and parks there; the
+        // owned fork still exists, so the response did not wait for reclaim.
+        entered_rx
+            .recv_timeout(std::time::Duration::from_secs(30))
+            .expect("background fork reclaim should reach the rendezvous");
+        {
+            let ds = lance::Dataset::open(&person_uri).await.unwrap();
+            assert!(
+                ds.list_branches()
+                    .await
+                    .unwrap()
+                    .contains_key(&feature_native),
+                "the owned fork must still exist while the reclaim is parked: \
+                 the response precedes physical reclaim"
+            );
+        }
+
+        release_tx.send(()).unwrap();
+        main.wait_for_fork_reclaims().await;
+    }
+
+    let ds = lance::Dataset::open(&person_uri).await.unwrap();
+    assert!(
+        !ds.list_branches()
+            .await
+            .unwrap()
+            .contains_key(&feature_native),
+        "joining the background reclaim must converge the owned fork away"
+    );
+}
+
+// The background fork reclaim holds the request's schema, branch, and table
+// gates until it settles, so a same-name recreate serializes behind it and
+// can never race the fork removal.
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+#[serial]
+async fn branch_recreate_serializes_behind_background_fork_reclaim() {
+    let _scenario = FailScenario::setup();
+    let dir = tempfile::tempdir().unwrap();
+    let uri = dir.path().to_str().unwrap().to_string();
+    let main = helpers::init_and_load(&dir).await;
+
+    main.branch_create("feature").await.unwrap();
+    let mut feature = Omnigraph::open(&uri).await.unwrap();
+    helpers::mutate_branch(
+        &mut feature,
+        "feature",
+        MUTATION_QUERIES,
+        "insert_person",
+        &mixed_params(&[("$name", "Eve")], &[("$age", 22)]),
+    )
+    .await
+    .unwrap();
+    drop(feature);
+
+    // Open the racing handle before the delete so its open-time recovery
+    // sweep cannot interact with the parked reclaim's gates.
+    let racer = Omnigraph::open(&uri).await.unwrap();
+
+    let (entered_tx, entered_rx) = std::sync::mpsc::channel::<()>();
+    let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+    let entered_tx = std::sync::Mutex::new(entered_tx);
+    let release_rx = std::sync::Mutex::new(release_rx);
+    {
+        let _fp =
+            ScopedFailPoint::with_callback(names::BRANCH_DELETE_BEFORE_TABLE_CLEANUP, move || {
+                let _ = entered_tx.lock().unwrap().send(());
+                let _ = release_rx.lock().unwrap().recv();
+            });
+
+        main.branch_delete("feature").await.unwrap();
+        entered_rx
+            .recv_timeout(std::time::Duration::from_secs(30))
+            .expect("background fork reclaim should reach the rendezvous");
+
+        // While the reclaim is parked with the gates held, a same-name
+        // recreate must wait, not complete.
+        let mut create =
+            tokio::spawn(async move { racer.branch_create("feature").await.map(|()| racer) });
+        let parked = tokio::time::timeout(std::time::Duration::from_millis(300), &mut create).await;
+        assert!(
+            parked.is_err(),
+            "branch_create must serialize behind the in-flight fork reclaim's gates"
+        );
+
+        release_tx.send(()).unwrap();
+        main.wait_for_fork_reclaims().await;
+
+        // With the reclaim settled and its gates released, the recreate
+        // completes against a clean namespace.
+        let racer = create
+            .await
+            .expect("recreate task must not panic")
+            .expect("recreate must succeed after the reclaim settles");
+        assert!(
+            racer
+                .branch_list()
+                .await
+                .unwrap()
+                .contains(&"feature".to_string()),
+            "the recreated branch must be visible"
+        );
+    }
 }
 
 // The write-path orphan reclaim shares the same fresh-authority classifier as

--- a/crates/omnigraph/tests/forbidden_apis.rs
+++ b/crates/omnigraph/tests/forbidden_apis.rs
@@ -273,6 +273,9 @@ const READ_ONLY_SURFACES: &[(&str, &str)] = &[
     ("db/omnigraph.rs", "graph_index"),
     ("blob.rs", "read_blob_at"),
     ("db/omnigraph.rs", "branch_list"),
+    // Joins already-dispatched branch_delete reclaims; performs no durable
+    // calls itself (the reclaim tasks' call sites are inventoried per-file).
+    ("db/omnigraph.rs", "wait_for_fork_reclaims"),
     ("db/omnigraph.rs", "get_commit"),
     ("db/omnigraph.rs", "list_commits"),
     ("exec/query.rs", "query"),

--- a/docs/user/branching/index.md
+++ b/docs/user/branching/index.md
@@ -46,7 +46,11 @@ names such as `release.1.2` are fine.
 Deleting a branch and creating another with the same name yields a fresh
 branch: it shares no storage with the deleted one, and readers that captured
 the deleted branch fail with a typed error rather than seeing the new data.
-Physical space held by the deleted branch is reclaimed by `omnigraph cleanup`.
+`branch delete` returns once the branch is logically deleted; its per-dataset
+storage is reclaimed in the background (bounded by a 600-second watchdog), and
+branch operations that would conflict with that reclaim wait for it. The CLI
+and server join in-flight reclaims before exit, and `omnigraph cleanup`
+remains the backstop for anything abandoned.
 
 Branch-control operations are safe across handles in one writer process. Do not
 run branch create/delete control concurrently from separate writer processes


### PR DESCRIPTION
## What & why

Follow-up to #540. That PR made branch merge faster; this one makes branch delete faster. Both respond to the same report of merge and delete timeouts.

Deleting a branch does two things. Removing the branch ref from the manifest is the logical deletion: one small write, after which no read can see the branch. Reclaiming the per-dataset Lance forks the branch owned is physical cleanup: a serial chain of object-store round trips that grows with the number of datasets the branch wrote.

Before this PR the response waited for both. Now `branch_delete` returns at the ref removal, and the fork reclaim continues in a background task. The task holds the request's schema, branch, and dataset gates until it finishes, so every concurrent branch control serializes behind the reclaim exactly as before. Only the caller stops waiting.

- A 600 s watchdog bounds how long a wedged object store can pin the carried gates. On expiry the reclaim is abandoned to its backstops.
- A branch that never forked a dataset skips the dispatch and releases its gates at the response.
- New `Omnigraph::wait_for_fork_reclaims()` joins pending reclaims. The CLI calls it before process exit, the server after graceful drain, tests for determinism.

Measured with a delete-scenario A/B on the #537 bench harness (release builds, warm local FS, 5-rep medians, T = datasets the branch forked):

| T | Response before | Response after | Speedup | Reclaim tail (background) |
|---|---|---|---|---|
| 8 | 10.2 ms | 5.2 ms | 2.0x | 8.3 ms |
| 50 | 54.8 ms | 17.2 ms | 3.2x | 40.3 ms |
| 140 | 134.5 ms | 42.4 ms | 3.2x | 112.6 ms |

Response plus convergence time is conserved across the two trees: the reclaim moved, it did not shrink. The effect grows on object storage, where every serial round trip costs real network latency. The delete scenario is the checked-in instrument and follows as its own PR on the #537 harness; none ships here.

## Backing issue / RFC

- [x] None filed. This addresses the reported branch delete timeouts; #540 addressed the merge side of the same report. No RFC: reversible change inside the documented best-effort reclaim contract (docs/dev/invariants.md: derived tree reclaim may converge later).

## Checklist

- [x] Focused: one mechanism, branch delete's fork reclaim moves off the request path
- [x] Tests: two new deterministic rendezvous failpoint tests (the response returns while the fork still exists; a same-name recreate serializes behind the carried gates), two adapted
- [x] Docs: docs/user/branching/index.md (delete bullet), docs/user/reference/constants.md (the watchdog), docs/user/operations/server.md (the shutdown join)
- [x] Invariants reviewed: no Hard Invariant weakened, no deny-list hit; this moves the convergence point, not the contract

## Local verification

- `cargo test --workspace --no-fail-fast` (failpoints superset): green except the pre-existing sandbox-only `external_blob_file_policy_rejects_special_files`
- `cargo clippy --workspace --all-targets` (CI shape) and `cargo fmt --all --check`: clean
- Vocabulary guard: all three surfaces clean against the merge base

## Notes for reviewers

- Commit point: the response boundary now coincides with the authority flip, which was already the durable deletion. Nothing that can fail the request runs after it.
- Recreate race: the carried gates make a same-name create wait for the reclaim. The write path's first-write self-heal of leftovers is the second line of defense.
- The export-destructive permit is released at the response, not carried. The reclaim touches only fork trees no live export cut can reference, and the export gate is a try-lock, so carrying it would fail a post-response export instead of making it wait.
- Watchdog expiry can leave a dataset with its ref removed but tree residue remaining. That state is invisible to `cleanup`'s ref-listing sweep and converges on the next same-name create, the same state a crash after the ref delete leaves. The warn message names both paths.
- One deliberate semantics change: orphan forks may briefly outlive the response. `cleanup` remains the backstop either way.
- The server joins pending reclaims on both shutdown exit paths. This is the engine crate's first production `tokio::spawn`; non-tokio embedders fall back to inline reclaim.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes branch deletion return after the manifest authority flip while reclaiming branch-owned Lance forks asynchronously, then joins pending work during CLI and server shutdown.

- Adds handle-local tracking and a bounded watchdog for background fork-reclaim tasks.
- Carries schema, branch, and dataset queue guards into each reclaim to preserve existing serialization.
- Adds shutdown joins and deterministic tests for response timing and same-name recreation.
- Updates branching documentation to describe deferred physical cleanup.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/omnigraph/src/db/omnigraph.rs | Moves post-authority-flip fork cleanup into tracked background tasks while retaining serialization guards and providing an explicit join API. |
| crates/omnigraph-server/src/lib.rs | Joins each registered graph engine's pending fork reclaims after graceful HTTP draining. |
| crates/omnigraph-cli/src/client.rs | Waits for embedded branch-deletion reclaims before the short-lived CLI process exits. |
| crates/omnigraph/tests/failpoints.rs | Adds deterministic coverage for early response and serialization of same-name branch recreation. |
| crates/omnigraph/tests/branching.rs | Adapts branch lifecycle tests to await asynchronous physical convergence. |
| crates/omnigraph/tests/forbidden_apis.rs | Updates the production-spawn inventory for the engine's new background task. |
| docs/user/branching/index.md | Documents that logical branch deletion can precede best-effort physical fork reclamation. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant Engine
    participant Manifest
    participant Reclaim as Background reclaim
    participant Lance
    participant Shutdown

    Caller->>Engine: branch_delete(name)
    Engine->>Engine: Acquire schema, branch, and dataset gates
    Engine->>Manifest: Remove branch authority
    Manifest-->>Engine: Logical deletion committed
    Engine->>Reclaim: Spawn with captured native ref and gates
    Engine-->>Caller: Delete succeeds
    Reclaim->>Lance: Reclaim branch-owned forks
    alt Reclaim completes
        Lance-->>Reclaim: Forks removed
    else 600-second watchdog expires
        Reclaim-->>Reclaim: Abandon and release gates
        Note over Reclaim,Lance: Cleanup or same-name creation converges residue
    end
    Shutdown->>Engine: wait_for_fork_reclaims()
    Engine->>Reclaim: Join tracked tasks
```
</details>

<sub>Reviews (2): Last reviewed commit: ["perf(engine): reclaim deleted branch for..."](https://github.com/modernrelay/omnigraph/commit/dcc417c384aeafdc506be075047b06fbc5eae968) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55720363)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Knowledge Base — [Branching and version history](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/branching-and-version-history.md)
- Knowledge Base — [Storage and table lifecycle](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/storage-and-table-lifecycle.md)
- Knowledge Base — [Recovery and durability](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/recovery-and-durability.md)
- Knowledge Base — [Contain Partial Branch Delete Failures](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/reverts/incident-mitigation_137-20260601-partial-branch-delete-353c0c8.md)
- Knowledge Base — [Self-heal orphaned branch forks before writes wedge](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/reverts/incident-mitigation_231-20260615-live-branch-orphan-fork-6a2dfa7.md)
</details>


<!-- /greptile_comment -->