### PR TITLE
fix(merge): bound the incremental authority refresh (stacked on #541)

### DIFF
--- a/crates/omnigraph/src/db/commit_graph.rs
+++ b/crates/omnigraph/src/db/commit_graph.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
 
 use crate::error::Result;
 
@@ -49,8 +50,16 @@ pub(crate) struct FirstParentEdge {
 pub struct CommitGraph {
     root_uri: String,
     active_branch: Option<String>,
-    commit_by_id: HashMap<String, GraphCommit>,
+    commit_by_id: Arc<HashMap<String, GraphCommit>>,
     head_commit: Option<GraphCommit>,
+}
+
+/// Immutable view handed from authority capture to merge-base selection.
+/// Cloning it is O(1); coordinator updates use copy-on-write, so an authority
+/// capture cannot change underneath its merge-base walk.
+#[derive(Clone)]
+pub(crate) struct CommitGraphSnapshot {
+    commit_by_id: Arc<HashMap<String, GraphCommit>>,
 }
 
 impl CommitGraph {
@@ -64,7 +73,7 @@ impl CommitGraph {
         Ok(Self {
             root_uri: root.to_string(),
             active_branch: None,
-            commit_by_id,
+            commit_by_id: Arc::new(commit_by_id),
             head_commit,
         })
     }
@@ -80,7 +89,7 @@ impl CommitGraph {
         Self {
             root_uri: root_uri.trim_end_matches('/').to_string(),
             active_branch: active_branch.map(str::to_string),
-            commit_by_id,
+            commit_by_id: Arc::new(commit_by_id),
             head_commit,
         }
     }
@@ -92,8 +101,28 @@ impl CommitGraph {
         rows: Vec<crate::db::manifest::GraphLineageRow>,
     ) {
         let (commit_by_id, head_commit) = build_commit_cache(rows);
-        self.commit_by_id = commit_by_id;
+        self.commit_by_id = Arc::new(commit_by_id);
         self.head_commit = head_commit;
+    }
+
+    /// Extend the cache with lineage rows decoded from newly appended
+    /// manifest fragments. The head reduction is identical to a full rebuild,
+    /// but no historical map or row vector is cloned.
+    pub(crate) fn append_manifest_rows(&mut self, rows: Vec<crate::db::manifest::GraphLineageRow>) {
+        let commits = Arc::make_mut(&mut self.commit_by_id);
+        for row in rows {
+            let commit = graph_commit_from_manifest_row(row);
+            if should_replace_head(self.head_commit.as_ref(), &commit) {
+                self.head_commit = Some(commit.clone());
+            }
+            commits.insert(commit.graph_commit_id.clone(), commit);
+        }
+    }
+
+    pub(crate) fn snapshot(&self) -> CommitGraphSnapshot {
+        CommitGraphSnapshot {
+            commit_by_id: Arc::clone(&self.commit_by_id),
+        }
     }
 
     /// Insert a just-published commit into the in-memory cache (RFC-013 Phase 7).
@@ -109,8 +138,7 @@ impl CommitGraph {
         if should_replace_head(self.head_commit.as_ref(), &commit) {
             self.head_commit = Some(commit.clone());
         }
-        self.commit_by_id
-            .insert(commit.graph_commit_id.clone(), commit);
+        Arc::make_mut(&mut self.commit_by_id).insert(commit.graph_commit_id.clone(), commit);
     }
 
     pub async fn open(root_uri: &str) -> Result<Self> {
@@ -119,7 +147,7 @@ impl CommitGraph {
         Ok(Self {
             root_uri: root.to_string(),
             active_branch: None,
-            commit_by_id,
+            commit_by_id: Arc::new(commit_by_id),
             head_commit,
         })
     }
@@ -132,7 +160,7 @@ impl CommitGraph {
         Ok(Self {
             root_uri: root.to_string(),
             active_branch: Some(branch.to_string()),
-            commit_by_id,
+            commit_by_id: Arc::new(commit_by_id),
             head_commit,
         })
     }
@@ -140,7 +168,7 @@ impl CommitGraph {
     pub async fn refresh(&mut self) -> Result<()> {
         let (commit_by_id, head_commit) =
             load_commit_cache_for_branch(&self.root_uri, self.active_branch.as_deref()).await?;
-        self.commit_by_id = commit_by_id;
+        self.commit_by_id = Arc::new(commit_by_id);
         self.head_commit = head_commit;
         Ok(())
     }
@@ -210,56 +238,40 @@ impl CommitGraph {
         source_commit_id: &str,
         target_commit_id: &str,
     ) -> Result<Option<GraphCommit>> {
-        Ok(Self::merge_base_from_commits(
-            source.load_commits().await?,
-            target.load_commits().await?,
+        Ok(Self::merge_base_from_snapshots(
+            source.snapshot(),
+            target.snapshot(),
             source_commit_id,
             target_commit_id,
         ))
     }
 
-    /// Compute a merge base from two already-captured lineage projections.
-    /// The caller is responsible for coupling each projection to the branch
-    /// authority snapshot it captured; this function is pure and performs no
-    /// storage I/O.
-    pub(crate) fn merge_base_from_commits(
-        source_commits: Vec<GraphCommit>,
-        target_commits: Vec<GraphCommit>,
+    /// Compute a merge base from two O(1) authority snapshots without cloning
+    /// either branch's complete lineage. The maps are read-only for the
+    /// duration of this synchronous walk. Snapshots are consumed so their Arc
+    /// references are structurally gone before a later publish updates either
+    /// coordinator via copy-on-write.
+    pub(crate) fn merge_base_from_snapshots(
+        source: CommitGraphSnapshot,
+        target: CommitGraphSnapshot,
         source_commit_id: &str,
         target_commit_id: &str,
     ) -> Option<GraphCommit> {
-        let mut commits = HashMap::new();
-        for commit in source_commits {
-            commits.insert(commit.graph_commit_id.clone(), commit);
-        }
-        for commit in target_commits {
-            commits.insert(commit.graph_commit_id.clone(), commit);
-        }
-
-        if !commits.contains_key(source_commit_id) || !commits.contains_key(target_commit_id) {
-            return None;
+        if Arc::ptr_eq(&source.commit_by_id, &target.commit_by_id) {
+            return merge_base_from_maps(
+                &source.commit_by_id,
+                &source.commit_by_id,
+                source_commit_id,
+                target_commit_id,
+            );
         }
 
-        let source_distances = ancestor_distances(source_commit_id, &commits);
-        let target_distances = ancestor_distances(target_commit_id, &commits);
-
-        source_distances
-            .iter()
-            .filter_map(|(id, source_distance)| {
-                target_distances.get(id).and_then(|target_distance| {
-                    commits.get(id).map(|commit| {
-                        (
-                            (
-                                *source_distance + *target_distance,
-                                u64::MAX - commit.graph_manifest_version,
-                            ),
-                            commit.clone(),
-                        )
-                    })
-                })
-            })
-            .min_by_key(|(score, _)| *score)
-            .map(|(_, commit)| commit)
+        merge_base_from_maps(
+            &source.commit_by_id,
+            &target.commit_by_id,
+            source_commit_id,
+            target_commit_id,
+        )
     }
 }
 
@@ -294,15 +306,7 @@ fn build_commit_cache(
     let mut commit_by_id = HashMap::with_capacity(rows.len());
     let mut head_commit = None;
     for row in rows {
-        let commit = GraphCommit {
-            graph_commit_id: row.graph_commit_id,
-            graph_branch: row.graph_branch,
-            graph_manifest_version: row.graph_manifest_version,
-            parent_commit_id: row.parent_commit_id,
-            merged_parent_commit_id: row.merged_parent_commit_id,
-            actor_id: row.actor_id,
-            created_at: row.created_at,
-        };
+        let commit = graph_commit_from_manifest_row(row);
         if should_replace_head(head_commit.as_ref(), &commit) {
             head_commit = Some(commit.clone());
         }
@@ -311,26 +315,67 @@ fn build_commit_cache(
     (commit_by_id, head_commit)
 }
 
-fn should_replace_head(current: Option<&GraphCommit>, candidate: &GraphCommit) -> bool {
-    current.is_none_or(|existing| candidate.lineage_key() > existing.lineage_key())
+fn graph_commit_from_manifest_row(row: crate::db::manifest::GraphLineageRow) -> GraphCommit {
+    GraphCommit {
+        graph_commit_id: row.graph_commit_id,
+        graph_branch: row.graph_branch,
+        graph_manifest_version: row.graph_manifest_version,
+        parent_commit_id: row.parent_commit_id,
+        merged_parent_commit_id: row.merged_parent_commit_id,
+        actor_id: row.actor_id,
+        created_at: row.created_at,
+    }
 }
 
-fn ancestor_distances(
+fn merge_base_from_maps(
+    source_commits: &HashMap<String, GraphCommit>,
+    target_commits: &HashMap<String, GraphCommit>,
+    source_commit_id: &str,
+    target_commit_id: &str,
+) -> Option<GraphCommit> {
+    let get = |id: &str| source_commits.get(id).or_else(|| target_commits.get(id));
+    if get(source_commit_id).is_none() || get(target_commit_id).is_none() {
+        return None;
+    }
+
+    let source_distances = ancestor_distances_from(source_commit_id, &get);
+    let target_distances = ancestor_distances_from(target_commit_id, &get);
+    source_distances
+        .iter()
+        .filter_map(|(id, source_distance)| {
+            target_distances.get(id).and_then(|target_distance| {
+                get(id).map(|commit| {
+                    (
+                        (
+                            *source_distance + *target_distance,
+                            u64::MAX - commit.graph_manifest_version,
+                        ),
+                        commit.clone(),
+                    )
+                })
+            })
+        })
+        .min_by_key(|(score, _)| *score)
+        .map(|(_, commit)| commit)
+}
+
+fn ancestor_distances_from<'a>(
     start_id: &str,
-    commits: &HashMap<String, GraphCommit>,
+    get: &impl Fn(&str) -> Option<&'a GraphCommit>,
 ) -> HashMap<String, u64> {
     let mut distances = HashMap::new();
     let mut queue = VecDeque::from([(start_id.to_string(), 0u64)]);
 
     while let Some((id, distance)) = queue.pop_front() {
-        if let Some(existing) = distances.get(&id) {
-            if *existing <= distance {
-                continue;
-            }
+        if distances
+            .get(&id)
+            .is_some_and(|existing| *existing <= distance)
+        {
+            continue;
         }
         distances.insert(id.clone(), distance);
 
-        if let Some(commit) = commits.get(&id) {
+        if let Some(commit) = get(&id) {
             if let Some(parent) = &commit.parent_commit_id {
                 queue.push_back((parent.clone(), distance + 1));
             }
@@ -339,8 +384,11 @@ fn ancestor_distances(
             }
         }
     }
-
     distances
+}
+
+fn should_replace_head(current: Option<&GraphCommit>, candidate: &GraphCommit) -> bool {
+    current.is_none_or(|existing| candidate.lineage_key() > existing.lineage_key())
 }
 
 async fn open_for_branch(root_uri: &str, branch: Option<&str>) -> Result<CommitGraph> {

--- a/crates/omnigraph/src/db/graph_coordinator.rs
+++ b/crates/omnigraph/src/db/graph_coordinator.rs
@@ -9,12 +9,12 @@ use crate::error::{OmniError, Result};
 use crate::failpoints;
 use crate::storage::{StorageAdapter, normalize_root_uri};
 
-use super::commit_graph::{CommitGraph, FirstParentEdge, GraphCommit};
+use super::commit_graph::{CommitGraph, CommitGraphSnapshot, FirstParentEdge, GraphCommit};
 use super::is_internal_system_branch;
 use super::manifest::{
     CapturedManifestProbe, DatasetUpdate, ExpectedTableVersions, GenesisManifestAttempt,
-    LineageIntent, ManifestChange, ManifestCoordinator, ManifestIncarnation, ManifestInitError,
-    PublishPrecondition, Snapshot,
+    LineageIntent, LineageRefresh, ManifestChange, ManifestCoordinator, ManifestIncarnation,
+    ManifestInitError, PublishPrecondition, Snapshot,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -297,8 +297,10 @@ impl GraphCoordinator {
     }
 
     pub async fn refresh(&mut self) -> Result<()> {
-        let lineage_rows = self.manifest.refresh_with_lineage().await?;
-        self.commit_graph.replace_from_manifest_rows(lineage_rows);
+        match self.manifest.refresh_with_lineage().await? {
+            LineageRefresh::Replace(rows) => self.commit_graph.replace_from_manifest_rows(rows),
+            LineageRefresh::Append(rows) => self.commit_graph.append_manifest_rows(rows),
+        }
         Ok(())
     }
 
@@ -333,6 +335,12 @@ impl GraphCoordinator {
     /// instances that supplied source/target authority.
     pub(crate) async fn load_commits(&self) -> Result<Vec<GraphCommit>> {
         self.commit_graph.load_commits().await
+    }
+
+    /// O(1) lineage authority handle for merge-base selection. Unlike
+    /// `load_commits`, this does not clone the complete history.
+    pub(crate) fn commit_graph_snapshot(&self) -> CommitGraphSnapshot {
+        self.commit_graph.snapshot()
     }
 
     pub async fn branch_list(&self) -> Result<Vec<String>> {

--- a/crates/omnigraph/src/db/manifest.rs
+++ b/crates/omnigraph/src/db/manifest.rs
@@ -786,6 +786,15 @@ pub(crate) struct ManifestCoordinator {
     projection: Option<(u64, ProjectionAccumulator)>,
 }
 
+/// How a manifest refresh updates the already-loaded commit projection.
+/// Incremental refreshes return only newly appended lineage rows; full
+/// refreshes replace the projection. Keeping the distinction avoids cloning
+/// all historical lineage merely to append one commit.
+pub(crate) enum LineageRefresh {
+    Replace(Vec<GraphLineageRow>),
+    Append(Vec<GraphLineageRow>),
+}
+
 impl ManifestCoordinator {
     fn default_batch_publisher(
         root_uri: &str,
@@ -1021,8 +1030,7 @@ impl ManifestCoordinator {
         let (dataset, branch_identifier) =
             open_manifest_dataset_with_identifier_with_session(root, branch, control_session)
                 .await?;
-        let (known_state, projection) = read_manifest_projection(&dataset).await?;
-        let lineage_rows = projection.lineage_rows().to_vec();
+        let (known_state, projection, lineage_rows) = read_manifest_projection(&dataset).await?;
         let projection_version = dataset.version().version;
         let mut coordinator = Self::from_parts_with_default_publisher(
             root,
@@ -1096,21 +1104,21 @@ impl ManifestCoordinator {
         }
     }
 
-    pub(crate) async fn refresh_with_lineage(&mut self) -> Result<Vec<GraphLineageRow>> {
+    pub(crate) async fn refresh_with_lineage(&mut self) -> Result<LineageRefresh> {
         // Boxed wholesale: this body carries the incremental fold (fragment
-        // maps, fold clone, debug verify) plus the full-scan fallback, and it
-        // is awaited deep inside the merge future — the engine's known
-        // stack-depth hazard. The box keeps that layout out of every caller's
-        // generator frame.
+        // maps and compact projection rollback state) plus the full-scan
+        // fallback, and it is awaited deep inside the merge future — the
+        // engine's known stack-depth hazard. The box keeps that layout out of
+        // every caller's generator frame.
         Box::pin(self.refresh_with_lineage_inner()).await
     }
 
-    async fn refresh_with_lineage_inner(&mut self) -> Result<Vec<GraphLineageRow>> {
+    async fn refresh_with_lineage_inner(&mut self) -> Result<LineageRefresh> {
         // Incremental first (the incremental-projection design): fold only the catalog fragments
         // appended since the held pin. Every unprovable precondition falls
         // back to the full scan below — provably current or full read.
         if let Some(lineage_rows) = self.refresh_incremental().await? {
-            return Ok(lineage_rows);
+            return Ok(LineageRefresh::Append(lineage_rows));
         }
         crate::instrumentation::record_projection_full_refresh();
         let control_session = self.dataset.session();
@@ -1120,21 +1128,21 @@ impl ManifestCoordinator {
             &control_session,
         )
         .await?;
-        let (known_state, projection) = read_manifest_projection(&dataset).await?;
-        let lineage_rows = projection.lineage_rows().to_vec();
+        let (known_state, projection, lineage_rows) = read_manifest_projection(&dataset).await?;
         let projection_version = dataset.version().version;
         self.dataset = dataset;
         self.known_state = known_state;
         self.branch_identifier = branch_identifier;
         self.projection = Some((projection_version, projection));
-        Ok(lineage_rows)
+        Ok(LineageRefresh::Replace(lineage_rows))
     }
 
     /// Incremental projection refresh. `Ok(None)` = a precondition
     /// was unprovable — the caller does the full scan. `Ok(Some(rows))` = the
     /// coordinator now describes the latest catalog version, having read only
     /// the appended fragments (plus the deletion-vector differences on shared
-    /// ones).
+    /// ones). The returned rows are only the lineage delta, not a clone of the
+    /// coordinator's complete commit history.
     ///
     /// Soundness rests on the catalog's write shape: publishes append new
     /// fragments and, for the mutable `graph_head:<branch>` rows, mark the
@@ -1144,9 +1152,6 @@ impl ManifestCoordinator {
     /// deletion-vector growth explained entirely by `graph_head` rows (any
     /// other deleted row means machinery this fold does not model — full
     /// read), and new fragments whose LIVE rows are the appended state. In
-    /// debug builds every successful fold is verified against a full scan of
-    /// the same version and any divergence fails loudly, so the entire test
-    /// suite oracles this path.
     async fn refresh_incremental(&mut self) -> Result<Option<Vec<GraphLineageRow>>> {
         let Some((projection_version, projection)) = self.projection.as_ref() else {
             return Ok(None);
@@ -1172,7 +1177,7 @@ impl ManifestCoordinator {
         }
         if new_dataset.version().version == self.dataset.version().version {
             crate::instrumentation::record_projection_incremental_refresh();
-            return Ok(Some(projection.lineage_rows().to_vec()));
+            return Ok(Some(Vec::new()));
         }
 
         let old_fragments: std::collections::HashMap<u64, lance::dataset::fragment::FileFragment> =
@@ -1226,8 +1231,8 @@ impl ManifestCoordinator {
             return Ok(None);
         }
 
-        // Exception safety: fold a clone (CPU-only, O(history) rows in
-        // memory), install on success.
+        // Exception safety: fold a compact O(tables + branches) clone and
+        // install only after every row classification succeeds.
         let mut folded = projection.clone();
         for (fragment, offsets) in &dead_head_rows {
             let identities =
@@ -1261,9 +1266,9 @@ impl ManifestCoordinator {
                 folded.remove_head(branch_key);
             }
         }
-        let known_state =
+        let (known_state, lineage_rows) =
             match fold_projection_delta(&new_dataset, delta_fragments, &mut folded).await {
-                Ok(state) => state,
+                Ok(delta) => delta,
                 Err(error) => {
                     // A fold inconsistency means a precondition this gate missed,
                     // not a caller error — degrade to the full scan.
@@ -1272,43 +1277,7 @@ impl ManifestCoordinator {
                 }
             };
 
-        #[cfg(debug_assertions)]
-        {
-            let (full_state, full_projection) = read_manifest_projection(&new_dataset).await?;
-            let mut folded_lineage = folded.lineage_rows().to_vec();
-            let mut full_lineage = full_projection.lineage_rows().to_vec();
-            folded_lineage.sort_by(|a, b| a.graph_commit_id.cmp(&b.graph_commit_id));
-            full_lineage.sort_by(|a, b| a.graph_commit_id.cmp(&b.graph_commit_id));
-            // Entries are a sorted Vec (Debug-comparable); graph_heads is a
-            // HashMap, whose Debug order is nondeterministic — compare it as
-            // an ordered map.
-            let full_heads: std::collections::BTreeMap<_, _> =
-                full_state.graph_heads.iter().collect();
-            let folded_heads: std::collections::BTreeMap<_, _> =
-                known_state.graph_heads.iter().collect();
-            if format!("{:?}", full_state.entries) != format!("{:?}", known_state.entries)
-                || full_state.version != known_state.version
-                || full_heads != folded_heads
-                || folded_lineage != full_lineage
-            {
-                return Err(OmniError::manifest_internal(format!(
-                    "incremental projection diverged from the full scan at manifest version {} \
-                     (branch {:?}) — this is a bug in the incremental-projection fold.\nfull state:   {:?}\n\
-                     folded state: {:?}\nfull lineage ({}): {:?}\nfolded lineage ({}): {:?}",
-                    new_dataset.version().version,
-                    self.active_branch,
-                    full_state,
-                    known_state,
-                    full_lineage.len(),
-                    full_lineage,
-                    folded_lineage.len(),
-                    folded_lineage,
-                )));
-            }
-        }
-
         crate::instrumentation::record_projection_incremental_refresh();
-        let lineage_rows = folded.lineage_rows().to_vec();
         let projection_version = new_dataset.version().version;
         self.dataset = new_dataset;
         self.known_state = known_state;

--- a/crates/omnigraph/src/db/manifest/state.rs
+++ b/crates/omnigraph/src/db/manifest/state.rs
@@ -199,16 +199,16 @@ fn manifest_state_from_scan(version: u64, scan: ManifestScan) -> Result<Manifest
 /// reductions `assemble_manifest_state` applies — both paths run through this
 /// type, so the incremental and full projections CANNOT diverge in
 /// dedup/filter/sort semantics. Sizes: `registrations`/`latest_versions`/
-/// `tombstone_map` are O(tables), `graph_heads` O(branches); only
-/// `lineage_rows` grows with commit history (it is the projection being
-/// preserved).
+/// `tombstone_map` are O(tables), and `graph_heads` is O(branches). Lineage is
+/// deliberately not retained here: `GraphCoordinator` already owns that
+/// projection, and duplicating it made an otherwise small exception-safety
+/// clone O(commit history).
 #[derive(Debug, Clone)]
 pub(super) struct ProjectionAccumulator {
     registrations: HashMap<TableIdentity, TableRegistration>,
     latest_versions: HashMap<TableIdentity, DatasetEntry>,
     tombstone_map: HashMap<TableIdentity, u64>,
     graph_heads: HashMap<String, String>,
-    lineage_rows: Vec<GraphLineageRow>,
 }
 
 impl ProjectionAccumulator {
@@ -218,7 +218,6 @@ impl ProjectionAccumulator {
             latest_versions: HashMap::new(),
             tombstone_map: HashMap::new(),
             graph_heads: HashMap::new(),
-            lineage_rows: Vec::new(),
         }
     }
 
@@ -232,7 +231,6 @@ impl ProjectionAccumulator {
         version_entries: Vec<DatasetEntry>,
         tombstones: impl IntoIterator<Item = (TableIdentity, u64)>,
         graph_heads: HashMap<String, String>,
-        lineage_rows: Vec<GraphLineageRow>,
     ) -> Result<()> {
         for (identity, registration) in registrations {
             if let Some(existing) = self.registrations.insert(identity, registration.clone()) {
@@ -261,11 +259,31 @@ impl ProjectionAccumulator {
             }
         }
         self.graph_heads.extend(graph_heads);
-        self.lineage_rows.extend(lineage_rows);
         Ok(())
     }
 
     fn fold_scan(&mut self, scan: ManifestScan) -> Result<()> {
+        // A delta tombstone may refer to a registration in an older fragment,
+        // so validate against the union of incoming and retained authority.
+        // Do this before mutating the accumulator to preserve exception safety.
+        for tombstone in &scan.tombstones {
+            let registration = scan
+                .table_registrations
+                .get(&tombstone.identity)
+                .or_else(|| self.registrations.get(&tombstone.identity))
+                .ok_or_else(|| {
+                    OmniError::manifest_internal(format!(
+                        "manifest tombstone for identity {} has no table registration",
+                        tombstone.identity
+                    ))
+                })?;
+            if registration.table_key != tombstone.table_key {
+                return Err(OmniError::manifest_internal(format!(
+                    "manifest tombstone identity {} has diagnostic alias '{}', current binding is '{}'",
+                    tombstone.identity, tombstone.table_key, registration.table_key
+                )));
+            }
+        }
         self.fold_parts(
             scan.table_registrations,
             scan.version_entries,
@@ -273,7 +291,6 @@ impl ProjectionAccumulator {
                 .into_iter()
                 .map(|t| (t.identity, t.tombstone_version)),
             scan.graph_heads,
-            scan.lineage_rows,
         )
     }
 
@@ -282,10 +299,6 @@ impl ProjectionAccumulator {
     /// when one exists, arrives via the delta fragments' live rows).
     pub(super) fn remove_head(&mut self, branch_key: &str) {
         self.graph_heads.remove(branch_key);
-    }
-
-    pub(super) fn lineage_rows(&self) -> &[GraphLineageRow] {
-        &self.lineage_rows
     }
 
     /// Reduce to the visible state at `version`. Pure and repeatable.
@@ -300,18 +313,19 @@ impl ProjectionAccumulator {
     }
 }
 
-/// One coherent scan producing both the finished state and the retained fold
-/// accumulators (with lineage). The projection-retaining open/refresh paths
-/// use this; the plain read paths keep `read_manifest_state`.
+/// One coherent scan producing the finished state, compact retained fold
+/// accumulators, and lineage rows handed off to `CommitGraph`. The plain read
+/// paths keep `read_manifest_state`.
 pub(super) async fn read_manifest_projection(
     dataset: &Dataset,
-) -> Result<(ManifestState, ProjectionAccumulator)> {
+) -> Result<(ManifestState, ProjectionAccumulator, Vec<GraphLineageRow>)> {
     let version = dataset.version().version;
-    let scan = read_manifest_scan_fragments(dataset, true, None).await?;
+    let mut scan = read_manifest_scan_fragments(dataset, true, None).await?;
+    let lineage_rows = std::mem::take(&mut scan.lineage_rows);
     let mut accumulator = ProjectionAccumulator::empty();
     accumulator.fold_scan(scan)?;
     let state = accumulator.finish(version)?;
-    Ok((state, accumulator))
+    Ok((state, accumulator, lineage_rows))
 }
 
 /// Fold ONLY the live rows of `fragments` of `dataset` into `accumulator`
@@ -321,11 +335,12 @@ pub(super) async fn fold_projection_delta(
     dataset: &Dataset,
     fragments: Vec<lance_table::format::Fragment>,
     accumulator: &mut ProjectionAccumulator,
-) -> Result<ManifestState> {
+) -> Result<(ManifestState, Vec<GraphLineageRow>)> {
     let version = dataset.version().version;
-    let scan = read_manifest_scan_fragments(dataset, true, Some(fragments)).await?;
+    let mut scan = read_manifest_scan_fragments(dataset, true, Some(fragments)).await?;
+    let lineage_rows = std::mem::take(&mut scan.lineage_rows);
     accumulator.fold_scan(scan)?;
-    accumulator.finish(version)
+    Ok((accumulator.finish(version)?, lineage_rows))
 }
 
 /// `(object_type, object_id)` of the rows at `offsets` inside one fragment,
@@ -337,44 +352,61 @@ pub(super) async fn read_object_identities_at_offsets(
     fragment: lance_table::format::Fragment,
     offsets: &std::collections::HashSet<u32>,
 ) -> Result<Vec<(String, String)>> {
-    let mut scanner = dataset.scan();
-    scanner
-        .project(&["object_id", "object_type"])
-        .map_err(OmniError::storage)?;
-    scanner.with_fragments(vec![fragment]);
-    scanner.with_row_address();
-    let batches: Vec<RecordBatch> = scanner
-        .try_into_stream()
-        .await
-        .map_err(OmniError::storage)?
-        .try_collect()
-        .await
-        .map_err(OmniError::storage)?;
-    let mut identities = Vec::new();
-    for batch in &batches {
-        let object_ids = string_column(batch, "object_id")?;
-        let object_types = string_column(batch, "object_type")?;
-        let addresses = batch
-            .column_by_name(lance_core::ROW_ADDR)
-            .ok_or_else(|| {
-                OmniError::manifest_internal("projection delta scan missing row addresses")
-            })?
-            .as_any()
-            .downcast_ref::<UInt64Array>()
-            .ok_or_else(|| {
-                OmniError::manifest_internal("projection delta row address column is not u64")
-            })?;
-        for row in 0..batch.num_rows() {
-            let address =
-                lance_core::utils::address::RowAddress::new_from_u64(addresses.value(row));
-            if offsets.contains(&address.row_offset()) {
-                identities.push((
-                    object_types.value(row).to_string(),
-                    object_ids.value(row).to_string(),
-                ));
-            }
-        }
+    if offsets.is_empty() {
+        return Ok(Vec::new());
     }
+
+    let fragment_id = u32::try_from(fragment.id).map_err(|_| {
+        OmniError::manifest_internal(format!(
+            "manifest fragment id {} cannot be represented as a Lance row address",
+            fragment.id
+        ))
+    })?;
+    let mut addresses = offsets
+        .iter()
+        .copied()
+        .map(|offset| {
+            u64::from(lance_core::utils::address::RowAddress::new_from_parts(
+                fragment_id,
+                offset,
+            ))
+        })
+        .collect::<Vec<_>>();
+    addresses.sort_unstable();
+
+    // A fragment restriction limits which files a scanner visits; it is not a
+    // row-level take. Use the physical addresses already supplied by the
+    // deletion-vector delta so a compacted, history-sized fragment still reads
+    // only the newly deleted head rows from the exact pinned old dataset.
+    let dataset = Arc::new(dataset.clone());
+    let projection_schema = dataset
+        .schema()
+        .project_preserve_system_columns(&["object_id", "object_type"])
+        .map_err(|e| OmniError::Lance(e.to_string()))?;
+    let projection = lance::dataset::ProjectionRequest::from_schema(projection_schema)
+        .into_projection_plan(Arc::clone(&dataset))
+        .map_err(|e| OmniError::Lance(e.to_string()))?;
+    let batch = lance::dataset::TakeBuilder::try_new_from_addresses(
+        dataset,
+        addresses,
+        Arc::new(projection),
+    )
+    .map_err(|e| OmniError::Lance(e.to_string()))?
+    .execute()
+    .await
+    .map_err(|e| OmniError::Lance(e.to_string()))?;
+    crate::instrumentation::record_projection_identity_rows(batch.num_rows());
+
+    let object_ids = string_column(&batch, "object_id")?;
+    let object_types = string_column(&batch, "object_type")?;
+    let identities = (0..batch.num_rows())
+        .map(|row| {
+            (
+                object_types.value(row).to_string(),
+                object_ids.value(row).to_string(),
+            )
+        })
+        .collect();
     Ok(identities)
 }
 
@@ -395,13 +427,7 @@ pub(super) fn assemble_manifest_state(
     graph_heads: HashMap<String, String>,
 ) -> Result<ManifestState> {
     let mut accumulator = ProjectionAccumulator::empty();
-    accumulator.fold_parts(
-        registrations,
-        version_entries,
-        tombstones,
-        graph_heads,
-        Vec::new(),
-    )?;
+    accumulator.fold_parts(registrations, version_entries, tombstones, graph_heads)?;
     accumulator.finish(version)
 }
 

--- a/crates/omnigraph/src/db/manifest/state.rs
+++ b/crates/omnigraph/src/db/manifest/state.rs
@@ -382,19 +382,19 @@ pub(super) async fn read_object_identities_at_offsets(
     let projection_schema = dataset
         .schema()
         .project_preserve_system_columns(&["object_id", "object_type"])
-        .map_err(|e| OmniError::Lance(e.to_string()))?;
+        .map_err(OmniError::storage)?;
     let projection = lance::dataset::ProjectionRequest::from_schema(projection_schema)
         .into_projection_plan(Arc::clone(&dataset))
-        .map_err(|e| OmniError::Lance(e.to_string()))?;
+        .map_err(OmniError::storage)?;
     let batch = lance::dataset::TakeBuilder::try_new_from_addresses(
         dataset,
         addresses,
         Arc::new(projection),
     )
-    .map_err(|e| OmniError::Lance(e.to_string()))?
+    .map_err(OmniError::storage)?
     .execute()
     .await
-    .map_err(|e| OmniError::Lance(e.to_string()))?;
+    .map_err(OmniError::storage)?;
     crate::instrumentation::record_projection_identity_rows(batch.num_rows());
 
     let object_ids = string_column(&batch, "object_id")?;

--- a/crates/omnigraph/src/db/manifest/tests.rs
+++ b/crates/omnigraph/src/db/manifest/tests.rs
@@ -2939,18 +2939,12 @@ async fn n_concurrent_disjoint_writers_converge_to_one_linear_chain() {
     assert_linear_chain(uri, N + 1).await;
 }
 
-/// Micro-benchmark of the exact operation the incremental projection
-/// replaces: ONE authority refresh on a deep catalog, full O(history) scan
-/// vs incremental fold, everything else excluded. Ignored by default (it
-/// builds a deep commit history); numbers are meaningful in RELEASE only
-/// (debug builds run the fold-vs-full oracle inside the incremental path):
-///
-/// `cargo test -p omnigraph-engine --release --lib \
-///  projection_refresh_deep_catalog -- --ignored --nocapture`
+/// The incremental fold and a clean full reopen must produce the same state
+/// and lineage. This is an explicit correctness oracle, kept out of the
+/// production refresh path so debug cost tests measure the same I/O shape as a
+/// release build.
 #[tokio::test]
-#[ignore = "micro-benchmark: builds a deep catalog; run --release --ignored --nocapture"]
-async fn projection_refresh_deep_catalog_full_vs_incremental() {
-    const HISTORY: usize = 1500;
+async fn projection_refresh_matches_clean_full_reopen() {
     let dir = tempfile::tempdir().unwrap();
     let uri = dir.path().to_str().unwrap();
     let catalog = build_test_catalog();
@@ -2970,44 +2964,40 @@ async fn projection_refresh_deep_catalog_full_vs_incremental() {
             .map(|_| ())
     }
     let publisher = GraphNamespacePublisher::new(uri, None);
-    for i in 0..HISTORY {
-        publish_empty_commit(&publisher).await.unwrap();
-        if i % 500 == 0 {
-            println!("history {i}/{HISTORY}");
-        }
-    }
-
-    // The reader = the merge-authority shape: a coordinator that did not
-    // write and must refresh to current.
     let control_session = crate::lance_access::control_session();
-    let (mut reader, _) = ManifestCoordinator::open_with_lineage(uri, None, &control_session)
-        .await
-        .unwrap();
+    let (mut reader, mut folded_lineage) =
+        ManifestCoordinator::open_with_lineage(uri, None, &control_session)
+            .await
+            .unwrap();
+    let old_head = reader.known_state.graph_heads[MAIN_BRANCH_HEAD_KEY].clone();
 
-    // Stale by one commit; force the full path by clearing the accumulators.
-    publish_empty_commit(&publisher).await.unwrap();
-    reader.projection = None;
-    let started = std::time::Instant::now();
-    let full_rows = reader.refresh_with_lineage().await.unwrap().len();
-    let full = started.elapsed();
-
-    // Stale by one commit again; the incremental path serves it.
-    publish_empty_commit(&publisher).await.unwrap();
-    let started = std::time::Instant::now();
-    let incremental_rows = reader.refresh_with_lineage().await.unwrap().len();
-    let incremental = started.elapsed();
-
-    assert_eq!(incremental_rows, full_rows + 1);
-    println!(
-        "authority refresh on a {HISTORY}-commit catalog: full scan {:.1} ms, \
-         incremental fold {:.3} ms ({}x)",
-        full.as_secs_f64() * 1000.0,
-        incremental.as_secs_f64() * 1000.0,
-        (full.as_secs_f64() / incremental.as_secs_f64().max(1e-9)) as u64,
+    for _ in 0..8 {
+        publish_empty_commit(&publisher).await.unwrap();
+    }
+    let LineageRefresh::Append(delta) = reader.refresh_with_lineage().await.unwrap() else {
+        panic!("append-only history must take the incremental refresh path");
+    };
+    assert_eq!(delta.len(), 8, "refresh must return only new lineage rows");
+    folded_lineage.extend(delta);
+    assert_ne!(
+        reader.known_state.graph_heads[MAIN_BRANCH_HEAD_KEY], old_head,
+        "the oracle must exercise mutable graph-head replacement, not only appends"
     );
-    #[cfg(not(debug_assertions))]
-    assert!(
-        incremental < full,
-        "the incremental fold must beat the full scan on a deep catalog"
+
+    let (fresh, mut full_lineage) =
+        ManifestCoordinator::open_with_lineage(uri, None, &control_session)
+            .await
+            .unwrap();
+    assert_eq!(reader.known_state.version, fresh.known_state.version);
+    assert_eq!(
+        format!("{:?}", reader.known_state.entries),
+        format!("{:?}", fresh.known_state.entries)
     );
+    assert_eq!(
+        reader.known_state.graph_heads,
+        fresh.known_state.graph_heads
+    );
+    folded_lineage.sort_by(|a, b| a.graph_commit_id.cmp(&b.graph_commit_id));
+    full_lineage.sort_by(|a, b| a.graph_commit_id.cmp(&b.graph_commit_id));
+    assert_eq!(folded_lineage, full_lineage);
 }

--- a/crates/omnigraph/src/db/omnigraph.rs
+++ b/crates/omnigraph/src/db/omnigraph.rs
@@ -22,6 +22,7 @@ use omnigraph_compiler::{
     plan_schema_migration,
 };
 
+use crate::db::commit_graph::CommitGraphSnapshot;
 use crate::db::graph_coordinator::{GraphCoordinator, PublishedSnapshot, ResolvedCommitRange};
 use crate::error::{OmniError, Result, dataset_subject};
 use crate::runtime_cache::RuntimeCache;
@@ -262,18 +263,22 @@ pub struct Omnigraph {
     /// `branch_create_from_impl`. Deferred because it requires unwinding
     /// every `self.snapshot()` call inside the merge body.
     merge_exclusive: Arc<tokio::sync::Mutex<()>>,
-    /// Per-branch merge-authority coordinators: one per branch a merge has
-    /// touched, so a merge's non-bound side stops paying a fresh open with a
-    /// full O(history) `__manifest` scan. Each use revalidates with the
+    /// One hot non-bound merge-authority coordinator, so a repeated merge
+    /// stops paying a fresh open with a full O(history) `__manifest` scan.
+    /// Each use revalidates with the
     /// manifest-incarnation probe (the same currency the bound-branch fast
     /// path trusts, including the BranchIdentifier delete/recreate fence)
     /// and refreshes via the incremental projection fold — provably current
     /// or full read. Entries are evicted on refresh failure and purged on
-    /// branch delete; growth is bounded by the live branch count (an
-    /// eviction policy is deferred until telemetry shows it matters). The
-    /// mutex serializes merge captures — acceptable because the schema
+    /// branch delete. Capacity is deliberately one: the handle's bound
+    /// coordinator is the common target and retaining one counterpart covers
+    /// that hot shape without multiplying complete lineage by live branches.
+    /// A merge between two non-bound branches temporarily references both
+    /// complete maps through O(1)-to-clone immutable snapshots, but persists
+    /// only the most recently used coordinator.
+    /// The mutex serializes merge captures — acceptable because the schema
     /// serial queue already serializes merges at capture time.
-    merge_authority_cache: tokio::sync::Mutex<std::collections::HashMap<String, GraphCoordinator>>,
+    merge_authority_cache: tokio::sync::Mutex<Option<(String, GraphCoordinator)>>,
     /// Optional policy checker for engine-layer enforcement (MR-722).
     /// `None` = no enforcement; mutating methods are unconditionally
     /// allowed (this is the embedded/dev default). `Some` = every
@@ -589,7 +594,7 @@ impl Omnigraph {
             })),
             write_queue,
             merge_exclusive: Arc::new(tokio::sync::Mutex::new(())),
-            merge_authority_cache: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+            merge_authority_cache: tokio::sync::Mutex::new(None),
             policy: None,
             embedding: Arc::new(tokio::sync::OnceCell::new()),
             embedding_config: None,
@@ -758,7 +763,7 @@ impl Omnigraph {
             })),
             write_queue,
             merge_exclusive: Arc::new(tokio::sync::Mutex::new(())),
-            merge_authority_cache: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+            merge_authority_cache: tokio::sync::Mutex::new(None),
             policy: None,
             embedding: Arc::new(tokio::sync::OnceCell::new()),
             embedding_config: None,
@@ -1210,7 +1215,7 @@ impl Omnigraph {
         &self,
         source_branch: Option<&str>,
         target_branch: Option<&str>,
-    ) -> Result<(WriteTxn, WriteTxn, Vec<GraphCommit>, Vec<GraphCommit>)> {
+    ) -> Result<(WriteTxn, WriteTxn, CommitGraphSnapshot, CommitGraphSnapshot)> {
         const MAX_CAPTURE_RETRIES: usize = 8;
         let source_branch = normalize_branch_name(source_branch.unwrap_or("main"))?;
         let target_branch = normalize_branch_name(target_branch.unwrap_or("main"))?;
@@ -1504,7 +1509,7 @@ impl Omnigraph {
         Option<String>,
         Option<String>,
         Snapshot,
-        Vec<GraphCommit>,
+        CommitGraphSnapshot,
         crate::db::manifest::CapturedManifestProbe,
     )> {
         {
@@ -1520,7 +1525,7 @@ impl Omnigraph {
                             .await?
                             .map(|head| head.as_str().to_string()),
                         coord.snapshot(),
-                        coord.load_commits().await?,
+                        coord.commit_graph_snapshot(),
                         coord.captured_manifest_probe(),
                     ));
                 }
@@ -1544,34 +1549,41 @@ impl Omnigraph {
         Option<String>,
         Option<String>,
         Snapshot,
-        Vec<GraphCommit>,
+        CommitGraphSnapshot,
         crate::db::manifest::CapturedManifestProbe,
     )> {
         let key = branch.unwrap_or("main").to_string();
         let mut cache = self.merge_authority_cache.lock().await;
-        if let Some(coord) = cache.get_mut(&key) {
+        if cache
+            .as_ref()
+            .is_some_and(|(cached_key, _)| cached_key != &key)
+        {
+            *cache = None;
+        }
+        if let Some((_, coord)) = cache.as_mut() {
             let held = coord.manifest_incarnation();
             let current = match coord.probe_latest_incarnation().await {
                 Ok(latest) => latest.matches(&held),
                 Err(error) => {
                     // A branch that no longer probes (deleted, storage error)
                     // must not linger as a cache entry.
-                    cache.remove(&key);
+                    *cache = None;
                     return Err(error);
                 }
             };
             if !current {
                 if let Err(error) = coord.refresh().await {
-                    cache.remove(&key);
+                    *cache = None;
                     return Err(error);
                 }
             }
         } else {
             let coord = self.open_coordinator_for_branch(branch).await?;
-            cache.insert(key.clone(), coord);
+            *cache = Some((key.clone(), coord));
         }
         let coord = cache
-            .get(&key)
+            .as_ref()
+            .map(|(_, coord)| coord)
             .expect("merge authority cache entry inserted above");
         Ok((
             coord.branch_identifier().await?,
@@ -1581,7 +1593,7 @@ impl Omnigraph {
                 .await?
                 .map(|head| head.as_str().to_string()),
             coord.snapshot(),
-            coord.load_commits().await?,
+            coord.commit_graph_snapshot(),
             coord.captured_manifest_probe(),
         ))
     }
@@ -3216,14 +3228,6 @@ impl Omnigraph {
         ensure_public_branch_ref(name, "branch_delete")?;
         let branch = normalize_branch_name(name)?
             .ok_or_else(|| OmniError::manifest("cannot delete branch 'main'".to_string()))?;
-        // Purge the branch's merge-authority coordinator: correctness is
-        // fenced without this (the identifier probe refuses a recreated
-        // lifetime), but a deleted branch's entry would otherwise retain its
-        // O(history) projection until a future merge happens to probe it.
-        self.merge_authority_cache
-            .lock()
-            .await
-            .remove(branch.as_str());
         let _export_exclusion = self.reserve_export_destructive_control()?;
         self.ensure_schema_state_valid().await?;
         self.heal_pending_recovery_sidecars_for_branch_delete(&branch)
@@ -3236,6 +3240,17 @@ impl Omnigraph {
             .acquire(&crate::db::manifest::schema_apply_serial_queue_key())
             .await;
         let _branch_guard = self.write_queue().acquire_branch(Some(&branch)).await;
+        // Purge only after taking the branch gate. Merge capture takes the
+        // same branch-gate -> cache-lock order, so no later insert for this
+        // incarnation can race between invalidation and deletion.
+        let mut cache = self.merge_authority_cache.lock().await;
+        if cache
+            .as_ref()
+            .is_some_and(|(cached_branch, _)| cached_branch == &branch)
+        {
+            *cache = None;
+        }
+        drop(cache);
         self.ensure_schema_apply_not_locked("branch_delete").await?;
         let control_catalog = self.build_accepted_catalog_with_schema_gate_held().await?;
         let table_queue_keys =

--- a/crates/omnigraph/src/exec/merge.rs
+++ b/crates/omnigraph/src/exec/merge.rs
@@ -4517,7 +4517,7 @@ impl Omnigraph {
             .effective_graph_head
             .clone()
             .ok_or_else(|| OmniError::manifest("target branch has no head commit".to_string()))?;
-        let base_commit = CommitGraph::merge_base_from_commits(
+        let base_commit = CommitGraph::merge_base_from_snapshots(
             source_commits,
             target_commits,
             &source_head_commit_id,

--- a/crates/omnigraph/src/instrumentation.rs
+++ b/crates/omnigraph/src/instrumentation.rs
@@ -155,6 +155,10 @@ pub struct QueryIoProbes {
     /// always-full-scan regression is structurally visible.
     pub projection_incremental_refreshes: Arc<AtomicU64>,
     pub projection_full_refreshes: Arc<AtomicU64>,
+    /// Physical manifest rows hydrated to classify deletion-vector deltas.
+    /// This must equal the newly deleted offset count; a fragment scan would
+    /// make it grow with the compacted catalog's history instead.
+    pub projection_identity_rows: Arc<AtomicU64>,
 }
 
 tokio::task_local! {
@@ -375,6 +379,15 @@ pub(crate) fn record_projection_incremental_refresh() {
 pub(crate) fn record_projection_full_refresh() {
     let _ = current(|p| {
         p.projection_full_refreshes.fetch_add(1, Ordering::Relaxed);
+    });
+}
+
+/// Record rows returned by the physical-address take used to classify newly
+/// deleted manifest rows. No-op unless a cost probe is active.
+pub(crate) fn record_projection_identity_rows(rows: usize) {
+    let _ = current(|p| {
+        p.projection_identity_rows
+            .fetch_add(rows as u64, Ordering::Relaxed);
     });
 }
 

--- a/crates/omnigraph/tests/helpers/cost.rs
+++ b/crates/omnigraph/tests/helpers/cost.rs
@@ -238,6 +238,10 @@ pub struct IoCounts {
     /// `__manifest` registry scans (publish state; includes the graph-lineage rows
     /// folded into `__manifest` by RFC-013 Phase 7).
     pub manifest_reads: u64,
+    /// Bytes returned by those real object-store reads. This distinguishes a
+    /// physical-address take from scanning a compacted history-sized fragment
+    /// even when both use a similar number of requests.
+    pub manifest_read_bytes: u64,
     /// Version-probe invocations (the cheap freshness check).
     pub version_probes: u64,
     /// DATA-table open CALL count through the two instrumented chokepoints — an
@@ -265,6 +269,11 @@ pub struct IoCounts {
     pub candidate_scan_target_rows_peak: u64,
     pub candidate_scan_target_bytes_peak: u64,
     pub change_images_materialized: u64,
+    /// Incremental vs full merge-authority projection refreshes and the exact
+    /// number of physical manifest rows hydrated to classify DV additions.
+    pub projection_incremental_refreshes: u64,
+    pub projection_full_refreshes: u64,
+    pub projection_identity_rows: u64,
 }
 
 impl IoCounts {
@@ -518,6 +527,9 @@ struct OpProbes {
     candidate_scan_target_rows_peak: Arc<AtomicU64>,
     candidate_scan_target_bytes_peak: Arc<AtomicU64>,
     change_images_materialized: Arc<AtomicU64>,
+    projection_incremental_refreshes: Arc<AtomicU64>,
+    projection_full_refreshes: Arc<AtomicU64>,
+    projection_identity_rows: Arc<AtomicU64>,
 }
 
 impl OpProbes {
@@ -544,6 +556,9 @@ impl OpProbes {
             candidate_scan_target_rows_peak: Arc::new(AtomicU64::new(0)),
             candidate_scan_target_bytes_peak: Arc::new(AtomicU64::new(0)),
             change_images_materialized: Arc::new(AtomicU64::new(0)),
+            projection_incremental_refreshes: Arc::new(AtomicU64::new(0)),
+            projection_full_refreshes: Arc::new(AtomicU64::new(0)),
+            projection_identity_rows: Arc::new(AtomicU64::new(0)),
         };
         let probes = QueryIoProbes {
             manifest_wrapper: Some(Arc::new(h.manifest.clone()) as Arc<dyn WrappingObjectStore>),
@@ -559,6 +574,9 @@ impl OpProbes {
             candidate_scan_target_rows_peak: Arc::clone(&h.candidate_scan_target_rows_peak),
             candidate_scan_target_bytes_peak: Arc::clone(&h.candidate_scan_target_bytes_peak),
             change_images_materialized: Arc::clone(&h.change_images_materialized),
+            projection_incremental_refreshes: Arc::clone(&h.projection_incremental_refreshes),
+            projection_full_refreshes: Arc::clone(&h.projection_full_refreshes),
+            projection_identity_rows: Arc::clone(&h.projection_identity_rows),
             // graph_build_count / graph_edges_built unused by this harness.
             ..Default::default()
         };
@@ -586,6 +604,7 @@ impl OpProbes {
             data_opener_reads: t.opener_reads,
             data_scan_reads: t.scan_reads,
             manifest_reads: manifest.read_iops,
+            manifest_read_bytes: manifest.read_bytes,
             version_probes: self.probe_count.load(Ordering::Relaxed),
             data_open_count: self.data_open_count.load(Ordering::Relaxed),
             internal_open_count: self.internal_open_count.load(Ordering::Relaxed),
@@ -603,6 +622,11 @@ impl OpProbes {
                 .candidate_scan_target_bytes_peak
                 .load(Ordering::Relaxed),
             change_images_materialized: self.change_images_materialized.load(Ordering::Relaxed),
+            projection_incremental_refreshes: self
+                .projection_incremental_refreshes
+                .load(Ordering::Relaxed),
+            projection_full_refreshes: self.projection_full_refreshes.load(Ordering::Relaxed),
+            projection_identity_rows: self.projection_identity_rows.load(Ordering::Relaxed),
         }
     }
 }

--- a/crates/omnigraph/tests/merge_projection_cache.rs
+++ b/crates/omnigraph/tests/merge_projection_cache.rs
@@ -1,19 +1,86 @@
 //! Structural gates for the incremental merge-authority projection cache: a
 //! repeated merge must serve its branch authority through the INCREMENTAL
-//! projection fold (reading only appended catalog fragments), and a
+//! projection fold (reading only appended catalog fragments), retains at most
+//! one non-bound branch's complete authority, and a
 //! delete/recreate of a cached branch must be fenced to a full re-read, never
-//! a stale reuse. Fold correctness itself is oracled everywhere: debug builds
-//! verify every incremental fold against a full scan of the same version and
-//! fail loudly on divergence, so the whole merge suite exercises it.
+//! a stale reuse. The explicit fold-vs-full correctness oracle lives with the
+//! manifest unit tests; it is not hidden in the measured production path.
 
 #![recursion_limit = "512"]
 
 mod helpers;
 
-use omnigraph::db::{MergeOutcome, Omnigraph};
-use omnigraph::instrumentation::{QueryIoProbes, with_query_io_probes};
+use std::future::Future;
 
+use omnigraph::db::{MergeOutcome, Omnigraph};
+
+use helpers::cost::{cost_harness, measure};
 use helpers::*;
+
+fn on_big_stack<F>(body: impl FnOnce() -> F + Send + 'static)
+where
+    F: Future<Output = ()>,
+{
+    std::thread::Builder::new()
+        .stack_size(64 * 1024 * 1024)
+        .spawn(move || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap()
+                .block_on(body());
+        })
+        .unwrap()
+        .join()
+        .unwrap();
+}
+
+/// Defense-in-depth for the physical cost boundary: selecting a fragment is
+/// not selecting rows. Keep the deletion-vector classifier on Lance's public
+/// physical-address take primitive, and reject the whole-fragment scanner
+/// shape that originally made a post-compaction refresh O(history).
+#[test]
+fn deleted_head_classifier_uses_physical_addresses_not_fragment_scan() {
+    let source = include_str!("../src/db/manifest/state.rs");
+    let helper = source
+        .split("pub(super) async fn read_object_identities_at_offsets")
+        .nth(1)
+        .and_then(|tail| tail.split("/// Reduce raw manifest rows").next())
+        .expect("read_object_identities_at_offsets source body");
+    assert!(
+        helper.contains("TakeBuilder::try_new_from_addresses"),
+        "deleted manifest heads must be hydrated with Lance's physical-address take"
+    );
+    for forbidden in [".scan()", "with_fragments", "try_into_stream"] {
+        assert!(
+            !helper.contains(forbidden),
+            "deleted-head classifier regressed to whole-fragment scan primitive {forbidden}"
+        );
+    }
+}
+
+/// Cache invalidation and merge insertion share the branch gate. Purging
+/// before that gate lets an already-running merge insert the deleted
+/// incarnation after the purge and retain it indefinitely.
+#[test]
+fn branch_delete_purges_merge_authority_after_acquiring_branch_gate() {
+    let source = include_str!("../src/db/omnigraph.rs");
+    let body = source
+        .split("pub async fn branch_delete_as")
+        .nth(1)
+        .and_then(|tail| tail.split("pub async fn get_commit").next())
+        .expect("branch_delete source body");
+    let gate = body
+        .find(".acquire_branch")
+        .expect("branch_delete must acquire its branch gate");
+    let purge = body
+        .find("merge_authority_cache.lock()")
+        .expect("branch_delete must purge cached merge authority");
+    assert!(
+        gate < purge,
+        "branch deletion must acquire the incarnation gate before purging cached authority"
+    );
+}
 
 /// One handle, two branches — the pattern `merge_truth_table.rs` documents
 /// (two handles for one store invite cache-coherency surprises that are out
@@ -41,47 +108,92 @@ async fn diverge(db: &mut Omnigraph, round: i64) {
 /// The headline pin: after a first merge has warmed the authority cache, a
 /// later merge (with real intervening publishes on both branches) refreshes
 /// the cached branch's projection incrementally — no full O(history) re-read.
+#[test]
+fn repeated_merge_refreshes_projection_incrementally() {
+    on_big_stack(|| async {
+        cost_harness(async {
+            let dir = tempfile::tempdir().unwrap();
+            let mut db = init_and_load(&dir).await;
+            db.branch_create("feature").await.unwrap();
+
+            diverge(&mut db, 0).await;
+            let outcome = db.branch_merge("feature", "main").await.unwrap();
+            assert_eq!(outcome, MergeOutcome::Merged);
+
+            // Real history advances between the merges, so the cached authority is
+            // provably stale and must REFRESH (not merely probe-hit).
+            diverge(&mut db, 1).await;
+
+            let (outcome, io) = measure(db.branch_merge("feature", "main")).await;
+            assert_eq!(outcome.unwrap(), MergeOutcome::Merged);
+            assert!(
+                io.projection_incremental_refreshes >= 1,
+                "the repeated merge must refresh at least one cached branch authority \
+                 through the incremental projection fold (incremental {}, full {})",
+                io.projection_incremental_refreshes,
+                io.projection_full_refreshes,
+            );
+            assert!(
+                io.projection_full_refreshes <= 1,
+                "the cached non-bound authority must stay incremental; only the publishing \
+                 bound coordinator may rebuild once (observed {})",
+                io.projection_full_refreshes,
+            );
+            assert_eq!(
+                io.projection_identity_rows, 1,
+                "one replaced feature head must hydrate one row by physical address, \
+                 never the containing history-sized fragment"
+            );
+            assert!(
+                io.manifest_reads > 0,
+                "the ground-truth object-store tracker must observe the measured refresh"
+            );
+            assert!(
+                io.manifest_read_bytes > 0,
+                "the ground-truth object-store tracker must measure returned bytes"
+            );
+            eprintln!(
+                "incremental repeated merge: manifest_reads={} manifest_read_bytes={}",
+                io.manifest_reads, io.manifest_read_bytes,
+            );
+            // Keep a fixed ground-truth request ceiling alongside the
+            // structural physical-take guard above. The ceiling leaves room
+            // for Lance metadata layout changes without allowing a hidden
+            // full coordinator reopen to multiply the measured reads.
+            assert!(
+                io.manifest_reads <= 32,
+                "incremental repeated merge used {} manifest object reads; hidden full scans must not ride the measured path",
+                io.manifest_reads,
+            );
+        })
+        .await;
+    });
+}
+
+/// The persistent cache has capacity one. Alternating to another non-bound
+/// branch must evict the first, so returning to it performs a real coordinator
+/// open rather than retaining O(branches * history) lineage.
 #[tokio::test]
-async fn repeated_merge_refreshes_projection_incrementally() {
+async fn merge_authority_cache_retains_only_one_non_bound_branch() {
     let dir = tempfile::tempdir().unwrap();
-    let mut db = init_and_load(&dir).await;
-    db.branch_create("feature").await.unwrap();
+    let db = init_and_load(&dir).await;
+    db.branch_create("feature-a").await.unwrap();
+    db.branch_create("feature-b").await.unwrap();
 
-    diverge(&mut db, 0).await;
-    let outcome = db.branch_merge("feature", "main").await.unwrap();
-    assert_eq!(outcome, MergeOutcome::Merged);
-
-    // Real history advances between the merges, so the cached authority is
-    // provably stale and must REFRESH (not merely probe-hit).
-    diverge(&mut db, 1).await;
-
-    let probes = QueryIoProbes::default();
-    let outcome = with_query_io_probes(probes.clone(), db.branch_merge("feature", "main"))
-        .await
-        .unwrap();
-    assert_eq!(outcome, MergeOutcome::Merged);
-    let incremental = probes
-        .projection_incremental_refreshes
-        .load(std::sync::atomic::Ordering::Relaxed);
-    let full = probes
-        .projection_full_refreshes
-        .load(std::sync::atomic::Ordering::Relaxed);
-    assert!(
-        incremental >= 1,
-        "the repeated merge must refresh at least one cached branch authority \
-         through the incremental projection fold (incremental {incremental}, full {full})"
+    assert_eq!(
+        db.branch_merge("feature-a", "main").await.unwrap(),
+        MergeOutcome::AlreadyUpToDate
     );
-    // The bound coordinator itself still pays ONE full re-read per merge:
-    // its accumulators are cleared by its own publishes (the staleness
-    // fence) and the post-merge restore-refresh rebuilds them full. Folding
-    // the publish delta into the accumulators instead of clearing is the
-    // named follow-up that takes this bound to zero — tightening this
-    // assertion is that change's red test.
+    assert_eq!(
+        db.branch_merge("feature-b", "main").await.unwrap(),
+        MergeOutcome::AlreadyUpToDate
+    );
+
+    let (outcome, io) = measure(db.branch_merge("feature-a", "main")).await;
+    assert_eq!(outcome.unwrap(), MergeOutcome::AlreadyUpToDate);
     assert!(
-        full <= 1,
-        "the repeated merge paid {full} full projection re-read(s) \
-         (incremental {incremental}); only the publishing coordinator's \
-         post-publish rebuild may pay one"
+        io.internal_open_count >= 1,
+        "feature-a must have been evicted when feature-b became the one hot authority"
     );
 }
 


### PR DESCRIPTION
Stacked on #541 — merge that first; this PR's diff then shrinks to the two hardening commits on top of it.

## What

Bounds the merge-authority cache that #541 introduces and makes its deletion-vector hydration exact:

- The per-branch `HashMap` of merge-authority coordinators becomes **one hot entry** (`Option<(branch, coordinator)>`), purged under the branch gate on branch delete with the same branch-gate → cache-lock order merge capture uses, so no insert can race between invalidation and deletion. Capacity is deliberately one: the handle's bound coordinator is the common target and retaining one counterpart covers that shape without multiplying complete lineage by live branches.
- Deleted-row identity hydration uses an exact `TakeBuilder` row-address read of the newly deleted head rows instead of a fragment-restricted scan, so a compacted history-sized fragment still reads only the delta.
- Three new cost-probe counters (incremental vs full projection refreshes, projection identity rows) so the incremental path's engagement is structurally visible to cost tests.

`merge_projection_cache` grows from 2 to 5 tests covering the bounded cache; `merge_truth_table`, `merge_fast_forward`, `branching` (41) and the canonical workspace graph are green on the stack.

## Cost: zero

Bracketed benchmark at today's main tip (`cb440846`), `branch-merge-d50-warm`, 5 reps each, every merge verified exact:

| SUT | wall p50 | manifest reads / merge |
|---|---|---|
| main (tip) | 0.237 s / 0.239 s | 1461 |
| + #541 pure | 0.221 s (−6.8%) | 1261 |
| + this PR | 0.221 s | 1261 |

The hardening lands inside the pure bracket — the cache bound and the exact take preserve all of #541's win (which is exactly the 200 load-history commits it stops re-decoding). Records are in the bench archive and pass `archive verify`.

## Notes for review

- The two commits were originally written against a base that also carried #542; the #542 context (`fork_reclaims`, quarantine-aware lock acquisition) was stripped during the rebase, leaving only the 541-hardening change.
- The original commit's `invariants.md`/`testing.md` edits targeted the pre-rewrite dev guides and were dropped; if the bounded cache deserves a guide note, it needs writing against the current docs.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR bounds the merge-authority cache to one non-bound branch and changes incremental manifest refreshes to append only newly decoded lineage while preserving immutable merge snapshots.
- Uses copy-on-write commit maps and immutable snapshots for merge-base selection.
- Hydrates deleted manifest-head identities through exact physical row-address takes.
- Purges cached branch authority under the branch gate and adds deterministic cost instrumentation and regression coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains in the eligible follow-up review scope.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/omnigraph/src/db/commit_graph.rs | Converts the lineage map to copy-on-write Arc storage and computes merge bases from immutable source and target snapshots. |
| crates/omnigraph/src/db/manifest.rs | Distinguishes full projection replacement from incremental lineage append and returns only newly decoded lineage rows. |
| crates/omnigraph/src/db/manifest/state.rs | Removes duplicated retained lineage and reads deletion-vector identities with exact Lance physical row addresses. |
| crates/omnigraph/src/db/omnigraph.rs | Bounds merge-authority retention to one hot entry and coordinates branch deletion with cache invalidation under the branch gate. |
| crates/omnigraph/tests/merge_projection_cache.rs | Adds structural and cost assertions for exact row hydration, bounded cache retention, incremental refresh, and branch-incarnation invalidation. |
| crates/omnigraph/tests/helpers/cost.rs | Extends deterministic I/O accounting with manifest bytes and projection refresh and identity-row counters. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  M[Merge capture] --> G[Acquire branch gates]
  G --> C[Probe one-entry authority cache]
  C -->|Current| S[Capture immutable commit-map snapshot]
  C -->|Stale| R[Incremental manifest refresh]
  R --> T[Take deleted head rows by physical address]
  T --> A[Append lineage delta]
  A --> S
  S --> B[Select merge base from source and target snapshots]
  D[Branch delete] --> G
  G --> P[Purge matching cached authority]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into perf/bound-merg..."](https://github.com/modernrelay/omnigraph/commit/d5c4f1d2e1948ef15718d81c3503bb935d371117) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58269615)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Branching and version history](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/branching-and-version-history.md)
- Knowledge Base — [Data mutation pipeline](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/data-mutation-pipeline.md)
- Knowledge Base — [Storage and table lifecycle](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/storage-and-table-lifecycle.md)
</details>


<!-- /greptile_comment -->