### PR TITLE
ci(dst): aggregate nightly fleet evidence into one downloadable report

### DIFF
--- a/.github/workflows/dst-nightly.yml
+++ b/.github/workflows/dst-nightly.yml
@@ -27,7 +27,7 @@ on:
         required: false
         default: ""
       det_seeds:
-        description: "Seeds per det-fleet shard (empty = 60; shard stride follows it)"
+        description: "Seeds per det-fleet shard, 1..=100 (empty = 60; shard stride follows it)"
         required: false
         default: ""
 
@@ -89,7 +89,11 @@ jobs:
           seeds="${DET_SEEDS_INPUT:-60}"
           case "$seeds" in (*[!0-9]*|'') echo "det_seeds must be numeric"; exit 1;; esac
           seeds=$(( 10#$seeds ))
-          if [ "$seeds" -lt 1 ]; then echo "det_seeds must be >= 1"; exit 1; fi
+          # Cap 100: 6 shards x 100 = 600, where the concurrent offsets
+          # begin — any higher and det shards replay concurrent seeds.
+          if [ "$seeds" -lt 1 ] || [ "$seeds" -gt 100 ]; then
+            echo "det_seeds must be 1..=100 (det tier owns night offsets 0..600)"; exit 1
+          fi
           # Shard stride follows the seed count so overridden counts stay disjoint.
           export DST_FLEET_SEED_BASE=$(( night_base + ${{ matrix.shard }} * seeds ))
           export DST_FLEET_SEEDS="$seeds"

--- a/.github/workflows/dst-nightly.yml
+++ b/.github/workflows/dst-nightly.yml
@@ -18,7 +18,18 @@ name: DST nightly
 on:
   schedule:
     - cron: "0 3 * * *"
+  # Manual replay of a past night: seed_base takes the NIGHT base (the
+  # "night base:" value any shard logged); empty = tonight's date arithmetic.
   workflow_dispatch:
+    inputs:
+      seed_base:
+        description: "Night base to replay (empty = tonight's date arithmetic)"
+        required: false
+        default: ""
+      det_seeds:
+        description: "Seeds per det-fleet shard (empty = 60; shard stride follows it)"
+        required: false
+        default: ""
 
 env:
   CARGO_TERM_COLOR: always
@@ -61,12 +72,57 @@ jobs:
       # det-fleet owns offsets 0..360 (6 shards x 60 seeds). Failures are
       # replayable seeds; the pass log carries the auto-replay bundles.
       - name: Fleet shard
+        # Dispatch inputs cross into the shell via env, never inline
+        # interpolation (script-injection hardening), and must be numeric.
+        env:
+          SEED_BASE_INPUT: ${{ inputs.seed_base }}
+          DET_SEEDS_INPUT: ${{ inputs.det_seeds }}
         run: |
           days=$(( ( $(date -u +%s) - $(date -u -d 2026-08-14 +%s) ) / 86400 ))
-          export DST_FLEET_SEED_BASE=$(( 200000 + days * 1000 + ${{ matrix.shard }} * 60 ))
-          export DST_FLEET_SEEDS=60
-          echo "night base interval: $DST_FLEET_SEED_BASE (+60)"
-          cargo test -p omnigraph-dst --locked --test scenarios dst_fleet -- --exact --ignored --nocapture
+          seed_floor=200000
+          night_span=1000
+          night_base=$(( seed_floor + days * night_span ))
+          if [ -n "$SEED_BASE_INPUT" ]; then
+            case "$SEED_BASE_INPUT" in (*[!0-9]*) echo "seed_base must be numeric"; exit 1;; esac
+            night_base=$(( 10#$SEED_BASE_INPUT ))
+          fi
+          seeds="${DET_SEEDS_INPUT:-60}"
+          case "$seeds" in (*[!0-9]*|'') echo "det_seeds must be numeric"; exit 1;; esac
+          seeds=$(( 10#$seeds ))
+          if [ "$seeds" -lt 1 ]; then echo "det_seeds must be >= 1"; exit 1; fi
+          # Shard stride follows the seed count so overridden counts stay disjoint.
+          export DST_FLEET_SEED_BASE=$(( night_base + ${{ matrix.shard }} * seeds ))
+          export DST_FLEET_SEEDS="$seeds"
+          # The base line opens the log file (tee, no -a) so the report can
+          # cross-check every shard's night base from the artifact; cargo
+          # then appends.
+          echo "night base: $night_base shard base: $DST_FLEET_SEED_BASE seeds: $DST_FLEET_SEEDS" | tee det-fleet-shard-${{ matrix.shard }}.log
+          set -o pipefail
+          cargo test -p omnigraph-dst --locked --test scenarios dst_fleet -- --exact --ignored --nocapture 2>&1 | tee -a det-fleet-shard-${{ matrix.shard }}.log
+      # Failure rows and replay verdicts go to the job summary.
+      - name: Failure rows into the job summary
+        if: always()
+        run: |
+          {
+            echo "### det-fleet shard ${{ matrix.shard }}"
+            echo '```'
+            if [ -f det-fleet-shard-${{ matrix.shard }}.log ]; then
+              grep -E "^dst fleet FAILURE seed=|^dst fleet BUNDLE verdict|^FLEET COMPLETE" det-fleet-shard-${{ matrix.shard }}.log || echo "no failure rows"
+            else
+              echo "shard log missing"
+            fi
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      # The full shard log (report lines + auto-replay BUNDLE transcripts)
+      # as a downloadable artifact, red or green.
+      - name: Upload shard log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: det-fleet-shard-${{ matrix.shard }}
+          path: det-fleet-shard-${{ matrix.shard }}.log
+          retention-days: 30
+          overwrite: true
 
   concurrent-fleet:
     name: Concurrent fleet ${{ matrix.mode }} (shard ${{ matrix.shard }})
@@ -102,6 +158,10 @@ jobs:
       # (wild) and 800..860 (sched) inside the night's interval keep
       # every job disjoint.
       - name: Concurrent shard
+        # Dispatch input crosses into the shell via env (same hardening as
+        # the det-fleet step).
+        env:
+          SEED_BASE_INPUT: ${{ inputs.seed_base }}
         run: |
           days=$(( ( $(date -u +%s) - $(date -u -d 2026-08-14 +%s) ) / 86400 ))
           offset=600
@@ -112,8 +172,143 @@ jobs:
             export LANCE_CPU_THREADS=4
             export RAYON_NUM_THREADS=4
           fi
-          base=$(( 200000 + days * 1000 + offset + ${{ matrix.shard }} * 15 ))
+          seed_floor=200000
+          night_span=1000
+          night_base=$(( seed_floor + days * night_span ))
+          if [ -n "$SEED_BASE_INPUT" ]; then
+            case "$SEED_BASE_INPUT" in (*[!0-9]*) echo "seed_base must be numeric"; exit 1;; esac
+            night_base=$(( 10#$SEED_BASE_INPUT ))
+          fi
+          base=$(( night_base + offset + ${{ matrix.shard }} * 15 ))
           OMNIGRAPH_DST_SEEDS=$(seq -s, "$base" $(( base + 14 )))
           export OMNIGRAPH_DST_SEEDS
+          # Base line opens the log (report cross-check), cargo appends.
+          echo "night base: $night_base (mode ${{ matrix.mode }} shard ${{ matrix.shard }})" | tee concurrent-${{ matrix.mode }}-shard-${{ matrix.shard }}.log
           echo "night seeds: $OMNIGRAPH_DST_SEEDS (mode ${{ matrix.mode }})"
-          cargo test -p omnigraph-dst --locked --test scenarios dst_concurrent_fleet -- --exact --ignored --nocapture
+          set -o pipefail
+          cargo test -p omnigraph-dst --locked --test scenarios dst_concurrent_fleet -- --exact --ignored --nocapture 2>&1 | tee -a concurrent-${{ matrix.mode }}-shard-${{ matrix.shard }}.log
+      # Violation and panic lines go to the job summary. Concurrent
+      # failures panic in place (no FAILURE rows, no completion line) —
+      # these anchors are their actual output.
+      - name: Failure rows into the job summary
+        if: always()
+        run: |
+          {
+            echo "### concurrent ${{ matrix.mode }} shard ${{ matrix.shard }}"
+            echo '```'
+            if [ -f concurrent-${{ matrix.mode }}-shard-${{ matrix.shard }}.log ]; then
+              grep -E "dst concurrent VIOLATION|panicked at|test result:" concurrent-${{ matrix.mode }}-shard-${{ matrix.shard }}.log || echo "no failure rows"
+            else
+              echo "shard log missing"
+            fi
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      # For the `wild` mode the artifact IS the evidence: those failures
+      # are non-replayable (real pool timing), so the log is the finding.
+      - name: Upload shard log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: concurrent-${{ matrix.mode }}-shard-${{ matrix.shard }}
+          path: concurrent-${{ matrix.mode }}-shard-${{ matrix.shard }}.log
+          retention-days: 30
+          overwrite: true
+
+  # ONE report for the whole night (the morning read; also shipped as the
+  # `nightly-report` artifact): det known/novel split from FAILURE_JSON
+  # rows, concurrent reds from their VIOLATION/panic lines, and a shard-log
+  # presence count so a missing log never reads as a green shard.
+  nightly-report:
+    name: Nightly report
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [det-fleet, concurrent-fleet]
+    if: ${{ !cancelled() }}
+    permissions:
+      contents: read
+    steps:
+      - name: Download all shard logs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: shards
+          # Shard artifacts only — on a re-run attempt the previous
+          # attempt's nightly-report artifact also exists, and ingesting
+          # it would duplicate every row.
+          pattern: "*-shard-*"
+      - name: Build the report
+        run: |
+          {
+            echo "# DST nightly report"
+            echo
+            echo "## Shard logs present (expected 14: 6 det + 8 concurrent)"
+            echo '```'
+            find shards -name "*.log" 2>/dev/null | sort || true
+            # Expected counts mirror the two matrix blocks above — update together.
+            log_count=$(find shards -name "*.log" 2>/dev/null | wc -l | tr -d ' ')
+            echo "count: $log_count"
+            if [ "$log_count" -ne 14 ]; then
+              echo "WARNING: shard logs missing — a missing log is NOT a green shard (cancelled/timed-out jobs upload nothing)"
+            fi
+            # A log can exist yet be PARTIAL (shard killed mid-fleet):
+            # completion is checked separately from presence.
+            det_done=$(grep -rh "^FLEET COMPLETE" shards 2>/dev/null | wc -l | tr -d ' ')
+            conc_done=$(grep -rl "test result:" shards/concurrent-* 2>/dev/null | wc -l | tr -d ' ')
+            echo "det completions: $det_done/6  concurrent completions: $conc_done/8"
+            if [ "$det_done" -ne 6 ] || [ "$conc_done" -ne 8 ]; then
+              echo "WARNING: a shard uploaded a log but never completed (timeout/kill?) — its failures appear in no section below"
+            fi
+            echo '```'
+            echo
+            echo "## Seed bases (every shard must agree on the night base)"
+            echo '```'
+            grep -rh "night base:" shards || echo "none"
+            echo '```'
+            echo
+            echo "## NOVEL det failures (triage these first)"
+            echo '```'
+            grep -rh "^dst fleet FAILURE_JSON" shards | grep '"known":null' || echo "none"
+            echo '```'
+            echo
+            echo "## Known-family det failures (triaged; still red)"
+            echo '```'
+            grep -rh "^dst fleet FAILURE_JSON" shards | grep -v '"known":null' || echo "none"
+            echo '```'
+            echo
+            echo "## Concurrent failures (violations and panics)"
+            echo '```'
+            grep -r -E "dst concurrent VIOLATION|panicked at|test result: FAILED" shards/concurrent-* 2>/dev/null || echo "none"
+            echo '```'
+            echo
+            echo "## Det failure rows (human form)"
+            echo '```'
+            grep -rh "^dst fleet FAILURE seed=" shards || echo "none"
+            echo '```'
+            echo
+            echo "## Replay verdicts"
+            echo '```'
+            grep -rh "^dst fleet BUNDLE verdict" shards || echo "none"
+            echo '```'
+            echo
+            echo "## Det completion lines (path = shard identity)"
+            echo '```'
+            grep -r "^FLEET COMPLETE" shards || echo "none"
+            echo '```'
+          } | tee nightly-report.md
+          # Step summaries cap at 1 MiB; on a mass-failure night ship the
+          # head and point at the artifact rather than losing the page.
+          if [ "$(wc -c < nightly-report.md | tr -d ' ')" -gt 900000 ]; then
+            head -c 900000 nightly-report.md >> "$GITHUB_STEP_SUMMARY"
+            echo "... (truncated; full report in the nightly-report artifact)" >> "$GITHUB_STEP_SUMMARY"
+          else
+            cat nightly-report.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+      # Shard logs keep 30d; the report keeps 90d — it is the durable
+      # summary, and transcripts are re-derivable from seeds.
+      - name: Upload the report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nightly-report
+          path: nightly-report.md
+          retention-days: 90
+          overwrite: true

--- a/crates/omnigraph-dst/src/harness.rs
+++ b/crates/omnigraph-dst/src/harness.rs
@@ -4181,7 +4181,9 @@ pub fn assert_strict_replay(first: &UniverseReport, second: &UniverseReport, con
     }
 }
 
-/// Render a caught universe panic as a one-line repro-bearing message.
+/// Render a caught universe panic as a repro-bearing message. MAY SPAN
+/// LINES (a violation's `observed` can embed newlines — e.g. the strict
+/// replay diff); the fleet's FAILURE_JSON row is the single-line form.
 /// Detector-tagged violations render their `detector=` field —
 /// the fleet's failure records carry it without any caller change.
 pub fn panic_message(panic: &(dyn std::any::Any + Send)) -> String {

--- a/crates/omnigraph-dst/tests/scenarios.rs
+++ b/crates/omnigraph-dst/tests/scenarios.rs
@@ -2689,6 +2689,20 @@ fn dst_window_reach_probe() {
     );
 }
 
+/// Family tag for a FAILURE_JSON row: a substring match against a triaged
+/// finding's signature, or None = novel. Report-only: the pass reds either
+/// way. Scope-in accepted: ANY Arrow batch-length panic is claimed by this
+/// family until a second source exists — the alternative, a looser pattern,
+/// would hide novel failures from the nightly report's NOVEL section.
+fn known_failure_family(msg: &str) -> Option<&'static str> {
+    // Deferred-fork staging corruption on a reborn branch
+    // (create -> delete -> create again); standalone repro exists.
+    if msg.contains("all columns in a record batch must have the same length") {
+        return Some("deferred-fork-arrow-batch-length");
+    }
+    None
+}
+
 /// THE FLEET: the volume instrument. Runs the full portfolio
 /// across FRESH seed space (seeds no pin or hunt has ever used), each seed
 /// one new life: (a) clean wide universe, (b) adapter-realm fault storm,
@@ -2756,6 +2770,17 @@ fn dst_fleet() {
             Err(p) => {
                 let msg = omnigraph_dst::harness::panic_message(p.as_ref());
                 println!("dst fleet FAILURE seed={seed} arm={arm}: {msg}");
+                // Machine-readable twin of the row above; consumers rely on
+                // one \n-delimited line (the report greps, then json.loads).
+                println!(
+                    "dst fleet FAILURE_JSON {}",
+                    serde_json::json!({
+                        "seed": seed,
+                        "arm": arm,
+                        "known": known_failure_family(&msg),
+                        "msg": msg,
+                    })
+                );
                 fails.push((seed, arm.to_string(), msg, root, sc));
                 None
             }


### PR DESCRIPTION
## What & why

This PR gives the DST nightly a triage surface: today a red run shows only `exit code 101` annotations, and the repro evidence (seed rows, replay verdicts) requires digging 14 raw job logs. Follow-up to #527's `dst-nightly.yml`.

- Every fleet shard writes its log to a downloadable artifact (`if: always()`, `overwrite: true` so job re-runs replace their log, 30-day retention). The log opens with a `night base:` line so the report can cross-check that all shards ran the same interval.
- A final `nightly-report` job aggregates all shards into one page, novel-first: a shard-log presence count against the expected 14 plus per-tier completion counts (a missing or partial log is flagged, never mistaken for green), NOVEL det failures, known-family det failures, concurrent failures (their `VIOLATION` and panic lines; they emit no failure rows), human-form det rows, replay verdicts, and completion lines. The same text lands on the run summary page (truncated at the 1 MiB cap with a pointer to the artifact) and ships as a 90-day `nightly-report` artifact. The download is scoped to `*-shard-*` so a re-run never re-ingests the previous attempt's report.
- `dst_fleet` failures also emit one machine-readable `FAILURE_JSON` line (`serde_json`-built: seed, arm, known-family tag, full message), so the report and later tooling aggregate without scraping prose. Report-only: a known-family failure still reds the pass. The known list has exactly one entry, the deferred-fork Arrow batch-length signature, and its match is a documented deliberate scope-in: any Arrow batch-length panic is claimed by that family until a second source exists.
- `workflow_dispatch` gains `seed_base` (replay any past night's interval from the Actions tab) and `det_seeds` (seeds per det shard; the shard stride follows the count so overridden runs stay disjoint). Inputs cross into the shell via `env:` with numeric validation, never inline interpolation. Scheduled runs are unchanged.

## Backing issue / RFC

- [x] None; motivated by nightly triage friction: reading the first red nightly required reconstructing shard seed intervals and rerunning them locally.

## Checklist

- [x] Change is focused (one idea: the nightly's evidence capture and aggregation; same fleets, same seeds, same exit-code semantics)
- [x] Tests added/updated for behavior changes (no test behavior changes: one classifier fn and one extra `println!` in the fleet's failure path, plus a corrected doc comment on `panic_message`; full dst suite green, 26 lib + 45 scenarios)
- [x] Public docs updated if user-facing surface changed (internal CI surface, no public docs)
- [x] Reviewed against docs/dev/invariants.md — no Hard Invariant weakened, no deny-list item hit (CI plus test-output change; both actions pinned to full SHAs like the workflow's existing steps)

## Local verification

- `cargo test -q` from `crates/omnigraph-dst` — 26 lib + 45 scenario tests green
- `cargo clippy --workspace` from `crates/omnigraph-dst` — clean, zero warnings; `cargo fmt --all` applied
- Single-seed fleet run on a known-red seed — emits `FAILURE_JSON {"arm":"wide","known":"deferred-fork-arrow-batch-length","msg":...,"seed":213017}`; the line parses with `json.loads`
- Full-night simulation — all 6 det shards of a real past interval (seeds 213000-213359, 2797 universes) run locally and the report assembled with this workflow's section logic: 21 failures split 18 known / 3 novel, 21/21 replay verdicts byte-identical, presence and completion warnings fire correctly for the deliberately omitted concurrent shards
- Workflow YAML parses; workflow execution itself not run: schedule-triggered Actions job, first verification is the next nightly or a `workflow_dispatch` run
- Vocabulary guard (`rust-string` vs merge base) — only pre-existing merge-base occurrences in `crates/omnigraph-bench`, untouched here; zero introduced by this diff

## Notes for reviewers

- Red semantics are unchanged everywhere: known-family failures are listed separately in the report but still fail their shard. Flipping known-only nights to green would be a deliberate follow-up policy change, not this PR.
- The known-family list is intentionally minimal (one triaged signature with a standalone repro); the recently caught row-id-index and silent-divergence families stay untagged so they surface at the top of the report.
- The concurrent fleet emits no `FAILURE_JSON` rows: it panics in place rather than collecting failures, so the report greps its actual output (`dst concurrent VIOLATION`, panic lines); restructuring its error handling is out of scope.
- Known residual: the night base is computed per job from the clock, so a shard re-run after 21:00 UTC the next day would derive a different interval; the report's seed-base section makes any divergence visible, and a single setup job with outputs is the structural fix if it ever bites.
- `actions/upload-artifact` pinned to `043fb46d...` (v7.0.1), `actions/download-artifact` to `3e5f45b2...` (v8.0.1); v8 download reads v7 uploads (same post-v4 artifact API).



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds downloadable shard logs and a consolidated nightly DST report while allowing manual replay of prior seed intervals.
- Captures deterministic and concurrent fleet output as per-shard artifacts.
- Aggregates shard presence, completion status, failures, replay verdicts, and seed bases.
- Adds validated `seed_base` and `det_seeds` workflow inputs.
- Emits machine-readable deterministic failure records with known-family classification.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/dst-nightly.yml | Adds validated manual seed controls, per-shard log artifacts, and an aggregation job; the corrected maximum deterministic range remains disjoint from concurrent seeds. |
| crates/omnigraph-dst/src/harness.rs | Corrects the panic-message documentation to acknowledge multiline messages. |
| crates/omnigraph-dst/tests/scenarios.rs | Adds known-family classification and single-line JSON failure records for deterministic fleet reporting. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  D[Six deterministic shards] --> DA[Shard log artifacts]
  C[Eight concurrent shards] --> CA[Shard log artifacts]
  DA --> R[Nightly report job]
  CA --> R
  R --> S[GitHub run summary]
  R --> A[Nightly report artifact]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["review"](https://github.com/modernrelay/omnigraph/commit/a409a19f68660f5189122d4bf763f63e9012c5a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57802117)</sub>

<!-- /greptile_comment -->