### PR TITLE
feat(bench): support process-fresh XFS runs

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -211,10 +211,10 @@ checked scale budgets, table bounds, cache-condition declarations, and
 reset/backend compatibility. Planning expands the suite into ordered run
 entries; it does not execute a benchmark.
 
-The checked-in smoke point declares APFS on local NVMe storage. Validation is
-host-independent; runner-v1 probes the actual scratch volume on macOS and
-refuses to measure when its APFS and internal-storage evidence does not match
-the declaration. S3-compatible cases likewise carry region, storage class,
+The checked-in smoke point declares APFS on local NVMe storage. The AWS point
+declares XFS on EC2 instance-store NVMe and a fresh process with an uncontrolled
+page cache. Validation is host-independent; runner-v1 probes the actual scratch
+volume and refuses declarations that do not match. S3-compatible cases carry region, storage class,
 implementation/version, bucket-versioning state, and a digest pin for MinIO or
 RustFS images in their point identity, but they are not executable by this
 runner slice.
@@ -229,6 +229,11 @@ Wall-clock execution is available only from a release-profile binary:
 cargo run --release --locked -p omnigraph-bench -- \
   suite run benchmarks/suites/local-smoke.suite-v1.yaml \
   --archive .bench/archive
+
+# On the AWS lab's XFS instance-store mount:
+target/release/omnigraph-bench suite run \
+  benchmarks/suites/aws-xfs-process-cold.suite-v1.yaml \
+  --scratch-root /mnt/nvme --archive /mnt/nvme/omnigraph-bench-archive
 ```
 
 Use `--case <ID>` to select one suite entry, `--scratch-root <EXISTING-DIR>` to
@@ -249,15 +254,12 @@ Runner-v1 constructs and verifies one fixture whose `bench-source` and
 complete directory by physical SHA-256. The fixture is built at a stable
 `active` path because Lance shallow-branch manifests can retain absolute base
 paths. Public execution constructs it in a dedicated process group under a
-bounded watchdog. That child also byte-digests the completed tree, makes the
-never-opened APFS clonefile template, and removes `active` before returning an
-identity-checked handoff. The parent accepts it only after the direct child is
-reaped and the group is gone. A failed, partial, or panicked build quarantines
-the entire disposable workspace. Every repetition clone-restores the template
-to that exact `active` path. Forced clonefile reset has no byte-copy fallback.
-Handoff acceptance, reset, and the pre-timer witness walk metadata but do not
-read file contents, so they do not prewarm the fixture's data pages merely to
-prove identity.
+bounded watchdog. The child freezes a byte-digested template and removes
+`active` before returning an identity-checked handoff. APFS uses forced
+clonefile with no byte-copy fallback. Linux XFS uses verified copies only for
+the process-fresh point: reset reads bytes outside timing, so its page cache is
+truthfully declared uncontrolled. Every repetition restores the exact stable
+`active` path; failed construction quarantines the workspace.
 
 Every repetition uses a fresh worker process and starts from the same frozen
 state. The parent pins and records the worker executable SHA-256 and requires

--- a/benchmarks/cases/branch-merge-d50-process-cold-xfs.case-v1.yaml
+++ b/benchmarks/cases/branch-merge-d50-process-cold-xfs.case-v1.yaml
@@ -1,0 +1,45 @@
+version: 1
+id: branch-merge-d50-process-cold-xfs
+scenario: branch-merge-v1
+
+fixture:
+  builder: { kind: synthetic-branch-merge, version: 2, seed: 0 }
+  data:
+    provenance: synthetic
+    tables: 8
+    rows_per_table: 100000
+    payload_bytes: 64
+    column_shape: scalars
+    topology_skew: uniform
+  state:
+    aging: bulk-loaded
+    indexes: []
+    deletion_history: none
+    compaction_recency: not-optimized
+    history_depth: 213
+
+workload:
+  delta_rows_per_side: 50
+  diverged_tables: 4
+  arrival: unscheduled-single-shot
+  clients: 1
+  read_write_mix: write-heavy
+  contention: distinct-key
+
+environment:
+  backend: { kind: local-fs, filesystem: xfs, storage_class: nvme-ssd }
+  network_position: same-host
+  execution: embedded
+  cache_condition:
+    process: fresh-per-repetition
+    engine: preparation-only
+    page_cache: uncontrolled
+    program: none
+    iterations: 0
+
+protocol:
+  deadline_seconds: 60
+  attribution: per-phase
+  schedule: manual
+  reset: plain-copy
+  timer: monotonic

--- a/benchmarks/suites/aws-xfs-process-cold.suite-v1.yaml
+++ b/benchmarks/suites/aws-xfs-process-cold.suite-v1.yaml
@@ -1,0 +1,6 @@
+version: 1
+name: aws-xfs-process-cold
+
+runs:
+  - case: ../cases/branch-merge-d50-process-cold-xfs.case-v1.yaml
+    repetitions: 5

--- a/crates/omnigraph-bench/README.md
+++ b/crates/omnigraph-bench/README.md
@@ -32,16 +32,18 @@ measurement protocol and identity vocabulary.
 - Runner-v1 builds one already-diverged fixture at a stable `active` path,
   verifies it, closes it, and freezes its complete physical tree by SHA-256.
   Public execution performs construction in a dedicated process group under a
-  bounded watchdog. That child also byte-digests the completed tree, makes the
-  never-opened APFS clonefile template, and removes `active` before returning
-  an identity-checked handoff. The parent accepts it only after the direct child
+  bounded watchdog. That child byte-digests the completed tree, makes a
+  never-opened reset template, and removes `active` before returning an
+  identity-checked handoff. APFS uses forced clonefile; Linux XFS uses a full
+  verified copy only for process-fresh points with an uncontrolled page cache.
+  The parent accepts it only after the direct child
   has been reaped and the process group is gone. Any failed, partial, or
   panicked fixture build quarantines its disposable workspace instead of
-  deleting possibly active state. Every repetition clone-restores the template
+  deleting possibly active state. Every repetition restores the template
   to that same `active` path, so Lance shallow
   branches retain valid absolute base paths and samples do not accumulate
-  branch, manifest, or deletion history. Reset and pre-timer proof traverse
-  metadata but never read file contents or fall back to a byte copy.
+  branch, manifest, or deletion history. Clonefile never falls back to copying;
+  plain-copy reset reads and verifies all bytes outside timing.
 - Every repetition runs in a fresh worker process whose executable SHA-256,
   source commit/dirty state, Cargo's
   release/opt-level observations, compiler-effective debug assertions, the
@@ -402,8 +404,9 @@ attribution, and a monotonic timer. Process-cold, warmed-by-program, and
 reopened-after-program engine preparation are supported with their exact
 cross-validated cache declarations.
 
-The host probe currently proves APFS on an internal macOS NVMe or SATA SSD. A
-debug build, S3 or Azure backend, server execution, plain-copy reset, unproved
+The host probe proves APFS on an internal macOS NVMe or SATA SSD, or XFS on a
+direct EC2 instance-store NVMe namespace (and distinguishes EBS). A debug
+build, S3 or Azure backend, server execution, unproved
 host declaration, unsupported scenario axis, deadline breach, reset witness
 mismatch, non-general merge route, or content mismatch is refused instead of
 being approximated. A true OS-page-cache-cold claim is not representable yet;

--- a/crates/omnigraph-bench/README.md
+++ b/crates/omnigraph-bench/README.md
@@ -399,10 +399,11 @@ total table count is split equally between immutable node endpoint tables and
 uniform-ring edge tables; declared divergence applies to edge tables. It uses
 scalar uniform bulk-loaded data, no indexes or pre-existing deletion history,
 local filesystem storage, same-host embedded execution, one client, distinct-key
-write-heavy divergence, manual scheduling, local-clonefile reset, per-phase
-attribution, and a monotonic timer. Process-cold, warmed-by-program, and
-reopened-after-program engine preparation are supported with their exact
-cross-validated cache declarations.
+write-heavy divergence, manual scheduling, per-phase attribution, and a
+monotonic timer. APFS uses local-clonefile reset and supports process-cold,
+warmed-by-program, and reopened-after-program engine preparation. Linux/XFS
+admits only verified plain-copy reset with the exact process-fresh,
+preparation-only, uncontrolled-page-cache, no-program contract described below.
 
 The host probe proves APFS on an internal macOS NVMe or SATA SSD, or XFS on a
 direct EC2 instance-store NVMe namespace (and distinguishes EBS). A debug

--- a/crates/omnigraph-bench/src/environment.rs
+++ b/crates/omnigraph-bench/src/environment.rs
@@ -131,8 +131,8 @@ fn verify_linux(
         storage_protocol: match observed_storage {
             LocalStorageClass::NvmeSsd => "nvme-ec2-instance-store",
             LocalStorageClass::NetworkBlock => "nvme-ebs",
-            LocalStorageClass::SataSsd => {
-                return Err("Linux NVMe probe produced a SATA storage class".to_string());
+            LocalStorageClass::SataSsd | LocalStorageClass::RamDisk => {
+                return Err("Linux NVMe probe produced a non-NVMe storage class".to_string());
             }
         }
         .to_string(),

--- a/crates/omnigraph-bench/src/environment.rs
+++ b/crates/omnigraph-bench/src/environment.rs
@@ -2,10 +2,12 @@
 //!
 //! Case validation proves that factor combinations are internally coherent;
 //! execution must additionally prove that the scratch tree really resides on
-//! the declared filesystem and storage class. This first runner slice supports
-//! the checked-in APFS case on macOS and fails closed elsewhere.
+//! the declared filesystem and storage class. Runner-v1 supports APFS on
+//! macOS and EC2 instance-store NVMe-backed XFS on Linux.
 
 use std::path::Path;
+#[cfg(any(target_os = "linux", test))]
+use std::path::PathBuf;
 #[cfg(target_os = "macos")]
 use std::{
     collections::VecDeque,
@@ -22,6 +24,8 @@ use std::{
     thread::JoinHandle,
     time::{Duration, Instant},
 };
+#[cfg(target_os = "linux")]
+use std::{fs::File, io::Read, os::unix::fs::MetadataExt};
 
 use serde::Serialize;
 
@@ -37,6 +41,8 @@ const PROBE_REAP_DEADLINE: Duration = Duration::from_secs(2);
 const PROBE_PIPE_STOP_DEADLINE: Duration = Duration::from_secs(1);
 #[cfg(target_os = "macos")]
 const PROBE_POLL: Duration = Duration::from_millis(5);
+#[cfg(target_os = "linux")]
+const MAX_LINUX_PROBE_BYTES: u64 = 1024 * 1024;
 
 /// Facts observed from the mounted volume that owns the runner scratch tree.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -59,13 +65,172 @@ pub fn verify_local_environment(
     {
         verify_macos(scratch_path, declared_filesystem, declared_storage)
     }
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "linux")]
+    {
+        verify_linux(scratch_path, declared_filesystem, declared_storage)
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     {
         let _ = (scratch_path, declared_filesystem, declared_storage);
         Err(
-            "local environment verification is implemented only for macOS/APFS in runner-v1; refusing to trust unproved filesystem and storage-class declarations"
+            "local environment verification is implemented only for macOS/APFS and Linux/XFS in runner-v1; refusing unproved declarations"
                 .to_string(),
         )
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn verify_linux(
+    scratch_path: &Path,
+    declared_filesystem: LocalFilesystem,
+    declared_storage: LocalStorageClass,
+) -> Result<LocalEnvironmentEvidence, String> {
+    let path = std::fs::canonicalize(scratch_path)
+        .map_err(|error| format!("could not resolve benchmark scratch path: {error}"))?;
+    let device = std::fs::metadata(&path)
+        .map_err(|error| format!("could not stat benchmark scratch path: {error}"))?
+        .dev();
+    let major = nix::sys::stat::major(device);
+    let minor = nix::sys::stat::minor(device);
+    let mountinfo = read_bounded_utf8(Path::new("/proc/self/mountinfo"), MAX_LINUX_PROBE_BYTES)?;
+    let mount_point = linux_xfs_mount(&mountinfo, major, minor, &path)?;
+    let device_root = std::fs::canonicalize(format!("/sys/dev/block/{major}:{minor}"))
+        .map_err(|error| format!("could not resolve Linux scratch device: {error}"))?;
+    let device_name = device_root
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| "Linux scratch device name is not canonical UTF-8".to_string())?;
+    if !is_nvme_namespace(device_name) {
+        return Err(format!(
+            "runner-v1 requires a directly mounted NVMe namespace, observed `{device_name}`"
+        ));
+    }
+    if read_trimmed(device_root.join("queue/rotational"))? != "0" {
+        return Err("runner-v1 requires non-rotating NVMe instance storage".to_string());
+    }
+    let model = read_trimmed(device_root.join("device/model"))?;
+    let observed_storage = classify_linux_nvme(&model)?;
+    if declared_filesystem != LocalFilesystem::Xfs || declared_storage != observed_storage {
+        return Err(format!(
+            "declared Linux backend {}/{} does not match observed xfs/{} (model `{model}`)",
+            filesystem_name(declared_filesystem),
+            storage_name(declared_storage),
+            storage_name(observed_storage),
+        ));
+    }
+    let status = nix::sys::statvfs::statvfs(&path)
+        .map_err(|error| format!("could not statvfs benchmark scratch: {error}"))?;
+    let available_bytes = status
+        .fragment_size()
+        .checked_mul(status.blocks_available())
+        .ok_or_else(|| "statvfs available-byte count overflowed u64".to_string())?;
+    Ok(LocalEnvironmentEvidence {
+        filesystem: "xfs".to_string(),
+        storage_class: storage_name(observed_storage).to_string(),
+        mount_point: mount_point.display().to_string(),
+        storage_protocol: match observed_storage {
+            LocalStorageClass::NvmeSsd => "nvme-ec2-instance-store",
+            LocalStorageClass::NetworkBlock => "nvme-ebs",
+            LocalStorageClass::SataSsd => {
+                return Err("Linux NVMe probe produced a SATA storage class".to_string());
+            }
+        }
+        .to_string(),
+        available_bytes,
+        probe: "linux-mountinfo-sysfs-v1",
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn read_bounded_utf8(path: &Path, limit: u64) -> Result<String, String> {
+    let mut bytes = Vec::new();
+    File::open(path)
+        .and_then(|file| file.take(limit + 1).read_to_end(&mut bytes))
+        .map_err(|error| format!("could not read {}: {error}", path.display()))?;
+    if bytes.len() as u64 > limit {
+        return Err(format!(
+            "Linux probe {} exceeded {limit} bytes",
+            path.display()
+        ));
+    }
+    String::from_utf8(bytes)
+        .map_err(|error| format!("Linux probe {} is not UTF-8: {error}", path.display()))
+}
+
+#[cfg(target_os = "linux")]
+fn read_trimmed(path: PathBuf) -> Result<String, String> {
+    let value = read_bounded_utf8(&path, 4096)?;
+    let value = value.trim();
+    if value.is_empty() || value.chars().any(char::is_control) {
+        return Err(format!("Linux probe {} was non-canonical", path.display()));
+    }
+    Ok(value.to_string())
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn linux_xfs_mount(
+    mountinfo: &str,
+    major: u64,
+    minor: u64,
+    scratch_path: &Path,
+) -> Result<PathBuf, String> {
+    let device = format!("{major}:{minor}");
+    let mut best = None::<PathBuf>;
+    for line in mountinfo.lines() {
+        let Some((mount_fields, fs_fields)) = line.split_once(" - ") else {
+            continue;
+        };
+        let mut fields = mount_fields.split_ascii_whitespace();
+        let observed_device = fields.nth(2);
+        let _root = fields.next();
+        let mount = fields.next();
+        if observed_device != Some(device.as_str()) || mount.is_none() {
+            continue;
+        }
+        let mount = mount.expect("checked above");
+        if mount.contains('\\') {
+            return Err("runner-v1 refuses an escaped Linux mount path".to_string());
+        }
+        let mount = PathBuf::from(mount);
+        if !scratch_path.starts_with(&mount) {
+            continue;
+        }
+        if fs_fields.split_ascii_whitespace().next() != Some("xfs") {
+            return Err(format!("scratch device {device} is not XFS"));
+        }
+        if best
+            .as_ref()
+            .is_none_or(|current| mount.as_os_str().len() > current.as_os_str().len())
+        {
+            best = Some(mount);
+        }
+    }
+    best.ok_or_else(|| format!("could not locate XFS scratch device {device} in mountinfo"))
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn is_nvme_namespace(device_name: &str) -> bool {
+    let Some(suffix) = device_name.strip_prefix("nvme") else {
+        return false;
+    };
+    let controller_digits = suffix.bytes().take_while(u8::is_ascii_digit).count();
+    let Some(namespace) = suffix
+        .get(controller_digits..)
+        .and_then(|rest| rest.strip_prefix('n'))
+    else {
+        return false;
+    };
+    controller_digits > 0
+        && !namespace.is_empty()
+        && namespace.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn classify_linux_nvme(model: &str) -> Result<LocalStorageClass, String> {
+    match model {
+        "Amazon EC2 NVMe Instance Storage" => Ok(LocalStorageClass::NvmeSsd),
+        "Amazon Elastic Block Store" => Ok(LocalStorageClass::NetworkBlock),
+        _ => Err(format!("unknown Linux NVMe storage model `{model}`")),
     }
 }
 
@@ -696,7 +861,7 @@ fn probe_value<'a>(output: &'a str, field: &str) -> Result<&'a str, String> {
     Ok(value)
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn filesystem_name(filesystem: LocalFilesystem) -> &'static str {
     match filesystem {
         LocalFilesystem::Apfs => "apfs",
@@ -705,13 +870,52 @@ fn filesystem_name(filesystem: LocalFilesystem) -> &'static str {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn storage_name(storage: LocalStorageClass) -> &'static str {
     match storage {
         LocalStorageClass::NvmeSsd => "nvme-ssd",
         LocalStorageClass::SataSsd => "sata-ssd",
         LocalStorageClass::NetworkBlock => "network-block",
         LocalStorageClass::RamDisk => "ram-disk",
+    }
+}
+
+#[cfg(test)]
+mod linux_tests {
+    use super::*;
+
+    #[test]
+    fn mountinfo_selects_the_deepest_matching_xfs_mount() {
+        let mountinfo = "1 0 259:1 / / rw - xfs /dev/nvme1n1 rw\n\
+                         2 1 259:1 /bench /mnt/nvme rw - xfs /dev/nvme1n1 rw\n";
+        assert_eq!(
+            linux_xfs_mount(mountinfo, 259, 1, Path::new("/mnt/nvme/run")).unwrap(),
+            PathBuf::from("/mnt/nvme")
+        );
+        assert!(
+            linux_xfs_mount(
+                "1 0 259:1 / /mnt rw - ext4 /dev/nvme1n1 rw",
+                259,
+                1,
+                Path::new("/mnt/run")
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn linux_storage_class_refuses_partitions_and_distinguishes_ebs() {
+        assert!(is_nvme_namespace("nvme12n3"));
+        assert!(!is_nvme_namespace("nvme12n3p1"));
+        assert_eq!(
+            classify_linux_nvme("Amazon EC2 NVMe Instance Storage").unwrap(),
+            LocalStorageClass::NvmeSsd
+        );
+        assert_eq!(
+            classify_linux_nvme("Amazon Elastic Block Store").unwrap(),
+            LocalStorageClass::NetworkBlock
+        );
+        assert!(classify_linux_nvme("Generic PCIe NVMe").is_err());
     }
 }
 

--- a/crates/omnigraph-bench/src/fixture_worker.rs
+++ b/crates/omnigraph-bench/src/fixture_worker.rs
@@ -18,8 +18,11 @@ use std::time::Instant;
 use serde::{Deserialize, Serialize};
 
 use crate::branch_merge::{BranchMergePlan, FixtureBuildSummary, initialize_local_fixture};
-use crate::case::CaseV1;
-use crate::reset::{MetadataDigest, PhysicalDigest, TraversalLimits, freeze_clonefile_template};
+use crate::case::{CaseV1, ResetMode};
+use crate::reset::{
+    MetadataDigest, PhysicalDigest, TraversalLimits, copy_verified, digest_metadata_tree,
+    digest_physical_tree, freeze_clonefile_template,
+};
 #[cfg(unix)]
 use crate::runner::{
     ChildProcessEvidence, configure_fixture_child_environment,
@@ -144,16 +147,48 @@ async fn execute_fixture_request(request: FixtureRequestV1) -> FixtureResultV1 {
         Ok(summary) => summary,
         Err(error) => return failure("fixture_build_failed", error.to_string()),
     };
-    let frozen = match freeze_clonefile_template(
-        &request.active_root,
-        &request.template_root,
-        TraversalLimits::default(),
-    ) {
-        Ok(frozen) => frozen,
-        Err(error) => return failure("fixture_freeze_failed", error.to_string()),
+    let limits = TraversalLimits::default();
+    let (physical, template_metadata) = match case.definition.protocol.reset {
+        ResetMode::LocalClonefile => {
+            let frozen = match freeze_clonefile_template(
+                &request.active_root,
+                &request.template_root,
+                limits,
+            ) {
+                Ok(frozen) => frozen,
+                Err(error) => return failure("fixture_freeze_failed", error.to_string()),
+            };
+            (
+                frozen.physical_digest().clone(),
+                frozen.metadata_digest().clone(),
+            )
+        }
+        ResetMode::PlainCopy => {
+            let physical = match digest_physical_tree(&request.active_root, limits) {
+                Ok(physical) => physical,
+                Err(error) => return failure("fixture_digest_failed", error.to_string()),
+            };
+            if let Err(error) = copy_verified(
+                &request.active_root,
+                &request.template_root,
+                &physical,
+                limits,
+            ) {
+                return failure("fixture_copy_failed", error.to_string());
+            }
+            let metadata = match digest_metadata_tree(&request.template_root, limits) {
+                Ok(metadata) => metadata,
+                Err(error) => return failure("fixture_metadata_failed", error.to_string()),
+            };
+            (physical, metadata)
+        }
+        ResetMode::S3Versioning => {
+            return failure(
+                "unsupported_runner_axis",
+                "local fixture worker cannot freeze an S3 reset template",
+            );
+        }
     };
-    let physical = frozen.physical_digest().clone();
-    let template_metadata = frozen.metadata_digest().clone();
     if let Err(error) = remove_active_tree(&request.active_root) {
         return failure("fixture_active_remove_failed", error);
     }
@@ -744,8 +779,7 @@ mod tests {
         .unwrap()
     }
 
-    #[cfg(target_os = "macos")]
-    fn tiny_case() -> ValidatedCase {
+    fn tiny_case(reset: ResetMode) -> ValidatedCase {
         let mut definition = test_case().definition;
         definition.id = "fixture-worker-tiny".to_string();
         definition.fixture.data.tables = 2;
@@ -753,6 +787,7 @@ mod tests {
         definition.fixture.state.history_depth = 6;
         definition.workload.delta_rows_per_side = 3;
         definition.workload.diverged_tables = 1;
+        definition.protocol.reset = reset;
         validate_case(definition).into_result().unwrap()
     }
 
@@ -1007,16 +1042,14 @@ mod tests {
         assert!(error.context.child_process.is_some(), "{error:?}");
     }
 
-    #[cfg(target_os = "macos")]
-    #[tokio::test]
-    async fn fixture_request_revalidates_builds_and_returns_checked_identity() {
+    async fn assert_fixture_request_round_trip(reset: ResetMode) {
         let workspace = tempfile::tempdir().unwrap();
         let active = workspace.path().join("active");
         let template = workspace.path().join("template");
         let fixture_scratch_root = workspace.path().join("fixture-scratch-v1");
         std::fs::create_dir(&active).unwrap();
         std::fs::create_dir(&fixture_scratch_root).unwrap();
-        let case = tiny_case();
+        let case = tiny_case(reset);
         let result_path = workspace.path().join("result.json");
         let request = FixtureRequestV1 {
             protocol_version: FIXTURE_PROTOCOL_VERSION,
@@ -1047,5 +1080,16 @@ mod tests {
             }
             result => panic!("unexpected fixture result: {result:?}"),
         }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn clonefile_fixture_request_revalidates_and_returns_checked_identity() {
+        assert_fixture_request_round_trip(ResetMode::LocalClonefile).await;
+    }
+
+    #[tokio::test]
+    async fn plain_copy_fixture_request_revalidates_and_returns_checked_identity() {
+        assert_fixture_request_round_trip(ResetMode::PlainCopy).await;
     }
 }

--- a/crates/omnigraph-bench/src/runner.rs
+++ b/crates/omnigraph-bench/src/runner.rs
@@ -36,8 +36,9 @@ use crate::branch_merge::{
     capture_protected_branch_heads, initialize_local_fixture, verify_merged_graph, warm_read_set,
 };
 use crate::case::{
-    Attribution, Backend, CacheCondition, Data, EnginePreparation, FixtureBuilder,
-    MAX_WARMUP_ITERATIONS, PageCacheCondition, ProcessLifecycle, ResetMode, State, WarmupProgram,
+    Attribution, Backend, CacheCondition, Data, EnginePreparation, FixtureBuilder, LocalFilesystem,
+    LocalStorageClass, MAX_WARMUP_ITERATIONS, PageCacheCondition, ProcessLifecycle, ResetMode,
+    State, WarmupProgram,
 };
 use crate::counting::{LogicalCallCounter, LogicalCallCounts};
 use crate::environment::{LocalEnvironmentEvidence, verify_local_environment};
@@ -48,6 +49,7 @@ use crate::reset::{
     ClonefileTemplate, MetadataDigest, PHYSICAL_TREE_DIGEST_ALGORITHM, PhysicalDigest,
     TraversalLimits, accept_clonefile_template_handoff, copy_verified, digest_metadata_tree,
     digest_physical_tree, freeze_clonefile_template, verify_metadata_shape, verify_metadata_tree,
+    verify_physical_tree,
 };
 use crate::suite::{MAX_REPETITIONS_PER_CASE, MAX_SUITE_RUNS, MAX_TOTAL_REPETITIONS};
 use crate::supervisor::{SupervisionInput, supervise_repetition};
@@ -1428,6 +1430,37 @@ struct ResolvedWorker {
     executable_sha256: String,
 }
 
+fn validate_production_reset(case: &crate::case::CaseV1) -> RunnerResult<()> {
+    let linux_xfs_process_cold = cfg!(target_os = "linux")
+        && matches!(
+            &case.environment.backend,
+            Backend::LocalFs {
+                filesystem: LocalFilesystem::Xfs,
+                storage_class: LocalStorageClass::NvmeSsd,
+            }
+        )
+        && case.environment.cache_condition
+            == (CacheCondition {
+                process: ProcessLifecycle::FreshPerRepetition,
+                engine: EnginePreparation::PreparationOnly,
+                page_cache: PageCacheCondition::Uncontrolled,
+                program: WarmupProgram::None,
+                iterations: 0,
+            });
+    match case.protocol.reset {
+        ResetMode::LocalClonefile => Ok(()),
+        ResetMode::PlainCopy if linux_xfs_process_cold => Ok(()),
+        ResetMode::PlainCopy => Err(RunnerError::new(
+            "unsupported_runner_axis",
+            "plain-copy requires verified Linux XFS instance-store NVMe with the process-fresh, preparation-only, page-cache-uncontrolled cache declaration",
+        )),
+        ResetMode::S3Versioning => Err(RunnerError::new(
+            "unsupported_runner_axis",
+            "runner-v1 does not implement S3 reset",
+        )),
+    }
+}
+
 async fn execute_run_inner(
     run: &ResolvedRun,
     options: &RunOptions,
@@ -1441,11 +1474,8 @@ async fn execute_run_inner(
             "runner-v1 requires protocol.attribution: per-phase so every measured merge carries exact phase evidence",
         ));
     }
-    if run.case.definition.protocol.reset != ResetMode::LocalClonefile && !guards.allow_plain_copy {
-        return Err(RunnerError::new(
-            "unsupported_runner_axis",
-            "runner-v1 wall-clock execution requires protocol.reset: local-clonefile; byte copying would pre-warm file contents",
-        ));
+    if !guards.allow_plain_copy {
+        validate_production_reset(&run.case.definition)?;
     }
 
     let plan = BranchMergePlan::try_from(&run.case)
@@ -1564,27 +1594,34 @@ async fn execute_owned_run(
                 workspace.path(),
                 FIXTURE_BUILD_WATCHDOG,
             )?;
-            let template = accept_clonefile_template_handoff(
-                &active_root,
-                &template_root,
-                handoff.physical.clone(),
-                handoff.template_metadata,
-                limits,
-            )
-            .map_err(|error| {
-                RunnerError::new(
-                    "fixture_handoff_failed",
-                    format!(
-                        "could not accept contained fixture template {}: {error}",
-                        template_root.display()
-                    ),
-                )
-            })?;
-            (
-                handoff.summary,
-                FrozenTemplate::Clonefile(template),
-                handoff.physical,
-            )
+            let template = match run.case.definition.protocol.reset {
+                ResetMode::LocalClonefile => FrozenTemplate::Clonefile(
+                    accept_clonefile_template_handoff(
+                        &active_root,
+                        &template_root,
+                        handoff.physical.clone(),
+                        handoff.template_metadata,
+                        limits,
+                    )
+                    .map_err(|error| {
+                        RunnerError::new("fixture_handoff_failed", error.to_string())
+                    })?,
+                ),
+                ResetMode::PlainCopy => FrozenTemplate::accept_plain_copy_handoff(
+                    &active_root,
+                    &template_root,
+                    handoff.physical.clone(),
+                    handoff.template_metadata,
+                    limits,
+                )?,
+                ResetMode::S3Versioning => {
+                    return Err(RunnerError::new(
+                        "unsupported_runner_axis",
+                        "local runner cannot accept an S3 reset handoff",
+                    ));
+                }
+            };
+            (handoff.summary, template, handoff.physical)
         } else {
             // Owning-layer tests keep their tiny fixtures in-process. Public
             // wall-clock execution always takes the bounded child path above.
@@ -1607,7 +1644,7 @@ async fn execute_owned_run(
                     )?,
                 )
             } else {
-                FrozenTemplate::plain_copy_for_test(&active_root, &template_root, limits)?
+                FrozenTemplate::freeze_plain_copy(&active_root, &template_root, limits)?
             };
             remove_active_tree(&active_root)?;
             let physical = template.physical_digest().clone();
@@ -2091,7 +2128,7 @@ fn stage_bound_worker(source: BoundWorkerSource, workspace: &Path) -> RunnerResu
 
 enum FrozenTemplate {
     Clonefile(ClonefileTemplate),
-    PlainCopyForTest {
+    PlainCopy {
         template_root: PathBuf,
         active_root: PathBuf,
         physical: PhysicalDigest,
@@ -2101,7 +2138,7 @@ enum FrozenTemplate {
 }
 
 impl FrozenTemplate {
-    fn plain_copy_for_test(
+    fn freeze_plain_copy(
         active_root: &Path,
         template_root: &Path,
         limits: TraversalLimits,
@@ -2112,7 +2149,41 @@ impl FrozenTemplate {
             .map_err(|error| RunnerError::new("fixture_copy_failed", error.to_string()))?;
         let metadata = digest_metadata_tree(template_root, limits)
             .map_err(|error| RunnerError::new("fixture_metadata_failed", error.to_string()))?;
-        Ok(Self::PlainCopyForTest {
+        Ok(Self::PlainCopy {
+            template_root: template_root.to_path_buf(),
+            active_root: active_root.to_path_buf(),
+            physical,
+            metadata,
+            limits,
+        })
+    }
+
+    fn accept_plain_copy_handoff(
+        active_root: &Path,
+        template_root: &Path,
+        physical: PhysicalDigest,
+        metadata: MetadataDigest,
+        limits: TraversalLimits,
+    ) -> RunnerResult<Self> {
+        match std::fs::symlink_metadata(active_root) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Ok(_) => {
+                return Err(RunnerError::new(
+                    "fixture_handoff_failed",
+                    "contained fixture worker left the active path behind",
+                ));
+            }
+            Err(error) => {
+                return Err(RunnerError::new(
+                    "fixture_handoff_failed",
+                    format!("could not inspect retired active path: {error}"),
+                ));
+            }
+        }
+        verify_physical_tree(template_root, &physical, limits)
+            .and_then(|_| verify_metadata_tree(template_root, &metadata, limits))
+            .map_err(|error| RunnerError::new("fixture_handoff_failed", error.to_string()))?;
+        Ok(Self::PlainCopy {
             template_root: template_root.to_path_buf(),
             active_root: active_root.to_path_buf(),
             physical,
@@ -2124,21 +2195,21 @@ impl FrozenTemplate {
     fn physical_digest(&self) -> &PhysicalDigest {
         match self {
             Self::Clonefile(template) => template.physical_digest(),
-            Self::PlainCopyForTest { physical, .. } => physical,
+            Self::PlainCopy { physical, .. } => physical,
         }
     }
 
     fn active_root(&self) -> &Path {
         match self {
             Self::Clonefile(template) => template.active_root(),
-            Self::PlainCopyForTest { active_root, .. } => active_root,
+            Self::PlainCopy { active_root, .. } => active_root,
         }
     }
 
     fn verify_unchanged(&self) -> RunnerResult<()> {
         match self {
             Self::Clonefile(template) => template.verify_unchanged().map(|_| ()),
-            Self::PlainCopyForTest {
+            Self::PlainCopy {
                 template_root,
                 metadata,
                 limits,
@@ -2158,7 +2229,7 @@ impl FrozenTemplate {
             Self::Clonefile(template) => template
                 .restore_active()
                 .map(|prepared| prepared.metadata_digest().clone()),
-            Self::PlainCopyForTest {
+            Self::PlainCopy {
                 template_root,
                 active_root,
                 physical,
@@ -3760,6 +3831,62 @@ mod tests {
         };
         let error = cache_preparation_action(&mismatched).unwrap_err();
         assert_eq!(error.code, "unsupported_cache_condition");
+    }
+
+    #[test]
+    fn production_plain_copy_requires_the_exact_linux_xfs_cold_contract() {
+        let mut definition = checked_catalog_run(1).case.definition;
+        definition.environment.backend = Backend::LocalFs {
+            filesystem: LocalFilesystem::Xfs,
+            storage_class: LocalStorageClass::NvmeSsd,
+        };
+        definition.environment.cache_condition = CacheCondition {
+            process: ProcessLifecycle::FreshPerRepetition,
+            engine: EnginePreparation::PreparationOnly,
+            page_cache: PageCacheCondition::Uncontrolled,
+            program: WarmupProgram::None,
+            iterations: 0,
+        };
+        definition.protocol.reset = ResetMode::PlainCopy;
+        let case = validate_case(definition.clone()).into_result().unwrap();
+        assert_eq!(
+            validate_production_reset(&case.definition).is_ok(),
+            cfg!(target_os = "linux")
+        );
+
+        definition.environment.cache_condition.engine = EnginePreparation::WarmedByProgram;
+        definition.environment.cache_condition.page_cache = PageCacheCondition::ProgramConditioned;
+        definition.environment.cache_condition.program = WarmupProgram::BranchMergeReadSetV1;
+        definition.environment.cache_condition.iterations = 1;
+        let case = validate_case(definition).into_result().unwrap();
+        assert_eq!(
+            validate_production_reset(&case.definition)
+                .unwrap_err()
+                .code,
+            "unsupported_runner_axis"
+        );
+    }
+
+    #[test]
+    fn plain_copy_handoff_accepts_and_restores_checked_bytes() {
+        let workspace = tempfile::tempdir().unwrap();
+        let template_root = workspace.path().join("template");
+        let active_root = workspace.path().join("active");
+        std::fs::create_dir(&template_root).unwrap();
+        std::fs::write(template_root.join("fixture"), b"frozen bytes").unwrap();
+        let limits = TraversalLimits::default();
+        let physical = digest_physical_tree(&template_root, limits).unwrap();
+        let metadata = digest_metadata_tree(&template_root, limits).unwrap();
+        let template = FrozenTemplate::accept_plain_copy_handoff(
+            &active_root,
+            &template_root,
+            physical.clone(),
+            metadata,
+            limits,
+        )
+        .unwrap();
+        template.restore_active().unwrap();
+        verify_physical_tree(&active_root, &physical, limits).unwrap();
     }
 
     #[test]

--- a/crates/omnigraph-bench/tests/cli.rs
+++ b/crates/omnigraph-bench/tests/cli.rs
@@ -388,6 +388,19 @@ fn checked_in_case_and_suite_validate() {
         .assert()
         .success()
         .stdout(predicate::str::contains("local-smoke"));
+
+    Command::cargo_bin("omnigraph-bench")
+        .expect("benchmark binary")
+        .args([
+            "suite",
+            "validate",
+            benchmark_path("suites/aws-xfs-process-cold.suite-v1.yaml")
+                .to_str()
+                .expect("UTF-8 path"),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("aws-xfs-process-cold"));
 }
 
 #[test]

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -136,8 +136,10 @@ Correctness tests may assert deterministic logical or object-store operation cou
 
 The current runner executes the narrow, fail-closed local envelope documented
 in `crates/omnigraph-bench/README.md`. It requires a release binary, restores
-every repetition from a never-opened APFS clonefile template at the fixture's
-stable path, contains each measured merge in a fresh SHA-attested,
+every repetition at the fixture's stable path from a never-opened APFS
+clonefile template or a verified Linux/XFS plain-copy template. Plain-copy
+reads fixture bytes before measurement and declares the page cache uncontrolled.
+The runner contains each measured merge in a fresh SHA-attested,
 hard-deadline worker process, and verifies exact target/source/main state.
 Fixture and repetition children clear the host environment, pin locale, and
 receive protocol-owned scratch siblings as `TMPDIR` and cwd; measured workers

--- a/docs/releases/v0.10.0.md
+++ b/docs/releases/v0.10.0.md
@@ -73,6 +73,9 @@ and GitHub Releases; see the current policy in
   only bounded counts/receipts; indeterminate directory-sync outcomes retain a
   typed reconciliation identity. Physical cloud attempts, comparison/noise-floor
   reports, and controlled cloud orchestration remain future slices.
+  The local runner also admits the checked-in process-fresh XFS suite on EC2
+  instance-store NVMe. Its verified plain-copy reset runs outside timing and
+  explicitly leaves the OS page cache uncontrolled.
   A separate `omnigraph-bench fixture fingerprint`/`fixture verify` interface prints a
   strict, location-free physical copy-source descriptor for a stable local
   tree, binds later copies by full physical digest, and returns the canonical


### PR DESCRIPTION
## Summary

- admit one exact Linux/XFS runner envelope: EC2 instance-store NVMe, fresh process per repetition, preparation-only engine state, uncontrolled page cache, and verified plain-copy reset
- reuse the existing node-plus-edge fixture builder, isolated fixture worker, physical digest, and byte-verified reset instead of adding an AWS-side harness
- add one declarative five-repetition XFS suite and document its honest cache semantics

## Safety boundary

- fail closed on partitions, device mapper/LVM/MD, non-XFS mounts, rotating devices, EBS for production plain-copy, and unknown NVMe model strings
- require the fixture child to retire the active path; the parent re-verifies the complete template before accepting the handoff
- recheck frozen bytes and restored bytes outside every measured interval
- make no OS-page-cache-cold claim: plain-copy runs declare page cache uncontrolled
- add no AWS workflows, IAM, queue, database, telemetry protocol, watchdog service, or benchmark-aws changes

## Validation

- `cargo test -p omnigraph-bench --locked --no-fail-fast`
- `cargo clippy -p omnigraph-bench --all-targets --locked -- -D warnings -W clippy::dbg_macro`
- `cargo fmt --all --check`
- `cargo test -p omnigraph-engine --test export --locked --no-fail-fast`
- `bash scripts/check-agents-md.sh`
- `python3 scripts/check-docs.py`
- `python3 scripts/check-workflow-action-pins.py`
- suite plan resolves point `922a2c96eb7441e0668baa8e3d209c352edafb42da14468d3c03fa4b09908d86`

## Live EC2/XFS qualification

Qualified exact head `7b7b4d9b80d5c922c1690422c099adc414409247` on an x86_64 `c6id.2xlarge` using direct EC2 instance-store NVMe mounted as XFS. The harness recorded `nvme-ec2-instance-store` through `linux-mountinfo-sysfs-v1`.

- the same suite refused the root EBS partition before fixture construction: `environment_mismatch`, 0 completed runs, 0 published records
- acquisition completed all 5 requested repetitions from one common physical input digest
- all 5 outcomes were `merged`; every sample passed exact-content, source, main, and protected-head verification across 8 tables / 799,998 rows
- wall clock was 426.159–439.941 ms, p50 432.078 ms
- archive verification passed with one durable record
- the lab server was restored and active after acquisition

The timing is directional only: five samples do not support p95, OS page-cache state is explicitly uncontrolled, and controlled digest-bound effective codegen evidence is still unproved. The record therefore remains claim-ineligible; this run qualifies the execution/reset protocol rather than establishing a publishable performance claim.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR extends the benchmark runner with a narrowly constrained Linux/XFS execution path using verified plain-copy fixture resets and fresh worker processes.

- Adds Linux mount and NVMe storage verification that distinguishes EC2 instance storage from EBS and rejects unsupported device arrangements.
- Adds verified plain-copy template creation, handoff, restoration, and failure quarantine.
- Adds a five-repetition XFS benchmark suite and documents its uncontrolled page-cache semantics.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/omnigraph-bench/src/environment.rs | Adds fail-closed Linux XFS and direct-NVMe environment verification, including explicit rejection of all non-NVMe storage-class variants. |
| crates/omnigraph-bench/src/fixture_worker.rs | Extends isolated fixture construction to create and verify plain-copy templates before retiring the active tree. |
| crates/omnigraph-bench/src/runner.rs | Restricts plain-copy execution to the declared Linux/XFS process-fresh envelope and verifies every handoff and repetition restore. |
| benchmarks/cases/branch-merge-d50-process-cold-xfs.case-v1.yaml | Declares the supported XFS benchmark point with preparation-only engine state and an explicitly uncontrolled page cache. |
| benchmarks/suites/aws-xfs-process-cold.suite-v1.yaml | Adds the declarative five-repetition suite for the new XFS benchmark point. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Validate XFS process-fresh case] --> B[Probe Linux mount and NVMe device]
    B -->|Supported EC2 instance-store XFS| C[Build active fixture in isolated child]
    B -->|Unsupported storage or filesystem| X[Refuse execution]
    C --> D[Copy and byte-verify frozen template]
    D --> E[Retire active fixture and verify handoff]
    E --> F[Restore and verify active tree]
    F --> G[Run one fresh worker process]
    G --> H[Verify result and unchanged template]
    H --> I{More repetitions?}
    I -->|Yes| F
    I -->|No| J[Publish benchmark evidence]
    C -->|Failure| Q[Quarantine workspace]
    D -->|Failure| Q
    F -->|Failure| Q
    G -->|Failure| Q
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(bench): reject every non-NVMe Linux ..."](https://github.com/modernrelay/omnigraph/commit/7b7b4d9b80d5c922c1690422c099adc414409247) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57980649)</sub>

<!-- /greptile_comment -->
