### PR TITLE
ci: move Azure and vocabulary audits off PRs

### DIFF
--- a/.github/branch-protection.json
+++ b/.github/branch-protection.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Branch protection policy for main. Applied via scripts/apply-branch-protection.sh. See docs/dev/branch-protection.md for rationale. CODEOWNERS was removed (2-person team where both maintainers own everything, so code-owner review added friction without value). Review is no longer code-owner-scoped and no approvals are required; the reporting PR checks below are the gate. The full workspace, format-fence, and RustFS suites run post-merge; immutable workflow refs are checked on pull requests. A red main branch is stop-the-line until fixed or reverted.",
+  "_comment": "Branch protection policy for main. Applied via scripts/apply-branch-protection.sh. See docs/dev/branch-protection.md for rationale. CODEOWNERS was removed (2-person team where both maintainers own everything, so code-owner review added friction without value). Review is no longer code-owner-scoped and no approvals are required; the reporting PR checks below are the gate. Graph Vocabulary Guard currently reports a successful PR skip while its full audit runs post-merge, on tags, and by manual dispatch. The full workspace, format-fence, and backend suites run post-merge; immutable workflow refs are checked on pull requests. A red main branch is stop-the-line until fixed or reverted.",
   "required_status_checks": {
     "strict": true,
     "contexts": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
       contents: read
     outputs:
       run_full_ci: ${{ steps.filter.outputs.run_full_ci }}
-      run_azure_ci: ${{ steps.filter.outputs.run_azure_ci }}
     steps:
       - name: Checkout source
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -43,7 +42,6 @@ jobs:
 
           if [[ "$EVENT_NAME" == "workflow_dispatch" || "$REF_TYPE" == "tag" ]]; then
             echo "run_full_ci=true" >> "$GITHUB_OUTPUT"
-            echo "run_azure_ci=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -60,7 +58,6 @@ jobs:
 
           if [[ -z "${base:-}" ]]; then
             echo "run_full_ci=true" >> "$GITHUB_OUTPUT"
-            echo "run_azure_ci=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -69,12 +66,10 @@ jobs:
           mapfile -t changed < <(git diff --name-only --no-renames "$base" "$head")
           if [[ "${#changed[@]}" -eq 0 ]]; then
             echo "run_full_ci=true" >> "$GITHUB_OUTPUT"
-            echo "run_azure_ci=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           run_full_ci=false
-          run_azure_ci=false
           for path in "${changed[@]}"; do
             case "$path" in
               docs/*.md|docs/*.mdx|docs/*.rst|docs/*.adoc) ;;
@@ -84,21 +79,11 @@ jobs:
                 run_full_ci=true
                 ;;
             esac
-            case "$path" in
-              Cargo.toml|Cargo.lock|Dockerfile|.dockerignore|docker/*|deploy/azure/*) run_azure_ci=true ;;
-              .github/workflows/ci.yml|.github/workflows/package.yml|.github/workflows/publish-image.yml) run_azure_ci=true ;;
-              .github/workflows/release.yml|.github/workflows/release-edge.yml|.github/workflows/omnigraph-package.yml) run_azure_ci=true ;;
-              scripts/install.sh|scripts/install.ps1|scripts/install-source.sh|scripts/update-homebrew-formula.sh) run_azure_ci=true ;;
-              scripts/check-azure-admission-boundary.py|scripts/check-container-binary-contract.py) run_azure_ci=true ;;
-              crates/omnigraph-storage/*|crates/omnigraph-azure-admission/*|crates/omnigraph/*) run_azure_ci=true ;;
-              crates/omnigraph-cluster/*|crates/omnigraph-server/*|crates/omnigraph-cli/*) run_azure_ci=true ;;
-            esac
           done
 
           printf 'Changed files:\n'
           printf '  %s\n' "${changed[@]}"
           echo "run_full_ci=$run_full_ci" >> "$GITHUB_OUTPUT"
-          echo "run_azure_ci=$run_azure_ci" >> "$GITHUB_OUTPUT"
 
   check_agents_md:
     name: Check AGENTS.md Links
@@ -144,9 +129,10 @@ jobs:
 
   graph_vocabulary_guard:
     name: Graph Vocabulary Guard
-    # Required PR context: keep this job independent of the documentation-only
-    # classifier so it always reports. The review-owned inventory protects the
-    # OpenAPI, Rust presentation-string, and public-Rust surfaces.
+    # Keep this exact reporting context while it remains required by branch
+    # protection, but do not run the substrate-sized audit on pull requests.
+    # The full audit still runs after merge, on tags, and by manual dispatch.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     # A cold default + relevant all-features rustdoc pass over all seven public
     # library crates is substrate-sized. The first hosted run completed the
@@ -791,12 +777,11 @@ jobs:
 
   azurite_integration:
     name: Azurite Azure Integration
-    # Azure-touching PRs gate on the configured backend contract; main, tag,
-    # and manual full-CI runs retain the same post-merge coverage. Keep this
-    # independent of `test` so cold backend graphs start together and a
-    # failure reports at its real boundary.
+    # This configured backend contract runs after merge, on tags, and by
+    # manual dispatch. Keep it independent of `test` so cold backend graphs
+    # start together and a failure reports at its real boundary.
     needs: classify_changes
-    if: needs.classify_changes.outputs.run_full_ci == 'true' && (github.event_name != 'pull_request' || needs.classify_changes.outputs.run_azure_ci == 'true')
+    if: github.event_name != 'pull_request' && needs.classify_changes.outputs.run_full_ci == 'true'
     runs-on: ubuntu-latest
     # Cold failpoint and default-feature Lance graphs compile sequentially on
     # the first cache miss; keep the timeout above the RustFS shard envelope.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,9 @@ jobs:
       - name: Reject mutable external action refs
         run: python3 scripts/check-workflow-action-pins.py
 
+      - name: Enforce release vocabulary gates
+        run: python3 scripts/check-release-vocabulary-gates.py
+
   azure_contract_guards:
     name: Azure Contract Guards
     runs-on: ubuntu-latest
@@ -247,6 +250,61 @@ jobs:
             --inventory tools/omnigraph-vocabulary-guard/graph-vocabulary-inventory.tsv \
             --cargo-public-api "$tool" \
             --public-api-target-dir target/vocabulary-public-api
+
+  release_edge_after_vocabulary:
+    name: Release edge after vocabulary audit
+    needs: [classify_changes, graph_vocabulary_guard]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.classify_changes.outputs.run_full_ci == 'true'
+    permissions:
+      actions: read
+      contents: write
+    uses: ./.github/workflows/release-edge.yml
+    with:
+      source_ref: ${{ github.sha }}
+      ci_run_id: ${{ format('{0}', github.run_id) }}
+
+  release_tag_after_vocabulary:
+    name: Release tag after vocabulary audit
+    needs: graph_vocabulary_guard
+    if: github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+    permissions:
+      actions: read
+      contents: write
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ github.ref_name }}
+      source_ref: ${{ github.ref }}
+      ci_run_id: ${{ format('{0}', github.run_id) }}
+    secrets: inherit
+
+  publish_tag_image_after_vocabulary:
+    name: Publish tag image after vocabulary audit
+    needs: graph_vocabulary_guard
+    if: github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+    permissions:
+      actions: read
+      contents: read
+      packages: write
+    uses: ./.github/workflows/publish-image.yml
+    with:
+      tag: ${{ github.ref_name }}
+      source_ref: ${{ github.ref }}
+      ci_run_id: ${{ format('{0}', github.run_id) }}
+    secrets: inherit
+
+  publish_tag_crates_after_vocabulary:
+    name: Publish tag crates after vocabulary audit
+    needs: graph_vocabulary_guard
+    if: github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+    permissions:
+      actions: read
+      contents: read
+    uses: ./.github/workflows/publish-crates.yml
+    with:
+      tag: ${{ github.ref_name }}
+      source_ref: ${{ github.ref }}
+      ci_run_id: ${{ format('{0}', github.run_id) }}
+    secrets: inherit
 
   entrypoint_test:
     name: Container Entrypoint

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -5,9 +5,8 @@ name: Publish to crates.io
 # the first step below fail-closes every invocation until that policy and
 # `docs/dev/versioning.md` are deliberately changed together.
 #
-# Triggers:
-#   - push of any v* tag (future releases auto-publish alongside release.yml)
-#   - workflow_dispatch with an explicit tag input (catch-up runs for past tags)
+# Automatic publication is called by CI only after the exact commit passes the
+# vocabulary audit. Manual backfills require a prior exact-commit audit too.
 #
 # Once publication is restored, each crate's current crates.io version is
 # checked before publish so a partial failure can be rerun idempotently.
@@ -15,9 +14,17 @@ name: Publish to crates.io
 # Prerequisite: repo secret CARGO_REGISTRY_TOKEN. The job exits cleanly if absent.
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+      source_ref:
+        required: true
+        type: string
+      ci_run_id:
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       tag:
@@ -26,12 +33,25 @@ on:
         type: string
 
 jobs:
+  vocabulary_gate:
+    name: Require audited crate source
+    permissions:
+      actions: read
+      contents: read
+    uses: ./.github/workflows/release-vocabulary-gate.yml
+    with:
+      source_ref: ${{ inputs.source_ref || format('refs/tags/{0}', inputs.tag) }}
+      ci_run_id: ${{ inputs.ci_run_id || '' }}
+
   publish_crates:
     name: Publish crates
+    needs: vocabulary_gate
     runs-on: ubuntu-latest
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       CARGO_TERM_COLOR: always
+      RELEASE_TAG: ${{ inputs.tag }}
+      SOURCE_SHA: ${{ needs.vocabulary_gate.outputs.source_sha }}
     steps:
       - name: Enforce registry publication pause
         run: |
@@ -44,20 +64,11 @@ jobs:
           echo "CARGO_REGISTRY_TOKEN is not set; skipping crates.io publish."
           echo "CARGO_PUBLISH_SKIP=1" >> "$GITHUB_ENV"
 
-
-      - name: Resolve ref
-        if: env.CARGO_PUBLISH_SKIP != '1'
-        id: ref
-        run: |
-          ref="${{ inputs.tag || github.ref_name }}"
-          echo "ref=${ref}" >> "$GITHUB_OUTPUT"
-          echo "Publishing from ref: ${ref}"
-
       - name: Checkout source at tag
         if: env.CARGO_PUBLISH_SKIP != '1'
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
-          ref: ${{ steps.ref.outputs.ref }}
+          ref: ${{ needs.vocabulary_gate.outputs.source_sha }}
 
       # Defense in depth for a future publication restart: crates.io rejects git
       # dependencies, so a rev-pinned substrate must still defer that release.
@@ -87,6 +98,22 @@ jobs:
         with:
           workspaces: |
             . -> target
+
+      - name: Verify release tag still selects audited source
+        if: env.CARGO_PUBLISH_SKIP != '1'
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_TAG" == v* ]]
+          refs="$(git ls-remote origin \
+            "refs/tags/${RELEASE_TAG}" "refs/tags/${RELEASE_TAG}^{}")"
+          tag_sha="$(awk '$2 ~ /\^\{\}$/ {print $1}' <<<"$refs")"
+          if [[ -z "$tag_sha" ]]; then
+            tag_sha="$(awk 'NR == 1 {print $1}' <<<"$refs")"
+          fi
+          [[ "$tag_sha" == "$SOURCE_SHA" ]] || {
+            echo "::error::${RELEASE_TAG} now selects ${tag_sha:-nothing}, expected ${SOURCE_SHA}"
+            exit 1
+          }
 
       - name: Publish crates in dependency order
         if: env.CARGO_PUBLISH_SKIP != '1'

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -7,10 +7,8 @@ name: Publish container image
 # not block the binary release / Homebrew chain, and a manual backfill of an
 # old tag must not re-run the four-platform release matrix.
 #
-# Triggers (same dual pattern as release.yml):
-#   - push of a v* tag (normal release)
-#   - workflow_dispatch with an explicit `tag` (publish an image for a past
-#     tag; resolves the same `${{ inputs.tag || github.ref_name }}`)
+# Automatic tag publication is called by CI only after the exact commit passes
+# the vocabulary audit. Manual backfills reuse a prior exact-commit audit.
 #
 # The binaries are compiled inside a rust:1-bookworm container, NOT on the
 # runner host: the Dockerfile's runtime base is debian bookworm-slim
@@ -18,9 +16,17 @@ name: Publish container image
 # there. Builder and runtime must share the same distro release.
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+      source_ref:
+        required: true
+        type: string
+      ci_run_id:
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       tag:
@@ -29,20 +35,31 @@ on:
         type: string
 
 jobs:
+  vocabulary_gate:
+    name: Require audited image source
+    permissions:
+      actions: read
+      contents: read
+    uses: ./.github/workflows/release-vocabulary-gate.yml
+    with:
+      source_ref: ${{ inputs.source_ref || format('refs/tags/{0}', inputs.tag) }}
+      ci_run_id: ${{ inputs.ci_run_id || '' }}
+
   publish_image:
     name: Build and push image
+    needs: vocabulary_gate
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     env:
-      RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+      RELEASE_TAG: ${{ inputs.tag }}
+      SOURCE_SHA: ${{ needs.vocabulary_gate.outputs.source_sha }}
     steps:
       # The dispatch `tag` input is free-form; without this guard a dispatcher
       # could pass a branch name or SHA and publish non-release code under a
       # release-looking image tag. Require an existing v* tag ref.
-      - name: Validate dispatch tag
-        if: github.event_name == 'workflow_dispatch'
+      - name: Validate release tag
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -54,8 +71,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
-          # Fully qualified so a branch of the same name can never shadow the tag.
-          ref: refs/tags/${{ env.RELEASE_TAG }}
+          ref: ${{ needs.vocabulary_gate.outputs.source_sha }}
 
       - name: Build release binaries (bookworm builder)
         run: |
@@ -75,6 +91,20 @@ jobs:
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" \
             | docker login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Verify release tag still selects audited source
+        run: |
+          set -euo pipefail
+          refs="$(git ls-remote origin \
+            "refs/tags/${RELEASE_TAG}" "refs/tags/${RELEASE_TAG}^{}")"
+          tag_sha="$(awk '$2 ~ /\^\{\}$/ {print $1}' <<<"$refs")"
+          if [[ -z "$tag_sha" ]]; then
+            tag_sha="$(awk 'NR == 1 {print $1}' <<<"$refs")"
+          fi
+          [[ "$tag_sha" == "$SOURCE_SHA" ]] || {
+            echo "::error::${RELEASE_TAG} now selects ${tag_sha:-nothing}, expected ${SOURCE_SHA}"
+            exit 1
+          }
 
       - name: Build and push image
         run: |

--- a/.github/workflows/release-edge.yml
+++ b/.github/workflows/release-edge.yml
@@ -1,37 +1,77 @@
 name: Release Edge
 
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - "**/*.md"
-      - "**/*.mdx"
-      - "**/*.txt"
-      - "**/*.rst"
-      - "**/*.adoc"
+  workflow_call:
+    inputs:
+      source_ref:
+        required: true
+        type: string
+      ci_run_id:
+        required: true
+        type: string
   workflow_dispatch:
+    inputs:
+      source_ref:
+        description: Current main ref or commit to release. Defaults to the selected workflow ref.
+        required: false
+        type: string
+      ci_run_id:
+        description: Optional CI run that contains the successful exact-SHA vocabulary audit.
+        required: false
+        type: string
 
 jobs:
+  vocabulary_gate:
+    name: Require audited edge source
+    permissions:
+      actions: read
+      contents: read
+    uses: ./.github/workflows/release-vocabulary-gate.yml
+    with:
+      source_ref: ${{ inputs.source_ref || github.sha }}
+      ci_run_id: ${{ inputs.ci_run_id || '' }}
+
   prepare_edge_release:
     name: Prepare edge release
+    needs: vocabulary_gate
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      publish: ${{ steps.freshness.outputs.publish }}
     steps:
       - name: Checkout source
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
+          ref: ${{ needs.vocabulary_gate.outputs.source_sha }}
           fetch-depth: 0
 
-      - name: Force-update edge tag
+      - name: Reject a stale edge source
+        id: freshness
+        env:
+          SOURCE_SHA: ${{ needs.vocabulary_gate.outputs.source_sha }}
         run: |
-          git tag -f edge "$GITHUB_SHA"
+          set -euo pipefail
+          current_main="$(git ls-remote origin refs/heads/main | awk '{print $1}')"
+          if [[ "$current_main" != "$SOURCE_SHA" ]]; then
+            echo "::notice::main advanced to ${current_main}; skipping stale edge source ${SOURCE_SHA}"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "publish=true" >> "$GITHUB_OUTPUT"
+
+      - name: Force-update edge tag
+        if: steps.freshness.outputs.publish == 'true'
+        env:
+          SOURCE_SHA: ${{ needs.vocabulary_gate.outputs.source_sha }}
+        run: |
+          git tag -f edge "$SOURCE_SHA"
           git push origin refs/tags/edge --force
 
   build_release:
     name: Build edge ${{ matrix.asset_name }}
-    needs: prepare_edge_release
+    needs: [vocabulary_gate, prepare_edge_release]
+    if: needs.prepare_edge_release.outputs.publish == 'true'
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: write
@@ -56,6 +96,8 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: ${{ needs.vocabulary_gate.outputs.source_sha }}
 
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
@@ -121,19 +163,21 @@ jobs:
           prerelease: true
           make_latest: false
           body: |
-            Rolling prerelease from `${{ github.sha }}`.
+            Rolling prerelease from `${{ needs.vocabulary_gate.outputs.source_sha }}`.
           files: |
             ${{ matrix.asset_name }}.*
 
   smoke_windows_installer:
     name: Smoke Windows installer
-    needs: build_release
+    needs: [vocabulary_gate, build_release]
     runs-on: windows-latest
     permissions:
       contents: read
     steps:
       - name: Checkout source
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: ${{ needs.vocabulary_gate.outputs.source_sha }}
 
       - name: Install from edge release
         run: ./scripts/install.ps1 -ReleaseChannel edge -InstallDir "$env:RUNNER_TEMP/omnigraph-bin"

--- a/.github/workflows/release-vocabulary-gate.yml
+++ b/.github/workflows/release-vocabulary-gate.yml
@@ -1,0 +1,106 @@
+name: Release vocabulary gate
+
+on:
+  workflow_call:
+    inputs:
+      source_ref:
+        description: Git ref or commit to resolve once as the release source.
+        required: true
+        type: string
+      ci_run_id:
+        description: Exact CI run that authorized an automatic release.
+        required: false
+        default: ""
+        type: string
+    outputs:
+      source_sha:
+        description: Immutable audited commit used by every release checkout.
+        value: ${{ jobs.verify.outputs.source_sha }}
+
+jobs:
+  verify:
+    name: Verify exact-SHA vocabulary audit
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      source_sha: ${{ steps.source.outputs.sha }}
+    steps:
+      - name: Resolve release source once
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: ${{ inputs.source_ref }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Record immutable source commit
+        id: source
+        run: |
+          set -euo pipefail
+          sha="$(git rev-parse 'HEAD^{commit}')"
+          [[ "$sha" =~ ^[0-9a-f]{40}$ ]]
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Require successful vocabulary audit
+        env:
+          CI_RUN_ID: ${{ inputs.ci_run_id }}
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ steps.source.outputs.sha }}
+        run: |
+          set -euo pipefail
+
+          audit_succeeded_in_run() {
+            local run_id="$1"
+            local jobs
+            jobs="$(gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs?filter=latest&per_page=100")"
+            jq -e --arg sha "$SOURCE_SHA" '
+              .jobs
+              | any(
+                  .name == "Graph Vocabulary Guard"
+                  and .head_sha == $sha
+                  and .status == "completed"
+                  and .conclusion == "success"
+                )
+            ' <<<"$jobs" >/dev/null
+          }
+
+          if [[ -n "$CI_RUN_ID" ]]; then
+            run="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${CI_RUN_ID}")"
+            jq -e --arg sha "$SOURCE_SHA" '
+              .path == ".github/workflows/ci.yml"
+              and .head_sha == $sha
+              and (.event == "push" or .event == "workflow_dispatch")
+            ' <<<"$run" >/dev/null || {
+              echo "::error::CI run ${CI_RUN_ID} does not authorize source ${SOURCE_SHA}"
+              exit 1
+            }
+            # `needs` guarantees the audit job completed, but allow the Jobs
+            # REST view a short consistency window before failing closed.
+            for _ in $(seq 1 12); do
+              if audit_succeeded_in_run "$CI_RUN_ID"; then
+                exit 0
+              fi
+              sleep 5
+            done
+            echo "::error::CI run ${CI_RUN_ID} has no successful exact-SHA Graph Vocabulary Guard"
+            exit 1
+          fi
+
+          # Manual backfills may reuse an earlier audit of the exact commit,
+          # but a skipped pull-request context never qualifies.
+          mapfile -t run_ids < <(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${SOURCE_SHA}&per_page=100" \
+              --jq '.workflow_runs[] | select(.event == "push" or .event == "workflow_dispatch") | .id'
+          )
+          for run_id in "${run_ids[@]}"; do
+            if audit_succeeded_in_run "$run_id"; then
+              exit 0
+            fi
+          done
+
+          echo "::error::source ${SOURCE_SHA} has no successful non-PR Graph Vocabulary Guard"
+          echo "Audit the exact ref first, then retry the manual release. Historical pre-guard tags require an explicit policy decision."
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,15 +7,22 @@ name: Release
 # The matrix now only uploads workflow artifacts; `publish_release` is the sole
 # writer of the release (no race).
 #
-# Triggers:
-#   - push of a v* tag (normal release)
-#   - workflow_dispatch with an explicit `tag` (re-publish a past tag without
-#     re-cutting it; resolves the same `${{ inputs.tag || github.ref_name }}`)
+# Automatic tag releases are called by CI only after the exact commit passes
+# the vocabulary audit. Manual backfills retain the same gate and fail closed
+# when the selected tag has no successful audit.
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+      source_ref:
+        required: true
+        type: string
+      ci_run_id:
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       tag:
@@ -24,8 +31,19 @@ on:
         type: string
 
 jobs:
+  vocabulary_gate:
+    name: Require audited release source
+    permissions:
+      actions: read
+      contents: read
+    uses: ./.github/workflows/release-vocabulary-gate.yml
+    with:
+      source_ref: ${{ inputs.source_ref || format('refs/tags/{0}', inputs.tag) }}
+      ci_run_id: ${{ inputs.ci_run_id || '' }}
+
   build_release:
     name: Build ${{ matrix.asset_name }}
+    needs: vocabulary_gate
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -51,7 +69,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
-          ref: ${{ inputs.tag || github.ref_name }}
+          ref: ${{ needs.vocabulary_gate.outputs.source_sha }}
 
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
@@ -114,7 +132,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ matrix.asset_name }}
+          name: release-${{ matrix.asset_name }}
           path: |
             ${{ matrix.asset_name }}.*
           if-no-files-found: error
@@ -122,33 +140,86 @@ jobs:
 
   publish_release:
     name: Publish GitHub release
-    needs: build_release
+    needs: [vocabulary_gate, build_release]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - name: Download all build artifacts
+      - name: Checkout audited source
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: ${{ needs.vocabulary_gate.outputs.source_sha }}
+          fetch-depth: 1
+
+      - name: Verify release tag still selects audited source
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          SOURCE_SHA: ${{ needs.vocabulary_gate.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_TAG" == v* ]]
+          refs="$(git ls-remote origin \
+            "refs/tags/${RELEASE_TAG}" "refs/tags/${RELEASE_TAG}^{}")"
+          tag_sha="$(awk '$2 ~ /\^\{\}$/ {print $1}' <<<"$refs")"
+          if [[ -z "$tag_sha" ]]; then
+            tag_sha="$(awk 'NR == 1 {print $1}' <<<"$refs")"
+          fi
+          [[ "$tag_sha" == "$SOURCE_SHA" ]] || {
+            echo "::error::${RELEASE_TAG} now selects ${tag_sha:-nothing}, expected ${SOURCE_SHA}"
+            exit 1
+          }
+
+      - name: Download release build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
+          pattern: release-omnigraph-*
           path: dist
           merge-multiple: true
+
+      - name: Verify exact release artifact set
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+
+          expected = {
+              "omnigraph-linux-arm64.sha256",
+              "omnigraph-linux-arm64.tar.gz",
+              "omnigraph-linux-x86_64.sha256",
+              "omnigraph-linux-x86_64.tar.gz",
+              "omnigraph-macos-arm64.sha256",
+              "omnigraph-macos-arm64.tar.gz",
+              "omnigraph-windows-x86_64.sha256",
+              "omnigraph-windows-x86_64.zip",
+          }
+          actual = {
+              str(path.relative_to("dist"))
+              for path in Path("dist").rglob("*")
+              if path.is_file()
+          }
+          if actual != expected:
+              missing = sorted(expected - actual)
+              unexpected = sorted(actual - expected)
+              raise SystemExit(
+                  f"invalid release artifact set: missing={missing}, unexpected={unexpected}"
+              )
+          PY
 
       - name: Publish release (single writer — no matrix race)
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
-          tag_name: ${{ inputs.tag || github.ref_name }}
+          tag_name: ${{ inputs.tag }}
           files: dist/**
           overwrite_files: true
 
   update_homebrew_tap:
     name: Update Homebrew tap
-    needs: publish_release
+    needs: [vocabulary_gate, publish_release]
     runs-on: ubuntu-latest
     permissions:
       contents: read
     env:
       HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-      RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+      RELEASE_TAG: ${{ inputs.tag }}
     steps:
       - name: Skip if HOMEBREW_TAP_TOKEN is not configured
         if: env.HOMEBREW_TAP_TOKEN == ''
@@ -160,7 +231,7 @@ jobs:
         if: env.HOMEBREW_TAP_SKIP != '1'
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: ${{ needs.vocabulary_gate.outputs.source_sha }}
 
       - name: Checkout Homebrew tap
         if: env.HOMEBREW_TAP_SKIP != '1'
@@ -219,18 +290,17 @@ jobs:
 
   smoke_windows_installer:
     name: Smoke Windows installer
-    needs: publish_release
-    if: ${{ inputs.tag != '' || startsWith(github.ref, 'refs/tags/v') }}
+    needs: [vocabulary_gate, publish_release]
     runs-on: windows-latest
     permissions:
       contents: read
     env:
-      RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+      RELEASE_TAG: ${{ inputs.tag }}
     steps:
       - name: Checkout source
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: ${{ needs.vocabulary_gate.outputs.source_sha }}
 
       - name: Install from tagged release
         run: ./scripts/install.ps1 -Version "$env:RELEASE_TAG" -InstallDir "$env:RUNNER_TEMP/omnigraph-bin"

--- a/docs/dev/branch-protection.md
+++ b/docs/dev/branch-protection.md
@@ -17,9 +17,10 @@ protection.
 - `Lint (clippy)`
 
 Checks are strict, so a PR must be current with `main`. `Graph Vocabulary
-Guard` always reports and protects the reviewed vocabulary inventory across
-OpenAPI, Rust presentation strings, and public Rust surfaces. User documentation
-is intentionally outside this exact-occurrence gate and is validated by the
+Guard` remains as an always-reporting context but reports a successful skip on
+pull requests; the full OpenAPI, Rust presentation-string, and public-Rust
+audit runs after merge, on tags, and by manual dispatch. User documentation is
+intentionally outside this exact-occurrence audit and is validated by the
 documentation structure check.
 Documentation-only PRs still receive every required context; work-heavy steps
 may report as skipped.

--- a/docs/dev/ci.md
+++ b/docs/dev/ci.md
@@ -29,6 +29,22 @@ audit and is owned by `scripts/check-docs.py`. The AWS job reports a successful
 skip for a documentation-only change; formatting and Clippy are also skipped by
 the classifier without leaving required contexts pending.
 
+Automatic edge and versioned publication are jobs in the same CI run and cannot
+start until that run's vocabulary audit succeeds. Each publishing workflow then
+re-verifies the authorizing CI run, resolves its source once to an immutable
+commit, and builds only that commit. Version tags are checked again immediately
+before publication; a stale main audit cannot move the rolling `edge` tag
+backward. A manual backfill must already have a successful non-PR vocabulary
+audit for the exact commit. The current manual workflows therefore fail closed
+for historical pre-guard tags rather than offering a force bypass.
+
+GitHub evaluates a tag-push workflow from the commit selected by that tag. A
+new `v*` tag must not be created against a commit that predates these gates,
+because no later workflow edit can retroactively replace that commit's old
+publisher definitions. Enforcing that administrative boundary against tag
+creators requires repository tag policy in addition to the checked-in workflow
+gate.
+
 Formatting and Clippy use the repository's pinned toolchain. Lints remain warnings in the workspace; CI applies `-D warnings`. Clippy runs both the default and failpoint-superset graphs.
 
 Repository metadata gates also check:
@@ -90,6 +106,7 @@ For repository metadata and workflow changes:
 bash scripts/check-agents-md.sh
 python3 scripts/check-docs.py
 python3 scripts/check-workflow-action-pins.py
+python3 scripts/check-release-vocabulary-gates.py
 python3 scripts/check-container-binary-contract.py
 python3 scripts/check-azure-admission-boundary.py
 actionlint .github/workflows/*.yml
@@ -102,10 +119,10 @@ shellcheck scripts/*.sh
 
 | Workflow | Trigger and output |
 |---|---|
-| `release-edge.yml` | Push to `main` or manual dispatch; updates the rolling `edge` release and platform archives. |
-| `release.yml` | `v*` tag or explicit manual release; builds platform archives, publishes the GitHub release, updates Homebrew when credentials are available, and smoke-tests the Windows installer. |
-| `publish-crates.yml` | `v*` tag or manual dispatch; publishes workspace crates in dependency order when the registry token and substrate state permit it. |
-| `publish-image.yml` | `v*` tag or explicit tag backfill; builds the bookworm-compatible public server image for GHCR and, when configured, Docker Hub. Backfills do not move `latest`. |
+| `release-edge.yml` | Called by a non-documentation `main` CI run after its vocabulary audit, or manually for an already-audited current `main`; updates the rolling `edge` release and platform archives. |
+| `release.yml` | Called by audited `v*` tag CI or manually for an already-audited tag; builds platform archives, publishes the GitHub release, updates Homebrew when credentials are available, and smoke-tests the Windows installer. |
+| `publish-crates.yml` | Called by audited `v*` tag CI or manually for an already-audited tag; publication remains paused until the registry-ownership policy changes. |
+| `publish-image.yml` | Called by audited `v*` tag CI or manually for an already-audited tag; builds the bookworm-compatible public server image for GHCR and, when configured, Docker Hub. Manual backfills do not move `latest`. |
 | `package.yml` / `omnigraph-package.yml` | Manual AWS CodeBuild packaging for default and AWS-feature artifacts, with checksums, digests, and attestations. |
 | `refresh-docs-site.yml` | Documentation changes on `main` or manual dispatch; requests a docs-site redeploy. |
 
@@ -117,4 +134,7 @@ Release archives and containers include the CLI, server, and Azure admission wra
 2. Keep external Actions and reusable workflows pinned to full commit SHAs.
 3. Update the documentation classifier when adding a new documentation format; never classify by extension outside the approved docs paths.
 4. Keep configured object-store jobs fail-closed on accidental skips.
-5. Update [branch-protection.md](branch-protection.md) only when the declared required contexts or policy actually change.
+5. Keep every automatic artifact publisher transitively behind a successful
+   exact-SHA vocabulary audit; a skipped pull-request context never authorizes
+   publication.
+6. Update [branch-protection.md](branch-protection.md) only when the declared required contexts or policy actually change.

--- a/docs/dev/ci.md
+++ b/docs/dev/ci.md
@@ -20,11 +20,14 @@ The `Check AGENTS.md Links` context also runs `scripts/check-docs.py`, which
 validates local documentation links, user/developer audience boundaries, RFC
 location and metadata, and registry agreement.
 
-The vocabulary guard checks OpenAPI, Rust presentation strings, and public Rust
-against the reviewed terminology inventory. User documentation is intentionally
-outside this exact-occurrence gate and is owned by `scripts/check-docs.py`. The AWS job reports
-a successful skip for a documentation-only change; formatting and Clippy are
-also skipped by the classifier without leaving required contexts pending.
+`Graph Vocabulary Guard` remains a required reporting context, but its
+substrate-sized audit is disabled on pull requests. It reports a successful
+skip there and checks OpenAPI, Rust presentation strings, and public Rust
+against the reviewed terminology inventory after merge, on tags, and by manual
+dispatch. User documentation is intentionally outside this exact-occurrence
+audit and is owned by `scripts/check-docs.py`. The AWS job reports a successful
+skip for a documentation-only change; formatting and Clippy are also skipped by
+the classifier without leaving required contexts pending.
 
 Formatting and Clippy use the repository's pinned toolchain. Lints remain warnings in the workspace; CI applies `-D warnings`. Clippy runs both the default and failpoint-superset graphs.
 
@@ -49,9 +52,15 @@ This is deliberate latency policy, not a lesser standard. Run the canonical suit
 
 Independent post-merge/tag/manual jobs own contracts that need special infrastructure:
 
+- **Graph vocabulary audit** checks OpenAPI, Rust presentation strings, and
+  public Rust against the reviewed terminology inventory.
 - **V5 ↔ V6 format fence** builds the immutable final-v5 CLI and proves mutual refusal plus the documented export/init/load rebuild.
 - **RustFS S3 integration** runs configured engine, server, cluster, CLI, recovery, and deterministic operation-count owners. A configured test that skips is a failure.
-- **Azurite Azure integration** runs configured storage, admission-lease, recovery, cluster, server, and CLI owners against a digest-pinned Azurite image. It also verifies control objects, Lance data, and the admission object use the declared container.
+- **Azurite Azure integration** runs only after merge, on tags, or by manual
+  dispatch. It exercises configured storage, admission-lease, recovery,
+  cluster, server, and CLI owners against a digest-pinned Azurite image, then
+  verifies that control objects, Lance data, and the admission object use the
+  declared container.
 - **AWS feature** builds and tests `omnigraph-server` with `--features aws`.
 
 Azure remains a qualification preview. Emulator coverage and the completed

--- a/scripts/check-release-vocabulary-gates.py
+++ b/scripts/check-release-vocabulary-gates.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Keep automatic public releases behind the exact-SHA vocabulary audit."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_ROOT = REPO_ROOT / ".github" / "workflows"
+JOB_RE = re.compile(r"^  ([a-zA-Z0-9_]+):\s*$", re.MULTILINE)
+
+
+def job_block(text: str, name: str) -> str:
+    jobs = text.split("\njobs:\n", 1)
+    if len(jobs) != 2:
+        raise ValueError("workflow has no jobs mapping")
+    body = jobs[1]
+    matches = list(JOB_RE.finditer(body))
+    for index, match in enumerate(matches):
+        if match.group(1) != name:
+            continue
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(body)
+        return body[match.start() : end]
+    raise ValueError(f"missing job {name}")
+
+
+def require(condition: bool, message: str, failures: list[str]) -> None:
+    if not condition:
+        failures.append(message)
+
+
+def main() -> int:
+    failures: list[str] = []
+    ci = (WORKFLOW_ROOT / "ci.yml").read_text()
+
+    graph = job_block(ci, "graph_vocabulary_guard")
+    require(
+        "if: github.event_name != 'pull_request'" in graph,
+        "ci.yml: Graph Vocabulary Guard must remain a job-level PR skip",
+        failures,
+    )
+
+    automatic_calls = {
+        "release_edge_after_vocabulary": "./.github/workflows/release-edge.yml",
+        "release_tag_after_vocabulary": "./.github/workflows/release.yml",
+        "publish_tag_image_after_vocabulary": "./.github/workflows/publish-image.yml",
+        "publish_tag_crates_after_vocabulary": "./.github/workflows/publish-crates.yml",
+    }
+    for job, target in automatic_calls.items():
+        block = job_block(ci, job)
+        require(
+            "graph_vocabulary_guard" in block,
+            f"ci.yml:{job}: must need Graph Vocabulary Guard",
+            failures,
+        )
+        require(
+            f"uses: {target}" in block,
+            f"ci.yml:{job}: must call {target}",
+            failures,
+        )
+        require(
+            "ci_run_id:" in block and "source_ref:" in block,
+            f"ci.yml:{job}: must pass exact CI-run and source identity",
+            failures,
+        )
+
+    publishers = {
+        "release-edge.yml": ("prepare_edge_release", "build_release"),
+        "release.yml": ("build_release", "publish_release", "update_homebrew_tap"),
+        "publish-image.yml": ("publish_image",),
+        "publish-crates.yml": ("publish_crates",),
+    }
+    for filename, writer_jobs in publishers.items():
+        text = (WORKFLOW_ROOT / filename).read_text()
+        trigger = text.split("\njobs:\n", 1)[0]
+        require(
+            "\n  push:" not in trigger,
+            f"{filename}: direct push publication bypasses the vocabulary gate",
+            failures,
+        )
+        require(
+            "  workflow_call:" in trigger and "  workflow_dispatch:" in trigger,
+            f"{filename}: must support audited CI calls and manual backfills",
+            failures,
+        )
+        gate = job_block(text, "vocabulary_gate")
+        require(
+            "uses: ./.github/workflows/release-vocabulary-gate.yml" in gate,
+            f"{filename}: must call the shared exact-SHA gate",
+            failures,
+        )
+        require(
+            "actions: read" in gate and "contents: read" in gate,
+            f"{filename}: nested gate call needs Actions and contents read permissions",
+            failures,
+        )
+        require(
+            "needs.vocabulary_gate.outputs.source_sha" in text,
+            f"{filename}: release source must use the audited SHA",
+            failures,
+        )
+        if filename == "release-edge.yml":
+            require(
+                "git ls-remote origin refs/heads/main" in text,
+                "release-edge.yml: stale audits must not move the rolling edge tag",
+                failures,
+            )
+        elif filename == "release.yml":
+            require(
+                "name: release-${{ matrix.asset_name }}" in text
+                and "pattern: release-omnigraph-*" in text
+                and "Verify exact release artifact set" in text,
+                "release.yml: publication must select and verify only release artifacts",
+                failures,
+            )
+            require(
+                '"refs/tags/${RELEASE_TAG}" "refs/tags/${RELEASE_TAG}^{}"' in text,
+                "release.yml: tag must be revalidated before publication",
+                failures,
+            )
+        else:
+            require(
+                '"refs/tags/${RELEASE_TAG}" "refs/tags/${RELEASE_TAG}^{}"' in text,
+                f"{filename}: tag must be revalidated before publication",
+                failures,
+            )
+        for writer_job in writer_jobs:
+            block = job_block(text, writer_job)
+            require(
+                "vocabulary_gate" in block,
+                f"{filename}:{writer_job}: writer must need the vocabulary gate",
+                failures,
+            )
+
+    gate = (WORKFLOW_ROOT / "release-vocabulary-gate.yml").read_text()
+    require(
+        '.conclusion == "success"' in gate,
+        "release-vocabulary-gate.yml: only a successful audit may authorize release",
+        failures,
+    )
+    require(
+        '.event == "push" or .event == "workflow_dispatch"' in gate,
+        "release-vocabulary-gate.yml: pull-request checks must not authorize release",
+        failures,
+    )
+
+    if failures:
+        print("Release vocabulary gate violations:", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        return 1
+
+    print("Release vocabulary gates OK (4 automatic publishers, exact-SHA source).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- skip the full Azurite Azure integration and Graph Vocabulary Guard jobs on pull requests while preserving their required reporting contexts
- keep both full audits on main, tags, and manual dispatch
- make the exact successful non-PR vocabulary audit a prerequisite for edge, release, image, and crates publication
- resolve release sources once to an immutable audited SHA, revalidate mutable refs before publication, and isolate the release artifact set
- add a static policy check so future publisher changes cannot silently bypass the gate
- remove the now-unused Azure path classifier and document the policy and historical-tag boundary

The quick Azure contract and deployment checks remain unchanged. The long-running Azurite suite and public-Rust vocabulary audit no longer consume PR CI time, while public artifacts cannot publish ahead of the deferred audit.

GitHub loads tag-push workflow definitions from the tagged commit. Current automatic and manual publisher paths fail closed, but preventing a maintainer from creating a new `v*` tag against a pre-gate historical commit requires repository tag policy; checked-in workflow changes cannot retroactively alter those old definitions.

## Validation

- `actionlint .github/workflows/*.yml`
- `python3 scripts/check-release-vocabulary-gates.py`
- `python3 scripts/check-workflow-action-pins.py`
- `python3 scripts/check-container-binary-contract.py`
- `python3 scripts/check-azure-admission-boundary.py`
- `bash scripts/check-agents-md.sh`
- `python3 scripts/check-docs.py`
- `python3 -m json.tool .github/branch-protection.json`
- `git diff --check`


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves the expensive vocabulary and Azurite audits off pull requests while preserving their reporting contexts and post-merge coverage.
- Routes automatic edge, release, image, and crate publication through the successful vocabulary-audit job.
- Adds a reusable exact-SHA audit gate and immutable-source checks to publishing workflows.
- Removes the obsolete Azure path classifier and documents the revised CI policy.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the previously reported release-vocabulary bypass is closed and no blocking failure remains.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Skips the expensive audits on pull requests and places all automatic artifact publishers behind the successful vocabulary-audit job. |
| .github/workflows/release-vocabulary-gate.yml | Resolves an immutable release SHA and requires a successful non-PR Graph Vocabulary Guard for that exact commit. |
| .github/workflows/release.yml | Converts versioned releases to gated reusable/manual execution and verifies tag identity and the exact artifact set before publication. |
| .github/workflows/release-edge.yml | Gates edge publication on an audited immutable SHA and declines stale main revisions. |
| .github/workflows/publish-image.yml | Builds and publishes from the audited SHA after confirming that the requested release tag still selects it. |
| scripts/check-release-vocabulary-gates.py | Adds structural checks that preserve the audit dependency, immutable source propagation, and publisher gating. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  PR[Pull request] --> Skip[Graph Vocabulary Guard reports skipped]
  Main[Push to main] --> Audit[Full Graph Vocabulary Guard]
  Tag[Push v* tag] --> Audit
  Manual[Manual CI dispatch] --> Audit
  Audit -->|success and exact SHA| Gate[Reusable release vocabulary gate]
  Gate --> Edge[Edge release]
  Gate --> Release[Versioned release]
  Gate --> Image[Container publication]
  Gate --> Crates[Crate publication]
  Audit -->|failure| Stop[No automatic publication]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["ci: gate releases on vocabulary audit"](https://github.com/modernrelay/omnigraph/commit/853eb39b432a4ad48f3df8c9cfd23349ad646bb3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56804190)</sub>

<!-- /greptile_comment -->