### PR TITLE
rfc: add RFC 0040, the system column namespace

### DIFF
--- a/docs/rfcs/0040-system-column-namespace.md
+++ b/docs/rfcs/0040-system-column-namespace.md
@@ -112,21 +112,25 @@ or `dst`.
 ### API results
 
 Payloads carry each graph's own column names: existing graphs keep `id`,
-new graphs carry `__id`/`__src`/`__dst`. The graph metadata surface gains
-the graph's system column spellings; that is the discovery mechanism for
-multi-graph clients, not raw storage.
+new graphs carry `__id`/`__src`/`__dst`. The schema introspection
+response (`GET /schema`) gains an optional field carrying the graph's
+system column spellings; reading it is the discovery mechanism for
+multi-graph clients, not raw storage (the spellings cannot appear in the
+`.pg` source itself, since system columns are undeclarable).
 
 ### Existing graphs
 
 Nothing changes at the release boundary. A graph changes only at its
-***upgrade***, the schema apply that renames its system columns and
-rewrites its stored queries, run explicitly by the owner. A schema apply
-that declares a freed name on a pre-upgrade graph is refused with an error
-naming the upgrade as the fix; the upgrade never runs implicitly. The owner
-accepts its consequences: the graph's
-API fields switch, and query text living outside the graph (application
-code, dashboards) must be updated by hand; only stored queries rewrite
-automatically. After it, the graph behaves like a new one.
+***upgrade***, the explicit operation that renames its system columns, run
+by the owner (mechanism in Reference-level design). A schema apply that declares a freed name on a
+pre-upgrade graph is refused with an error naming the upgrade as the fix;
+the upgrade never runs implicitly. Stored queries are configuration, not
+graph state (declared in the cluster config, loaded at boot), so a
+mechanical rewrite tool updates their `.gq` sources beforehand and the
+upgrade refuses while any still uses a legacy spelling. The owner accepts
+the remaining consequences: the graph's API fields switch, and query text
+in application code and dashboards spelling `$x.id` is the owner's to
+update. After it, the graph behaves like a new one.
 
 ## Reference-level design
 
@@ -147,9 +151,10 @@ The compiler models system columns as roles (`SystemFieldRole::Id`/`Src`/
 identities. This RFC extends that to system columns (amending 0028 once,
 see Invariants): no code path may assume a system column's spelling. The
 vintage is concretely the version field of the graph's accepted schema IR.
-New graphs record the new version; ordinary schema applies re-emit the
-accepted version unchanged, so no unrelated apply can flip spellings; only
-the upgrade advances it. One graph is always internally uniform, and a
+New graphs record the new version. Ordinary schema applies re-emit the
+accepted version unchanged (a required change to the resolver, which today
+stamps the current version constant unconditionally on every resolution),
+so no unrelated apply can flip spellings; only the upgrade advances it. One graph is always internally uniform, and a
 graph with no schema apply keeps its IR bytes and hash identical to
 today's. The catalog, a projection of the IR, is the one resolution point,
 and builds its Arrow schemas with the vintage's spelling. A grep of the
@@ -163,7 +168,9 @@ Meta-fields resolve by role. Bare names resolve against declared
 properties, plus, on old-vintage graphs only, the legacy spellings `id`
 (and `src`/`dst` on edges) resolve to the system columns; the vintage keys
 the rule, never physical inspection. A new lint marks a bare name resolving
-to a system column as the legacy spelling. Inside the reserved namespace,
+to a system column as the legacy spelling, surfacing where query
+diagnostics already surface; whether responses carry a structured warnings
+field is settled during implementation. Inside the reserved namespace,
 single underscore belongs to the substrate (`_rowid`), double to OmniGraph
 (`__manifest`, `__graph_index`, now `__id`).
 
@@ -199,17 +206,45 @@ Per-name reservation lists must never come back.
 
 ### The upgrade
 
-One schema apply, atomic with its normal commit discipline: rename the
-system columns, advance the vintage, rewrite stored queries. The rewrite
-operates on the parsed query, never text: binding kinds come from the match
-clause; `$x.id` becomes `$x.@id`, `$e.src`/`$e.dst` the meta-field forms,
-bare `id`/`src`/`dst` in mutation predicates their meta-field forms. It is
-provably unambiguous for every graph the upgrade accepts: this RFC's
-collision validation (above) refuses IRs carrying a user property with
-those names, so every such reference means the system column. A stored query that fails to parse or compile fails the whole apply
-with a named error before any effect. The design assumes Lance column
-renames are metadata-only; verifying that is an implementation gate, with
-an explicit one-shot migration tool as fallback.
+The upgrade is invoked explicitly through one engine operation exposed on
+two surfaces: a CLI command in single-graph mode, and a per-graph field in
+the cluster configuration applied through the normal cluster apply in
+cluster mode (where HTTP schema apply is already disabled). The trigger
+path never invokes it: declaring a freed name on a pre-upgrade graph
+errors and names the upgrade; the layer that knows the invocation surface
+adds its remediation (the CLI command, or the cluster-config field). The upgrade apply renames the system columns
+and advances the vintage, atomic with its normal commit discipline. Stored queries stay outside that
+transaction deliberately: they are configuration the server loads into its
+registry at boot, and the graph transaction has no write authority over
+the operator's `.gq` sources or the cluster ledger. They are rewritten
+before the upgrade by a mechanical tool over the `.gq` sources. The
+rewrite operates on the parsed query, never text: binding kinds come from
+the match clause; `$x.id` becomes `$x.@id`, `$e.src`/`$e.dst` the
+meta-field forms, bare `id`/`src`/`dst` in mutation predicates their
+meta-field forms; a query that fails to parse is reported, never guessed
+at. Validation is assigned to the layers that own the state: in cluster
+mode, cluster apply validates the desired revision's query sources against
+the post-upgrade catalog before invoking the engine operation and refuses
+with a named error listing every stored query still using a legacy
+identity spelling; the existing boot-time registry check remains the
+enforcement on load, and in single-graph mode that same boot check is the
+gate at the next server start. Nothing mutates the registry or the query
+sources except the rewrite tool. The applied revision is always
+internally consistent: meta-fields resolve by role on every vintage, so a
+rewritten query is already valid on the still-old-vintage graph, and one
+cluster apply revision carries the rewritten query resources and the
+upgrade together. A serving process holds the registry it loaded at boot,
+so the upgrade revision is followed by the server restart the cluster
+workflow already requires for schema changes; the boot check refuses a
+stale registry, which closes that window. The
+rewrite is provably unambiguous for every graph the upgrade accepts: it
+runs pre-upgrade, where this RFC's collision validation (above) refuses
+IRs carrying a user property with those names, and an apply declaring a
+freed name pre-upgrade is refused, so no colliding property can appear
+between rewrite and upgrade; every such reference means the system column.
+The design assumes Lance column renames are metadata-only; verifying that
+is an implementation gate, with an explicit one-shot migration tool as
+fallback.
 
 ### Compiler and language
 
@@ -282,11 +317,14 @@ with the strongest external precedent.
 
 ## Unresolved questions
 
-1. Is a Lance column rename metadata-only? Implementation gate for the
-   upgrade; fallback is the migration tool.
+1. Is a Lance column rename metadata-only, and do existing indexes on the
+   renamed column survive it? Index names derive from column spellings and
+   index replacement is by name, so the upgrade may need to rebuild or
+   re-register indexes even if the data needs no rewrite. Implementation
+   gate for the upgrade; fallback is the migration tool.
 2. Do constraint references to endpoint columns adopt the meta-field
    spelling (`@unique(@src, @dst)`) or the storage spelling
-   (`@unique(__src, __dst)`, as the accompanying draft implementation is
-   expected to do)? Settled during implementation review.
+   (`@unique(__src, __dst)`, as the draft implementation is expected to
+   do)? Settled during implementation review.
 3. Release timing relative to other pre-1.0 format work. Settled by the
    maintainers when scheduling the format batch.

--- a/docs/rfcs/0040-system-column-namespace.md
+++ b/docs/rfcs/0040-system-column-namespace.md
@@ -229,14 +229,19 @@ with a named error listing every stored query still using a legacy
 identity spelling; the existing boot-time registry check remains the
 enforcement on load, and in single-graph mode that same boot check is the
 gate at the next server start. Nothing mutates the registry or the query
-sources except the rewrite tool. The applied revision is always
-internally consistent: meta-fields resolve by role on every vintage, so a
-rewritten query is already valid on the still-old-vintage graph, and one
-cluster apply revision carries the rewritten query resources and the
-upgrade together. A serving process holds the registry it loaded at boot,
-so the upgrade revision is followed by the server restart the cluster
-workflow already requires for schema changes; the boot check refuses a
-stale registry, which closes that window. The
+sources except the rewrite tool. Because a serving process holds the
+registry it loaded at boot, the rollout is two ordered revisions, and the
+ordering is what removes every degraded interval: the first revision
+ships the rewritten query sources and is followed by the restart the
+cluster workflow already requires, which is safe because meta-fields
+resolve by role on every vintage, so a rewritten query is already valid
+on the still-old-vintage graph; the upgrade rides a later revision, and
+the serving process's rewritten registry stays valid straight through the
+rename. Combining both into one revision remains permitted but leaves the
+running server's pre-rewrite registry failing against the renamed columns
+until its restart; an operator who accepts that window is choosing it
+knowingly, and the boot check refuses a stale registry on the restart
+either way. The
 rewrite is provably unambiguous for every graph the upgrade accepts: it
 runs pre-upgrade, where this RFC's collision validation (above) refuses
 IRs carrying a user property with those names, and an apply declaring a

--- a/docs/rfcs/0040-system-column-namespace.md
+++ b/docs/rfcs/0040-system-column-namespace.md
@@ -1,16 +1,21 @@
+---
+rfc: "0040"
+title: "System column namespace"
+track: public
+status: draft
+implementation: in-progress
+authors:
+  - azimafroozeh
+created: 2026-08-23
+updated: 2026-09-01
+discussion: https://github.com/ModernRelay/omnigraph/issues/529
+supersedes: []
+superseded_by: []
+blocked_on:
+  - "Lance column rename verified metadata-only with existing indexes surviving the rename, OR the one-shot migration tool shipped in its place"
+---
+
 # RFC 0040: System column namespace
-
-| | |
-|---|---|
-| **Status** | Proposed |
-| **Author track** | Public contribution |
-| **Author(s)** | azim afroozeh ([`azimafroozeh`](https://github.com/azimafroozeh)) |
-| **Discussion** | [Issue #529](https://github.com/ModernRelay/omnigraph/issues/529) |
-| **Implementation** | to follow |
-| **Number** | provisional; reserved only by merge, re-checked at PR time |
-
-> Status is maintained by maintainers: `Proposed` while the PR is open,
-> `Accepted` on merge, `Declined` on close, and `Superseded by NNNN` later.
 
 > A term set in ***bold italics*** is being defined at that exact spot.
 
@@ -22,16 +27,20 @@ columns, the columns the engine adds to every table without a declaration,
 are spelled `__id`, `__src`, `__dst` on newly created graphs. Today the
 engine hardcodes those spellings; this RFC replaces every such assumption
 with per-graph resolution by role, keyed on the graph's ***vintage***, the
-version generation recorded in its stored schema authority. That is what lets every existing graph keep
-its spellings and stay readable with no migration. The query language gains
+spelling generation recorded in its stored schema authority. That is what
+lets every existing graph keep its spellings and stay readable with no
+migration. The query language gains
 a ***meta-field namespace***: `$p.@id` (edges: `$e.@src`, `$e.@dst`) reads
 the system identity on every graph. `$p.id` keeps its exact current behavior
 on existing graphs and refers only to a user property on new ones, so no
 meaning is ever ambiguous. API payloads carry each graph's own column names.
+The RFC also ends the schema IR's version scalar at 4: an `ir_version` 4
+IR carries a set of feature names, and every later schema feature adds a
+name, never a version (Design).
 At the release boundary, existing graphs, queries, and clients see no
 behavior change beyond a deprecation lint on legacy identity spellings; the
 `_`-prefix rejection applies to newly created graphs' schema admission. Each
-graph adopts the new spellings at its own explicit upgrade.
+graph adopts the new spellings at its own explicit upgrade, defined below.
 
 ## Motivation
 
@@ -40,21 +49,21 @@ Issue #529 reports the visible half: `node Grp { id: String @key }` fails
 with "@key must reference declared properties" although the property is
 declared. The silent half is worse: without `@key` the schema is accepted
 and the table carries two `id` columns. Edge properties named `src`/`dst`
-hit both failure modes. A companion patch, to be submitted alongside this
-RFC, will reserve the three names with a clear error. Three liabilities
-remain:
+hit both failure modes. A companion patch (tracked on issue #529; Rollout
+step 1), to be submitted alongside this RFC, will reserve the three names
+with a clear error. Three liabilities remain:
 
 1. Porting friction is permanent: a natural key literally named `id` is the
    default in relational tables, REST payloads, and CSV exports.
 2. Per-name reservation lists: the compiler already carries one for Lance's
-   `_rowid` family, with an audit obligation on every Lance upgrade.
+   `_rowid` family, with an audit obligation on every Lance version bump.
 3. The names sit in the user's namespace. ArangoDB (`_id`, `_from`, `_to`),
    MongoDB (`_id`), Elasticsearch, and Lance all chose a reserved prefix;
    SQLite/DuckDB `rowid` shadowing is a documented footgun; Neo4j's one
    accessor rename took a multi-year deprecation cycle. Pre-1.0 is the
    cheap moment.
 
-## Guide-level explanation
+## User and operational behavior
 
 ### Schema language
 
@@ -93,13 +102,13 @@ On any single graph, `id` has exactly one meaning:
 | Old-vintage graph | the system column, as today (deprecation lint) | system identity |
 | New-vintage graph | a user property, or a loud unknown-property error | system identity |
 
-The upgrade moves a graph to the new-vintage row. A valid old-vintage graph
+The upgrade (below) moves a graph to the new-vintage row. A valid old-vintage graph
 cannot contain a user `id` property (the companion patch will enforce it at
 admission; this RFC's schema-authority validation enforces it for old
-graphs; the already-corrupt case is refused, see Reference), so `$p.id`
-there is always the system column. On new graphs, with no such property declared, the
-compiler fails with "unknown property 'id'; the system identity is
-`$p.@id`". No query is ever silently reinterpreted.
+graphs; the already-corrupt case is refused, see Design), so `$p.id`
+there is always the system column. On new graphs, with no such property
+declared, the compiler fails with "unknown property 'id'; the system
+identity is `$p.@id`". No query is ever silently reinterpreted.
 
 ### What does not change: user properties
 
@@ -122,7 +131,7 @@ multi-graph clients, not raw storage (the spellings cannot appear in the
 
 Nothing changes at the release boundary. A graph changes only at its
 ***upgrade***, the explicit operation that renames its system columns, run
-by the owner (mechanism in Reference-level design). A schema apply that declares a freed name on a
+by the owner (mechanism in Design). A schema apply that declares a freed name on a
 pre-upgrade graph is refused with an error naming the upgrade as the fix;
 the upgrade never runs implicitly. Stored queries are configuration, not
 graph state (declared in the cluster config, loaded at boot), so a
@@ -132,7 +141,7 @@ the remaining consequences: the graph's API fields switch, and query text
 in application code and dashboards spelling `$x.id` is the owner's to
 update. After it, the graph behaves like a new one.
 
-## Reference-level design
+## Design
 
 ### Prefix reservation, keyed on vintage
 
@@ -144,23 +153,82 @@ five Lance names (a legally declared `_row_id` stays readable) plus the
 three-name collision rule, whose error names the upgrade as the fix.
 Brand-new graphs always admit under the new rule.
 
+### `ir_version` ends at 4
+
+The accepted schema IR gains a ***feature set***, a set of feature names
+stamped as exactly the capabilities the graph requires; a binary refuses
+an IR carrying any name it does not know, the same fail-closed refusal
+`ir_version` gives today, per name instead of per number. `ir_version` 4
+marks an IR as carrying the set and is the scalar's last value: 2 and 3
+keep the meanings RFC 0044's merged text assigns them, and every schema
+feature after this RFC adds a name, never a version.
+
+From this RFC's release the stamping rule is total. An accept whose
+derived set is empty stamps `ir_version` 2, exactly today's base; an
+accept requiring any name stamps 4 with the set; 3 is never emitted
+again; 4 with an empty set is refused as malformed. Stamps therefore
+move in both directions, as under RFC 0044's re-stamp rule, which this
+subsumes: an old-spelling graph whose last keyed edge type is removed
+returns to 2 and to the reach of every older binary. The set exists only
+at 4: an `ir_version` 2 or 3 IR carrying a set field is refused, an
+absent set serializes to exactly today's IR bytes, and a binary too old
+to know the set refuses on the number before ever reading it.
+
+This RFC mints two names. `system-columns` marks the new spellings; it
+is recorded at graph creation or added by the upgrade, never by an
+ordinary apply. `edge-keys` is the spelling of RFC 0044's capability on
+set-carrying graphs. The set is derived, not authored: apart from
+`system-columns`, membership is recomputed from the schema's
+declarations at every accept and again by `validate_schema_ir` on load,
+so a hand-authored IR whose set mismatches its declarations is refused.
+An old-spelling graph that later requires a new capability moves to
+`ir_version` 4 carrying its required names, without `system-columns`;
+its spellings do not change, because the vintage keys on
+`system-columns` membership, never on the number. This is what a single
+counting scalar cannot express: old-spelling graphs are permanent and
+keep gaining capabilities, so the spelling fact cannot be a position in
+an ordering.
+
+Future names follow one rule: a name is minted in the Design section of
+the RFC that owns its capability, spelled kebab-case, one name per
+capability, and registered in the RFC registry's index
+(`docs/rfcs/README.md`) beside the owning RFC's row, so a duplicate
+claim is caught where number collisions are caught today.
+
+Two pieces of RFC 0044's merged text are superseded from this RFC's
+acceptance, with the same explicitness as the 0028 amendment in
+Invariants: its highest-required-version stamping rule (subsumed by the
+total rule above, direction preserved) and its deferral of the
+cross-feature scheme to a dedicated versioning RFC. The number 3 and its
+meaning are untouched. The amendment to RFC 0044's text (minting
+`edge-keys`, retiring the deferral and its pointers to this RFC's former
+unresolved question) lands with or before RFC 0044's acceptance; until
+then, RFC 0044's deferral text stands and this section is the proposed
+resolution it defers to.
+
 ### Per-graph role resolution
 
 The compiler models system columns as roles (`SystemFieldRole::Id`/`Src`/
 `Dst`) and, per RFC 0028, treats user column names as spellings over stable
 identities. This RFC extends that to system columns (amending 0028 once,
 see Invariants): no code path may assume a system column's spelling. The
-vintage is concretely the version field of the graph's accepted schema IR.
-New graphs record the new version. Ordinary schema applies re-emit the
-accepted version unchanged (a required change to the resolver, which today
-stamps the current version constant unconditionally on every resolution),
-so no unrelated apply can flip spellings; only the upgrade advances it. One graph is always internally uniform, and a
-graph with no schema apply keeps its IR bytes and hash identical to
-today's. The catalog, a projection of the IR, is the one resolution point,
-and builds its Arrow schemas with the vintage's spelling. A grep of the
-literals `"id"`/`"src"`/`"dst"` in the engine crate's non-test sources at
-`a99907b4` counts roughly one hundred occurrences in 21 files; each is
-rerouted through the resolution point by this RFC.
+vintage is concretely the `system-columns` membership in the graph's
+accepted schema IR: absent, including on every graph at `ir_version` 2
+or 3, the vintage is old; present, new. New graphs record `ir_version` 4
+with `system-columns` in the set. Ordinary schema applies never change
+`system-columns` membership (a required change to the resolver, which
+today stamps the current version constant unconditionally on every
+resolution and must instead preserve `system-columns` while recomputing
+the derived members), so no unrelated apply can flip spellings; only the
+upgrade adds the name. One graph is always
+internally uniform, and a graph with no schema apply keeps its IR bytes
+and hash identical to today's. The catalog, a projection of the IR, is the
+one resolution point, and builds its Arrow schemas with the vintage's
+spelling. The reroute worklist is the grep
+`git grep -E '"(id|src|dst)"' -- crates/omnigraph/src` at `a99907b4`: 205
+matching lines across 21 files, 160 across the 19 files outside the
+crate's two in-tree test modules; each is rerouted through the resolution
+point by this RFC.
 
 ### Name resolution and coexistence
 
@@ -182,24 +250,16 @@ corrupt today (the property is shadowed). Validation refuses such IR with a
 named collision error directing export and rebuild. Every guarantee in this
 document is scoped to graphs that pass validation.
 
-### Format activation and refusal
-
-Old binaries validate the IR version with strict equality, so they refuse
-new-vintage graphs with the existing "unsupported ir_version" error; no old
-binary can half-read unknown spellings. The new binary accepts exactly two
-vintages, permanently: the predecessor is not a deprecation window, because
-this RFC's promise is that old graphs never migrate. The set is closed at
-two (next section). Evidence gates: an old-vintage fixture opens and
-answers identically before and after; a new-vintage graph is refused by the
-predecessor binary; a corrupt IR is refused with the named error.
-
 ### Future system columns: no further versions
 
-This vintage is the last one this concern will mint. Versioning was needed
-only because the legacy names sit in the user namespace; with the prefix
+The `system-columns` name is the last marker this concern will mint. A
+marker was needed only because the legacy names sit in the user namespace; with the prefix
 reserved, every future engine-owned field takes `__name` in storage and
-`@name` in the language, lands beside `__id` with no version bump, and
-cannot collide. Guideline for all future work: **engine-owned names use the
+`@name` in the language, lands beside `__id` with no version bump and no
+feature name, and cannot collide. The criterion against a feature name:
+an addition old binaries simply do not read needs nothing; any
+capability an old binary would misread, or drop on rewrite, mints a name
+(`ir_version` ends at 4). Guideline for all future work: **engine-owned names use the
 `__` prefix, surfaced as `@name`; single underscore stays with the
 substrate; nothing engine-owned is added outside the reserved namespace.**
 Per-name reservation lists must never come back.
@@ -212,8 +272,10 @@ the cluster configuration applied through the normal cluster apply in
 cluster mode (where HTTP schema apply is already disabled). The trigger
 path never invokes it: declaring a freed name on a pre-upgrade graph
 errors and names the upgrade; the layer that knows the invocation surface
-adds its remediation (the CLI command, or the cluster-config field). The upgrade apply renames the system columns
-and advances the vintage, atomic with its normal commit discipline. Stored queries stay outside that
+adds its remediation (the CLI command, or the cluster-config field). The
+upgrade apply renames the system columns and stamps the recomputed
+derived set with `system-columns` added, at `ir_version` 4, atomic
+with its normal commit discipline. Stored queries stay outside that
 transaction deliberately: they are configuration the server loads into its
 registry at boot, and the graph transaction has no write authority over
 the operator's `.gq` sources or the cluster ledger. They are rewritten
@@ -241,15 +303,17 @@ rename. Combining both into one revision remains permitted but leaves the
 running server's pre-rewrite registry failing against the renamed columns
 until its restart; an operator who accepts that window is choosing it
 knowingly, and the boot check refuses a stale registry on the restart
-either way. The
-rewrite is provably unambiguous for every graph the upgrade accepts: it
+either way. The rewrite is provably unambiguous for every graph the
+upgrade accepts: it
 runs pre-upgrade, where this RFC's collision validation (above) refuses
 IRs carrying a user property with those names, and an apply declaring a
 freed name pre-upgrade is refused, so no colliding property can appear
 between rewrite and upgrade; every such reference means the system column.
-The design assumes Lance column renames are metadata-only; verifying that
-is an implementation gate, with an explicit one-shot migration tool as
-fallback.
+The design assumes Lance column renames are metadata-only. Index names
+derive from column spellings and index replacement is by name, so the
+upgrade may need to rebuild or re-register indexes even when the data
+needs no rewrite. Verifying both is the `blocked_on` implementation gate,
+with an explicit one-shot migration tool as fallback.
 
 ### Compiler and language
 
@@ -259,7 +323,7 @@ annotations). Lowering emits role-resolved column references instead of the
 literal `id`. The `.pg` catalog builders prepend the spelling the
 resolution point dictates instead of `Field::new("id", ...)`.
 
-## Invariants & deny-list check
+## Invariants
 
 Aligned with logical contract over physical state: the logical contract
 (every table has an identity column, edges have endpoints) is unchanged;
@@ -271,15 +335,47 @@ amends the rename half of that sentence, applying 0028's own
 names-are-spellings principle to the fields it had exempted. The
 declaration half stands: system columns remain undeclarable.
 
-One deny-list item is knowingly brushed: this is an on-disk format change,
-which demands compatibility, refusal, and rebuild evidence. Format
-activation and refusal carries that plan. No other deny-list item is
-touched; no new background process, cache, or coordination primitive is
-introduced. Checked against [../dev/invariants.md](../dev/invariants.md):
-no Hard Invariant is weakened and no Known Gap moves; the governing
-principle is the one invariant touched, and it is strengthened.
+This is an on-disk format change, which is on the RFC-required list and
+is why this document exists; Compatibility and reversibility carries the
+plan, and Evidence and tests carries its gates. Checked against
+[../dev/invariants.md](../dev/invariants.md): no deny-list item is
+touched, and no new background process, cache, or coordination primitive
+is introduced. Invariant 6 (stable identity survives renames, not
+lifetimes) is the one Hard Invariant this RFC engages, through the 0028
+amendment above, and it is strengthened: system column identity becomes
+role-resolved exactly as user column identity already is. No other Hard
+Invariant is weakened.
 
-## Drawbacks & alternatives
+## Compatibility and reversibility
+
+Old binaries refuse graphs beyond their knowledge with the existing hard
+"unsupported ir_version" error: binaries predating RFC 0044's
+implementation accept only 2 (today's main binary is one; its
+exact-equality check is the mechanism), a binary implementing RFC 0044
+accepts {2, 3}, and this RFC's binary accepts {2, 3, 4}, refusing within
+4 any feature name it does not know; no binary can half-read unknown
+spellings. Acceptance of 3 is contingent on the edge-key machinery being
+present: this RFC's implementation ships with or after RFC 0044's, and
+otherwise must refuse 3, because accepting a keyed graph without that
+machinery re-opens the duplicate-edge bug (#583) on exactly the tables
+whose schema declares immunity. A 3-stamped graph stays 3 until its
+first accept under this RFC's release, which re-stamps it 4 (or 2 when
+nothing requires a name) and moves it beyond the {2, 3} generation that
+minted it; the move is fail-closed on those binaries. The spelling
+populations are exactly two, permanently: neither is a deprecation
+window, because this RFC's promise is that old graphs never migrate, and
+Future system columns (in Design) adds no third. The scalar ends at 4,
+so the numbering race between this RFC, RFC 0044, and their successors
+is closed: the number 3 keeps its merged meaning, and features after
+this RFC add names, never versions.
+
+Once no code assumes a spelling, the spelling is per-graph data; changing
+the default for new graphs is a one-line policy change. The meta-field
+namespace is additive. The prefix reservation is the least reversible piece
+socially (releasing a namespace is easy, reclaiming it is not) and the one
+with the strongest external precedent.
+
+## Alternatives
 
 **Cost: per-vintage surfaces.** A `$p.id` query written against an old
 graph fails loudly against a new one; multi-graph clients read spellings
@@ -308,28 +404,142 @@ reopens #529's silent variant.
 Elegant but overloads bare bindings in projections; separable, composes
 with the meta-field namespace.
 
+**Rejected: a further counting version for the rename.** Any position N
+on the scalar makes "old spellings plus a feature after N" inexpressible,
+because old-spelling graphs are permanent and keep gaining capabilities.
+
+**Rejected: deferring the scheme to a dedicated versioning RFC.** Same
+scheme, one more document; the first capability it governs is this RFC's
+own, and RFC 0044 already carries its half (3, as merged), so settling it
+here keeps one owner and lets acceptance close the question.
+
+**Rejected: a dedicated spelling flag beside the scalar.** Solves this
+RFC alone with one field and no registry; but every later orthogonal
+capability then needs its own ad-hoc flag plus a scalar bump to avoid
+being silently ignored by older binaries, where the set gives all of
+them one mechanism with per-name fail-closed refusal.
+
 **Do nothing.** The companion patch will replace the misleading error on
 its own; stopping there hardens the break's cost with every release toward
 1.0.
 
-## Reversibility
+## Evidence and tests
 
-Once no code assumes a spelling, the spelling is per-graph data; changing
-the default for new graphs is a one-line policy change. The meta-field
-namespace is additive. The prefix reservation is the least reversible piece
-socially (releasing a namespace is easy, reclaiming it is not) and the one
-with the strongest external precedent.
+The gates this RFC owns, each stated beside the behavior that defines it:
+
+- Old-vintage continuity: an old-vintage fixture graph opens and answers
+  identically before and after the release (result rows; diagnostics may
+  gain the deprecation lint), and a graph with no schema apply keeps its
+  IR bytes and hash identical to today's (Per-graph role resolution).
+- Refusal: the 2-only binary generation (today's main) and the {2, 3}
+  generation each refuse an `ir_version` 4 graph with the existing hard
+  "unsupported ir_version" error; a set-carrying graph naming a
+  capability the binary does not know is refused; an IR whose feature
+  set mismatches its declarations is refused at accept and by
+  `validate_schema_ir` on load; a 2 or 3 IR carrying a set field is
+  refused; a corrupt IR carrying a user `id`/`src`/`dst` property is
+  refused with the named collision error (`ir_version` ends at 4;
+  Compatibility and reversibility; Pre-RFC graphs with colliding
+  properties).
+- Stamping: a post-release accept whose derived set is empty stamps 2;
+  one requiring any name stamps 4 with exactly the derived set, never 3;
+  the upgrade stamps the recomputed set with `system-columns` added; an
+  untouched old graph's absent set keeps its IR bytes and hash identical
+  (`ir_version` ends at 4).
+- Admission: a `_`-leading property name on a new graph is refused with
+  the reserved-namespace error, and the five Lance names admit through
+  the prefix rule alone (Schema language).
+- New-graph spellings: a graph created after the release stores
+  `__id`/`__src`/`__dst` (Summary; Per-graph role resolution).
+- Meta-field resolution: `$p.@id`, `$e.@src`, `$e.@dst` answer on both
+  vintages; `$p.id` on a new graph with no such declared property fails
+  with the unknown-property error naming `$p.@id` (Query language).
+- Deprecation lint: a bare legacy spelling resolving to a system column
+  on an old-vintage graph carries the lint (Name resolution and
+  coexistence).
+- Vintage stability: an ordinary schema apply never changes
+  `system-columns` membership; only the upgrade adds it (Per-graph role
+  resolution names the resolver change this requires).
+- Upgrade: the upgrade renames the system columns and stamps the
+  recomputed derived set with `system-columns` added, atomically with
+  its commit discipline; a schema apply declaring
+  a freed name on a pre-upgrade graph is refused with the error naming
+  the upgrade, the fence behind the unambiguous-rewrite claim (The
+  upgrade; Existing graphs).
+- Rewrite and upgrade gating: the rewrite operates on the parsed query and
+  reports a query that fails to parse; cluster apply refuses the upgrade
+  with a named error listing every stored query still using a legacy
+  identity spelling; the boot-time registry check enforces on load (The
+  upgrade).
+- Surface survey: the grep pinned in Per-graph role resolution (205
+  lines, 21 files at `a99907b4`) is the reroute worklist; complete when
+  the same grep matches only the resolution point's own module and test
+  code.
+
+The suites these gates extend exist today:
+`crates/omnigraph/tests/schema_apply.rs` and
+`crates/omnigraph/tests/validators.rs` (admission and schema-authority
+validation), the compiler's schema-IR unit tests beside
+`validate_schema_ir`, the graph fixture suites, and
+`crates/omnigraph-cli/tests/crossversion_upgrade.rs` (cross-version
+refusal and continuity). Acceptance: every gate above lands as a test in
+one of these suites, or a new suite beside them, and passes in the same
+CI battery as today's. The draft implementation (#548) carries the
+per-test enumeration.
+
+## Rollout
+
+1. The companion reservation patch lands first and ships alone: `id`,
+   `src`, `dst` are refused at admission with a clear error, closing
+   #529's misleading failure and fencing the coexistence guarantees this
+   RFC depends on.
+2. Resolution and admission (the draft implementation, #548): system
+   columns resolve by role through the accepted vintage, new graphs admit
+   under the prefix rule and spell `__id`/`__src`/`__dst`, the meta-field
+   namespace and the deprecation lint land, and the versioning machinery
+   ships whole: the feature-set field, {2, 3, 4} acceptance (3 contingent
+   on the edge-key machinery, per Compatibility), unknown-name refusal,
+   the derivation check at accept and load, and the total stamping rule
+   (2 or 4 with the set, never 3). Old graphs see no behavior change
+   beyond that lint. `implementation` stays `in-progress`.
+3. The upgrade: the engine operation, its CLI and cluster-config surfaces,
+   and the mechanical `.gq` rewrite tool; the two ordered cluster
+   revisions are the documented operating procedure. The step is gated on
+   the `blocked_on` Lance rename verification; on the fallback path, the
+   one-shot migration tool replaces the in-place rename here.
+   `implementation` advances to `complete` when this lands.
+
+Stopping after step 1 leaves the bug fenced; stopping after step 2 leaves
+every graph fully working with the upgrade not yet offered. No step
+strands a graph. Release timing relative to other pre-1.0 format work is
+the maintainers' scheduling call for the format batch, outside this
+document.
 
 ## Unresolved questions
 
-1. Is a Lance column rename metadata-only, and do existing indexes on the
-   renamed column survive it? Index names derive from column spellings and
-   index replacement is by name, so the upgrade may need to rebuild or
-   re-register indexes even if the data needs no rewrite. Implementation
-   gate for the upgrade; fallback is the migration tool.
-2. Do constraint references to endpoint columns adopt the meta-field
+1. Do constraint references to endpoint columns adopt the meta-field
    spelling (`@unique(@src, @dst)`) or the storage spelling
    (`@unique(__src, __dst)`, as the draft implementation is expected to
-   do)? Settled during implementation review.
-3. Release timing relative to other pre-1.0 format work. Settled by the
-   maintainers when scheduling the format batch.
+   do)? Decided by the #548 reviewers, before this RFC's acceptance.
+
+## Decision log
+
+- 2026-08-23: Draft opened for review as PR #546; motivating discussion on
+  issue #529.
+- 2026-09-01: Review (ragnorc, #546): the design approach confirmed
+  (vintage-keyed resolution, meta-fields, the no-migration posture, the
+  reserved `__` namespace as the home for future engine-owned columns).
+  Applied from the same review: conversion to the normalized template and
+  the registry row; in the conversion, the former unresolved question on
+  the Lance rename moved to `blocked_on`, and the old Format activation
+  and refusal material folded into Compatibility and reversibility plus
+  Evidence and tests.
+- 2026-09-01: The joint `ir_version` numbering with RFC 0044, raised in
+  the same review, is proposed settled in this RFC (`ir_version` ends at
+  4, in Design), with acceptance closing it: an `ir_version` 4 IR
+  carries a derived feature-name set with fail-closed refusal of unknown
+  names, the vintage keys on `system-columns` membership, and the number
+  3 keeps its merged meaning, respelled as the `edge-keys` name on
+  set-carrying graphs at RFC 0044's acceptance. A dedicated versioning
+  RFC, a further counting version, and a dedicated spelling flag were
+  considered and rejected (Alternatives).

--- a/docs/rfcs/0040-system-column-namespace.md
+++ b/docs/rfcs/0040-system-column-namespace.md
@@ -1,0 +1,292 @@
+# RFC 0040: System column namespace
+
+| | |
+|---|---|
+| **Status** | Proposed |
+| **Author track** | Public contribution |
+| **Author(s)** | azim afroozeh ([`azimafroozeh`](https://github.com/azimafroozeh)) |
+| **Discussion** | [Issue #529](https://github.com/ModernRelay/omnigraph/issues/529) |
+| **Implementation** | to follow |
+| **Number** | provisional; reserved only by merge, re-checked at PR time |
+
+> Status is maintained by maintainers: `Proposed` while the PR is open,
+> `Accepted` on merge, `Declined` on close, and `Superseded by NNNN` later.
+
+> A term set in ***bold italics*** is being defined at that exact spot.
+
+## Summary
+
+OmniGraph reserves the leading-underscore property namespace for the system
+and releases `id`, `src`, and `dst` to user schemas. The implicit stored
+columns, the columns the engine adds to every table without a declaration,
+are spelled `__id`, `__src`, `__dst` on newly created graphs. Today the
+engine hardcodes those spellings; this RFC replaces every such assumption
+with per-graph resolution by role, keyed on the graph's ***vintage***, the
+version generation recorded in its stored schema authority. That is what lets every existing graph keep
+its spellings and stay readable with no migration. The query language gains
+a ***meta-field namespace***: `$p.@id` (edges: `$e.@src`, `$e.@dst`) reads
+the system identity on every graph. `$p.id` keeps its exact current behavior
+on existing graphs and refers only to a user property on new ones, so no
+meaning is ever ambiguous. API payloads carry each graph's own column names.
+At the release boundary, existing graphs, queries, and clients see no
+behavior change beyond a deprecation lint on legacy identity spellings; the
+`_`-prefix rejection applies to newly created graphs' schema admission. Each
+graph adopts the new spellings at its own explicit upgrade.
+
+## Motivation
+
+A user property named `id` collides with the implicit physical id column.
+Issue #529 reports the visible half: `node Grp { id: String @key }` fails
+with "@key must reference declared properties" although the property is
+declared. The silent half is worse: without `@key` the schema is accepted
+and the table carries two `id` columns. Edge properties named `src`/`dst`
+hit both failure modes. A companion patch, to be submitted alongside this
+RFC, will reserve the three names with a clear error. Three liabilities
+remain:
+
+1. Porting friction is permanent: a natural key literally named `id` is the
+   default in relational tables, REST payloads, and CSV exports.
+2. Per-name reservation lists: the compiler already carries one for Lance's
+   `_rowid` family, with an audit obligation on every Lance upgrade.
+3. The names sit in the user's namespace. ArangoDB (`_id`, `_from`, `_to`),
+   MongoDB (`_id`), Elasticsearch, and Lance all chose a reserved prefix;
+   SQLite/DuckDB `rowid` shadowing is a documented footgun; Neo4j's one
+   accessor rename took a multi-year deprecation cycle. Pre-1.0 is the
+   cheap moment.
+
+## Guide-level explanation
+
+### Schema language
+
+New schema admission rejects property names starting with `_`: "property
+name '_x' is reserved for system columns". The five Lance-name reservations
+collapse into this rule. The companion patch's three-name reservation does
+not: on pre-RFC graphs it survives as the upgrade trigger (below). On new
+graphs `id`, `src`, `dst` are ordinary names:
+
+```
+node Grp {
+    id: String @key      // legal on graphs created after this RFC
+    name: String
+}
+```
+
+### Query language: the meta-field namespace
+
+System fields are read through `@`-prefixed meta-fields, a namespace user
+properties can never enter:
+
+```
+return { $b.@id, $b.email }
+```
+
+`$x.@id` is a binding's system identity; `$e.@src`/`$e.@dst` are edge
+endpoints; in mutation predicates, which carry no binding, the bare form
+serves: `delete Person where @id = "..."`. These resolve by role, so they
+work on every graph. The rule in one sentence: user things are bare names,
+system things are `@name` in the language and `__name` in the bucket.
+
+On any single graph, `id` has exactly one meaning:
+
+| | `$p.id` / `where id = …` | `$p.@id` / `where @id = …` |
+|---|---|---|
+| Old-vintage graph | the system column, as today (deprecation lint) | system identity |
+| New-vintage graph | a user property, or a loud unknown-property error | system identity |
+
+The upgrade moves a graph to the new-vintage row. A valid old-vintage graph
+cannot contain a user `id` property (the companion patch will enforce it at
+admission; this RFC's schema-authority validation enforces it for old
+graphs; the already-corrupt case is refused, see Reference), so `$p.id`
+there is always the system column. On new graphs, with no such property declared, the
+compiler fails with "unknown property 'id'; the system identity is
+`$p.@id`". No query is ever silently reinterpreted.
+
+### What does not change: user properties
+
+A declared property such as `since: Date?` is untouched on every vintage:
+column name, type, access (`$e.since`), constraints, wire field. The RFC
+moves three engine-owned columns and reserves one prefix; the only change
+user properties see is a gain: on new graphs they may be named `id`, `src`,
+or `dst`.
+
+### API results
+
+Payloads carry each graph's own column names: existing graphs keep `id`,
+new graphs carry `__id`/`__src`/`__dst`. The graph metadata surface gains
+the graph's system column spellings; that is the discovery mechanism for
+multi-graph clients, not raw storage.
+
+### Existing graphs
+
+Nothing changes at the release boundary. A graph changes only at its
+***upgrade***, the schema apply that renames its system columns and
+rewrites its stored queries, run explicitly by the owner. A schema apply
+that declares a freed name on a pre-upgrade graph is refused with an error
+naming the upgrade as the fix; the upgrade never runs implicitly. The owner
+accepts its consequences: the graph's
+API fields switch, and query text living outside the graph (application
+code, dashboards) must be updated by hand; only stored queries rewrite
+automatically. After it, the graph behaves like a new one.
+
+## Reference-level design
+
+### Prefix reservation, keyed on vintage
+
+Admission rejects `_`-leading property names as a semantic check after
+parse (a grammar rejection would give an unhelpful error). Schema authority
+validation repeats it, and on both paths the rule is vintage-keyed: new
+graphs get the prefix rule; old graphs keep the historical rules, the exact
+five Lance names (a legally declared `_row_id` stays readable) plus the
+three-name collision rule, whose error names the upgrade as the fix.
+Brand-new graphs always admit under the new rule.
+
+### Per-graph role resolution
+
+The compiler models system columns as roles (`SystemFieldRole::Id`/`Src`/
+`Dst`) and, per RFC 0028, treats user column names as spellings over stable
+identities. This RFC extends that to system columns (amending 0028 once,
+see Invariants): no code path may assume a system column's spelling. The
+vintage is concretely the version field of the graph's accepted schema IR.
+New graphs record the new version; ordinary schema applies re-emit the
+accepted version unchanged, so no unrelated apply can flip spellings; only
+the upgrade advances it. One graph is always internally uniform, and a
+graph with no schema apply keeps its IR bytes and hash identical to
+today's. The catalog, a projection of the IR, is the one resolution point,
+and builds its Arrow schemas with the vintage's spelling. A grep of the
+literals `"id"`/`"src"`/`"dst"` in the engine crate's non-test sources at
+`a99907b4` counts roughly one hundred occurrences in 21 files; each is
+rerouted through the resolution point by this RFC.
+
+### Name resolution and coexistence
+
+Meta-fields resolve by role. Bare names resolve against declared
+properties, plus, on old-vintage graphs only, the legacy spellings `id`
+(and `src`/`dst` on edges) resolve to the system columns; the vintage keys
+the rule, never physical inspection. A new lint marks a bare name resolving
+to a system column as the legacy spelling. Inside the reserved namespace,
+single underscore belongs to the substrate (`_rowid`), double to OmniGraph
+(`__manifest`, `__graph_index`, now `__id`).
+
+### Pre-RFC graphs with colliding properties
+
+A graph created before the companion patch can hold an accepted IR with a
+user `id`/`src`/`dst` property and a duplicate physical column; it is
+corrupt today (the property is shadowed). Validation refuses such IR with a
+named collision error directing export and rebuild. Every guarantee in this
+document is scoped to graphs that pass validation.
+
+### Format activation and refusal
+
+Old binaries validate the IR version with strict equality, so they refuse
+new-vintage graphs with the existing "unsupported ir_version" error; no old
+binary can half-read unknown spellings. The new binary accepts exactly two
+vintages, permanently: the predecessor is not a deprecation window, because
+this RFC's promise is that old graphs never migrate. The set is closed at
+two (next section). Evidence gates: an old-vintage fixture opens and
+answers identically before and after; a new-vintage graph is refused by the
+predecessor binary; a corrupt IR is refused with the named error.
+
+### Future system columns: no further versions
+
+This vintage is the last one this concern will mint. Versioning was needed
+only because the legacy names sit in the user namespace; with the prefix
+reserved, every future engine-owned field takes `__name` in storage and
+`@name` in the language, lands beside `__id` with no version bump, and
+cannot collide. Guideline for all future work: **engine-owned names use the
+`__` prefix, surfaced as `@name`; single underscore stays with the
+substrate; nothing engine-owned is added outside the reserved namespace.**
+Per-name reservation lists must never come back.
+
+### The upgrade
+
+One schema apply, atomic with its normal commit discipline: rename the
+system columns, advance the vintage, rewrite stored queries. The rewrite
+operates on the parsed query, never text: binding kinds come from the match
+clause; `$x.id` becomes `$x.@id`, `$e.src`/`$e.dst` the meta-field forms,
+bare `id`/`src`/`dst` in mutation predicates their meta-field forms. It is
+provably unambiguous for every graph the upgrade accepts: this RFC's
+collision validation (above) refuses IRs carrying a user property with
+those names, so every such reference means the system column. A stored query that fails to parse or compile fails the whole apply
+with a named error before any effect. The design assumes Lance column
+renames are metadata-only; verifying that is an implementation gate, with
+an explicit one-shot migration tool as fallback.
+
+### Compiler and language
+
+The `.gq` grammar gains `binding.@ident` and bare `@ident` in mutation
+predicate position (`@` is free in both; today it appears only in top-level
+annotations). Lowering emits role-resolved column references instead of the
+literal `id`. The `.pg` catalog builders prepend the spelling the
+resolution point dictates instead of `Field::new("id", ...)`.
+
+## Invariants & deny-list check
+
+Aligned with logical contract over physical state: the logical contract
+(every table has an identity column, edges have endpoints) is unchanged;
+the spelling becomes per-graph logical state resolved from the schema
+authority, never inspected from storage. RFC 0028's identity model is
+preserved with one stated amendment: 0028 declares the `id`/`src`/`dst`
+fields cannot be renamed or supplied by a schema declaration; this RFC
+amends the rename half of that sentence, applying 0028's own
+names-are-spellings principle to the fields it had exempted. The
+declaration half stands: system columns remain undeclarable.
+
+One deny-list item is knowingly brushed: this is an on-disk format change,
+which demands compatibility, refusal, and rebuild evidence. Format
+activation and refusal carries that plan. No other deny-list item is
+touched; no new background process, cache, or coordination primitive is
+introduced. Checked against [../dev/invariants.md](../dev/invariants.md):
+no Hard Invariant is weakened and no Known Gap moves; the governing
+principle is the one invariant touched, and it is strengthened.
+
+## Drawbacks & alternatives
+
+**Cost: per-vintage surfaces.** A `$p.id` query written against an old
+graph fails loudly against a new one; multi-graph clients read spellings
+from the graph metadata surface; raw-Lance tools see both spellings. The
+alternative, a flag-day break with eager store-wide migration, breaks every
+existing query, stored query, and client at once; this RFC prefers
+zero-action compatibility.
+
+**Cost: a novel spelling.** Cypher/ISO GQL users know `id(n)`, not `.@id`.
+The function spelling was rejected: it consumes generic function names and
+needs a new function per future system field; the sigil reserves a
+namespace once, mirroring `__`. The docs owe one line: "instead of `id(n)`,
+write `n.@id`".
+
+**Rejected: documentation only.** Leaves the friction and the audit
+obligation in place.
+
+**Rejected: the reservation as the end state.** The companion patch closes
+the bug but keeps `id` unavailable forever; it is the fence that makes this
+RFC's guarantees provable, not the destination.
+
+**Rejected: user-wins shadowing.** SQLite's documented `rowid` footgun;
+reopens #529's silent variant.
+
+**Rejected: binding-as-identity** (`$a = $b` as identity equality).
+Elegant but overloads bare bindings in projections; separable, composes
+with the meta-field namespace.
+
+**Do nothing.** The companion patch will replace the misleading error on
+its own; stopping there hardens the break's cost with every release toward
+1.0.
+
+## Reversibility
+
+Once no code assumes a spelling, the spelling is per-graph data; changing
+the default for new graphs is a one-line policy change. The meta-field
+namespace is additive. The prefix reservation is the least reversible piece
+socially (releasing a namespace is easy, reclaiming it is not) and the one
+with the strongest external precedent.
+
+## Unresolved questions
+
+1. Is a Lance column rename metadata-only? Implementation gate for the
+   upgrade; fallback is the migration tool.
+2. Do constraint references to endpoint columns adopt the meta-field
+   spelling (`@unique(@src, @dst)`) or the storage spelling
+   (`@unique(__src, __dst)`, as the accompanying draft implementation is
+   expected to do)? Settled during implementation review.
+3. Release timing relative to other pre-1.0 format work. Settled by the
+   maintainers when scheduling the format batch.

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -38,9 +38,14 @@ issue and implementation PR are usually enough.
 - Do not create `pre-merge`, `final`, `v2`, `internal`, or review-ledger copies.
   Revise the canonical file; preserve meaningful changes in its decision log.
 
+<<<<<<< HEAD
 The next available number is **0045**. RFC 0040 is reserved by
 [PR #546](https://github.com/ModernRelay/omnigraph/pull/546); lower gaps are
 historical and must not be reused.
+=======
+The next available number is **0045**; lower gaps are historical and must
+not be reused.
+>>>>>>> 463fd70e (review)
 
 ## Required frontmatter
 
@@ -166,6 +171,7 @@ This table is the human index for the canonical RFC corpus.
 | [0037](0037-deterministic-simulation-harness.md) | Deterministic simulation harness | public | accepted | in-progress |
 | [0038](0038-typed-storage-failures.md) | Typed storage failures | public | accepted | complete |
 | [0039](0039-end-to-end-benchmark.md) | The end-to-end benchmark | public | accepted | in-progress |
+| [0040](0040-system-column-namespace.md) | System column namespace | public | draft | in-progress |
 | [0041](0041-inline-stored-queries.md) | Inline and stored queries | maintainer | accepted | partial |
 | [0042](0042-incarnation-suffixed-branch-refs.md) | Incarnation-suffixed native branch refs | maintainer | accepted | complete |
 | [0043](0043-full-text-index-compatibility.md) | Full-text index compatibility and explicit rebuild | maintainer | accepted | complete |


### PR DESCRIPTION
## What & why

This PR adds RFC 0040, which frees the property names `id`, `src`, and `dst` for user schemas and moves OmniGraph's implicit stored columns into a reserved namespace. Motivated by #529: a ported schema whose natural key is named `id` collides with the implicit physical id column, failing with a misleading error when declared with `@key` and silently producing a duplicate physical column without it.

- Reserve the leading-underscore property namespace for the system; the per-name Lance reservations collapse into one prefix rule, and future system columns need no further reservations or versions.
- Newly created graphs spell the system columns `__id`/`__src`/`__dst`; every existing graph keeps its current spellings through per-graph resolution keyed on its schema IR version, so the design contains no migration.
- The query language gains meta-fields (`$p.@id`, `$e.@src`, `$e.@dst`) that work on every graph; `$p.id` keeps its exact current behavior on existing graphs (with a deprecation lint) and refers only to a user property on new ones.
- API payloads carry each graph's own column names; an explicit per-graph upgrade renames the columns and mechanically rewrites the graph's stored queries in one schema apply.

## Backing issue / RFC

- [x] This PR is the RFC (`docs/rfcs/0040-system-column-namespace.md`); motivated by #529. A companion bug-fix patch reserving the three names lands separately before the implementation: it is the fence that makes the RFC's coexistence guarantees provable.

## Checklist

- [x] Change is focused (adds one RFC document, no source changes)
- [x] Tests added/updated for behavior changes (none: docs-only, no behavior change)
- [x] Public docs updated if user-facing surface changed (the RFC is the added document; user docs change with the implementation)
- [x] Reviewed against docs/dev/invariants.md: no Hard Invariant weakened; the RFC's Invariants section names the one knowingly brushed deny-list item (on-disk format change) and carries its refusal and compatibility evidence plan

## Local verification

- no build or test commands: docs-only RFC addition, no source touched
- vocabulary guard not run: the diff touches only `docs/rfcs/`, outside the guarded surfaces

## Notes for reviewers

- No flag day: at the release boundary, existing graphs, queries, and clients see no behavior change beyond a deprecation lint; each graph adopts the new spellings at its own explicit upgrade.
- The new binary permanently accepts exactly two schema IR vintages; old binaries refuse new-vintage graphs through the existing strict version validation.
- A draft implementation is in progress alongside; unresolved questions 1 and 2 (Lance rename metadata-only, constraint endpoint spelling) are implementation gates, and question 3 is release timing.







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds RFC 0040, proposing a reserved system-column namespace while preserving existing graph spellings through per-graph schema vintage.
- Introduces `__id`, `__src`, and `__dst` storage names and corresponding query meta-fields.
- Defines feature-set-based schema IR compatibility and explicit graph upgrades.
- Documents stored-query rewriting, cluster rollout ordering, compatibility gates, and implementation tests.
- Registers RFC 0040 in the RFC index.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains from the previously reported issues.

The revised RFC preserves vintage during ordinary applies, moves stored-query rewriting outside the graph transaction with a post-upgrade validation gate, and documents an ordered restart-before-upgrade rollout.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/rfcs/0040-system-column-namespace.md | Defines the system-column namespace, vintage-preserving compatibility model, explicit upgrade workflow, and associated validation gates. |
| docs/rfcs/README.md | Registers RFC 0040 in the canonical RFC index. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Old[Old-vintage graph<br/>id / src / dst] --> Apply[Ordinary schema apply]
  Apply --> Old
  Old --> Rewrite[Rewrite stored queries<br/>to meta-fields]
  Rewrite --> Restart[Restart with rewritten registry]
  Restart --> Upgrade[Explicit graph upgrade]
  Upgrade --> New[New-vintage graph<br/>__id / __src / __dst]
  New --> Meta[Queries use @id / @src / @dst]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["review"](https://github.com/modernrelay/omnigraph/commit/cd7aef7e55b94f059499052a03c1e8bbd6b3952e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56023988)</sub>

<!-- /greptile_comment -->