### PR TITLE
rfc: add RFC 0046, read-only index status

### DIFF
--- a/docs/rfcs/0042-index-status.md
+++ b/docs/rfcs/0042-index-status.md
@@ -16,10 +16,6 @@ blocked_on: []
 
 # RFC 0042: Read-only index status
 
-> Number provisional: 0042 is the next available per this README at
-> base `bb0e3dc8` (0040 is reserved by PR #546); re-verify at PR-open
-> time and renumber if raced. Remove this note before merge.
-
 > A term set in ***bold italics*** is being defined at that exact spot;
 > it is used in plain text everywhere after.
 
@@ -264,8 +260,11 @@ coordinated by `__manifest`. Per report:
    system indexes (Lance-internal bookkeeping indexes, the
    `is_system_index` set) are omitted (rule 8); a
    present-but-undeclared index reports `declared: false`, state
-   from coverage alone. The reconciler still maintains undeclared
-   indexes; reporting them keeps that drift visible.
+   from coverage alone. The reconciler's top-up pass still maintains
+   undeclared indexes, because its trigger and Lance's
+   `optimize_indices` filter only system indexes, never declaration;
+   creation and retrain remain declared-only. Reporting undeclared
+   indexes keeps that drift visible.
 4. Counts: fragments from bitmap containment; rows by summing
    logical fragment row counts, the `index_statistics` arithmetic. No column
    data, one bounded exception: `unbuildable` classification reuses the
@@ -402,3 +401,7 @@ None.
 
 - 2026-08-25: drafted from the #550 request (read-only index readiness
   status plus a blocking wait command) and the #486 monitoring gap.
+- 2026-08-25: PR review: clarified undeclared-index maintenance (the
+  top-up pass is declaration-blind, filtering only system indexes;
+  creation and retrain are declared-only) and removed the provisional
+  numbering note after the registry allocated 0042.

--- a/docs/rfcs/0042-index-status.md
+++ b/docs/rfcs/0042-index-status.md
@@ -1,0 +1,404 @@
+---
+rfc: "0042"
+title: "Read-only index status"
+track: maintainer
+status: draft
+implementation: not-started
+authors:
+  - Azim Afroozeh
+created: 2026-08-25
+updated: 2026-08-25
+discussion: "https://github.com/ModernRelay/omnigraph/issues/550"
+supersedes: []
+superseded_by: []
+blocked_on: []
+---
+
+# RFC 0042: Read-only index status
+
+> Number provisional: 0042 is the next available per this README at
+> base `bb0e3dc8` (0040 is reserved by PR #546); re-verify at PR-open
+> time and renumber if raced. Remove this note before merge.
+
+> A term set in ***bold italics*** is being defined at that exact spot;
+> it is used in plain text everywhere after.
+
+## Summary
+
+OmniGraph gains a read-only index-status surface: `omnigraph index
+status` and a served `GET` route report, per index (declared or
+not), a ***state*** (`ready`, `unbuildable`, `missing`, `degraded`), a
+machine-readable reason, and coverage counts, derived entirely from
+published state. `omnigraph index await` blocks until the gating
+states (`missing`, `degraded`) clear, or exits nonzero on timeout.
+
+The unchanged boundary: this surface observes, never builds.
+`optimize` remains the only index reconciler; no background scheduler,
+no new authority, no stored work list.
+
+## Motivation
+
+The only structured index readout today is `pending_indexes` in
+`optimize --json`, so observing index state requires a command that
+also commits: `optimize` compacts fragments, builds indexes, and
+publishes the result through `__manifest`. A health signal with write
+side effects cannot be polled freely, cannot run under a read-only
+credential, and violates command-query separation (the rule that a
+query returns a result without mutating state, while a command
+mutates): the readout can build the very index it was asked about,
+so its answer describes a state the question just changed. Issue #550
+asks for a read-only alternative: its
+control-plane POC loads a graph, traversals warn about full scans
+(the edge `id`/`src`/`dst` BTREEs are unbuilt), and automation has no
+way to see that without mutating. #486 is the monitoring twin: a
+degenerate mono-partition vector index is invisible to operators.
+#533 is adjacent, not overlapping: planner behavior when indexes
+exist, versus this RFC's "do they exist and what do they cover".
+
+New CLI and HTTP surface meets the RFC bar in [README.md](README.md);
+the lasting liability is the JSON contract automation will script
+against.
+
+## User and operational behavior
+
+### CLI
+
+```
+omnigraph index status [<uri>] [--branch <b> | --snapshot <s>] [--json]
+```
+
+The command runs in capability class "any": embedded against the
+positional URI, or served via the global `--server`/`--profile`
+flags, addressed per RFC 0011. `--branch` defaults to the graph's
+default branch, as the `snapshot` command does. Human output: one
+row per (table_key, index). `--json` emits one envelope object: the
+snapshot identity (`graph_branch`, `graph_manifest_version`) plus an
+`indexes` array of per-index rows; embedded and served output share
+this envelope. Under snapshot addressing, `graph_branch` is null
+when the snapshot resolves to no branch. A `degraded` row:
+
+```json
+{
+  "table_key": "edge:knows",
+  "name": "src_idx",
+  "kind": "btree",
+  "declared": true,
+  "state": "degraded",
+  "reason": "uncovered_fragments",
+  "message": "3 fragment(s) not covered by the index on 'src'",
+  "indexed_rows": 4000000,
+  "unindexed_rows": 120000,
+  "indexed_fragments": 40,
+  "unindexed_fragments": 3,
+  "updated_at": "2026-08-25T09:00:00Z"
+}
+```
+
+An `unbuildable` row (no physical index exists yet):
+
+```json
+{
+  "table_key": "node:Person",
+  "name": null,
+  "kind": "vector",
+  "declared": true,
+  "state": "unbuildable",
+  "reason": "no_trainable_vectors",
+  "message": "property has no non-null vectors to train on yet",
+  "indexed_rows": 0,
+  "unindexed_rows": 4000000,
+  "indexed_fragments": 0,
+  "unindexed_fragments": 40,
+  "updated_at": null
+}
+```
+
+Field notes:
+
+- `table_key`: `node:<type>` or `edge:<type>`.
+- `kind`: `btree` | `fts` | `vector`; `other` for a
+  present-but-undeclared index whose Lance type is outside this set.
+- `reason` is a token, `message` its human reading. OmniGraph mints
+  the token vocabulary here; today's free-string reconciler reasons
+  (`PendingIndex.reason`) map to tokens, string preserved in
+  `message`. `message` is free text for humans, never contract
+  (rule 9).
+- `updated_at`: RFC 3339 UTC, converted by OmniGraph from the
+  millisecond timestamp on the index's latest ***segment*** (one
+  immutable build unit; an incrementally reindexed index is several
+  segments under one name); null when the index was never built or
+  its segments predate Lance's `created_at` field.
+- For `missing` and `unbuildable` rows no physical index exists: `name`
+  and `updated_at` are null, the indexed counts are 0, and the
+  unindexed counts are the dataset's logical totals (the rows that
+  full-scan today).
+- `declared: false`: present in the dataset, no longer declared (its
+  `@index` intent was dropped by a schema change).
+
+The states:
+
+| state | meaning | operator response |
+|---|---|---|
+| `ready` | built, covers every current fragment | none |
+| `unbuildable` | declared, cannot be built as things stand (reason says why, e.g. a vector index whose property has no non-null vectors to train on) | load data, then `optimize` |
+| `missing` | declared (schema `@index`, or a fixed node/edge BTREE), never built | `optimize` |
+| `degraded` | built, below full quality; today's one reason is `uncovered_fragments` (rows appended or rewritten after the build, scanned until reindex) | `optimize` |
+
+The `unbuildable` state corresponds to `optimize --json`'s
+`pending_indexes` field; the word `pending` is deliberately unused
+on this surface, reserved for a true in-progress meaning should a
+background builder ever exist. When #486 lands its detection, a
+degenerate vector index reports `degraded` / `mono_partition` with
+no schema change.
+
+`status` exits 0 whenever a report is produced; states are data, not
+errors. Producing no report is a typed error that exits nonzero, in
+the same failure family as `snapshot` (exit codes owned by the CLI
+reference, `docs/user/cli/reference.md`): unresolvable URI, unknown
+branch or snapshot, empty root, or a root holding only orphan
+artifacts (files present, no `__manifest` Create committed).
+
+```
+omnigraph index await [<uri>] [--branch <b>] [--timeout <dur>] [--json]
+```
+
+Blocks until every gating index is `ready`, then exits 0. `missing`
+and `degraded` gate (`optimize` can clear them); `unbuildable` never
+gates: waiting cannot build it, only more data can, and blocking on it
+would hang the pipeline this command serves. `unbuildable` indexes
+appear in the final report. Zero declared indexes satisfies `await`
+immediately. `await` rejects `--snapshot`: a frozen snapshot's
+states can never change, so waiting on one is meaningless. Without
+`--timeout` it waits indefinitely (CI should always pass one).
+Timeout exits with its own code, distinct from the `snapshot`
+failure family and owned by the same CLI-reference exit-code
+section, printing the last report to stderr, in the `status`
+envelope when `--json` is set and human rows otherwise.
+
+`await` complements `optimize`, never replaces it (the observe-only
+boundary above): the pipeline is load, `optimize`, `await`. With
+nothing building, `await` runs out its timeout and fails.
+
+### Server
+
+`GET /index-status` (single-graph) and
+`GET /graphs/{graph_id}/index-status` (multi-graph) return the same
+envelope as the CLI (identity fields in the `SnapshotOutput`
+vocabulary). Both routes accept `branch`
+and `snapshot` query parameters with the CLI's defaulting. Gated
+like every read route: bearer auth resolves the actor at the
+boundary, then the server's Cedar read policy action applies. Served
+`await` runs its poll loop in the CLI over this route.
+
+### Semantics
+
+The report reads ***committed state only***: facts a `__manifest`
+publication or Lance commit has made visible. A mid-run `optimize` is
+invisible; until its publish lands, its output is orphan artifacts in
+the bucket. Consequences:
+
+- The report may say `missing` or `degraded` seconds before a build
+  commits. Polling (or `await`) is the contract; no in-progress state
+  exists.
+- "Never attempted" and "crashed before publishing" are
+  indistinguishable, the correct fail-closed reading.
+
+Each report runs under snapshot isolation: it derives from one pinned
+snapshot for its whole lifetime, a consistent cut across all
+datasets, never torn by a concurrent publish.
+
+A zero-row dataset reports its declared indexes `ready` with zero
+counts, vacuously covered: no rows exist to cover, and the
+reconciler skips empty tables, so any other classification would
+hang `await`. First rows flip the state to `missing`, or straight
+to `unbuildable` for a vector index whose rows still hold no
+non-null vectors.
+
+Counts are logical rows (physical rows minus deletions, from
+fragment metadata); a deleted row still in an index is not coverage.
+Computing a logical count may read small deletion sidecars, never
+column data.
+
+### Contract rules
+
+1. The report derives from committed state only; no in-progress state
+   exists on this surface.
+2. Every report is assembled from one pinned snapshot.
+3. The state set is exactly `ready`, `unbuildable`, `missing`,
+   `degraded`; it changes only by amendment to this RFC.
+4. `reason` tokens are an open set; consumers must tolerate unknown
+   tokens.
+5. Response fields may be added; existing fields are never removed or
+   retyped without deprecation.
+6. `await` gates on `missing` and `degraded` only; `unbuildable`
+   never gates.
+7. Neither `status` nor `await` ever triggers reconciliation.
+8. System indexes are omitted; a present-but-undeclared index is
+   reported with `declared: false`.
+9. `message` is human-readable free text, never contract; consumers
+   must not parse it.
+
+## Design
+
+A graph is many Lance datasets (one per node and edge type)
+coordinated by `__manifest`. Per report:
+
+1. Resolve one snapshot from `__manifest`: published `table_version`
+   per `(table_key, table_branch)` plus the accepted schema. The
+   declared set = the schema's `@index` intent + the fixed BTREEs
+   (`id` on node datasets; `id`/`src`/`dst` on edge datasets).
+2. Per dataset, read the Lance manifest at the published version. Its
+   index section holds one `IndexMetadata` per index segment: name,
+   typed `index_details` (kind), and `fragment_bitmap`, the Roaring
+   bitmap of covered fragment ids.
+3. Classify each declared index, first match wins. A zero-row
+   dataset short-circuits: its declared indexes report `ready` with
+   zero counts (per Semantics). Otherwise: listed in the
+   reconciler's `PendingIndex` set per
+   `index_work_status_on_dataset_for_catalog`
+   (`PendingIndex { type_key, property, reason }`), `unbuildable`;
+   absent from the manifest and buildable, `missing`; every current
+   fragment id in the union of its segments' bitmaps, `ready`;
+   uncovered fragments (`TableStore::has_unindexed_fragments` /
+   `IndexCoverage::Degraded`), `degraded`. Outside the declared set:
+   system indexes (Lance-internal bookkeeping indexes, the
+   `is_system_index` set) are omitted (rule 8); a
+   present-but-undeclared index reports `declared: false`, state
+   from coverage alone. The reconciler still maintains undeclared
+   indexes; reporting them keeps that drift visible.
+4. Counts: fragments from bitmap containment; rows by summing
+   logical fragment row counts, the `index_statistics` arithmetic. No column
+   data, one bounded exception: `unbuildable` classification reuses the
+   reconciler's trainability probe, a filtered null count over the
+   vector column. The per-segment plugin statistics path (which can
+   open index files) is not used.
+
+Lance owns the index metadata, bitmaps, and statistics; OmniGraph
+adds the catalog-intent diff, state classification, and graph-level
+aggregation. The inputs are the checks `optimize` already runs,
+exposed through a read-only engine entry point that widens their
+return shapes: per-index rows where `IndexWorkStatus` exposes only
+`needs_commit` plus the `pending` list, per-index coverage where
+`has_unindexed_fragments` is a dataset-level boolean. Shared checks
+keep endpoint and reconciler aligned; the widened shapes are new
+code, covered by the truth-table tests.
+
+Caching: physical coverage is cacheable per `(table_key,
+table_branch, table_version)`, because index builds become visible
+through the same single atomic `__manifest` publication (the
+publication door) as data, so coverage cannot change without the
+version moving. Declared intent is not covered by that key, because
+an index-only schema change (an `@index` addition applies as pure
+metadata, touching no table data) bumps no table version. Full key: `(table_key, table_branch, table_version,
+accepted-schema version)`. Warm poll: one `__manifest` read plus
+cache hits. The cache is a hint keyed by immutable versions, never
+authority.
+
+`await` is a poll loop with backoff over the same derivation, in the
+CLI in both modes; it is stateless: no lock, no server-side session,
+no persisted cursor.
+
+## Invariants
+
+- **Invariant 7** (physical acceleration is derived state) is the
+  foundation, unchanged: missing coverage changes cost, not
+  correctness; index work still happens only through explicit
+  reconciliation. This surface makes that derived state observable.
+- **Invariant 12**: derived on demand from Lance and `__manifest`;
+  the cache is immutable-pinned, a hint, never commit authority; no
+  shadow copy.
+- **Invariant 10**: the served route resolves the actor at the HTTP
+  boundary and applies the server's Cedar read policy, like every
+  read route.
+- **Deny-list, "a job queue for state derivable from accepted
+  manifest state"**: this RFC is the compliant shape; the work list
+  is derived every time (stored alternatives rejected below).
+- **Deny-list, "a logical precondition based on physical index
+  coverage"**: `await` is an operator pipeline gate outside the
+  engine. The item's other members (fragment count, cache entry,
+  staged layout) are engine-internal preconditions; this RFC adds
+  none. No engine operation, planner choice, or mutation precondition
+  consumes the status.
+
+No invariant is weakened. The support boundary "physical index
+reconciliation is explicit; there is no background scheduler whose
+queue is a second authority" is unchanged.
+
+## Compatibility and reversibility
+
+Additive only: one CLI verb pair, one GET route, new
+`omnigraph-api-types` response types; no storage or wire format
+change. The JSON field set and state vocabulary are the compatibility
+surface, governed by rules 3 to 5. Reverting is technically cheap but
+breaks gating scripts, so removal means deprecation, not deletion:
+the reversible end of the evidence-demand scale.
+
+## Alternatives
+
+- **Do nothing**: polling `optimize --json` mutates on every check,
+  conflating observing with reconciling.
+- **Extend `snapshot`**: `SnapshotOutput` is version topology;
+  per-index derived-state health has a different row shape and
+  cadence.
+- **Expose Lance `index_statistics` raw**: misses the catalog side;
+  `missing` and `unbuildable` live in schema intent, invisible to
+  Lance.
+- **Stored work list / progress sidecar**: a shadow copy (invariant
+  12's term) of derivable state that can lie after a crash, needs its
+  own concurrency control, and is deny-listed; derivation is too
+  cheap to be worth caching durably.
+
+Out of scope, compatible later (deliberately not `blocked_on`):
+
+- **In-flight progress** (heartbeat object for a running
+  `optimize`): real machinery, own lease-staleness questions.
+- **Index events on the change feed** (RFC 0030): builds already
+  commit through the publication door the feed observes.
+- **Server-side long-poll for `await`**: a transport swap under an
+  unchanged contract.
+- **Fleet-level aggregation**: per-graph reports compose; an
+  aggregate route can follow operational demand.
+
+## Evidence and tests
+
+- Unit: state-classification truth table over kind (`Btree`, `Fts`,
+  `Vector`) times presence times coverage times buildability (a
+  trainable versus untrainable vector property, so `unbuildable`
+  rows are reachable in the table), including the fixed node
+  `id` and edge `id`/`src`/`dst` BTREEs, zero-row datasets (`ready`,
+  zero counts), `declared: false`, and `None` `fragment_bitmap`
+  (coverage unreportable, treated as covered, mirroring
+  `has_unindexed_fragments`).
+- Integration, extending the existing CLI test owner: fresh load
+  reports `missing`; post-`optimize`, `ready`; post-append,
+  `degraded`/`uncovered_fragments`; `await` returns after the
+  publish, ignores an `unbuildable` vector index, times out nonzero when
+  nothing builds.
+- Consistency: a concurrent publish never tears a report (one pinned
+  snapshot).
+- Cost: "metadata and deletion sidecars only, no column data except
+  the trainability probe" is backed by a checked-in IO-probe
+  instrument, per invariant 13.
+- Lance survey, per the Lance reading protocol, at the pinned Lance
+  10.0.0 (workspace `Cargo.toml`), read at lance `d644e7a6`
+  (2026-08-03): `IndexMetadata` (`fragment_bitmap`, typed
+  `index_details`, delta segments, millisecond `created_at`),
+  `index_statistics` arithmetic, logical-row fragment counts.
+
+## Rollout
+
+1. Engine: one read-only entry point over the derivation (today
+   internal to the engine crate); embedded CLI `index status`.
+2. Server route + `omnigraph-api-types`; CLI `--server` path.
+3. CLI `index await`.
+
+Each phase ships alone; `implementation` advances as each lands.
+
+## Unresolved questions
+
+None.
+
+## Decision log
+
+- 2026-08-25: drafted from the #550 request (read-only index readiness
+  status plus a blocking wait command) and the #486 monitoring gap.

--- a/docs/rfcs/0042-index-status.md
+++ b/docs/rfcs/0042-index-status.md
@@ -7,7 +7,7 @@ implementation: not-started
 authors:
   - Azim Afroozeh
 created: 2026-08-25
-updated: 2026-08-25
+updated: 2026-08-26
 discussion: "https://github.com/ModernRelay/omnigraph/issues/550"
 supersedes: []
 superseded_by: []
@@ -25,12 +25,17 @@ OmniGraph gains a read-only index-status surface: `omnigraph index
 status` and a served `GET` route report, per index (declared or
 not), a ***state*** (`ready`, `unbuildable`, `missing`, `degraded`), a
 machine-readable reason, and coverage counts, derived entirely from
-published state. `omnigraph index await` blocks until the gating
-states (`missing`, `degraded`) clear, or exits nonzero on timeout.
+published state. `omnigraph index await` blocks until every declared
+index leaves the gating states (`missing`, `degraded`), or exits
+nonzero on timeout.
 
 The unchanged boundary: this surface observes, never builds.
-`optimize` remains the only index reconciler; no background scheduler,
-no new authority, no stored work list.
+`optimize` remains the only index ***reconciler***, the component
+that compares index intent against the indexes actually
+present and builds or maintains what closes the gap; no background
+scheduler, no new authority, no stored work list. One owned
+exception rides along: `optimize` gains a repair for indexes
+carrying no coverage record (Compatibility owns it).
 
 ## Motivation
 
@@ -43,10 +48,10 @@ credential, and violates command-query separation (the rule that a
 query returns a result without mutating state, while a command
 mutates): the readout can build the very index it was asked about,
 so its answer describes a state the question just changed. Issue #550
-asks for a read-only alternative: its
-control-plane POC loads a graph, traversals warn about full scans
-(the edge `id`/`src`/`dst` BTREEs are unbuilt), and automation has no
-way to see that without mutating. #486 is the monitoring twin: a
+asks for a read-only alternative: a query
+warning reports a condition for one query, not index readiness
+across the graph, and automation has no read-only way to see
+graph-wide readiness. #486 is the monitoring twin: a
 degenerate mono-partition vector index is invisible to operators.
 #533 is adjacent, not overlapping: planner behavior when indexes
 exist, versus this RFC's "do they exist and what do they cover".
@@ -65,9 +70,9 @@ omnigraph index status [<uri>] [--branch <b> | --snapshot <s>] [--json]
 
 The command runs in capability class "any": embedded against the
 positional URI, or served via the global `--server`/`--profile`
-flags, addressed per RFC 0011. `--branch` defaults to the graph's
+flags, addressed per [RFC 0011](0011-cli-addressing-and-config.md). `--branch` defaults to the graph's
 default branch, as the `snapshot` command does. Human output: one
-row per (table_key, index). `--json` emits one envelope object: the
+row per index (identity per rule 10). `--json` emits one envelope object: the
 snapshot identity (`graph_branch`, `graph_manifest_version`) plus an
 `indexes` array of per-index rows; embedded and served output share
 this envelope. Under snapshot addressing, `graph_branch` is null
@@ -78,6 +83,7 @@ when the snapshot resolves to no branch. A `degraded` row:
   "table_key": "edge:knows",
   "name": "src_idx",
   "kind": "btree",
+  "fields": ["src"],
   "declared": true,
   "state": "degraded",
   "reason": "uncovered_fragments",
@@ -97,6 +103,7 @@ An `unbuildable` row (no physical index exists yet):
   "table_key": "node:Person",
   "name": null,
   "kind": "vector",
+  "fields": ["embedding"],
   "declared": true,
   "state": "unbuildable",
   "reason": "no_trainable_vectors",
@@ -109,39 +116,79 @@ An `unbuildable` row (no physical index exists yet):
 }
 ```
 
-Field notes:
+Field notes, identity:
 
 - `table_key`: `node:<type>` or `edge:<type>`.
 - `kind`: `btree` | `fts` | `vector`; `other` for a
-  present-but-undeclared index whose Lance type is outside this set.
+  present-but-undeclared index whose Lance type is outside this
+  set, or whose `index_details` is absent (legacy metadata: an
+  unknowable kind reads as outside the set, default deny).
+- `fields`: the indexed column or columns, in index order; a
+  composite `@index(a, b)` lists both (composites classify
+  `unbuildable`, per the Design cascade). Sourced from the declared
+  intent when no physical index exists, from the Lance index
+  metadata otherwise.
+- (`table_key`, `kind`, `fields`) identifies an index across
+  reports and states (rule 10); `name` never identifies, null
+  until the first build.
+
+Field notes, contract fields:
+
 - `reason` is a token, `message` its human reading. OmniGraph mints
-  the token vocabulary here; today's free-string reconciler reasons
+  the token vocabulary here (the reasons table below); today's
+  free-string reconciler reasons
   (`PendingIndex.reason`) map to tokens, string preserved in
-  `message`. `message` is free text for humans, never contract
-  (rule 9).
+  `message`: the widened per-index rows carry a typed reason minted
+  at the classification site, and the legacy string is never
+  parsed. `message` is free text for humans, never contract
+  (rule 9). Neither field is ever omitted.
 - `updated_at`: RFC 3339 UTC, converted by OmniGraph from the
   millisecond timestamp on the index's latest ***segment*** (one
   immutable build unit; an incrementally reindexed index is several
   segments under one name); null when the index was never built or
   its segments predate Lance's `created_at` field.
-- For `missing` and `unbuildable` rows no physical index exists: `name`
-  and `updated_at` are null, the indexed counts are 0, and the
-  unindexed counts are the dataset's logical totals (the rows that
-  full-scan today).
-- `declared: false`: present in the dataset, no longer declared (its
-  `@index` intent was dropped by a schema change).
+- `declared: false`: present in the dataset, not declared (its
+  `@index`/`@key` intent was dropped by a schema change, or it was
+  created outside omnigraph).
 
 The states:
 
 | state | meaning | operator response |
 |---|---|---|
 | `ready` | built, covers every current fragment | none |
-| `unbuildable` | declared, cannot be built as things stand (reason says why, e.g. a vector index whose property has no non-null vectors to train on) | load data, then `optimize` |
-| `missing` | declared (schema `@index`, or a fixed node/edge BTREE), never built | `optimize` |
-| `degraded` | built, below full quality; today's one reason is `uncovered_fragments` (rows appended or rewritten after the build, scanned until reindex) | `optimize` |
+| `unbuildable` | declared, cannot be built or rebuilt as things stand; the reason says why | per reason (below) |
+| `missing` | declared (schema `@index`/`@key`, or a fixed node/edge BTREE), never built | `optimize` |
+| `degraded` | built, below full quality; the reason says why | `optimize` |
 
-The `unbuildable` state corresponds to `optimize --json`'s
-`pending_indexes` field; the word `pending` is deliberately unused
+The reasons (the owning list of today's token vocabulary; open set
+per rule 4):
+
+| reason | state | meaning | operator response |
+|---|---|---|---|
+| `uncovered_fragments` | `degraded` | rows appended or rewritten after the build, scanned until reindex | `optimize` |
+| `coverage_unknown` | `degraded` | no coverage record (`fragment_bitmap: None`); see Semantics | `optimize` (the Repair procedure) |
+| `no_trainable_vectors` | `unbuildable` | the property has no non-null vectors to train on yet | load data, then `optimize` |
+| `composite_unsupported` | `unbuildable` | multi-column `@index`; the reconciler builds single-column indexes only | amend the schema |
+| `edge_index_unsupported` | `unbuildable` | property `@index` on an edge type; edge datasets receive only the fixed `id`/`src`/`dst` BTREEs | amend the schema |
+| `type_unindexable` | `unbuildable` | property type with no index kind (a list, or `Blob`) | amend the schema |
+
+Per-row shape, the value rules for every case (counts are the four
+`indexed_`/`unindexed_` fields; "per `created_at`" means set when
+Lance recorded a timestamp, null for older metadata):
+
+| row case | `name` | `reason`/`message` | counts | `updated_at` |
+|---|---|---|---|---|
+| `ready` | set | null | set | per `created_at` |
+| `missing` | null | null | indexed 0; unindexed = the dataset's logical totals (the rows that full-scan today) | null |
+| never-built `unbuildable` | null | set | indexed 0; unindexed = the dataset's logical totals | null |
+| built `unbuildable` (an untrainable `None`-bitmap vector index) | set | set | all null (the `None`-bitmap rule) | per `created_at` |
+| `degraded` / `coverage_unknown` | set | set | all null | per `created_at` |
+| `degraded` / `uncovered_fragments` | set | set | set | per `created_at` |
+
+The `no_trainable_vectors` reason corresponds to `optimize
+--json`'s `pending_indexes` field; the other `unbuildable` reasons
+have no reconciler counterpart, which is part of why this surface
+exists. The word `pending` is deliberately unused
 on this surface, reserved for a true in-progress meaning should a
 background builder ever exist. When #486 lands its detection, a
 degenerate vector index reports `degraded` / `mono_partition` with
@@ -150,21 +197,29 @@ no schema change.
 `status` exits 0 whenever a report is produced; states are data, not
 errors. Producing no report is a typed error that exits nonzero, in
 the same failure family as `snapshot` (exit codes owned by the CLI
-reference, `docs/user/cli/reference.md`): unresolvable URI, unknown
-branch or snapshot, empty root, or a root holding only orphan
-artifacts (files present, no `__manifest` Create committed).
+reference, `docs/user/cli/reference.md`, which gains its exit-code
+section in phase 1): unresolvable URI, unknown
+branch or snapshot, empty root, a root holding only orphan
+artifacts (files present, no `__manifest` Create committed), or a
+snapshot whose tables cannot bind to today's schema.
 
 ```
 omnigraph index await [<uri>] [--branch <b>] [--timeout <dur>] [--json]
 ```
 
-Blocks until every gating index is `ready`, then exits 0. `missing`
-and `degraded` gate (`optimize` can clear them); `unbuildable` never
-gates: waiting cannot build it, only more data can, and blocking on it
-would hang the pipeline this command serves. `unbuildable` indexes
-appear in the final report. Zero declared indexes satisfies `await`
-immediately. `await` rejects `--snapshot`: a frozen snapshot's
-states can never change, so waiting on one is meaningless. Without
+Blocks until no declared index is in a gating state, then exits 0.
+`missing` and `degraded` gate (`optimize` can clear them);
+`unbuildable` never gates (waiting cannot build it, only more data
+or a schema change can, and blocking on it would hang the pipeline
+this command serves), and a `declared: false` row never blocks
+(drift is reported, not gated). Exit 0 therefore guarantees that
+every declared index is `ready` or `unbuildable`, never that all
+are `ready` (rule 6); a pipeline that cannot accept an unbuildable
+index fails on the final report, not the exit code. On exit 0 that
+report prints to stdout, human rows or the `status` envelope under
+`--json`. Zero declared indexes satisfies `await` immediately. `await` rejects `--snapshot`: physical state under a
+frozen snapshot can never change, so a gating state can never
+clear and waiting on one is meaningless. Without
 `--timeout` it waits indefinitely (CI should always pass one).
 Timeout exits with its own code, distinct from the `snapshot`
 failure family and owned by the same CLI-reference exit-code
@@ -177,10 +232,11 @@ nothing building, `await` runs out its timeout and fails.
 
 ### Server
 
-`GET /index-status` (single-graph) and
-`GET /graphs/{graph_id}/index-status` (multi-graph) return the same
+`GET /graphs/{graph_id}/index-status` returns the same
 envelope as the CLI (identity fields in the `SnapshotOutput`
-vocabulary). Both routes accept `branch`
+vocabulary); the server is cluster-only, so the route nests under
+`/graphs/{graph_id}` like every per-graph read, with no flat
+variant. It accepts `branch`
 and `snapshot` query parameters with the CLI's defaulting. Gated
 like every read route: bearer auth resolves the actor at the
 boundary, then the server's Cedar read policy action applies. Served
@@ -197,23 +253,48 @@ the bucket. Consequences:
   commits. Polling (or `await`) is the contract; no in-progress state
   exists.
 - "Never attempted" and "crashed before publishing" are
-  indistinguishable, the correct fail-closed reading.
+  indistinguishable, the correct default-deny reading.
 
 Each report runs under snapshot isolation: it derives from one pinned
 snapshot for its whole lifetime, a consistent cut across all
-datasets, never torn by a concurrent publish.
-
-A zero-row dataset reports its declared indexes `ready` with zero
-counts, vacuously covered: no rows exist to cover, and the
-reconciler skips empty tables, so any other classification would
-hang `await`. First rows flip the state to `missing`, or straight
-to `unbuildable` for a vector index whose rows still hold no
-non-null vectors.
+datasets, never torn by a concurrent publish. The declared set
+always comes from the currently accepted schema; snapshot
+addressing pins physical state only (matching `capture_read_view`,
+which binds the current catalog to a historical snapshot). A
+snapshot whose tables cannot bind to today's schema joins the
+no-report error family.
 
 Counts are logical rows (physical rows minus deletions, from
 fragment metadata); a deleted row still in an index is not coverage.
 Computing a logical count may read small deletion sidecars, never
 column data.
+
+A zero-row dataset reports its buildable declared indexes `ready`
+with zero counts, vacuously covered: no rows exist to cover, and
+the reconciler skips empty tables, so a gating classification
+would hang `await`. Declarations the reconciler does not build
+classify `unbuildable` even at zero rows: that verdict depends
+only on the schema, and it should surface before data arrives.
+First rows flip the state to `missing`, or straight to
+`unbuildable` for a vector index whose rows still hold no
+non-null vectors.
+
+An index segment can carry no coverage record at all
+(`fragment_bitmap: None`, metadata written before Lance tracked
+coverage): whether it covers the current fragments is unknowable
+from metadata. Such an index classifies `degraded` /
+`coverage_unknown` (or `unbuildable` / `no_trainable_vectors` for
+an untrainable vector column, per the Design cascade), the default-deny
+reading again: absent evidence never reads as coverage, and all
+four count fields are null (partial per-segment bitmaps would
+claim precision the metadata lacks). `optimize` repairs it
+(Design, the Repair procedure).
+
+`ready` asserts coverage, not planner use: Lance disables scalar
+indexes for an entire scan when any fragment lacks
+`physical_rows` metadata, so a `ready` index can still be bypassed
+per query. That condition is planner-side observability, #533's
+territory, not a coverage state.
 
 ### Contract rules
 
@@ -226,13 +307,21 @@ column data.
    tokens.
 5. Response fields may be added; existing fields are never removed or
    retyped without deprecation.
-6. `await` gates on `missing` and `degraded` only; `unbuildable`
-   never gates.
+6. `await` gates on declared indexes in `missing` or `degraded`
+   only; `unbuildable` and `declared: false` rows never gate: on
+   exit 0, every declared index is `ready` or `unbuildable`.
 7. Neither `status` nor `await` ever triggers reconciliation.
-8. System indexes are omitted; a present-but-undeclared index is
-   reported with `declared: false`.
+8. System indexes (Lance-internal bookkeeping indexes, the
+   `is_system_index` set) are omitted; a present-but-undeclared
+   index is reported with `declared: false`.
 9. `message` is human-readable free text, never contract; consumers
    must not parse it.
+10. A row is identified by (`table_key`, `kind`, `fields`) across
+    reports and states; `name` never identifies. The key is unique
+    for omnigraph-managed indexes; a manifest holding duplicates
+    (same kind and column under distinct names, which Lance
+    permits) renders one row per physical index, keys colliding
+    as-is.
 
 ## Design
 
@@ -241,32 +330,54 @@ coordinated by `__manifest`. Per report:
 
 1. Resolve one snapshot from `__manifest`: published `table_version`
    per `(table_key, table_branch)` plus the accepted schema. The
-   declared set = the schema's `@index` intent + the fixed BTREEs
+   declared set = the catalog's index-intent list (a property
+   reaches it through `@index` or `@key`) + the fixed BTREEs
    (`id` on node datasets; `id`/`src`/`dst` on edge datasets).
 2. Per dataset, read the Lance manifest at the published version. Its
    index section holds one `IndexMetadata` per index segment: name,
    typed `index_details` (kind), and `fragment_bitmap`, the Roaring
    bitmap of covered fragment ids.
-3. Classify each declared index, first match wins. A zero-row
-   dataset short-circuits: its declared indexes report `ready` with
-   zero counts (per Semantics). Otherwise: listed in the
-   reconciler's `PendingIndex` set per
-   `index_work_status_on_dataset_for_catalog`
-   (`PendingIndex { type_key, property, reason }`), `unbuildable`;
-   absent from the manifest and buildable, `missing`; every current
-   fragment id in the union of its segments' bitmaps, `ready`;
-   uncovered fragments (`TableStore::has_unindexed_fragments` /
-   `IndexCoverage::Degraded`), `degraded`. Outside the declared set:
-   system indexes (Lance-internal bookkeeping indexes, the
-   `is_system_index` set) are omitted (rule 8); a
+3. Classify each declared index through the following cascade,
+   first match wins (declared intent matches a physical index by
+   column):
+
+   a. A declaration the reconciler does not build, regardless of
+      row count: `unbuildable`, reason `composite_unsupported`,
+      `edge_index_unsupported`, or `type_unindexable` (the reasons
+      table).
+   b. A column-matched physical index whose `index_details` is
+      absent: `degraded` / `coverage_unknown` (present, kind and
+      coverage unknowable), never `missing`, so no duplicate is
+      built beside it; the Repair procedure (below) skips it.
+   c. A zero-row dataset short-circuits: its remaining declared
+      indexes report `ready` with zero counts (per Semantics).
+   d. Listed in the reconciler's `PendingIndex` set per
+      `index_work_status_on_dataset_for_catalog`
+      (`PendingIndex { type_key, property, reason }`):
+      `unbuildable`.
+   e. Absent from the manifest and buildable: `missing`.
+   f. Any segment without a coverage record
+      (`fragment_bitmap: None`): `degraded` / `coverage_unknown`;
+      for a vector index whose column is currently untrainable,
+      `unbuildable` / `no_trainable_vectors` instead (the repair
+      cannot run until data arrives).
+   g. Every current fragment id in the union of its segments'
+      bitmaps: `ready`.
+   h. Uncovered fragments (`TableStore::has_unindexed_fragments` /
+      `IndexCoverage::Degraded`): `degraded` /
+      `uncovered_fragments`.
+
+   Outside the declared set: system indexes are omitted (rule 8); a
    present-but-undeclared index reports `declared: false`, state
    from coverage alone. The reconciler's top-up pass still maintains
    undeclared indexes, because its trigger and Lance's
    `optimize_indices` filter only system indexes, never declaration;
-   creation and retrain remain declared-only. Reporting undeclared
+   creation, deliberate retrain, and the `None`-bitmap repair are
+   declared-only (the Repair procedure below). Reporting undeclared
    indexes keeps that drift visible.
 4. Counts: fragments from bitmap containment; rows by summing
-   logical fragment row counts, the `index_statistics` arithmetic. No column
+   logical fragment row counts, the `index_statistics` arithmetic
+   (null for `None`-bitmap rows, per Semantics). No column
    data, one bounded exception: `unbuildable` classification reuses the
    reconciler's trainability probe, a filtered null count over the
    vector column. The per-segment plugin statistics path (which can
@@ -274,13 +385,71 @@ coordinated by `__manifest`. Per report:
 
 Lance owns the index metadata, bitmaps, and statistics; OmniGraph
 adds the catalog-intent diff, state classification, and graph-level
-aggregation. The inputs are the checks `optimize` already runs,
+aggregation. In code the reconciler is the shared planner/builder pair,
+`plan_index_work_node` / `plan_index_work_edge_on_dataset` feeding
+`build_indices_on_dataset_for_catalog`, reached through `optimize`
+and the `ensure_indices` entry point; the planners compute the
+same declared-versus-present diff this surface reports. The inputs are
+the checks `optimize` already runs,
 exposed through a read-only engine entry point that widens their
 return shapes: per-index rows where `IndexWorkStatus` exposes only
 `needs_commit` plus the `pending` list, per-index coverage where
 `has_unindexed_fragments` is a dataset-level boolean. Shared checks
 keep endpoint and reconciler aligned; the widened shapes are new
 code, covered by the truth-table tests.
+
+One reconciler change rides along: the ***Repair procedure***, the
+path that heals a `None` bitmap. Today
+`has_unindexed_fragments` skips a `None` `fragment_bitmap`, so
+a coverage-unknown index neither reports as work nor gets
+repaired. This RFC specifies:
+
+1. Trigger: `has_unindexed_fragments` widens so a `None` bitmap
+   counts as uncovered, for kinds omnigraph builds (`btree`,
+   `fts`, `vector`) only, decidable from `index_details` alone.
+   The pre-existing uncovered-fragments arm stays kind- and
+   declaration-blind, so top-up maintenance of `other`-kind and
+   undeclared indexes continues.
+2. Scope gates, applied at `optimize`'s call sites (catalog,
+   storage handle, and snapshot in hand; a call-site skip treats
+   the index as quiesced): declared indexes only (omnigraph does
+   not rewrite indexes it does not own, which a rebuild would
+   silently re-parameterize), and, for vector indexes, a
+   trainable column (creation's probe; an untrainable column
+   skips without error, the row classifying `unbuildable` /
+   `no_trainable_vectors` until data arrives).
+3. Mechanism: a full per-index rebuild, not the incremental
+   top-up (Lance's `optimize_indices` path errors on a `None`
+   bitmap rather than folding it in). The index is rebuilt from
+   its own Lance metadata, same kind, same column, same name,
+   with builder parameters from the declaration (the declaration
+   is the authority for a declared index's shape). Lance replaces
+   an index by name in one commit, so the broken segments are
+   swapped out atomically and the new segments carry real
+   bitmaps.
+4. Exclusion: the top-up runs with an explicit
+   `OptimizeOptions::index_names` include-list naming every index
+   except the `None`-bitmap ones. The excluded rest (undeclared,
+   `other` or unknown kind, or untrainable) is deliberately left,
+   keeping `optimize` green, their rows persisting
+   `coverage_unknown` (or `unbuildable`), never gating.
+5. Ordering: the rebuild commits after compaction and the top-up,
+   so its bitmap covers the final fragment set.
+6. Outcome: for declared, buildable, trainable indexes,
+   `coverage_unknown` is self-clearing: report, `optimize`, next
+   report `ready` with proof.
+
+The two sides must move together:
+reporting `degraded` against today's reconciler would gate `await`
+on a state `optimize` can never clear, and keeping the covered
+reading would have the report claim proof the metadata cannot
+give. A third reader of the bitmap, `key_column_index_coverage`
+(scan pricing and full-scan warnings), keeps its covered reading:
+its consumer is per-query cost estimation, the mispricing is
+transient, and the first `optimize` heals the state for all three
+readers. The rebuild cost is one-time, paid only by indexes whose
+metadata predates coverage tracking (imported or legacy datasets;
+every index built at the pinned Lance version writes its bitmap).
 
 Caching: physical coverage is cacheable per `(table_key,
 table_branch, table_version)`, because index builds become visible
@@ -289,9 +458,12 @@ publication door) as data, so coverage cannot change without the
 version moving. Declared intent is not covered by that key, because
 an index-only schema change (an `@index` addition applies as pure
 metadata, touching no table data) bumps no table version. Full key: `(table_key, table_branch, table_version,
-accepted-schema version)`. Warm poll: one `__manifest` read plus
+accepted-schema fingerprint)`, where the fingerprint is a content
+hash of the accepted SchemaIR (no monotonic schema version exists
+to cite). Warm poll: one `__manifest` read plus
 cache hits. The cache is a hint keyed by immutable versions, never
-authority.
+authority, and unphased: phase 1 may ship derivation-only, with
+the warm-poll cost holding once the cache lands.
 
 `await` is a poll loop with backoff over the same derivation, in the
 CLI in both modes; it is stateless: no lock, no server-side session,
@@ -299,38 +471,47 @@ no persisted cursor.
 
 ## Invariants
 
+Checked against the
+[architectural invariants](../dev/invariants.md):
+
 - **Invariant 7** (physical acceleration is derived state) is the
   foundation, unchanged: missing coverage changes cost, not
   correctness; index work still happens only through explicit
   reconciliation. This surface makes that derived state observable.
-- **Invariant 12**: derived on demand from Lance and `__manifest`;
-  the cache is immutable-pinned, a hint, never commit authority; no
-  shadow copy.
-- **Invariant 10**: the served route resolves the actor at the HTTP
-  boundary and applies the server's Cedar read policy, like every
-  read route.
+- **Invariant 12** (one source of truth, cheaply derived): derived
+  on demand from Lance and `__manifest`; the cache is
+  immutable-pinned, a hint, never commit authority; no parallel
+  copy that can drift.
+- **Invariant 10** (trust is established at the boundary and
+  enforced at the engine): the served route resolves the actor at
+  the HTTP boundary and applies the server's Cedar read policy,
+  like every read route.
 - **Deny-list, "a job queue for state derivable from accepted
-  manifest state"**: this RFC is the compliant shape; the work list
-  is derived every time (stored alternatives rejected below).
+  manifest state, where an idempotent reconciler suffices"**: this
+  RFC is the compliant shape; the work list is derived every time
+  (stored alternatives rejected below).
 - **Deny-list, "a logical precondition based on physical index
-  coverage"**: `await` is an operator pipeline gate outside the
-  engine. The item's other members (fragment count, cache entry,
-  staged layout) are engine-internal preconditions; this RFC adds
-  none. No engine operation, planner choice, or mutation precondition
-  consumes the status.
+  coverage, fragment count, a cache entry, or staged layout"**:
+  `await` is an operator pipeline gate outside the engine; this RFC
+  adds no such precondition. No engine operation, planner choice,
+  or mutation precondition consumes the status.
 
-No invariant is weakened. The support boundary "physical index
+No invariant is weakened. The support boundary "Physical index
 reconciliation is explicit; there is no background scheduler whose
 queue is a second authority" is unchanged.
 
 ## Compatibility and reversibility
 
-Additive only: one CLI verb pair, one GET route, new
-`omnigraph-api-types` response types; no storage or wire format
-change. The JSON field set and state vocabulary are the compatibility
+Additive but for one owned exception: one CLI verb pair, one GET
+route, new `omnigraph-api-types` response types; no storage or
+wire format change. The exception: `optimize`
+gains the `None`-bitmap repair, so its first run over an imported
+legacy dataset rebuilds indexes it previously skipped (one-time,
+priced in Design). The JSON field set and state vocabulary are the compatibility
 surface, governed by rules 3 to 5. Reverting is technically cheap but
 breaks gating scripts, so removal means deprecation, not deletion:
-the reversible end of the evidence-demand scale.
+the reversible end of the evidence-demand scale (evidence
+proportional to reversibility, invariant 13).
 
 ## Alternatives
 
@@ -342,8 +523,8 @@ the reversible end of the evidence-demand scale.
 - **Expose Lance `index_statistics` raw**: misses the catalog side;
   `missing` and `unbuildable` live in schema intent, invisible to
   Lance.
-- **Stored work list / progress sidecar**: a shadow copy (invariant
-  12's term) of derivable state that can lie after a crash, needs its
+- **Stored work list / progress sidecar**: the maintained parallel
+  truth the deny-list rejects: it can lie after a crash, needs its
   own concurrency control, and is deny-listed; derivation is too
   cheap to be worth caching durably.
 
@@ -351,7 +532,8 @@ Out of scope, compatible later (deliberately not `blocked_on`):
 
 - **In-flight progress** (heartbeat object for a running
   `optimize`): real machinery, own lease-staleness questions.
-- **Index events on the change feed** (RFC 0030): builds already
+- **Index events on the change feed**
+  ([RFC 0030](0030-cdc-time-travel.md)): builds already
   commit through the publication door the feed observes.
 - **Server-side long-poll for `await`**: a transport swap under an
   unchanged contract.
@@ -365,14 +547,25 @@ Out of scope, compatible later (deliberately not `blocked_on`):
   trainable versus untrainable vector property, so `unbuildable`
   rows are reachable in the table), including the fixed node
   `id` and edge `id`/`src`/`dst` BTREEs, zero-row datasets (`ready`,
-  zero counts), `declared: false`, and `None` `fragment_bitmap`
-  (coverage unreportable, treated as covered, mirroring
-  `has_unindexed_fragments`).
+  zero counts), `declared: false`, `None` `fragment_bitmap`
+  (`degraded` / `coverage_unknown`, null counts), an `other`-kind
+  `None`-bitmap index (`coverage_unknown` persists, excluded from
+  the repair, never gates), a multi-column declaration, an
+  edge-property `@index`, and a list/`Blob` `@index` (`unbuildable`
+  with their reason tokens, at zero rows too), and two declared FTS indexes on different
+  properties of one type (rows distinguished by `fields`).
 - Integration, extending the existing CLI test owner: fresh load
   reports `missing`; post-`optimize`, `ready`; post-append,
-  `degraded`/`uncovered_fragments`; `await` returns after the
+  `degraded`/`uncovered_fragments`; a legacy `None`-bitmap index
+  reports `degraded`/`coverage_unknown`, then `ready` with counts
+  after `optimize` repairs it; `await` returns after the
   publish, ignores an `unbuildable` vector index, times out nonzero when
   nothing builds.
+- Legacy `None`-bitmap fixtures cannot come from the production
+  writer (it always writes bitmaps): tests construct them with a
+  test-only doctored `CreateIndex` commit (Lance's transaction
+  apply copies `new_indices` unvalidated) or a checked-in legacy
+  fixture dataset.
 - Consistency: a concurrent publish never tears a report (one pinned
   snapshot).
 - Cost: "metadata and deletion sidecars only, no column data except
@@ -387,8 +580,19 @@ Out of scope, compatible later (deliberately not `blocked_on`):
 ## Rollout
 
 1. Engine: one read-only entry point over the derivation (today
-   internal to the engine crate); embedded CLI `index status`.
-2. Server route + `omnigraph-api-types`; CLI `--server` path.
+   internal to the engine crate) plus the Repair procedure in
+   `optimize` (Design; its widened trigger, scope gates, rebuild,
+   which widens `IndexBuildSpec::FullText`/`Vector` with
+   `name: Option<String>` so the repair replaces under the legacy
+   name, and the `OptimizeOptions::index_names` include-list omitting
+   every `None`-bitmap index); the new `omnigraph-api-types`
+   response types (embedded and served share the envelope by
+   construction); embedded CLI `index status`, whose served path
+   rejects with a typed not-yet-served error in the `status`
+   failure family until phase 2; the CLI reference's exit-code
+   section, covering today's codes plus a reserved distinct
+   timeout code wired in phase 3.
+2. Server route; CLI `--server` path.
 3. CLI `index await`.
 
 Each phase ships alone; `implementation` advances as each lands.
@@ -403,5 +607,31 @@ None.
   status plus a blocking wait command) and the #486 monitoring gap.
 - 2026-08-25: PR review: clarified undeclared-index maintenance (the
   top-up pass is declaration-blind, filtering only system indexes;
-  creation and retrain are declared-only) and removed the provisional
-  numbering note after the registry allocated 0042.
+  creation and retrain are declared-only).
+- 2026-08-26: PR review: rows gained `fields` and the (`table_key`,
+  `kind`, `fields`) identity (unbuilt rows on different properties
+  were indistinguishable); the `None` `fragment_bitmap` reading
+  reclassified from covered to `degraded` / `coverage_unknown`
+  (the covered reading claimed proof the metadata cannot give);
+  the repair specified: a full per-index rebuild in `optimize`,
+  committing after compaction under the legacy name
+  (`IndexBuildSpec` name widening), scoped to declared indexes of
+  buildable kinds with trainable columns (omnigraph does not
+  rewrite indexes it does not own; the declaration is the
+  parameter authority), every `None`-bitmap index excluded from
+  the top-up include-list (Lance's top-up errors on a `None`
+  bitmap); declarations the reconciler does not build classify
+  `unbuildable` (`composite_unsupported`,
+  `edge_index_unsupported`, `type_unindexable`), decided at zero
+  rows (structural verdicts precede the empty-table
+  short-circuit); kind-unknown metadata reads as `other`, and
+  column-matched intent with absent `index_details` as
+  `coverage_unknown`, never `missing` (no duplicate build);
+  gating restricted to declared indexes, with `await`'s exit-0
+  guarantee stated explicitly (every declared index `ready` or
+  `unbuildable`, never all `ready`); the served route nests
+  cluster-only under `/graphs/{graph_id}`; the declared set is the
+  catalog's index-intent list (`@index` or `@key`) from the
+  currently accepted schema (snapshot addressing pins physical
+  state only); envelope types and the exit-code section assigned
+  to phase 1.

--- a/docs/rfcs/0046-index-status.md
+++ b/docs/rfcs/0046-index-status.md
@@ -1,5 +1,5 @@
 ---
-rfc: "0042"
+rfc: "0046"
 title: "Read-only index status"
 track: maintainer
 status: draft
@@ -7,14 +7,14 @@ implementation: not-started
 authors:
   - Azim Afroozeh
 created: 2026-08-25
-updated: 2026-08-26
-discussion: "https://github.com/ModernRelay/omnigraph/issues/550"
+updated: 2026-09-01
+discussion: https://github.com/ModernRelay/omnigraph/issues/550
 supersedes: []
 superseded_by: []
 blocked_on: []
 ---
 
-# RFC 0042: Read-only index status
+# RFC 0046: Read-only index status
 
 > A term set in ***bold italics*** is being defined at that exact spot;
 > it is used in plain text everywhere after.
@@ -34,8 +34,11 @@ The unchanged boundary: this surface observes, never builds.
 that compares index intent against the indexes actually
 present and builds or maintains what closes the gap; no background
 scheduler, no new authority, no stored work list. One owned
-exception rides along: `optimize` gains a repair for indexes
-carrying no coverage record (Compatibility owns it).
+exception rides along: `optimize` gains a repair for `btree` and
+`vector` indexes carrying no coverage record (Compatibility owns
+it); full-text conditions route to
+[RFC 0043](0043-full-text-index-compatibility.md)'s explicit
+rebuild command instead.
 
 ## Motivation
 
@@ -127,7 +130,12 @@ Field notes, identity:
   composite `@index(a, b)` lists both (composites classify
   `unbuildable`, per the Design cascade). Sourced from the declared
   intent when no physical index exists, from the Lance index
-  metadata otherwise.
+  metadata otherwise. Values carry the graph's own column
+  spellings for its vintage: the fixed BTREEs read `id`/`src`/`dst`
+  today, and a graph on
+  [RFC 0040](0040-system-column-namespace.md)'s namespace reports
+  that vintage's spellings, mirroring its rule that API payloads
+  carry each graph's own column names.
 - (`table_key`, `kind`, `fields`) identifies an index across
   reports and states (rule 10); `name` never identifies, null
   until the first build.
@@ -158,18 +166,20 @@ The states:
 | `ready` | built, covers every current fragment | none |
 | `unbuildable` | declared, cannot be built or rebuilt as things stand; the reason says why | per reason (below) |
 | `missing` | declared (schema `@index`/`@key`, or a fixed node/edge BTREE), never built | `optimize` |
-| `degraded` | built, below full quality; the reason says why | `optimize` |
+| `degraded` | built, below full quality; the reason says why | per reason (below) |
 
 The reasons (the owning list of today's token vocabulary; open set
 per rule 4):
 
 | reason | state | meaning | operator response |
 |---|---|---|---|
-| `uncovered_fragments` | `degraded` | rows appended or rewritten after the build, scanned until reindex | `optimize` |
-| `coverage_unknown` | `degraded` | no coverage record (`fragment_bitmap: None`); see Semantics | `optimize` (the Repair procedure) |
+| `uncovered_fragments` | `degraded` | rows appended or rewritten after the build, scanned until reindex | `optimize` (`btree`/`vector`); `omnigraph rebuild-full-text-indexes` (`fts`: ordinary `optimize` never folds full-text, [RFC 0043](0043-full-text-index-compatibility.md)) |
+| `coverage_unknown` | `degraded` | no coverage record (`fragment_bitmap: None`); see Semantics | `optimize` (the Repair procedure; `btree`/`vector`); `rebuild-full-text-indexes` (`fts`) |
+| `full_text_index_rebuild_required` | `degraded` | built `fts` index without RFC 0043's verified compatibility certificate; search refuses it (HTTP 409, the same token) until rebuilt | `rebuild-full-text-indexes` |
 | `no_trainable_vectors` | `unbuildable` | the property has no non-null vectors to train on yet | load data, then `optimize` |
+| `kind_unknown` | `unbuildable` | a physical index matched to the declaration carries no `index_details`; kind and coverage are unknowable, and no omnigraph command rebuilds an index it cannot type | replace the foreign index out of band, or amend the schema |
 | `composite_unsupported` | `unbuildable` | multi-column `@index`; the reconciler builds single-column indexes only | amend the schema |
-| `edge_index_unsupported` | `unbuildable` | property `@index` on an edge type; edge datasets receive only the fixed `id`/`src`/`dst` BTREEs | amend the schema |
+| `edge_index_unsupported` | `unbuildable` | property `@index`, or a scalar `@key` member ([RFC 0044](0044-edge-keys.md)), on an edge type; edge datasets receive only the fixed `id`/`src`/`dst` BTREEs | amend the schema |
 | `type_unindexable` | `unbuildable` | property type with no index kind (a list, or `Blob`) | amend the schema |
 
 Per-row shape, the value rules for every case (counts are the four
@@ -181,16 +191,23 @@ Lance recorded a timestamp, null for older metadata):
 | `ready` | set | null | set | per `created_at` |
 | `missing` | null | null | indexed 0; unindexed = the dataset's logical totals (the rows that full-scan today) | null |
 | never-built `unbuildable` | null | set | indexed 0; unindexed = the dataset's logical totals | null |
-| built `unbuildable` (an untrainable `None`-bitmap vector index) | set | set | all null (the `None`-bitmap rule) | per `created_at` |
+| built `unbuildable` (an untrainable `None`-bitmap vector index, or `kind_unknown`) | set | set | all null (the `None`-bitmap rule) | per `created_at` |
 | `degraded` / `coverage_unknown` | set | set | all null | per `created_at` |
+| `degraded` / `full_text_index_rebuild_required` | set | set | set (coverage is real; the certificate is what is missing) | per `created_at` |
 | `degraded` / `uncovered_fragments` | set | set | set | per `created_at` |
 
-The `no_trainable_vectors` reason corresponds to `optimize
---json`'s `pending_indexes` field; the other `unbuildable` reasons
-have no reconciler counterpart, which is part of why this surface
-exists. The word `pending` is deliberately unused
-on this surface, reserved for a true in-progress meaning should a
-background builder ever exist. When #486 lands its detection, a
+`optimize --json`'s `pending_indexes` field carries two
+populations, and each maps here: the reconciler's
+untrainable-vector entries (`no_trainable_vectors`), and the
+deferred full-text coverage entries RFC 0043 added
+(`append_deferred_full_text_indexes`), which this surface reports
+as `degraded` / `uncovered_fragments` or `coverage_unknown` with
+the rebuild command as the operator response. The other
+`unbuildable` reasons have no reconciler counterpart, which is
+part of why this surface exists. `pending` is not a state here:
+`pending_indexes` rows are deferred or unbuildable work, never
+work in progress, and the word stays reserved for a true
+in-progress meaning should a background builder ever exist. When #486 lands its detection, a
 degenerate vector index reports `degraded` / `mono_partition` with
 no schema change.
 
@@ -208,7 +225,9 @@ omnigraph index await [<uri>] [--branch <b>] [--timeout <dur>] [--json]
 ```
 
 Blocks until no declared index is in a gating state, then exits 0.
-`missing` and `degraded` gate (`optimize` can clear them);
+`missing` and `degraded` gate; each reason's operator response
+names the command that clears it (`optimize`, or
+`rebuild-full-text-indexes` for full-text conditions);
 `unbuildable` never gates (waiting cannot build it, only more data
 or a schema change can, and blocking on it would hang the pipeline
 this command serves), and a `declared: false` row never blocks
@@ -226,9 +245,11 @@ failure family and owned by the same CLI-reference exit-code
 section, printing the last report to stderr, in the `status`
 envelope when `--json` is set and human rows otherwise.
 
-`await` complements `optimize`, never replaces it (the observe-only
-boundary above): the pipeline is load, `optimize`, `await`. With
-nothing building, `await` runs out its timeout and fails.
+`await` complements the maintenance commands, never replaces them
+(the observe-only boundary above): the pipeline is load,
+`optimize`, `await`, adding `rebuild-full-text-indexes` when the
+report names a full-text condition. With nothing building, `await`
+runs out its timeout and fails.
 
 ### Server
 
@@ -287,14 +308,22 @@ from metadata. Such an index classifies `degraded` /
 an untrainable vector column, per the Design cascade), the default-deny
 reading again: absent evidence never reads as coverage, and all
 four count fields are null (partial per-segment bitmaps would
-claim precision the metadata lacks). `optimize` repairs it
-(Design, the Repair procedure).
+claim precision the metadata lacks). `optimize` repairs a `btree`
+or `vector` index in this condition (Design, the Repair
+procedure); a full-text index is healed by
+`rebuild-full-text-indexes` alone, since RFC 0043 excludes
+full-text folding from ordinary `optimize`.
 
 `ready` asserts coverage, not planner use: Lance disables scalar
 indexes for an entire scan when any fragment lacks
 `physical_rows` metadata, so a `ready` index can still be bypassed
 per query. That condition is planner-side observability, #533's
-territory, not a coverage state.
+territory, not a coverage state. Analyzer compatibility is
+likewise not coverage, and unlike planner choice it is
+operator-action-required: a covered full-text index without RFC
+0043's verified certificate classifies `degraded` /
+`full_text_index_rebuild_required` (the Design cascade), never
+`ready`.
 
 ### Contract rules
 
@@ -346,9 +375,12 @@ coordinated by `__manifest`. Per report:
       `edge_index_unsupported`, or `type_unindexable` (the reasons
       table).
    b. A column-matched physical index whose `index_details` is
-      absent: `degraded` / `coverage_unknown` (present, kind and
-      coverage unknowable), never `missing`, so no duplicate is
-      built beside it; the Repair procedure (below) skips it.
+      absent: `unbuildable` / `kind_unknown` (present, kind and
+      coverage unknowable; no omnigraph command rebuilds an index
+      it cannot type), never `missing`, so no duplicate is built
+      beside it; the Repair procedure (below) skips it, and per
+      rule 6 it never gates `await` (gating would wait on a state
+      no command clears).
    c. A zero-row dataset short-circuits: its remaining declared
       indexes report `ready` with zero counts (per Semantics).
    d. Listed in the reconciler's `PendingIndex` set per
@@ -361,26 +393,35 @@ coordinated by `__manifest`. Per report:
       for a vector index whose column is currently untrainable,
       `unbuildable` / `no_trainable_vectors` instead (the repair
       cannot run until data arrives).
-   g. Every current fragment id in the union of its segments'
+   g. A full-text index without RFC 0043's verified compatibility
+      certificate (the same bounded certificate check search
+      performs): `degraded` / `full_text_index_rebuild_required`;
+      coverage alone never proves it servable, and search refuses
+      it until the explicit rebuild publishes.
+   h. Every current fragment id in the union of its segments'
       bitmaps: `ready`.
-   h. Uncovered fragments (`TableStore::has_unindexed_fragments` /
+   i. Uncovered fragments (`TableStore::has_unindexed_fragments` /
       `IndexCoverage::Degraded`): `degraded` /
       `uncovered_fragments`.
 
    Outside the declared set: system indexes are omitted (rule 8); a
    present-but-undeclared index reports `declared: false`, state
-   from coverage alone. The reconciler's top-up pass still maintains
-   undeclared indexes, because its trigger and Lance's
-   `optimize_indices` filter only system indexes, never declaration;
-   creation, deliberate retrain, and the `None`-bitmap repair are
-   declared-only (the Repair procedure below). Reporting undeclared
-   indexes keeps that drift visible.
+   from coverage alone. The reconciler's folding pass still
+   maintains undeclared indexes of foldable kinds: its
+   `can_fold_index` filter excludes system, kind-unknown, and
+   full-text indexes, never declaration; creation, deliberate
+   retrain, and the `None`-bitmap repair are declared-only (the
+   Repair procedure below). Reporting undeclared indexes keeps
+   that drift visible.
 4. Counts: fragments from bitmap containment; rows by summing
    logical fragment row counts, the `index_statistics` arithmetic
    (null for `None`-bitmap rows, per Semantics). No column
-   data, one bounded exception: `unbuildable` classification reuses the
-   reconciler's trainability probe, a filtered null count over the
-   vector column. The per-segment plugin statistics path (which can
+   data, two bounded exceptions: `unbuildable` classification
+   reuses the reconciler's trainability probe, a filtered null
+   count over the vector column; and the full-text compatibility
+   verdict reads RFC 0043's bounded certificate object through
+   its session-cached verification, never an index-file parse.
+   The per-segment plugin statistics path (which can
    open index files) is not used.
 
 Lance owns the index metadata, bitmaps, and statistics; OmniGraph
@@ -399,17 +440,26 @@ keep endpoint and reconciler aligned; the widened shapes are new
 code, covered by the truth-table tests.
 
 One reconciler change rides along: the ***Repair procedure***, the
-path that heals a `None` bitmap. Today
-`has_unindexed_fragments` skips a `None` `fragment_bitmap`, so
-a coverage-unknown index neither reports as work nor gets
-repaired. This RFC specifies:
+path that heals a `None` bitmap on a `btree` or `vector` index.
+Today the fold planner (`has_foldable_unindexed_fragments` over
+the `can_fold_index` predicate, landed with RFC 0043) skips a
+`None` `fragment_bitmap`, so a coverage-unknown `btree` or
+`vector` index neither reports as work nor gets repaired. A
+full-text index in that condition needs no new mechanism: it
+already reports (RFC 0043's deferred entries in
+`pending_indexes`) and already owns its remedy, the explicit
+rebuild that replaces every full-text segment under the
+historical names and writes the compatibility certificate;
+`optimize` must never duplicate that path. This RFC specifies:
 
-1. Trigger: `has_unindexed_fragments` widens so a `None` bitmap
-   counts as uncovered, for kinds omnigraph builds (`btree`,
-   `fts`, `vector`) only, decidable from `index_details` alone.
-   The pre-existing uncovered-fragments arm stays kind- and
-   declaration-blind, so top-up maintenance of `other`-kind and
-   undeclared indexes continues.
+1. Trigger: the fold planning behind
+   `has_foldable_unindexed_fragments` widens so a `None` bitmap
+   counts as uncovered, for `btree` and `vector` indexes only,
+   decidable from `index_details` alone; full-text stays excluded
+   by `can_fold_index`. The pre-existing uncovered-fragments arm
+   stays declaration-blind, so top-up maintenance of undeclared
+   foldable indexes continues (kind-unknown and full-text indexes
+   sit outside folding by the landed predicate, not by this RFC).
 2. Scope gates, applied at `optimize`'s call sites (catalog,
    storage handle, and snapshot in hand; a call-site skip treats
    the index as quiesced): declared indexes only (omnigraph does
@@ -427,37 +477,48 @@ repaired. This RFC specifies:
    an index by name in one commit, so the broken segments are
    swapped out atomically and the new segments carry real
    bitmaps.
-4. Exclusion: the top-up runs with an explicit
-   `OptimizeOptions::index_names` include-list naming every index
-   except the `None`-bitmap ones. The excluded rest (undeclared,
-   `other` or unknown kind, or untrainable) is deliberately left,
-   keeping `optimize` green, their rows persisting
-   `coverage_unknown` (or `unbuildable`), never gating.
+4. Exclusion: the top-up's `OptimizeOptions::index_names`
+   include-list already exists, built from `can_fold_index` (it
+   omits system, kind-unknown, and full-text indexes); the repair
+   extends the omission to the `None`-bitmap `btree`/`vector`
+   indexes being fully rebuilt. The excluded rest (undeclared,
+   kind-unknown, untrainable, or full-text) is deliberately left,
+   keeping `optimize` green, their rows persisting their states,
+   gating only where the operator response names a clearing
+   command (rule 6 and the reasons table).
 5. Ordering: the rebuild commits after compaction and the top-up,
    so its bitmap covers the final fragment set.
-6. Outcome: for declared, buildable, trainable indexes,
+6. Outcome: for declared `btree` and `vector` indexes (trainable
+   where vector),
    `coverage_unknown` is self-clearing: report, `optimize`, next
-   report `ready` with proof.
+   report `ready` with proof. A full-text index reaches the same
+   end through `rebuild-full-text-indexes`.
 
 The two sides must move together:
 reporting `degraded` against today's reconciler would gate `await`
-on a state `optimize` can never clear, and keeping the covered
+on a state no command clears, and keeping the covered
 reading would have the report claim proof the metadata cannot
 give. A third reader of the bitmap, `key_column_index_coverage`
 (scan pricing and full-scan warnings), keeps its covered reading:
 its consumer is per-query cost estimation, the mispricing is
-transient, and the first `optimize` heals the state for all three
+transient, and the first repair (`optimize`, or the explicit
+full-text rebuild) heals the state for all three
 readers. The rebuild cost is one-time, paid only by indexes whose
 metadata predates coverage tracking (imported or legacy datasets;
 every index built at the pinned Lance version writes its bitmap).
 
-Caching: physical coverage is cacheable per `(table_key,
-table_branch, table_version)`, because index builds become visible
+Caching: physical coverage is cacheable per `(table_key, native
+branch ref, table_version)`, because index builds become visible
 through the same single atomic `__manifest` publication (the
 publication door) as data, so coverage cannot change without the
-version moving. Declared intent is not covered by that key, because
+version moving. The branch component is the incarnation-suffixed
+native ref ([RFC 0042](0042-incarnation-suffixed-branch-refs.md)'s
+`native_dataset_branch`), never the logical branch name: versions
+restart when a logical name is deleted and recreated, and a
+logical-name key would alias a dead life's coverage onto its
+successor. Declared intent is not covered by that key, because
 an index-only schema change (an `@index` addition applies as pure
-metadata, touching no table data) bumps no table version. Full key: `(table_key, table_branch, table_version,
+metadata, touching no table data) bumps no table version. Full key: `(table_key, native branch ref, table_version,
 accepted-schema fingerprint)`, where the fingerprint is a content
 hash of the accepted SchemaIR (no monotonic schema version exists
 to cite). Warm poll: one `__manifest` read plus
@@ -505,9 +566,11 @@ queue is a second authority" is unchanged.
 Additive but for one owned exception: one CLI verb pair, one GET
 route, new `omnigraph-api-types` response types; no storage or
 wire format change. The exception: `optimize`
-gains the `None`-bitmap repair, so its first run over an imported
-legacy dataset rebuilds indexes it previously skipped (one-time,
-priced in Design). The JSON field set and state vocabulary are the compatibility
+gains the `None`-bitmap repair for `btree` and `vector` indexes,
+so its first run over an imported legacy dataset rebuilds indexes
+it previously skipped (one-time, priced in Design); legacy
+full-text indexes follow RFC 0043's migration and explicit
+rebuild instead. The JSON field set and state vocabulary are the compatibility
 surface, governed by rules 3 to 5. Reverting is technically cheap but
 breaks gating scripts, so removal means deprecation, not deletion:
 the reversible end of the evidence-demand scale (evidence
@@ -548,17 +611,27 @@ Out of scope, compatible later (deliberately not `blocked_on`):
   rows are reachable in the table), including the fixed node
   `id` and edge `id`/`src`/`dst` BTREEs, zero-row datasets (`ready`,
   zero counts), `declared: false`, `None` `fragment_bitmap`
-  (`degraded` / `coverage_unknown`, null counts), an `other`-kind
-  `None`-bitmap index (`coverage_unknown` persists, excluded from
-  the repair, never gates), a multi-column declaration, an
-  edge-property `@index`, and a list/`Blob` `@index` (`unbuildable`
+  (`degraded` / `coverage_unknown`, null counts), an undeclared
+  `other`-kind `None`-bitmap index (`coverage_unknown` persists,
+  excluded from the repair, never gates), a declared index whose
+  physical match carries no `index_details` (`unbuildable` /
+  `kind_unknown`, never gates), a declared full-text `None`-bitmap
+  index (`degraded` / `coverage_unknown`, excluded from the
+  `optimize` repair, cleared only by the explicit rebuild), a
+  covered full-text index without a verified certificate
+  (`degraded` / `full_text_index_rebuild_required`), a multi-column
+  declaration, an edge-property `@index`, a scalar edge `@key`
+  member, and a list/`Blob` `@index` (`unbuildable`
   with their reason tokens, at zero rows too), and two declared FTS indexes on different
   properties of one type (rows distinguished by `fields`).
 - Integration, extending the existing CLI test owner: fresh load
   reports `missing`; post-`optimize`, `ready`; post-append,
-  `degraded`/`uncovered_fragments`; a legacy `None`-bitmap index
+  `degraded`/`uncovered_fragments`; a legacy `None`-bitmap `btree`
+  or `vector` index
   reports `degraded`/`coverage_unknown`, then `ready` with counts
-  after `optimize` repairs it; `await` returns after the
+  after `optimize` repairs it; a full-text condition clears to
+  `ready` only after `rebuild-full-text-indexes` publishes;
+  `await` returns after the
   publish, ignores an `unbuildable` vector index, times out nonzero when
   nothing builds.
 - Legacy `None`-bitmap fixtures cannot come from the production
@@ -568,24 +641,29 @@ Out of scope, compatible later (deliberately not `blocked_on`):
   fixture dataset.
 - Consistency: a concurrent publish never tears a report (one pinned
   snapshot).
-- Cost: "metadata and deletion sidecars only, no column data except
+- Cost: "metadata, deletion sidecars, and bounded certificate
+  objects only, no column data except
   the trainability probe" is backed by a checked-in IO-probe
   instrument, per invariant 13.
-- Lance survey, per the Lance reading protocol, at the pinned Lance
-  10.0.0 (workspace `Cargo.toml`), read at lance `d644e7a6`
-  (2026-08-03): `IndexMetadata` (`fragment_bitmap`, typed
+- Lance survey, per the Lance reading protocol: first read at
+  Lance 10.0.0 (lance `d644e7a6`, 2026-08-03), re-verified at the
+  pinned Lance 11.0.0 (workspace `Cargo.toml`, crate source):
+  `IndexMetadata` (`fragment_bitmap`, typed
   `index_details`, delta segments, millisecond `created_at`),
-  `index_statistics` arithmetic, logical-row fragment counts.
+  `index_statistics` arithmetic, logical-row fragment counts, and
+  the fold path's error on a `None` `fragment_bitmap`.
 
 ## Rollout
 
 1. Engine: one read-only entry point over the derivation (today
    internal to the engine crate) plus the Repair procedure in
    `optimize` (Design; its widened trigger, scope gates, rebuild,
-   which widens `IndexBuildSpec::FullText`/`Vector` with
+   which widens `IndexBuildSpec::Vector` with
    `name: Option<String>` so the repair replaces under the legacy
-   name, and the `OptimizeOptions::index_names` include-list omitting
-   every `None`-bitmap index); the new `omnigraph-api-types`
+   name (`BTree` already carries one; full-text is outside the
+   repair's scope), and the extension of the landed
+   `can_fold_index` include-list to omit
+   every `None`-bitmap `btree`/`vector` index); the new `omnigraph-api-types`
    response types (embedded and served share the envelope by
    construction); embedded CLI `index status`, whose served path
    rejects with a typed not-yet-served error in the `status`
@@ -606,7 +684,7 @@ None.
 - 2026-08-25: drafted from the #550 request (read-only index readiness
   status plus a blocking wait command) and the #486 monitoring gap.
 - 2026-08-25: PR review: clarified undeclared-index maintenance (the
-  top-up pass is declaration-blind, filtering only system indexes;
+  folding pass is declaration-blind, never reading declaration;
   creation and retrain are declared-only).
 - 2026-08-26: PR review: rows gained `fields` and the (`table_key`,
   `kind`, `fields`) identity (unbuilt rows on different properties
@@ -625,8 +703,8 @@ None.
   `edge_index_unsupported`, `type_unindexable`), decided at zero
   rows (structural verdicts precede the empty-table
   short-circuit); kind-unknown metadata reads as `other`, and
-  column-matched intent with absent `index_details` as
-  `coverage_unknown`, never `missing` (no duplicate build);
+  column-matched intent with absent `index_details` classifies
+  without a duplicate build, never `missing`;
   gating restricted to declared indexes, with `await`'s exit-0
   guarantee stated explicitly (every declared index `ready` or
   `unbuildable`, never all `ready`); the served route nests
@@ -635,3 +713,14 @@ None.
   currently accepted schema (snapshot addressing pins physical
   state only); envelope types and the exit-code section assigned
   to phase 1.
+- 2026-09-01: aligned with landed RFC 0043 and the Lance 11
+  upgrade: full-text conditions route to
+  `rebuild-full-text-indexes` (ordinary `optimize` never folds
+  full-text), the Repair procedure narrowed to `btree`/`vector`
+  over the landed `can_fold_index` fold predicate, a covered but
+  uncertified full-text index classifies `degraded` /
+  `full_text_index_rebuild_required`, and a declared index whose
+  physical match carries no `index_details` reclassifies
+  `unbuildable` / `kind_unknown` (`await` never waits on a state
+  no command clears); the coverage cache keys on RFC 0042's
+  incarnation-suffixed native ref, never the logical branch name.

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -38,8 +38,9 @@ issue and implementation PR are usually enough.
 - Do not create `pre-merge`, `final`, `v2`, `internal`, or review-ledger copies.
   Revise the canonical file; preserve meaningful changes in its decision log.
 
-The next available number is **0045**; lower gaps are historical and must
-not be reused.
+The next available number is **0047**. RFC 0045 is reserved by
+[PR #584](https://github.com/ModernRelay/omnigraph/pull/584); lower gaps are
+historical and must not be reused.
 
 ## Required frontmatter
 
@@ -167,7 +168,7 @@ This table is the human index for the canonical RFC corpus.
 | [0039](0039-end-to-end-benchmark.md) | The end-to-end benchmark | public | accepted | in-progress |
 | [0040](0040-system-column-namespace.md) | System column namespace | public | draft | in-progress |
 | [0041](0041-inline-stored-queries.md) | Inline and stored queries | maintainer | accepted | partial |
-| [0042](0042-index-status.md) | Read-only index status | maintainer | draft | not-started |
 | [0042](0042-incarnation-suffixed-branch-refs.md) | Incarnation-suffixed native branch refs | maintainer | accepted | complete |
 | [0043](0043-full-text-index-compatibility.md) | Full-text index compatibility and explicit rebuild | maintainer | accepted | complete |
 | [0044](0044-edge-keys.md) | Edge keys: derived edge identity | maintainer | draft | in-progress |
+| [0046](0046-index-status.md) | Read-only index status | maintainer | draft | not-started |

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -167,6 +167,7 @@ This table is the human index for the canonical RFC corpus.
 | [0039](0039-end-to-end-benchmark.md) | The end-to-end benchmark | public | accepted | in-progress |
 | [0040](0040-system-column-namespace.md) | System column namespace | public | draft | in-progress |
 | [0041](0041-inline-stored-queries.md) | Inline and stored queries | maintainer | accepted | partial |
+| [0042](0042-index-status.md) | Read-only index status | maintainer | draft | not-started |
 | [0042](0042-incarnation-suffixed-branch-refs.md) | Incarnation-suffixed native branch refs | maintainer | accepted | complete |
 | [0043](0043-full-text-index-compatibility.md) | Full-text index compatibility and explicit rebuild | maintainer | accepted | complete |
 | [0044](0044-edge-keys.md) | Edge keys: derived edge identity | maintainer | draft | in-progress |


### PR DESCRIPTION
## What & why

This PR adds RFC 0042: a read-only index-status surface. `omnigraph index status` and `GET /index-status` report, per index, a state (`ready`, `unbuildable`, `missing`, `degraded`) with a machine-readable reason and coverage counts, derived from committed metadata under snapshot isolation; `omnigraph index await` blocks until the gating states clear. Requested in #550: the only structured index readout today is `pending_indexes` inside `optimize --json`, so observing index state requires a command that also commits, a command-query separation violation this surface removes.

- The derivation reuses the checks `optimize` already runs (the catalog-intent diff and fragment-bitmap coverage), exposed through one read-only entry point, so endpoint and reconciler cannot disagree on their inputs.
- `degraded` carries an open reason vocabulary, giving #486's degenerate-index detection a reporting surface with no schema change.
- Registry updates: the index row for 0042 and the next-available bump to 0043 (0040 stays reserved for #546).

## Backing issue / RFC

- [x] #550 (the feature request this designs); adds `docs/rfcs/0042-index-status.md`. Related: #486 (the `degraded` reporting hook); distinct from #533 (planner behavior when indexes exist).

## Checklist

- [x] Change is focused (one RFC document plus its two registry lines in `docs/rfcs/README.md`)
- [x] Tests added/updated for behavior changes (design record only; the RFC's Evidence and tests section defines the implementation's test obligations)
- [x] Public docs updated if user-facing surface changed (the RFC is the document; this PR ships no behavior)
- [x] Reviewed against docs/dev/invariants.md — no Hard Invariant weakened, no deny-list item hit (the RFC's Invariants section addresses the two nearest items: derived-not-stored work lists, and why `await` is not a coverage-based engine precondition)

## Local verification

- `python3 scripts/check-docs.py` — Documentation OK (110 Markdown files checked)
- `cargo test` — not run: docs-only change, no code touched

## Notes for reviewers

- The state for declared-but-unbuildable indexes is named `unbuildable`, and `pending` is deliberately reserved: an in-progress reading is unrepresentable on a committed-state-only surface, so the word stays free for a future background builder (note after the states table).
- `await` gates on `missing` and `degraded` only and never triggers reconciliation; rollout phase 3 (`await`) is independently droppable if review reads the deny-list differently.
- RFC number 0042 taken per the registry's next-available line at this base; re-checked for races before opening.









<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds RFC 0046, specifying a read-only index-status API and CLI surface derived from committed metadata.
- Defines index states, reason tokens, coverage counts, and snapshot-isolated reporting semantics.
- Specifies polling behavior for `index await` and a repair path for legacy indexes without coverage metadata.
- Registers RFC 0046, reserves RFC 0045, and advances the next available number to 0047.

<h3>Confidence Score: 5/5</h3>

The documentation-only PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/rfcs/0046-index-status.md | Adds the read-only index-status RFC and consistently identifies it as RFC 0046, resolving the prior numbering issue. |
| docs/rfcs/README.md | Registers RFC 0046, documents the RFC 0045 reservation, and advances the next available number to 0047. |

</details>

<sub>Reviews (5): Last reviewed commit: ["review"](https://github.com/modernrelay/omnigraph/commit/65e9ca942c808f3a62b7d96ac7f6340a8e782717) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56798237)</sub>

<!-- /greptile_comment -->