### PR TITLE
docs: add Azure Blob (Azurite) to the bug report environment hint

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -42,7 +42,7 @@ body:
     id: environment
     attributes:
       label: Environment
-      description: OS, architecture, and storage backend (local FS / S3 / RustFS / MinIO).
+      description: OS, architecture, and storage backend (local FS / S3 / RustFS / MinIO / Azure Blob (Azurite)).
     validations:
       required: false
   - type: textarea


### PR DESCRIPTION
## What & why

This PR adds Azure Blob (Azurite) to the storage-backend list in the bug report form's environment hint. The list (local FS / S3 / RustFS / MinIO) predates the native Azure Blob storage preview in the v0.10.0 line, so an Azure preview reporter gets no cue to name their backend, and backend identity is load-bearing for triage.

## Backing issue / RFC

- [x] None; motivated by the v0.10.0 release notes shipping the native Azure Blob preview (`docs/releases/v0.10.0.md`) while the intake form still enumerates only the S3-family backends.

## Checklist

- [x] Change is focused (one line in `.github/ISSUE_TEMPLATE/bug_report.yml`)
- [x] Tests added/updated for behavior changes (none; repo-metadata YAML, no behavior)
- [x] Public docs updated if user-facing surface changed (the changed line is the user-facing surface)
- [x] Reviewed against docs/dev/invariants.md — no Hard Invariant weakened, no deny-list item hit (docs-only change)

## Local verification

- No cargo gates apply (no Rust surface touched); the edit adds plain text inside an existing unquoted YAML scalar, and GitHub validates issue-form YAML on push.

## Notes for reviewers

- Azurite is named as the emulator cue the way MinIO cues local S3 setups; wording follows the release notes ("Azure Blob").

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Azure Blob and its Azurite emulator to the storage-backend examples in the bug-report environment hint.

- Updates one GitHub issue-form description.
- Aligns bug-report guidance with the Azure Blob preview documented for v0.10.0.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable issues identified.

The change preserves valid issue-form YAML and uses Azure Blob/Azurite terminology consistent with the repository’s existing documentation.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/ISSUE_TEMPLATE/bug_report.yml | The environment hint now includes accurate Azure Blob/Azurite terminology without changing the issue form’s structure or validity. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add Azure Blob (Azurite) to the bu..."](https://github.com/modernrelay/omnigraph/commit/b345c75b17d42e74f79eccbe792d4eabe9286d3b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58276065)</sub>

<!-- /greptile_comment -->