### PR TITLE
fix(bench): accept retired fixture handoff and publish observed phases

### DIFF
--- a/crates/omnigraph-bench/src/branch_merge.rs
+++ b/crates/omnigraph-bench/src/branch_merge.rs
@@ -2523,6 +2523,11 @@ mod tests {
         use omnigraph::db::MergeOutcome;
         use omnigraph::instrumentation::{MergeWriteProbes, with_merge_write_probes};
 
+        use crate::runner::{
+            MergePhaseEvidenceForm, MergeRouteObservation, phase_observations,
+            validate_successful_merge_phase_topology,
+        };
+
         let mut plan = plan(16, 2, 6);
         plan.compaction_recency = CompactionRecency::NotOptimized;
         plan.requested_history_depth = 11;
@@ -2544,6 +2549,25 @@ mod tests {
         .unwrap();
         assert_eq!(outcome, MergeOutcome::Merged);
         assert_eq!(probes.table_walk_interval_count(), 2);
+        let route = MergeRouteObservation::from_probes(&probes);
+        assert!(route.stage_merge_insert_calls >= 2);
+        let phases = phase_observations(probes.merge_timing_snapshot());
+        validate_successful_merge_phase_topology(
+            &phases,
+            &route,
+            2,
+            MergePhaseEvidenceForm::RawSnapshot,
+        )
+        .unwrap();
+        assert_eq!(
+            phases
+                .iter()
+                .find(|phase| phase.phase == "PhysicalPublish")
+                .unwrap()
+                .interval_count,
+            1,
+            "one merge operation with two changed tables publishes physically once"
+        );
 
         let verified = verify_merged_graph(&db, &plan, &protected).await.unwrap();
         assert_eq!(verified.target.tables, 4);

--- a/crates/omnigraph-bench/src/record.rs
+++ b/crates/omnigraph-bench/src/record.rs
@@ -10,7 +10,6 @@
 //! Rejecting reordered, duplicate, unknown, or otherwise non-canonical input
 //! makes the SHA-256 content address unambiguous.
 
-use std::collections::BTreeSet;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 
@@ -26,9 +25,9 @@ use crate::counting::LogicalCallCounts;
 use crate::machine::MachineIdentityV1;
 use crate::model::typed_sha256;
 use crate::runner::{
-    ControlCallObservation, EffectiveEnvironmentValue, MergeRouteObservation,
-    PHYSICAL_TREE_DIGEST_ALGORITHM, PhaseObservation, RepObservation, RunExecution,
-    VerificationObservation,
+    ControlCallObservation, EffectiveEnvironmentValue, MergePhaseEvidenceForm,
+    MergeRouteObservation, PHYSICAL_TREE_DIGEST_ALGORITHM, PhaseObservation, RepObservation,
+    RunExecution, VerificationObservation, validate_successful_merge_phase_topology,
 };
 use crate::suite::MAX_REPETITIONS_PER_CASE;
 use crate::{CASE_FORMAT_VERSION, POINT_IDENTITY_VERSION, ResolvedRun, validate_case};
@@ -40,6 +39,10 @@ pub use crate::runner::{
 };
 
 /// Version of the durable run-record contract.
+///
+/// RFC 0039 permits semantic corrections in place before the first published
+/// citation. After that boundary, any validity-rule change requires a new
+/// record version.
 pub const RUN_RECORD_FORMAT_VERSION: u32 = 1;
 /// Rule-7 default: a claim must exceed two times its applicable floor.
 pub const DEFAULT_FLOOR_MULTIPLIER_MILLIS: u32 = 2_000;
@@ -1306,14 +1309,25 @@ fn validate_measurements(
             ));
         }
         validate_projected_call_totals(index, sample)?;
-        if sample.route.table_walk_intervals != expected_walks {
-            return Err(RecordError::new(
-                "route_evidence_mismatch",
-                format!("measurements.raw_samples[{index}].route.table_walk_intervals"),
-                format!("expected exactly {expected_walks} TableWalk intervals"),
-            ));
+        for (phase_index, phase) in sample.phases.iter().enumerate() {
+            validate_text(
+                &phase.phase,
+                &format!("measurements.raw_samples[{index}].phases[{phase_index}].phase"),
+            )?;
         }
-        validate_phases(index, &sample.phases, expected_walks)?;
+        validate_successful_merge_phase_topology(
+            &sample.phases,
+            &sample.route,
+            expected_walks,
+            MergePhaseEvidenceForm::StoredSample,
+        )
+        .map_err(|error| {
+            RecordError::new(
+                error.code(),
+                format!("measurements.raw_samples[{index}].phases"),
+                error.to_string(),
+            )
+        })?;
         let verification = &sample.verification;
         validate_text(
             &verification.branch,
@@ -1440,53 +1454,6 @@ fn checked_call_sum(
         })?;
     }
     Ok(total)
-}
-
-fn validate_phases(
-    index: usize,
-    phases: &[PhaseObservation],
-    expected_walks: u64,
-) -> RecordResult<()> {
-    if phases.is_empty() {
-        return Err(RecordError::new(
-            "missing_phase_evidence",
-            format!("measurements.raw_samples[{index}].phases"),
-            "per-phase attribution requires at least one observed phase",
-        ));
-    }
-    let mut names = BTreeSet::new();
-    let mut table_walk = None;
-    for (phase_index, phase) in phases.iter().enumerate() {
-        validate_text(
-            &phase.phase,
-            &format!("measurements.raw_samples[{index}].phases[{phase_index}].phase"),
-        )?;
-        if !names.insert(phase.phase.as_str()) {
-            return Err(RecordError::new(
-                "duplicate_phase",
-                format!("measurements.raw_samples[{index}].phases[{phase_index}].phase"),
-                format!("phase `{}` occurs more than once", phase.phase),
-            ));
-        }
-        if phase.interval_count == 0 || phase.max_us > phase.total_us {
-            return Err(RecordError::new(
-                "invalid_phase_measurement",
-                format!("measurements.raw_samples[{index}].phases[{phase_index}]"),
-                "phase intervals must be nonzero and max_us cannot exceed total_us",
-            ));
-        }
-        if phase.phase == "TableWalk" {
-            table_walk = Some(phase.interval_count);
-        }
-    }
-    if table_walk != Some(expected_walks) {
-        return Err(RecordError::new(
-            "table_walk_phase_mismatch",
-            format!("measurements.raw_samples[{index}].phases"),
-            format!("TableWalk must contain exactly {expected_walks} intervals"),
-        ));
-    }
-    Ok(())
 }
 
 fn summarize_wall_clock(samples: &[RawSampleV1]) -> RecordResult<WallClockSummaryV1> {
@@ -1726,6 +1693,7 @@ pub(crate) mod tests {
     use crate::machine::MACHINE_IDENTITY_FORMAT_VERSION;
     use crate::runner::{
         BuildEvidence, FixtureObservation, LogicalStoreCallObservation, WallClockSummary,
+        test_general_merge_route, test_general_merge_stored_phases,
     };
     use crate::{RUNNER_OUTPUT_VERSION, parse_case};
 
@@ -1766,22 +1734,8 @@ protocol: { deadline_seconds: 60, attribution: per-phase, schedule: manual, rese
             elapsed_us,
             peak_rss_bytes: Some(32 * 1024 * 1024),
             outcome: "merged".to_string(),
-            phases: vec![PhaseObservation {
-                phase: "TableWalk".to_string(),
-                total_us: 8,
-                max_us: 3,
-                interval_count: 4,
-            }],
-            route: MergeRouteObservation {
-                table_walk_intervals: 4,
-                stage_merge_insert_calls: 1,
-                stage_merge_insert_rows: 10,
-                stage_known_present_update_calls: 1,
-                stage_known_present_update_rows: 10,
-                stage_fenced_insert_calls: 1,
-                stage_fenced_insert_rows: 10,
-                strict_insert_preflight_calls: 1,
-            },
+            phases: test_general_merge_stored_phases(4, 4),
+            route: test_general_merge_route(4, 4),
             logical_store_calls: LogicalStoreCallObservation {
                 manifest: LogicalCallCounts {
                     get: 2,
@@ -2033,6 +1987,37 @@ protocol: { deadline_seconds: 60, attribution: per-phase, schedule: manual, rese
             record.measurements.raw_samples[1].input_physical_digest_sha256
         );
         validate_run_record(&record).unwrap();
+    }
+
+    #[test]
+    fn durable_records_reject_empty_missing_publish_and_bad_enclosure_phase_evidence() {
+        let mut empty = valid_record();
+        empty.measurements.raw_samples[0].phases.clear();
+        assert_eq!(
+            validate_run_record(&empty).unwrap_err().code,
+            "missing_phase_evidence"
+        );
+
+        let mut missing_publish = valid_record();
+        missing_publish.measurements.raw_samples[0]
+            .phases
+            .retain(|phase| phase.phase != "PhysicalPublish");
+        assert_eq!(
+            validate_run_record(&missing_publish).unwrap_err().code,
+            "missing_phase_evidence"
+        );
+
+        let mut bad_enclosure = valid_record();
+        let physical_publish = bad_enclosure.measurements.raw_samples[0]
+            .phases
+            .iter_mut()
+            .find(|phase| phase.phase == "PhysicalPublish")
+            .unwrap();
+        physical_publish.total_us = 20;
+        physical_publish.max_us = 20;
+        let error = validate_run_record(&bad_enclosure).unwrap_err();
+        assert_eq!(error.code, "phase_topology_mismatch");
+        assert!(error.message.contains("does not enclose"));
     }
 
     #[test]

--- a/crates/omnigraph-bench/src/reset.rs
+++ b/crates/omnigraph-bench/src/reset.rs
@@ -1581,6 +1581,26 @@ mod tests {
         assert!(error.to_string().contains("special files"));
     }
 
+    #[test]
+    fn retired_source_containment_accepts_a_sibling_but_refuses_the_source_path() {
+        let workspace = tempfile::tempdir().unwrap();
+        let active = workspace.path().join("active");
+        let template = workspace.path().join("template");
+        fs::create_dir(&template).unwrap();
+        assert!(!active.exists());
+
+        refuse_destination_below_retired_source(&active, &template).unwrap();
+
+        let error = refuse_destination_below_retired_source(&active, &active).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+        assert!(
+            error
+                .to_string()
+                .contains("must not equal or lie below the fixture root"),
+            "{error}"
+        );
+    }
+
     #[cfg(target_os = "macos")]
     #[test]
     fn clonefile_template_restores_exact_active_path_with_cow_isolation() {

--- a/crates/omnigraph-bench/src/reset.rs
+++ b/crates/omnigraph-bench/src/reset.rs
@@ -219,7 +219,7 @@ pub(crate) fn accept_clonefile_template_handoff(
     require_clonefile_platform()?;
     let active_root = stable_absolute_path("active fixture root", active_root)?;
     let template_root = stable_absolute_path("clonefile template root", template_root)?;
-    refuse_destination_below_source(&active_root, &template_root)?;
+    refuse_destination_below_retired_source(&active_root, &template_root)?;
     match fs::symlink_metadata(&active_root) {
         Ok(_) => {
             return Err(invalid_data(format!(
@@ -1149,6 +1149,43 @@ fn refuse_destination_below_source(source: &Path, destination: &Path) -> io::Res
             format!("canonicalizing fixture root {}", source.display()),
         )
     })?;
+    refuse_resolved_destination_below(&canonical_source, destination)
+}
+
+/// Containment for the contained-fixture handoff, where the worker has
+/// already retired the active path: resolve the absent fixture root through
+/// its canonical parent, then refuse a template that equals or lies below it.
+fn refuse_destination_below_retired_source(source: &Path, destination: &Path) -> io::Result<()> {
+    let parent = source
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .ok_or_else(|| {
+            invalid_input(format!(
+                "fixture root has no parent directory: {}",
+                source.display()
+            ))
+        })?;
+    let name = source.file_name().ok_or_else(|| {
+        invalid_input(format!(
+            "fixture root has no final component: {}",
+            source.display()
+        ))
+    })?;
+    let canonical_source = fs::canonicalize(parent)
+        .map_err(|error| {
+            contextual(
+                error,
+                format!("canonicalizing fixture-root parent {}", parent.display()),
+            )
+        })?
+        .join(name);
+    refuse_resolved_destination_below(&canonical_source, destination)
+}
+
+fn refuse_resolved_destination_below(
+    canonical_source: &Path,
+    destination: &Path,
+) -> io::Result<()> {
     let canonical_destination = match fs::symlink_metadata(destination) {
         Ok(metadata) => {
             if metadata.file_type().is_symlink() {
@@ -1192,7 +1229,7 @@ fn refuse_destination_below_source(source: &Path, destination: &Path) -> io::Res
         }
     };
 
-    if canonical_destination.starts_with(&canonical_source) {
+    if canonical_destination.starts_with(canonical_source) {
         return Err(invalid_input(format!(
             "fixture-copy destination must not equal or lie below the fixture root: {}",
             destination.display()
@@ -1606,6 +1643,52 @@ mod tests {
         let error = frozen.restore_active().unwrap_err();
         assert_eq!(error.kind(), io::ErrorKind::InvalidData);
         assert!(!active.exists());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn contained_handoff_accepts_only_a_retired_active_path() {
+        let Some(workspace) = apfs_tempdir() else {
+            return;
+        };
+        let active = workspace.path().join("active");
+        let template = workspace.path().join("template");
+        fs::create_dir(&active).unwrap();
+        fixture_tree(&active);
+        let limits = TraversalLimits::default();
+        let frozen = freeze_clonefile_template(&active, &template, limits).unwrap();
+        let physical = frozen.physical_digest().clone();
+        let metadata = digest_metadata_tree(&template, limits).unwrap();
+
+        let left_behind = accept_clonefile_template_handoff(
+            &active,
+            &template,
+            physical.clone(),
+            metadata.clone(),
+            limits,
+        )
+        .unwrap_err();
+        assert!(
+            left_behind
+                .to_string()
+                .contains("left the active path behind"),
+            "{left_behind}"
+        );
+
+        // The contained worker retires the active tree before handing off;
+        // the parent must accept exactly that state.
+        fs::remove_dir_all(&active).unwrap();
+        let accepted =
+            accept_clonefile_template_handoff(&active, &template, physical, metadata, limits)
+                .unwrap();
+        assert_eq!(accepted.active_root(), active);
+        assert_eq!(accepted.template_root(), template);
+        let prepared = accepted.restore_active().unwrap();
+        assert_eq!(
+            digest_physical_tree(&active, limits).unwrap(),
+            *accepted.physical_digest()
+        );
+        prepared.verify_unchanged().unwrap();
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/omnigraph-bench/src/runner.rs
+++ b/crates/omnigraph-bench/src/runner.rs
@@ -24,7 +24,7 @@ use futures::FutureExt;
 use lance::io::WrappingObjectStore;
 use omnigraph::db::{MergeOutcome, Omnigraph};
 use omnigraph::instrumentation::{
-    CountingStorageAdapter, MergeWriteProbes, QueryIoProbes, StorageReadCounts,
+    CountingStorageAdapter, MergeTimingReading, MergeWriteProbes, QueryIoProbes, StorageReadCounts,
     with_merge_write_probes, with_query_io_probes,
 };
 use serde::{Deserialize, Serialize};
@@ -2138,6 +2138,22 @@ fn local_environment(
         .map_err(|message| RunnerError::new("environment_mismatch", message))
 }
 
+/// The engine timing snapshot enumerates every stable phase, including phases
+/// the measured route never entered. A sample carries measurements, not the
+/// enumeration: keep only phases with at least one completed interval.
+fn observed_phase_evidence(readings: Vec<MergeTimingReading>) -> Vec<PhaseObservation> {
+    readings
+        .into_iter()
+        .filter(|reading| reading.interval_count > 0)
+        .map(|reading| PhaseObservation {
+            phase: reading.phase.to_string(),
+            total_us: reading.total_us,
+            max_us: reading.max_us,
+            interval_count: reading.interval_count,
+        })
+        .collect()
+}
+
 async fn execute_rep(
     repetition: u32,
     root: &Path,
@@ -2402,15 +2418,7 @@ async fn execute_rep_body<S: MeasurementSignals>(
         elapsed_us,
         peak_rss_bytes: None,
         outcome: "merged".to_string(),
-        phases: phase_readings
-            .into_iter()
-            .map(|reading| PhaseObservation {
-                phase: reading.phase.to_string(),
-                total_us: reading.total_us,
-                max_us: reading.max_us,
-                interval_count: reading.interval_count,
-            })
-            .collect(),
+        phases: observed_phase_evidence(phase_readings),
         route: MergeRouteObservation {
             table_walk_intervals: merge_probes.table_walk_interval_count(),
             stage_merge_insert_calls: merge_probes.stage_merge_insert_calls(),
@@ -2583,6 +2591,16 @@ mod tests {
 
     use super::*;
     use crate::parse_case;
+
+    #[test]
+    fn phase_evidence_excludes_unobserved_phases() {
+        // A fresh probe snapshot is the engine's complete stable-phase
+        // enumeration with no completed intervals; none of it is evidence.
+        let snapshot = MergeWriteProbes::default().merge_timing_snapshot();
+        assert!(snapshot.len() > 1);
+        assert!(snapshot.iter().all(|reading| reading.interval_count == 0));
+        assert!(observed_phase_evidence(snapshot).is_empty());
+    }
 
     fn assert_json_object_keys(value: &serde_json::Value, expected: &[&str]) {
         let actual = value

--- a/crates/omnigraph-bench/src/runner.rs
+++ b/crates/omnigraph-bench/src/runner.rs
@@ -10,6 +10,7 @@
 //! layer; fixture caching, cold page-cache control, S3 reset, and AWS
 //! orchestration remain separate slices.
 
+use std::collections::BTreeMap;
 use std::error::Error;
 use std::ffi::{OsStr, OsString};
 use std::fmt::{Display, Formatter};
@@ -410,6 +411,388 @@ pub struct MergeRouteObservation {
     pub stage_fenced_insert_calls: u64,
     pub stage_fenced_insert_rows: u64,
     pub strict_insert_preflight_calls: u64,
+}
+
+impl MergeRouteObservation {
+    pub(crate) fn from_probes(probes: &MergeWriteProbes) -> Self {
+        Self {
+            table_walk_intervals: probes.table_walk_interval_count(),
+            stage_merge_insert_calls: probes.stage_merge_insert_calls(),
+            stage_merge_insert_rows: probes.stage_merge_insert_rows(),
+            stage_known_present_update_calls: probes.stage_known_present_update_calls(),
+            stage_known_present_update_rows: probes.stage_known_present_update_rows(),
+            stage_fenced_insert_calls: probes.stage_fenced_insert_calls(),
+            stage_fenced_insert_rows: probes.stage_fenced_insert_rows(),
+            strict_insert_preflight_calls: probes.strict_insert_preflight_calls(),
+        }
+    }
+}
+
+const CURRENT_STABLE_MERGE_PHASES: [&str; 14] = [
+    "OuterPrepare",
+    "ProvenInsertHistory",
+    "ProvenInsertPlanScan",
+    "TableWalk",
+    "CandidateValidation",
+    "FinalRevalidation",
+    "RecoveryArm",
+    "PhysicalPublish",
+    "KeyedStage",
+    "KeyedCommit",
+    "RecoveryConfirm",
+    "ManifestPublish",
+    "RecoveryCleanup",
+    "OuterRestoreRefresh",
+];
+const REQUIRED_GENERAL_TOP_LEVEL_PHASES: [&str; 9] = [
+    "OuterPrepare",
+    "CandidateValidation",
+    "FinalRevalidation",
+    "RecoveryArm",
+    "PhysicalPublish",
+    "RecoveryConfirm",
+    "ManifestPublish",
+    "RecoveryCleanup",
+    "OuterRestoreRefresh",
+];
+const GENERAL_ROUTE_UNENTERED_PHASES: [&str; 2] = ["ProvenInsertHistory", "ProvenInsertPlanScan"];
+
+#[cfg(test)]
+pub(crate) fn test_general_merge_route(
+    table_walk_intervals: u64,
+    merge_insert_calls: u64,
+) -> MergeRouteObservation {
+    MergeRouteObservation {
+        table_walk_intervals,
+        stage_merge_insert_calls: merge_insert_calls,
+        stage_merge_insert_rows: merge_insert_calls,
+        stage_known_present_update_calls: 0,
+        stage_known_present_update_rows: 0,
+        stage_fenced_insert_calls: 0,
+        stage_fenced_insert_rows: 0,
+        strict_insert_preflight_calls: 0,
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn test_general_merge_stored_phases(
+    table_walk_intervals: u64,
+    merge_insert_calls: u64,
+) -> Vec<PhaseObservation> {
+    let phase = |name: &str, total_us, max_us, interval_count| PhaseObservation {
+        phase: name.to_string(),
+        total_us,
+        max_us,
+        interval_count,
+    };
+    vec![
+        phase("OuterPrepare", 5, 5, 1),
+        phase("TableWalk", 20, 10, table_walk_intervals),
+        phase("CandidateValidation", 4, 4, 1),
+        phase("FinalRevalidation", 5, 5, 1),
+        phase("RecoveryArm", 2, 2, 1),
+        phase("PhysicalPublish", 100, 100, 1),
+        phase("KeyedStage", 20, 10, merge_insert_calls),
+        phase("KeyedCommit", 30, 15, merge_insert_calls),
+        phase("RecoveryConfirm", 2, 2, 1),
+        phase("ManifestPublish", 6, 6, 1),
+        phase("RecoveryCleanup", 1, 1, 1),
+        phase("OuterRestoreRefresh", 2, 2, 1),
+    ]
+}
+
+/// Whether phase evidence is the engine's complete raw snapshot or the
+/// compact, durable evidence stored on an admitted sample.
+///
+/// The raw snapshot enumerates stable optional phases that were not entered as
+/// zero-count readings. Those entries are deliberately removed only after the
+/// required successful-merge topology has been checked. Durable evidence, by
+/// contrast, may contain only phases that were actually observed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MergePhaseEvidenceForm {
+    RawSnapshot,
+    StoredSample,
+}
+
+/// A fail-closed violation of the successful branch-merge phase topology.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MergePhaseTopologyError {
+    code: &'static str,
+    message: String,
+}
+
+impl MergePhaseTopologyError {
+    fn new(code: &'static str, message: String) -> Self {
+        Self { code, message }
+    }
+
+    pub(crate) const fn code(&self) -> &'static str {
+        self.code
+    }
+}
+
+impl Display for MergePhaseTopologyError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+/// Validate the one successful-merge phase contract used by worker execution,
+/// parent admission, and durable-record loading.
+///
+/// Runner-v1 admits only its declared non-fast-forward general three-way
+/// route. `KeyedStage` and `KeyedCommit` are sub-buckets of
+/// `PhysicalPublish`; their expected interval count is the route's admitted
+/// merge-insert call count. Additive unknown phases remain valid only when
+/// observed; a new zero-count phase must be classified here before the compact
+/// stored representation may omit it.
+pub(crate) fn validate_successful_merge_phase_topology(
+    phases: &[PhaseObservation],
+    route: &MergeRouteObservation,
+    expected_table_walks: u64,
+    form: MergePhaseEvidenceForm,
+) -> Result<(), MergePhaseTopologyError> {
+    if route.table_walk_intervals != expected_table_walks {
+        return Err(MergePhaseTopologyError::new(
+            "phase_topology_mismatch",
+            format!(
+                "route.table_walk_intervals mismatch: expected={expected_table_walks}, observed={}",
+                route.table_walk_intervals
+            ),
+        ));
+    }
+    if route.stage_merge_insert_calls < expected_table_walks {
+        return Err(MergePhaseTopologyError::new(
+            "phase_topology_mismatch",
+            format!(
+                "route.stage_merge_insert_calls must be at least the diverged-table count: minimum={expected_table_walks}, observed={}",
+                route.stage_merge_insert_calls
+            ),
+        ));
+    }
+    if route.stage_merge_insert_rows < route.stage_merge_insert_calls {
+        return Err(MergePhaseTopologyError::new(
+            "phase_topology_mismatch",
+            format!(
+                "route.stage_merge_insert_rows must be at least the merge-insert call count: minimum={}, observed={}",
+                route.stage_merge_insert_calls, route.stage_merge_insert_rows
+            ),
+        ));
+    }
+    for (field, observed) in [
+        (
+            "route.stage_known_present_update_calls",
+            route.stage_known_present_update_calls,
+        ),
+        (
+            "route.stage_known_present_update_rows",
+            route.stage_known_present_update_rows,
+        ),
+        (
+            "route.stage_fenced_insert_calls",
+            route.stage_fenced_insert_calls,
+        ),
+        (
+            "route.stage_fenced_insert_rows",
+            route.stage_fenced_insert_rows,
+        ),
+        (
+            "route.strict_insert_preflight_calls",
+            route.strict_insert_preflight_calls,
+        ),
+    ] {
+        if observed != 0 {
+            return Err(MergePhaseTopologyError::new(
+                "phase_topology_mismatch",
+                format!(
+                    "{field} is not part of the general three-way route: expected=0, observed={observed}"
+                ),
+            ));
+        }
+    }
+
+    let mut by_name = BTreeMap::new();
+    for phase in phases {
+        if phase.phase.is_empty() {
+            return Err(MergePhaseTopologyError::new(
+                "invalid_phase_measurement",
+                "phase names must not be empty".to_string(),
+            ));
+        }
+        if by_name.insert(phase.phase.as_str(), phase).is_some() {
+            return Err(MergePhaseTopologyError::new(
+                "duplicate_phase",
+                format!("phase `{}` occurs more than once", phase.phase),
+            ));
+        }
+        if phase.max_us > phase.total_us {
+            return Err(MergePhaseTopologyError::new(
+                "invalid_phase_measurement",
+                format!(
+                    "phase `{}` has max_us={} greater than total_us={}",
+                    phase.phase, phase.max_us, phase.total_us
+                ),
+            ));
+        }
+        match (form, phase.interval_count) {
+            (MergePhaseEvidenceForm::RawSnapshot, 0) => {
+                if !GENERAL_ROUTE_UNENTERED_PHASES.contains(&phase.phase.as_str()) {
+                    return Err(MergePhaseTopologyError::new(
+                        "phase_topology_mismatch",
+                        format!(
+                            "raw phase `{}` has zero intervals but is not a declared unentered phase of the general three-way route",
+                            phase.phase
+                        ),
+                    ));
+                }
+                if phase.total_us != 0 || phase.max_us != 0 {
+                    return Err(MergePhaseTopologyError::new(
+                        "invalid_phase_measurement",
+                        format!(
+                            "unentered raw phase `{}` must have zero total_us and max_us",
+                            phase.phase
+                        ),
+                    ));
+                }
+            }
+            (MergePhaseEvidenceForm::StoredSample, 0) => {
+                return Err(MergePhaseTopologyError::new(
+                    "invalid_phase_measurement",
+                    format!(
+                        "stored phase `{}` must contain at least one completed interval",
+                        phase.phase
+                    ),
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    if form == MergePhaseEvidenceForm::RawSnapshot {
+        for name in CURRENT_STABLE_MERGE_PHASES {
+            if !by_name.contains_key(name) {
+                return Err(MergePhaseTopologyError::new(
+                    "missing_phase_evidence",
+                    format!("raw merge timing snapshot is missing stable phase `{name}`"),
+                ));
+            }
+        }
+    }
+
+    for name in REQUIRED_GENERAL_TOP_LEVEL_PHASES {
+        let phase = by_name.get(name).ok_or_else(|| {
+            MergePhaseTopologyError::new(
+                "missing_phase_evidence",
+                format!("successful general merge is missing mandatory phase `{name}`"),
+            )
+        })?;
+        if phase.interval_count != 1 {
+            return Err(MergePhaseTopologyError::new(
+                "phase_topology_mismatch",
+                format!(
+                    "{name} interval_count mismatch: expected=1, observed={}",
+                    phase.interval_count
+                ),
+            ));
+        }
+    }
+
+    let table_walk = by_name.get("TableWalk").ok_or_else(|| {
+        MergePhaseTopologyError::new(
+            "missing_phase_evidence",
+            "successful general merge is missing required phase `TableWalk`".to_string(),
+        )
+    })?;
+    if table_walk.interval_count != expected_table_walks {
+        return Err(MergePhaseTopologyError::new(
+            "phase_topology_mismatch",
+            format!(
+                "TableWalk interval_count mismatch: expected={expected_table_walks}, observed={}",
+                table_walk.interval_count
+            ),
+        ));
+    }
+
+    for name in GENERAL_ROUTE_UNENTERED_PHASES {
+        match (form, by_name.get(name)) {
+            (MergePhaseEvidenceForm::RawSnapshot, Some(phase)) if phase.interval_count == 0 => {}
+            (MergePhaseEvidenceForm::RawSnapshot, Some(phase)) => {
+                return Err(MergePhaseTopologyError::new(
+                    "phase_topology_mismatch",
+                    format!(
+                        "general three-way route must not enter {name}: expected=0, observed={}",
+                        phase.interval_count
+                    ),
+                ));
+            }
+            (MergePhaseEvidenceForm::StoredSample, None) => {}
+            (MergePhaseEvidenceForm::StoredSample, Some(_)) => {
+                return Err(MergePhaseTopologyError::new(
+                    "phase_topology_mismatch",
+                    format!("stored general-route evidence must omit unentered phase `{name}`"),
+                ));
+            }
+            // Raw stable-name validation above owns this refusal, but retain a
+            // total match so this route rule stays independently fail closed.
+            (MergePhaseEvidenceForm::RawSnapshot, None) => {
+                return Err(MergePhaseTopologyError::new(
+                    "missing_phase_evidence",
+                    format!("raw merge timing snapshot is missing stable phase `{name}`"),
+                ));
+            }
+        }
+    }
+
+    let keyed_stage = by_name.get("KeyedStage").copied();
+    let keyed_commit = by_name.get("KeyedCommit").copied();
+    for (name, phase) in [("KeyedStage", keyed_stage), ("KeyedCommit", keyed_commit)] {
+        match phase {
+            Some(phase) if phase.interval_count != route.stage_merge_insert_calls => {
+                return Err(MergePhaseTopologyError::new(
+                    "phase_topology_mismatch",
+                    format!(
+                        "{name} interval_count mismatch: expected={}, observed={}",
+                        route.stage_merge_insert_calls, phase.interval_count
+                    ),
+                ));
+            }
+            None => {
+                return Err(MergePhaseTopologyError::new(
+                    "missing_phase_evidence",
+                    format!(
+                        "successful general merge has {} merge-insert calls but is missing required phase `{name}`",
+                        route.stage_merge_insert_calls
+                    ),
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    let physical_publish = by_name
+        .get("PhysicalPublish")
+        .expect("mandatory phase was checked above");
+    let keyed_stage_total = keyed_stage.map_or(0, |phase| phase.total_us);
+    let keyed_commit_total = keyed_commit.map_or(0, |phase| phase.total_us);
+    let keyed_total = keyed_stage_total
+        .checked_add(keyed_commit_total)
+        .ok_or_else(|| {
+            MergePhaseTopologyError::new(
+                "phase_topology_overflow",
+                "KeyedStage plus KeyedCommit total_us does not fit u64".to_string(),
+            )
+        })?;
+    if physical_publish.total_us < keyed_total {
+        return Err(MergePhaseTopologyError::new(
+            "phase_topology_mismatch",
+            format!(
+                "PhysicalPublish total_us={} does not enclose KeyedStage + KeyedCommit total_us={keyed_total}",
+                physical_publish.total_us
+            ),
+        ));
+    }
+
+    Ok(())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -2138,19 +2521,25 @@ fn local_environment(
         .map_err(|message| RunnerError::new("environment_mismatch", message))
 }
 
-/// The engine timing snapshot enumerates every stable phase, including phases
-/// the measured route never entered. A sample carries measurements, not the
-/// enumeration: keep only phases with at least one completed interval.
-fn observed_phase_evidence(readings: Vec<MergeTimingReading>) -> Vec<PhaseObservation> {
+pub(crate) fn phase_observations(readings: Vec<MergeTimingReading>) -> Vec<PhaseObservation> {
     readings
         .into_iter()
-        .filter(|reading| reading.interval_count > 0)
         .map(|reading| PhaseObservation {
             phase: reading.phase.to_string(),
             total_us: reading.total_us,
             max_us: reading.max_us,
             interval_count: reading.interval_count,
         })
+        .collect()
+}
+
+/// A sample carries measurements, not the engine's complete stable-phase
+/// enumeration. This filter is valid only after the raw snapshot passes
+/// [`validate_successful_merge_phase_topology`].
+fn observed_phase_evidence(phases: Vec<PhaseObservation>) -> Vec<PhaseObservation> {
+    phases
+        .into_iter()
+        .filter(|phase| phase.interval_count > 0)
         .collect()
 }
 
@@ -2383,28 +2772,36 @@ async fn execute_rep_body<S: MeasurementSignals>(
         ));
     }
 
-    let phase_readings = merge_probes.merge_timing_snapshot();
-    let table_walk = phase_readings
-        .iter()
-        .find(|reading| reading.phase == "TableWalk")
-        .ok_or_else(|| {
-            RunnerError::new(
-                "missing_table_walk_phase",
-                "merge timing snapshot did not contain the stable TableWalk phase",
-            )
-        })?;
     let expected_intervals = u64::try_from(plan.diverged_tables).map_err(|_| {
         RunnerError::new("interval_overflow", "diverged table count does not fit u64")
     })?;
-    if table_walk.interval_count != expected_intervals {
-        return Err(RunnerError::new(
-            "vacuous_merge",
-            format!(
-                "repetition {repetition} completed {} TableWalk intervals; expected exactly {expected_intervals}",
-                table_walk.interval_count
-            ),
-        ));
-    }
+    let route = MergeRouteObservation::from_probes(&merge_probes);
+    let raw_phases = phase_observations(merge_probes.merge_timing_snapshot());
+    validate_successful_merge_phase_topology(
+        &raw_phases,
+        &route,
+        expected_intervals,
+        MergePhaseEvidenceForm::RawSnapshot,
+    )
+    .map_err(|error| {
+        RunnerError::new(
+            error.code(),
+            format!("repetition {repetition} phase evidence is invalid: {error}"),
+        )
+    })?;
+    let phases = observed_phase_evidence(raw_phases);
+    validate_successful_merge_phase_topology(
+        &phases,
+        &route,
+        expected_intervals,
+        MergePhaseEvidenceForm::StoredSample,
+    )
+    .map_err(|error| {
+        RunnerError::new(
+            error.code(),
+            format!("repetition {repetition} stored phase evidence is invalid: {error}"),
+        )
+    })?;
 
     // Verification runs only after all measured clocks and counters are read.
     let verification = verify_merged_graph(&db, plan, &protected_heads)
@@ -2418,17 +2815,8 @@ async fn execute_rep_body<S: MeasurementSignals>(
         elapsed_us,
         peak_rss_bytes: None,
         outcome: "merged".to_string(),
-        phases: observed_phase_evidence(phase_readings),
-        route: MergeRouteObservation {
-            table_walk_intervals: merge_probes.table_walk_interval_count(),
-            stage_merge_insert_calls: merge_probes.stage_merge_insert_calls(),
-            stage_merge_insert_rows: merge_probes.stage_merge_insert_rows(),
-            stage_known_present_update_calls: merge_probes.stage_known_present_update_calls(),
-            stage_known_present_update_rows: merge_probes.stage_known_present_update_rows(),
-            stage_fenced_insert_calls: merge_probes.stage_fenced_insert_calls(),
-            stage_fenced_insert_rows: merge_probes.stage_fenced_insert_rows(),
-            strict_insert_preflight_calls: merge_probes.strict_insert_preflight_calls(),
-        },
+        phases,
+        route,
         logical_store_calls: LogicalStoreCallObservation {
             manifest: manifest_calls,
             table: table_calls,
@@ -2592,14 +2980,255 @@ mod tests {
     use super::*;
     use crate::parse_case;
 
+    fn general_route(merge_insert_calls: u64) -> MergeRouteObservation {
+        test_general_merge_route(2, merge_insert_calls)
+    }
+
+    fn phase(name: &str, total_us: u64, max_us: u64, interval_count: u64) -> PhaseObservation {
+        PhaseObservation {
+            phase: name.to_string(),
+            total_us,
+            max_us,
+            interval_count,
+        }
+    }
+
+    fn valid_stored_phases() -> Vec<PhaseObservation> {
+        test_general_merge_stored_phases(2, 2)
+    }
+
+    fn valid_raw_phases() -> Vec<PhaseObservation> {
+        let mut phases = valid_stored_phases();
+        phases.push(phase("ProvenInsertHistory", 0, 0, 0));
+        phases.push(phase("ProvenInsertPlanScan", 0, 0, 0));
+        phases
+    }
+
     #[test]
-    fn phase_evidence_excludes_unobserved_phases() {
+    fn raw_phase_topology_is_validated_before_unobserved_phases_are_filtered() {
         // A fresh probe snapshot is the engine's complete stable-phase
-        // enumeration with no completed intervals; none of it is evidence.
-        let snapshot = MergeWriteProbes::default().merge_timing_snapshot();
-        assert!(snapshot.len() > 1);
-        assert!(snapshot.iter().all(|reading| reading.interval_count == 0));
-        assert!(observed_phase_evidence(snapshot).is_empty());
+        // enumeration with no completed intervals. It must not turn into an
+        // apparently valid empty sample merely because zero-count phases are
+        // omitted from durable evidence.
+        let raw = phase_observations(MergeWriteProbes::default().merge_timing_snapshot());
+        assert!(raw.len() > 1);
+        assert!(raw.iter().all(|reading| reading.interval_count == 0));
+        let error = validate_successful_merge_phase_topology(
+            &raw,
+            &general_route(2),
+            2,
+            MergePhaseEvidenceForm::RawSnapshot,
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "phase_topology_mismatch");
+        assert!(observed_phase_evidence(raw).is_empty());
+    }
+
+    #[test]
+    fn successful_merge_phase_topology_requires_publish_and_enclosure() {
+        let route = general_route(2);
+        let phases = valid_stored_phases();
+        validate_successful_merge_phase_topology(
+            &phases,
+            &route,
+            2,
+            MergePhaseEvidenceForm::StoredSample,
+        )
+        .unwrap();
+
+        let mut missing_publish = phases.clone();
+        missing_publish.retain(|phase| phase.phase != "PhysicalPublish");
+        let error = validate_successful_merge_phase_topology(
+            &missing_publish,
+            &route,
+            2,
+            MergePhaseEvidenceForm::StoredSample,
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "missing_phase_evidence");
+
+        let mut missing_mandatory = phases.clone();
+        missing_mandatory.retain(|phase| phase.phase != "CandidateValidation");
+        let error = validate_successful_merge_phase_topology(
+            &missing_mandatory,
+            &route,
+            2,
+            MergePhaseEvidenceForm::StoredSample,
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "missing_phase_evidence");
+        assert!(error.to_string().contains("CandidateValidation"));
+
+        let mut bad_enclosure = phases;
+        let physical_publish = bad_enclosure
+            .iter_mut()
+            .find(|phase| phase.phase == "PhysicalPublish")
+            .unwrap();
+        physical_publish.total_us = 24;
+        physical_publish.max_us = 24;
+        let error = validate_successful_merge_phase_topology(
+            &bad_enclosure,
+            &route,
+            2,
+            MergePhaseEvidenceForm::StoredSample,
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "phase_topology_mismatch");
+        assert!(error.to_string().contains("does not enclose"));
+
+        let mut wrong_publish_count = valid_stored_phases();
+        wrong_publish_count
+            .iter_mut()
+            .find(|phase| phase.phase == "PhysicalPublish")
+            .unwrap()
+            .interval_count = 2;
+        assert_eq!(
+            validate_successful_merge_phase_topology(
+                &wrong_publish_count,
+                &route,
+                2,
+                MergePhaseEvidenceForm::StoredSample,
+            )
+            .unwrap_err()
+            .code(),
+            "phase_topology_mismatch"
+        );
+
+        let mut wrong_keyed_count = valid_stored_phases();
+        wrong_keyed_count
+            .iter_mut()
+            .find(|phase| phase.phase == "KeyedStage")
+            .unwrap()
+            .interval_count = 3;
+        assert_eq!(
+            validate_successful_merge_phase_topology(
+                &wrong_keyed_count,
+                &route,
+                2,
+                MergePhaseEvidenceForm::StoredSample,
+            )
+            .unwrap_err()
+            .code(),
+            "phase_topology_mismatch"
+        );
+
+        let mut duplicate = valid_stored_phases();
+        let duplicate_phase = duplicate[0].clone();
+        duplicate.push(duplicate_phase);
+        assert_eq!(
+            validate_successful_merge_phase_topology(
+                &duplicate,
+                &route,
+                2,
+                MergePhaseEvidenceForm::StoredSample,
+            )
+            .unwrap_err()
+            .code(),
+            "duplicate_phase"
+        );
+
+        let mut zero_count = valid_stored_phases();
+        zero_count.push(PhaseObservation {
+            phase: "OptionalFuturePhase".to_string(),
+            total_us: 0,
+            max_us: 0,
+            interval_count: 0,
+        });
+        assert_eq!(
+            validate_successful_merge_phase_topology(
+                &zero_count,
+                &route,
+                2,
+                MergePhaseEvidenceForm::StoredSample,
+            )
+            .unwrap_err()
+            .code(),
+            "invalid_phase_measurement"
+        );
+    }
+
+    #[test]
+    fn general_route_rejects_false_zero_wrong_route_and_incomplete_raw_evidence() {
+        let phases = valid_stored_phases();
+        validate_successful_merge_phase_topology(
+            &valid_raw_phases(),
+            &general_route(2),
+            2,
+            MergePhaseEvidenceForm::RawSnapshot,
+        )
+        .unwrap();
+
+        let mut false_zero = general_route(2);
+        false_zero.stage_merge_insert_calls = 0;
+        false_zero.stage_merge_insert_rows = 0;
+        let error = validate_successful_merge_phase_topology(
+            &phases,
+            &false_zero,
+            2,
+            MergePhaseEvidenceForm::StoredSample,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("stage_merge_insert_calls"));
+
+        let mut wrong_route = general_route(2);
+        wrong_route.stage_known_present_update_calls = 1;
+        wrong_route.stage_known_present_update_rows = 1;
+        let error = validate_successful_merge_phase_topology(
+            &phases,
+            &wrong_route,
+            2,
+            MergePhaseEvidenceForm::StoredSample,
+        )
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("stage_known_present_update_calls")
+        );
+
+        let mut zero_rows = general_route(2);
+        zero_rows.stage_merge_insert_rows = 0;
+        let error = validate_successful_merge_phase_topology(
+            &phases,
+            &zero_rows,
+            2,
+            MergePhaseEvidenceForm::StoredSample,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("stage_merge_insert_rows"));
+
+        let mut incomplete_raw = valid_raw_phases();
+        incomplete_raw.retain(|phase| phase.phase != "ProvenInsertHistory");
+        let error = validate_successful_merge_phase_topology(
+            &incomplete_raw,
+            &general_route(2),
+            2,
+            MergePhaseEvidenceForm::RawSnapshot,
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "missing_phase_evidence");
+        assert!(error.to_string().contains("ProvenInsertHistory"));
+
+        let mut entered_proven = valid_raw_phases();
+        let proven = entered_proven
+            .iter_mut()
+            .find(|phase| phase.phase == "ProvenInsertHistory")
+            .unwrap();
+        proven.total_us = 1;
+        proven.max_us = 1;
+        proven.interval_count = 1;
+        let error = validate_successful_merge_phase_topology(
+            &entered_proven,
+            &general_route(2),
+            2,
+            MergePhaseEvidenceForm::RawSnapshot,
+        )
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("must not enter ProvenInsertHistory")
+        );
     }
 
     fn assert_json_object_keys(value: &serde_json::Value, expected: &[&str]) {
@@ -3291,6 +3920,23 @@ protocol:
                             for sample in execution.samples {
                                 assert_eq!(sample.outcome, "merged");
                                 assert_eq!(sample.route.table_walk_intervals, 1);
+                                validate_successful_merge_phase_topology(
+                                    &sample.phases,
+                                    &sample.route,
+                                    1,
+                                    MergePhaseEvidenceForm::StoredSample,
+                                )
+                                .unwrap();
+                                assert!(sample.phases.iter().all(|phase| phase.interval_count > 0));
+                                assert_eq!(
+                                    sample
+                                        .phases
+                                        .iter()
+                                        .find(|phase| phase.phase == "PhysicalPublish")
+                                        .unwrap()
+                                        .interval_count,
+                                    1
+                                );
                                 assert!(sample.verification.exact_content);
                                 assert!(sample.verification.source_exact_content);
                                 assert!(sample.verification.main_exact_content);

--- a/crates/omnigraph-bench/src/supervisor.rs
+++ b/crates/omnigraph-bench/src/supervisor.rs
@@ -19,8 +19,9 @@ use crate::branch_merge::{BranchMergePlan, TARGET_BRANCH};
 use crate::machine::MachineIdentityV1;
 use crate::reset::{MetadataDigest, PhysicalDigest};
 use crate::runner::{
-    ChildProcessEvidence, RepObservation, RunnerError, RunnerResult,
-    configure_benchmark_worker_environment, validate_worker_build_attestation,
+    ChildProcessEvidence, MergePhaseEvidenceForm, RepObservation, RunnerError, RunnerResult,
+    configure_benchmark_worker_environment, validate_successful_merge_phase_topology,
+    validate_worker_build_attestation,
 };
 use crate::worker_protocol::{
     ChildFrameV1, MAX_WORKER_FRAME_BYTES, ParentFrameV1, WORKER_PROTOCOL_VERSION, WorkerBuildV1,
@@ -1211,17 +1212,13 @@ fn validate_sample_admission(
     let expected_rows = plan
         .expected_merged_rows()
         .map_err(|error| format!("parent could not derive expected merged rows: {error}"))?;
-    let table_walk_phases = sample
-        .phases
-        .iter()
-        .filter(|phase| phase.phase == "TableWalk")
-        .collect::<Vec<_>>();
-
-    let table_walk_interval_counts = table_walk_phases
-        .iter()
-        .map(|phase| phase.interval_count)
-        .collect::<Vec<_>>();
-    let expected_table_walk_interval_counts = vec![expected_intervals];
+    validate_successful_merge_phase_topology(
+        &sample.phases,
+        &sample.route,
+        expected_intervals,
+        MergePhaseEvidenceForm::StoredSample,
+    )
+    .map_err(|error| format!("worker sample phase topology invalid: {error}"))?;
     let expected_outcome = "merged".to_string();
     let expected_branch = TARGET_BRANCH.to_string();
     let mut mismatches = Vec::new();
@@ -1254,18 +1251,6 @@ fn validate_sample_admission(
         "outcome",
         &expected_outcome,
         &sample.outcome,
-    );
-    record_admission_mismatch(
-        &mut mismatches,
-        "route.table_walk_intervals",
-        &expected_intervals,
-        &sample.route.table_walk_intervals,
-    );
-    record_admission_mismatch(
-        &mut mismatches,
-        "table_walk_phase_interval_counts",
-        &expected_table_walk_interval_counts,
-        &table_walk_interval_counts,
     );
     record_admission_mismatch(
         &mut mismatches,
@@ -1383,8 +1368,8 @@ fn remaining(total: Duration, elapsed: Duration) -> Duration {
 mod tests {
     use crate::counting::LogicalCallCounts;
     use crate::runner::{
-        ControlCallObservation, LogicalStoreCallObservation, MergeRouteObservation,
-        PhaseObservation, VerificationObservation,
+        ControlCallObservation, LogicalStoreCallObservation, VerificationObservation,
+        test_general_merge_route, test_general_merge_stored_phases,
     };
     use crate::worker_protocol::ChildFrameV1;
     use crate::{ValidatedCase, parse_case};
@@ -1548,22 +1533,8 @@ mod tests {
             elapsed_us: TEST_ELAPSED_US,
             peak_rss_bytes: None,
             outcome: "merged".to_string(),
-            phases: vec![PhaseObservation {
-                phase: "TableWalk".to_string(),
-                total_us: 700,
-                max_us: 250,
-                interval_count: intervals,
-            }],
-            route: MergeRouteObservation {
-                table_walk_intervals: intervals,
-                stage_merge_insert_calls: 0,
-                stage_merge_insert_rows: 0,
-                stage_known_present_update_calls: 0,
-                stage_known_present_update_rows: 0,
-                stage_fenced_insert_calls: 0,
-                stage_fenced_insert_rows: 0,
-                strict_insert_preflight_calls: 0,
-            },
+            phases: test_general_merge_stored_phases(intervals, intervals),
+            route: test_general_merge_route(intervals, intervals),
             logical_store_calls: LogicalStoreCallObservation {
                 manifest: LogicalCallCounts::default(),
                 table: LogicalCallCounts::default(),
@@ -2012,8 +1983,13 @@ mod tests {
             ("route.table_walk_intervals", |sample| {
                 sample.route.table_walk_intervals += 1;
             }),
-            ("table_walk_phase_interval_counts", |sample| {
-                sample.phases[0].interval_count += 1;
+            ("TableWalk", |sample| {
+                sample
+                    .phases
+                    .iter_mut()
+                    .find(|phase| phase.phase == "TableWalk")
+                    .unwrap()
+                    .interval_count += 1;
             }),
             ("verification.branch", |sample| {
                 sample.verification.branch = "source".to_string();
@@ -2050,6 +2026,45 @@ mod tests {
             assert!(message.contains("expected="), "field={field}: {message}");
             assert!(message.contains("observed="), "field={field}: {message}");
         }
+    }
+
+    #[test]
+    fn parent_admission_enforces_successful_merge_phase_topology() {
+        let (_workspace, input) = supervision_input(PathBuf::from("/unused"));
+        validate_sample_admission(&valid_sample(&input), &input, TEST_ELAPSED_US).unwrap();
+
+        let mut empty = valid_sample(&input);
+        empty.phases.clear();
+        assert!(
+            validate_sample_admission(&empty, &input, TEST_ELAPSED_US)
+                .unwrap_err()
+                .contains("missing mandatory phase `OuterPrepare`")
+        );
+
+        let mut missing_publish = valid_sample(&input);
+        missing_publish
+            .phases
+            .retain(|phase| phase.phase != "PhysicalPublish");
+        assert!(
+            validate_sample_admission(&missing_publish, &input, TEST_ELAPSED_US)
+                .unwrap_err()
+                .contains("missing mandatory phase `PhysicalPublish`")
+        );
+
+        let mut bad_enclosure = valid_sample(&input);
+        for phase in bad_enclosure
+            .phases
+            .iter_mut()
+            .filter(|phase| matches!(phase.phase.as_str(), "KeyedStage" | "KeyedCommit"))
+        {
+            phase.total_us = 60;
+            phase.max_us = 20;
+        }
+        assert!(
+            validate_sample_admission(&bad_enclosure, &input, TEST_ELAPSED_US)
+                .unwrap_err()
+                .contains("does not enclose")
+        );
     }
 
     #[test]

--- a/crates/omnigraph-bench/src/worker_protocol.rs
+++ b/crates/omnigraph-bench/src/worker_protocol.rs
@@ -425,8 +425,8 @@ mod tests {
 
     use crate::counting::LogicalCallCounts;
     use crate::runner::{
-        ControlCallObservation, LogicalStoreCallObservation, MergeRouteObservation,
-        PhaseObservation, VerificationObservation,
+        ControlCallObservation, LogicalStoreCallObservation, VerificationObservation,
+        test_general_merge_route, test_general_merge_stored_phases,
     };
     use crate::validate_case;
 
@@ -528,22 +528,8 @@ protocol:
             elapsed_us: 42,
             peak_rss_bytes: None,
             outcome: "merged".to_string(),
-            phases: vec![PhaseObservation {
-                phase: "TableWalk".to_string(),
-                total_us: 20,
-                max_us: 20,
-                interval_count: 1,
-            }],
-            route: MergeRouteObservation {
-                table_walk_intervals: 1,
-                stage_merge_insert_calls: 1,
-                stage_merge_insert_rows: 2,
-                stage_known_present_update_calls: 1,
-                stage_known_present_update_rows: 2,
-                stage_fenced_insert_calls: 0,
-                stage_fenced_insert_rows: 0,
-                strict_insert_preflight_calls: 0,
-            },
+            phases: test_general_merge_stored_phases(1, 1),
+            route: test_general_merge_route(1, 1),
             logical_store_calls: LogicalStoreCallObservation {
                 manifest: LogicalCallCounts {
                     get: 1,

--- a/crates/omnigraph/src/exec/merge.rs
+++ b/crates/omnigraph/src/exec/merge.rs
@@ -3250,9 +3250,6 @@ async fn publish_proven_pure_insert_adopt(
     prepared_target: PreparedExistingMergeTarget,
     planned_transactions: &[crate::table_store::StagedTransactionIdentity],
 ) -> Result<crate::db::DatasetUpdate> {
-    let publish_timing = crate::instrumentation::start_merge_timing(
-        crate::instrumentation::MergeTimingPhase::PhysicalPublish,
-    );
     let (current, full_path, table_branch) = prepared_target.into_parts();
     let source = SnapshotHandle::new(proven.source.clone());
     let stream = target_db
@@ -3290,7 +3287,6 @@ async fn publish_proven_pure_insert_adopt(
         .storage()
         .table_state(&full_path, &committed)
         .await?;
-    publish_timing.finish();
 
     Ok(crate::db::DatasetUpdate {
         identity,
@@ -4414,6 +4410,9 @@ impl Omnigraph {
                 )?;
             }
 
+            let physical_publish_timing = crate::instrumentation::start_merge_timing(
+                crate::instrumentation::MergeTimingPhase::PhysicalPublish,
+            );
             let mut updates = Vec::new();
             let mut changed_edge_tables = false;
             let mut confirmed_ref_identifiers = HashMap::new();
@@ -4542,6 +4541,7 @@ impl Omnigraph {
                 }
                 updates.push(update);
             }
+            physical_publish_timing.finish();
 
             // The Armed body remains rollback-only until every physical effect,
             // every first-touch ref identity, and every logical output slot are

--- a/crates/omnigraph/tests/merge_fast_forward.rs
+++ b/crates/omnigraph/tests/merge_fast_forward.rs
@@ -41,6 +41,68 @@ async fn append_new_persons(db: &mut Omnigraph, branch: &str, n: usize) {
     }
 }
 
+/// Every successful physical merge operation contributes exactly one publish
+/// interval, including ref-only routes with no keyed storage work.
+fn assert_single_physical_publish(probes: &MergeWriteProbes) {
+    let timings = probes.merge_timing_snapshot();
+    let physical_publish = timings
+        .iter()
+        .find(|reading| reading.phase == "PhysicalPublish")
+        .expect("merge timing snapshot must include PhysicalPublish");
+
+    assert_eq!(
+        physical_publish.interval_count, 1,
+        "one merge operation must complete exactly one PhysicalPublish interval: {timings:?}"
+    );
+}
+
+/// Keyed storage work is nested inside the operation-level publish interval,
+/// so the outer interval must enclose every completed stage and commit.
+fn assert_single_physical_publish_encloses_keyed_work(probes: &MergeWriteProbes) {
+    assert_single_physical_publish(probes);
+
+    let timings = probes.merge_timing_snapshot();
+    let phase = |name| {
+        timings
+            .iter()
+            .find(|reading| reading.phase == name)
+            .unwrap_or_else(|| panic!("merge timing snapshot lacks phase '{name}'"))
+    };
+    let physical_publish = phase("PhysicalPublish");
+    let keyed_stage = phase("KeyedStage");
+    let keyed_commit = phase("KeyedCommit");
+
+    assert!(
+        keyed_stage.interval_count > 0,
+        "fixture must exercise keyed staging: {timings:?}"
+    );
+    assert!(
+        keyed_commit.interval_count > 0,
+        "fixture must exercise keyed commit: {timings:?}"
+    );
+    let keyed_stage_calls = probes
+        .stage_merge_insert_calls()
+        .checked_add(probes.stage_known_present_update_calls())
+        .and_then(|calls| calls.checked_add(probes.stage_fenced_insert_calls()))
+        .expect("test stage-call total must not overflow");
+    assert_eq!(
+        keyed_stage.interval_count, keyed_stage_calls,
+        "each successful keyed storage stage must complete one KeyedStage interval: {timings:?}"
+    );
+    assert_eq!(
+        keyed_commit.interval_count, keyed_stage.interval_count,
+        "each successfully staged keyed chunk must complete one KeyedCommit interval: {timings:?}"
+    );
+    let keyed_total_us = keyed_stage
+        .total_us
+        .checked_add(keyed_commit.total_us)
+        .expect("test timing totals must not overflow");
+    assert!(
+        physical_publish.total_us >= keyed_total_us,
+        "PhysicalPublish must enclose KeyedStage + KeyedCommit: {timings:?}"
+    );
+}
+
 /// THE structural gate. A one-chunk append-only source delta must use one
 /// exact-id fenced insert and zero bare appends. The storage adapter converts
 /// Lance's uncommitted data fragments into a filter-bearing `Update`, so the
@@ -101,6 +163,7 @@ async fn append_only_fast_forward_merge_uses_fenced_insert() {
         0,
         "exact pure-insert fast-forward with only identity-backed @key must not rescan its already accepted source rows for validation",
     );
+    assert_single_physical_publish_encloses_keyed_work(&probes);
 }
 
 /// A lazy graph branch pins an immutable table version while continuing to
@@ -161,6 +224,7 @@ async fn lazy_target_ref_only_fast_forward_uses_pin_after_main_advances() {
     assert_eq!(probes.stage_merge_insert_calls(), 0);
     assert_eq!(probes.strict_insert_preflight_calls(), 0);
     assert_eq!(probes.stage_append_calls(), 0);
+    assert_single_physical_publish(&probes);
 
     let names = collect_column_strings(
         &read_table_branch(&merger, "target", "node:Person").await,
@@ -578,6 +642,7 @@ async fn changed_only_adopt_uses_known_present_update() {
     );
     assert_eq!(probes.stage_known_present_update_calls(), 1);
     assert_eq!(probes.stage_known_present_update_rows(), 1);
+    assert_single_physical_publish_encloses_keyed_work(&probes);
 }
 
 /// Read `column` for the node whose `id == id` from `main`. Outer `None` = id
@@ -839,25 +904,55 @@ async fn branch_merge_validation_delta_is_aggregate_bounded_pre_arm() {
 }
 
 /// Functional correctness: a fast-forward merge of an append-only branch leaves
-/// main equal to the source branch. Independent of the cost-budget gate.
+/// main equal to the source branch. The fixture changes both a node and an edge
+/// table so the operation-level publish interval cannot accidentally become a
+/// per-candidate interval. Independent of the cost-budget gate.
 #[tokio::test]
 async fn fast_forward_merge_yields_source_state() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
     let main = init_and_load(&dir).await;
-    let base_count = count_rows(&main, "node:Person").await;
+    let base_person_count = count_rows(&main, "node:Person").await;
+    let base_knows_count = count_rows(&main, "edge:Knows").await;
 
     main.branch_create("feature").await.unwrap();
     let mut feature = Omnigraph::open(uri).await.unwrap();
     append_new_persons(&mut feature, "feature", 5).await;
-    let source_count = count_rows_branch(&feature, "feature", "node:Person").await;
-    assert_eq!(source_count, base_count + 5);
+    let mutation = feature
+        .mutate(
+            "feature",
+            MUTATION_QUERIES,
+            "insert_person_and_friend",
+            &mixed_params(
+                &[("$name", "ff_linked"), ("$friend", "Alice")],
+                &[("$age", 31)],
+            ),
+        )
+        .await
+        .unwrap();
+    assert_eq!(mutation.affected_nodes, 1);
+    assert_eq!(mutation.affected_edges, 1);
 
-    let outcome = main.branch_merge("feature", "main").await.unwrap();
+    let source_person_count = count_rows_branch(&feature, "feature", "node:Person").await;
+    let source_knows_count = count_rows_branch(&feature, "feature", "edge:Knows").await;
+    assert_eq!(source_person_count, base_person_count + 6);
+    assert_eq!(source_knows_count, base_knows_count + 1);
+
+    let probes = MergeWriteProbes::default();
+    let outcome = with_merge_write_probes(probes.clone(), main.branch_merge("feature", "main"))
+        .await
+        .unwrap();
     assert_eq!(outcome, MergeOutcome::FastForward);
+    assert_eq!(
+        probes.stage_fenced_insert_calls(),
+        2,
+        "node:Person and edge:Knows must each publish one proven-insert candidate"
+    );
+    assert_single_physical_publish_encloses_keyed_work(&probes);
 
-    // main now equals source: the 5 new persons are present, the base rows kept.
-    assert_eq!(count_rows(&main, "node:Person").await, source_count);
+    // main now equals source: both changed tables landed and their base rows remain.
+    assert_eq!(count_rows(&main, "node:Person").await, source_person_count);
+    assert_eq!(count_rows(&main, "edge:Knows").await, source_knows_count);
     let names = collect_column_strings(&read_table(&main, "node:Person").await, "name");
     for i in 0..5 {
         assert!(
@@ -865,6 +960,7 @@ async fn fast_forward_merge_yields_source_state() {
             "merged main missing new person ff_new_{i}; have {names:?}"
         );
     }
+    assert!(names.iter().any(|name| name == "ff_linked"));
 }
 
 const VEC_SCHEMA: &str = "node Chunk {\n  slug: String @key\n  embedding: Vector(8) @index\n}\n";
@@ -965,6 +1061,7 @@ async fn merged_outcome_defers_vector_index_to_reconciler() {
         0,
         "three-way merge must not stage derived vector-index work inline"
     );
+    assert_single_physical_publish_encloses_keyed_work(&probes);
     assert_eq!(count_rows(&main, "node:Chunk").await, 25);
 }
 


### PR DESCRIPTION
Two defects landed with the #556/#557 runner slice left public wall-clock execution unable to complete or publish. Both are fixed with the failure reproduced red-first in the owning suites.

## 1. Fixture handoff was dead on arrival

The contained fixture worker retires the `active` tree before returning its handoff, and `accept_clonefile_template_handoff` requires that absence — but its containment guard ran first and `fs::canonicalize`d the retired path, so every public run failed with `fixture_handoff_failed`/ENOENT before a single repetition:

```
error[fixture_handoff_failed] ... canonicalizing fixture root .../active: No such file or directory (os error 2)
```

`refuse_destination_below_source` keeps its strict canonicalize for the freeze path (source must exist there); the handoff path now uses a retired-source variant that resolves the absent fixture root through its canonical parent — the same pattern the check already used for missing destinations — with the destination resolution shared between both. The new `contained_handoff_accepts_only_a_retired_active_path` test pins the full freeze → retire → accept → restore protocol, including refusal of a worker that left `active` behind.

## 2. Record publication refused every completed run

The engine's `merge_timing_snapshot()` deliberately enumerates every stable phase, including phases the measured route never entered, and the runner forwarded that enumeration verbatim into the record. Record validation — correctly, per its evidence contract — refuses any listed phase with zero completed intervals, so a fully verified 5-repetition run died at finalization:

```
error[invalid_phase_measurement] at measurements.raw_samples[0].phases[1]: phase intervals must be nonzero ...
```

Samples now pass through `observed_phase_evidence`, which keeps only phases with completed intervals; the validator stays strict. `MergeTimingReading` construction is sealed cross-crate (`#[non_exhaustive]`, no serde), so the unit test drives a real `MergeWriteProbes` snapshot and proves the full zero enumeration collapses to empty evidence.

## Evidence

- `cargo test -p omnigraph-bench --locked`: 221 passed, plus the three integration suites; fmt and clippy (`-D warnings -W clippy::dbg_macro`) clean.
- With both fixes, `suite run benchmarks/suites/local-smoke.suite-v1.yaml --archive` completed 5/5 repetitions (exact-state verification on target/source/main, protected heads unchanged) and published the first immutable run record; `archive verify` accepts the archive. The published record carries only the 11 observed phases.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR repairs benchmark finalization by accepting fixture handoffs after the active tree is retired and by storing only phases with completed timing intervals. It also centralizes successful-merge topology validation across worker execution, supervisor admission, and durable-record loading.
- Resolves retired fixture roots through their canonical parent while retaining destination-containment checks.
- Validates raw timing topology before removing unobserved phases from stored evidence.
- Extends merge instrumentation and regression coverage for the complete freeze, retire, accept, restore, measure, and publish flow.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/omnigraph-bench/src/reset.rs | Resolves containment for a deliberately absent active fixture through its canonical parent while preserving sibling and overlap checks. |
| crates/omnigraph-bench/src/runner.rs | Centralizes successful general-merge phase validation and filters unentered phases only after validating the complete raw snapshot. |
| crates/omnigraph-bench/src/record.rs | Reuses stored-sample topology validation so durable records accept observed-only evidence while retaining strict route and timing checks. |
| crates/omnigraph-bench/src/supervisor.rs | Applies the same stored phase-topology contract when admitting worker samples. |
| crates/omnigraph/src/exec/merge.rs | Refines merge timing instrumentation and tests to establish one physical publication enclosing keyed staging and commit work. |
| crates/omnigraph/tests/merge_fast_forward.rs | Expands merge-route regression assertions around timing and publication behavior. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Build active fixture] --> B[Freeze clonefile template]
    B --> C[Retire active tree]
    C --> D[Accept worker handoff]
    D --> E[Restore active fixture]
    E --> F[Execute measured merge]
    F --> G[Validate raw phase topology]
    G --> H[Keep observed phases]
    H --> I[Supervisor admission]
    I --> J[Validate and publish durable record]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(bench): validate complete merge phas..."](https://github.com/modernrelay/omnigraph/commit/a9af49da4e8817902190399f9c3925f9abc5c902) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57543419)</sub>

**Context used:**

- Knowledge Base — [Branching and version history](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/branching-and-version-history.md)
- Knowledge Base — [Data mutation pipeline](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/data-mutation-pipeline.md)

<!-- /greptile_comment -->