### PR TITLE
feat(bench): run FinGraph diagnostics on XFS NVMe

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -365,29 +365,37 @@ target/release/omnigraph-bench fixture run-graph \
   --reference \
     benchmarks/fixtures/finbench-2026-08-21-sf10-v1.fixture-reference-v1.yaml \
   --fixture finbench-2026-08-21-sf10-v1=/path/to/finbench-2026-08-21-sf10-v1 \
-  --scratch-root /path/to/existing-apfs-scratch --json
+  --scratch-root /path/to/existing-qualified-scratch --json
 ```
 
-`run-graph` refuses a debug build. It is currently a local APFS diagnostic:
-the harness copies and validates the registered graph, prepares two branches
-whose disjoint changes each contain two `Account` nodes and one
-`AccountTransferAccount` edge, and freezes that prepared input. Each repetition
-restores the same path with APFS clonefiles and runs only the branch merge in a
-fresh worker process. The registered source is never opened as an OmniGraph
-database and remains unchanged.
+`run-graph` refuses a debug build. The harness copies and validates the
+registered graph, prepares two branches whose disjoint changes each contain
+two `Account` nodes and one `AccountTransferAccount` edge, and freezes that
+prepared input. Each repetition restores the same path and runs only the branch
+merge in a fresh worker process. macOS requires qualified local APFS and uses
+forced clonefiles. Linux requires XFS on a directly mounted EC2 instance-store
+NVMe namespace, refuses EBS, and uses a complete verified plain copy outside
+the timer. Use a dedicated benchmark mount: after freezing and after each
+restore, Linux `syncfs` waits for all writeback on that filesystem so reset I/O
+does not overlap the merge. The recorded reset is
+`xfs-plain-copy-syncfs-same-active-path`. Before making that template, the Linux
+path requires free space for one prepared-tree copy plus 1 GiB. The registered
+source is never opened as an OmniGraph database and remains unchanged.
 Before returning either success or failure, the command explicitly attempts to
 remove its disposable workspace. A cleanup failure is reported, and a run plus
 cleanup double failure retains both causes.
 The result includes raw elapsed samples, p50, merge route/phases, the prepared
-physical digest, and verification evidence for the inserted delta, protected
-heads, and untouched tables. Pre-existing rows in the two changed tables are
-not yet fully re-read and are reported as unverified rather than implied to be
-proved.
+physical digest, per-worker machine and backend evidence, and verification evidence for
+the inserted delta, protected heads, and untouched tables. Pre-existing rows
+in the two changed tables are not yet fully re-read and are reported as
+unverified rather than implied to be proved. Machine identity is captured just
+before timing in every worker; differing identities fail the run.
 
 This path deliberately does not make a publishable performance claim. Every
 result says `claim_eligible: false` and `durable_record: false`; it has no
 warm-up program, and although each measurement uses a fresh process, the
-operating-system page cache is uncontrolled. `run-graph` does not accept
+operating-system page cache is uncontrolled; Linux plain-copy reset reads every
+fixture byte outside timing and can warm it. `run-graph` does not accept
 `--archive`, publish durable telemetry, calculate a noise floor, download an
 S3 fixture, or dispatch work through the AWS benchmark infrastructure. AWS may
 hold the source snapshot, but an operator must first provide the verified local

--- a/crates/omnigraph-bench/README.md
+++ b/crates/omnigraph-bench/README.md
@@ -243,14 +243,24 @@ it up. They neither download from S3 nor open or mutate the registered source
 as an OmniGraph database.
 
 `fixture run-graph` is the narrow runnable adapter for the checked-in FinGraph
-reference and strict real-graph run YAML. From a release binary on local APFS,
-it validates the copied graph, prepares a deterministic disjoint node-and-edge
-delta on two branches, freezes that prepared state, and restores identical
-clonefile inputs for fresh-process merge repetitions. This path is deliberately
-diagnostic: its output always records `claim_eligible: false` and
-`durable_record: false`, has no warm-up, leaves the OS page cache uncontrolled,
-and cannot publish through `--archive`. It also does not dispatch through the
-AWS benchmark infrastructure or publish durable telemetry. See the
+reference and strict real-graph run YAML. From a release binary, it validates
+the copied graph, prepares a deterministic disjoint node-and-edge delta on two
+branches, freezes that prepared state, and restores identical inputs at the
+same path for fresh-process merge repetitions. macOS uses forced APFS
+clonefiles. Linux requires XFS on a directly mounted EC2 instance-store NVMe
+namespace and uses complete verified plain copies; it reserves one additional
+prepared-tree copy plus 1 GiB before freezing. On a dedicated benchmark mount,
+it waits for filesystem-wide writeback with `syncfs` after freezing and after
+each restore, outside timing. The result records
+`xfs-plain-copy-syncfs-same-active-path`, backend evidence, and machine evidence
+captured in each measured worker; differing worker identities fail the run.
+
+This path is deliberately diagnostic: its output always records
+`claim_eligible: false` and `durable_record: false`, has no warm-up, leaves the
+OS page cache uncontrolled, and cannot publish through `--archive`. Plain-copy
+reset reads the complete tree outside timing and can warm that cache. The
+command still does not download a fixture, dispatch through AWS, or publish
+durable telemetry. See the
 [FinGraph diagnostic instructions](../../benchmarks/README.md#fingraph-diagnostic-runner)
 for the declarative run shape and exact command.
 

--- a/crates/omnigraph-bench/src/fixture_worker.rs
+++ b/crates/omnigraph-bench/src/fixture_worker.rs
@@ -20,8 +20,12 @@ use serde::{Deserialize, Serialize};
 use crate::branch_merge::{BranchMergePlan, FixtureBuildSummary, initialize_local_fixture};
 use crate::case::{CaseV1, ResetMode};
 use crate::reset::{
-    MetadataDigest, PhysicalDigest, TraversalLimits, copy_verified, digest_metadata_tree,
-    digest_physical_tree, freeze_clonefile_template,
+    MetadataDigest, PhysicalDigest, TraversalLimits, freeze_clonefile_template,
+    freeze_plain_copy_template,
+};
+#[cfg(test)]
+use crate::reset::{
+    accept_clonefile_template_handoff, accept_plain_copy_template_handoff, verify_physical_tree,
 };
 #[cfg(unix)]
 use crate::runner::{
@@ -164,23 +168,18 @@ async fn execute_fixture_request(request: FixtureRequestV1) -> FixtureResultV1 {
             )
         }
         ResetMode::PlainCopy => {
-            let physical = match digest_physical_tree(&request.active_root, limits) {
-                Ok(physical) => physical,
-                Err(error) => return failure("fixture_digest_failed", error.to_string()),
-            };
-            if let Err(error) = copy_verified(
+            let frozen = match freeze_plain_copy_template(
                 &request.active_root,
                 &request.template_root,
-                &physical,
                 limits,
             ) {
-                return failure("fixture_copy_failed", error.to_string());
-            }
-            let metadata = match digest_metadata_tree(&request.template_root, limits) {
-                Ok(metadata) => metadata,
-                Err(error) => return failure("fixture_metadata_failed", error.to_string()),
+                Ok(frozen) => frozen,
+                Err(error) => return failure("fixture_freeze_failed", error.to_string()),
             };
-            (physical, metadata)
+            (
+                frozen.physical_digest().clone(),
+                frozen.metadata_digest().clone(),
+            )
         }
         ResetMode::S3Versioning => {
             return failure(
@@ -1077,6 +1076,32 @@ mod tests {
                 assert_eq!(handoff.summary.target_history_depth, 6);
                 assert!(!active.exists());
                 assert!(template.is_dir());
+                let physical = handoff.physical.clone();
+                let restored = match reset {
+                    ResetMode::LocalClonefile => accept_clonefile_template_handoff(
+                        &active,
+                        &template,
+                        handoff.physical,
+                        handoff.template_metadata,
+                        TraversalLimits::default(),
+                    )
+                    .unwrap()
+                    .restore_active()
+                    .unwrap(),
+                    ResetMode::PlainCopy => accept_plain_copy_template_handoff(
+                        &active,
+                        &template,
+                        handoff.physical,
+                        handoff.template_metadata,
+                        TraversalLimits::default(),
+                    )
+                    .unwrap()
+                    .restore_active()
+                    .unwrap(),
+                    ResetMode::S3Versioning => panic!("test helper does not support S3 reset"),
+                };
+                assert_eq!(restored.root(), active);
+                verify_physical_tree(&active, &physical, TraversalLimits::default()).unwrap();
             }
             result => panic!("unexpected fixture result: {result:?}"),
         }

--- a/crates/omnigraph-bench/src/real_graph_run.rs
+++ b/crates/omnigraph-bench/src/real_graph_run.rs
@@ -3,9 +3,10 @@
 //! V1 deliberately supports one FinGraph-native branch-merge probe. The
 //! imported graph supplies realistic catalog size, history, fragments, and
 //! indexes; each side inserts two `Account` nodes and one transfer edge. The
-//! prepared tree is frozen once, every repetition is restored with APFS
-//! clonefiles, and the measured merge runs in a fresh process. Results are
-//! diagnostic JSON only and cannot enter the durable benchmark archive.
+//! prepared tree is frozen once, every repetition is restored at the same
+//! path with APFS clonefiles or verified Linux/XFS plain copies, and the
+//! measured merge runs in a fresh process. Results are diagnostic JSON only
+//! and cannot enter the durable benchmark archive.
 
 use std::collections::BTreeMap;
 use std::fs;
@@ -21,7 +22,10 @@ use serde_json::{Value, json};
 use tokio::process::Command;
 use tokio::time::timeout;
 
+use crate::case::{LocalFilesystem, LocalStorageClass};
+use crate::environment::{LocalEnvironmentEvidence, verify_local_environment};
 use crate::fixture_reference::NormalizedFixtureReferenceV1;
+use crate::machine::{MachineIdentityV1, capture_machine_identity};
 use crate::model::{
     Diagnostic, ValidationOutcome, declared_version, read_yaml_file, strict_yaml, valid_kebab_id,
 };
@@ -29,7 +33,10 @@ use crate::real_graph::{observe_real_graph, validate_real_graph_reference};
 use crate::registered_fixture::{
     FixtureCopyPreflightReceiptV1, StagedRegisteredFixtureV1, stage_registered_fixture_binding,
 };
-use crate::reset::{PhysicalDigest, TraversalLimits, freeze_clonefile_template};
+use crate::reset::{
+    ClonefileTemplate, PhysicalDigest, PlainCopyTemplate, PreparedFixtureTree, TraversalLimits,
+    digest_metadata_tree, freeze_clonefile_template, freeze_plain_copy_template,
+};
 use crate::runner::{
     MergePhaseEvidenceForm, MergeRouteObservation, PhaseObservation,
     configure_benchmark_worker_environment, phase_observations,
@@ -42,6 +49,7 @@ const MAX_REPETITIONS: u32 = 20;
 const MAX_DEADLINE_SECONDS: u64 = 3_600;
 const MAX_WORKER_FILE_BYTES: u64 = 1024 * 1024;
 const WORKER_VERIFY_GRACE_SECONDS: u64 = 120;
+const PLAIN_COPY_HEADROOM_BYTES: u64 = 1024 * 1024 * 1024;
 const SOURCE_BRANCH: &str = "bench-source";
 const TARGET_BRANCH: &str = "bench-target";
 const ACCOUNT_TABLE: &str = "node:Account";
@@ -164,6 +172,8 @@ pub struct RealGraphRunReportV1 {
     pub fixture: FixtureCopyPreflightReceiptV1,
     pub reference_sha256: String,
     pub prepared_input_physical: PhysicalDigest,
+    pub machine: MachineIdentityV1,
+    pub environment: LocalEnvironmentEvidence,
     pub reset: String,
     pub process_state: String,
     pub page_cache_state: String,
@@ -214,7 +224,124 @@ struct WorkerEnvelopeV1 {
     version: u32,
     ok: bool,
     sample: Option<RealGraphRepV1>,
+    machine: Option<MachineIdentityV1>,
     error: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RealGraphReset {
+    Clonefile,
+    PlainCopy,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RealGraphLocalProfile {
+    filesystem: LocalFilesystem,
+    storage_class: LocalStorageClass,
+    reset: RealGraphReset,
+    reset_label: &'static str,
+}
+
+#[cfg(target_os = "macos")]
+fn real_graph_local_profile() -> Result<RealGraphLocalProfile, RealGraphRunError> {
+    Ok(RealGraphLocalProfile {
+        filesystem: LocalFilesystem::Apfs,
+        storage_class: LocalStorageClass::NvmeSsd,
+        reset: RealGraphReset::Clonefile,
+        reset_label: "apfs-clonefile-same-active-path",
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn real_graph_local_profile() -> Result<RealGraphLocalProfile, RealGraphRunError> {
+    Ok(RealGraphLocalProfile {
+        filesystem: LocalFilesystem::Xfs,
+        storage_class: LocalStorageClass::NvmeSsd,
+        reset: RealGraphReset::PlainCopy,
+        reset_label: "xfs-plain-copy-syncfs-same-active-path",
+    })
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn real_graph_local_profile() -> Result<RealGraphLocalProfile, RealGraphRunError> {
+    Err(RealGraphRunError::new(
+        "unsupported_real_graph_platform",
+        "real-graph execution supports macOS/APFS clonefile or Linux/XFS EC2 instance-store NVMe only",
+    ))
+}
+
+enum RealGraphTemplate {
+    Clonefile(ClonefileTemplate),
+    PlainCopy(PlainCopyTemplate),
+}
+
+impl RealGraphTemplate {
+    fn freeze(
+        profile: RealGraphLocalProfile,
+        active: &Path,
+        template: &Path,
+        limits: TraversalLimits,
+    ) -> std::io::Result<Self> {
+        match profile.reset {
+            RealGraphReset::Clonefile => {
+                freeze_clonefile_template(active, template, limits).map(Self::Clonefile)
+            }
+            RealGraphReset::PlainCopy => {
+                let frozen = freeze_plain_copy_template(active, template, limits)?;
+                sync_plain_copy_filesystem(frozen.template_root())?;
+                Ok(Self::PlainCopy(frozen))
+            }
+        }
+    }
+
+    fn physical_digest(&self) -> &PhysicalDigest {
+        match self {
+            Self::Clonefile(template) => template.physical_digest(),
+            Self::PlainCopy(template) => template.physical_digest(),
+        }
+    }
+
+    fn verify_unchanged(&self) -> std::io::Result<()> {
+        match self {
+            Self::Clonefile(template) => template.verify_unchanged().map(|_| ()),
+            Self::PlainCopy(template) => template.verify_unchanged().map(|_| ()),
+        }
+    }
+
+    fn restore_active(&self) -> std::io::Result<PreparedFixtureTree> {
+        match self {
+            Self::Clonefile(template) => template.restore_active(),
+            Self::PlainCopy(template) => {
+                let prepared = template.restore_active()?;
+                sync_plain_copy_filesystem(prepared.root())?;
+                Ok(prepared)
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn sync_plain_copy_filesystem(root: &Path) -> std::io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let directory = fs::File::open(root)?;
+    // SAFETY: the descriptor remains open for this call; syncfs does not
+    // retain it. This waits for the entire dedicated benchmark filesystem,
+    // including data and directory metadata, outside the measured interval.
+    let result = unsafe { libc::syncfs(directory.as_raw_fd()) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn sync_plain_copy_filesystem(_root: &Path) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "real-graph plain-copy writeback synchronization requires Linux syncfs",
+    ))
 }
 
 pub async fn execute_real_graph_run(
@@ -261,6 +388,16 @@ async fn execute_staged_real_graph_run(
             ),
         ));
     }
+    let active = staged.root().to_path_buf();
+    let workspace = active.parent().ok_or_else(|| {
+        RealGraphRunError::new(
+            "real_graph_scratch_failed",
+            "staged graph root has no run-owned parent",
+        )
+    })?;
+    let profile = real_graph_local_profile()?;
+    let mut environment = observe_real_graph_environment(workspace, profile)?;
+
     let observation = observe_real_graph(staged.root()).await.map_err(|error| {
         RealGraphRunError::new("real_graph_observation_failed", error.to_string())
     })?;
@@ -271,22 +408,33 @@ async fn execute_staged_real_graph_run(
         RealGraphRunError::new("staged_fixture_changed", diagnostic.message)
     })?;
 
-    let active = staged.root().to_path_buf();
-    let workspace = active.parent().ok_or_else(|| {
-        RealGraphRunError::new(
-            "real_graph_scratch_failed",
-            "staged graph root has no run-owned parent",
-        )
-    })?;
     let template = workspace.join("template");
     let fixture_receipt = staged.receipt().clone();
 
     prepare_finbench_delta(&active).await?;
-    let frozen = freeze_clonefile_template(&active, &template, TraversalLimits::default())
-        .map_err(|error| {
+    let limits = TraversalLimits::default();
+    if profile.reset == RealGraphReset::PlainCopy {
+        let prepared = digest_metadata_tree(&active, limits).map_err(|error| {
+            RealGraphRunError::new(
+                "real_graph_capacity_probe_failed",
+                format!("inventory prepared graph before plain-copy freeze: {error}"),
+            )
+        })?;
+        environment = observe_real_graph_environment(&active, profile)?;
+        require_plain_copy_capacity(
+            prepared.bytes,
+            environment.available_bytes,
+            &environment.mount_point,
+        )?;
+    }
+    let frozen =
+        RealGraphTemplate::freeze(profile, &active, &template, limits).map_err(|error| {
             RealGraphRunError::new(
                 "real_graph_freeze_failed",
-                format!("freeze prepared graph with APFS clonefiles: {error}"),
+                format!(
+                    "freeze prepared graph with {}: {error}",
+                    profile.reset_label
+                ),
             )
         })?;
     remove_active(&active, workspace)?;
@@ -298,6 +446,7 @@ async fn execute_staged_real_graph_run(
         )
     })?;
     let mut samples = Vec::with_capacity(spec.repetitions as usize);
+    let mut worker_machine = None::<MachineIdentityV1>;
     for repetition in 1..=spec.repetitions {
         frozen.verify_unchanged().map_err(|error| {
             RealGraphRunError::new(
@@ -347,7 +496,7 @@ async fn execute_staged_real_graph_run(
                 format!("write worker request: {error}"),
             )
         })?;
-        let sample = invoke_worker(
+        let outcome = invoke_worker(
             &executable,
             &request_path,
             &result_path,
@@ -356,12 +505,20 @@ async fn execute_staged_real_graph_run(
         )
         .await;
         remove_active(&active, workspace)?;
-        samples.push(sample?);
+        let (sample, machine) = outcome?;
+        accept_worker_machine(&mut worker_machine, machine, repetition)?;
+        samples.push(sample);
     }
     frozen.verify_unchanged().map_err(|error| {
         RealGraphRunError::new(
             "real_graph_template_changed",
             format!("prepared template changed after execution: {error}"),
+        )
+    })?;
+    let machine = worker_machine.ok_or_else(|| {
+        RealGraphRunError::new(
+            "real_graph_worker_protocol_failed",
+            "real-graph execution produced no repetition-worker machine identity",
         )
     })?;
 
@@ -379,7 +536,9 @@ async fn execute_staged_real_graph_run(
         fixture: fixture_receipt,
         reference_sha256: reference.reference_sha256.clone(),
         prepared_input_physical,
-        reset: "apfs-clonefile-same-active-path".to_string(),
+        machine,
+        environment,
+        reset: profile.reset_label.to_string(),
         process_state: "fresh-process-per-repetition".to_string(),
         page_cache_state: "uncontrolled".to_string(),
         warmup: "none".to_string(),
@@ -390,6 +549,56 @@ async fn execute_staged_real_graph_run(
         p50_us,
         samples,
     })
+}
+
+fn observe_real_graph_environment(
+    scratch_path: &Path,
+    profile: RealGraphLocalProfile,
+) -> Result<LocalEnvironmentEvidence, RealGraphRunError> {
+    verify_local_environment(scratch_path, profile.filesystem, profile.storage_class)
+        .map_err(|message| RealGraphRunError::new("environment_mismatch", message))
+}
+
+fn require_plain_copy_capacity(
+    prepared_bytes: u64,
+    available_bytes: u64,
+    mount_point: &str,
+) -> Result<u64, RealGraphRunError> {
+    let required = prepared_bytes
+        .checked_add(PLAIN_COPY_HEADROOM_BYTES)
+        .ok_or_else(|| {
+            RealGraphRunError::new(
+                "required_scratch_capacity_overflow",
+                "prepared graph plus plain-copy headroom overflowed u64",
+            )
+        })?;
+    if available_bytes < required {
+        return Err(RealGraphRunError::new(
+            "insufficient_scratch_capacity",
+            format!(
+                "real-graph plain-copy reset requires at least {required} available bytes, but {available_bytes} are available at {mount_point}"
+            ),
+        ));
+    }
+    Ok(required)
+}
+
+fn accept_worker_machine(
+    expected: &mut Option<MachineIdentityV1>,
+    observed: MachineIdentityV1,
+    repetition: u32,
+) -> Result<(), RealGraphRunError> {
+    match expected {
+        Some(machine) if machine != &observed => Err(RealGraphRunError::new(
+            "machine_identity_changed",
+            format!("repetition-worker machine identity changed before repetition {repetition}"),
+        )),
+        None => {
+            *expected = Some(observed);
+            Ok(())
+        }
+        Some(_) => Ok(()),
+    }
 }
 
 fn complete_real_graph_run<T>(
@@ -548,7 +757,7 @@ async fn invoke_worker(
     result: &Path,
     worker_scratch: &Path,
     deadline_seconds: u64,
-) -> Result<RealGraphRepV1, RealGraphRunError> {
+) -> Result<(RealGraphRepV1, MachineIdentityV1), RealGraphRunError> {
     let mut command = Command::new(executable);
     configure_benchmark_worker_environment(command.as_std_mut(), worker_scratch);
     command
@@ -603,12 +812,19 @@ async fn invoke_worker(
                 .unwrap_or_else(|| format!("worker exited {status}")),
         ));
     }
-    envelope.sample.ok_or_else(|| {
+    let sample = envelope.sample.ok_or_else(|| {
         RealGraphRunError::new(
             "real_graph_worker_protocol_failed",
             "successful worker returned no sample",
         )
-    })
+    })?;
+    let machine = envelope.machine.ok_or_else(|| {
+        RealGraphRunError::new(
+            "real_graph_worker_protocol_failed",
+            "successful worker returned no machine identity",
+        )
+    })?;
+    Ok((sample, machine))
 }
 
 pub async fn run_real_graph_worker_files(request: &Path, result: &Path) -> ExitCode {
@@ -617,16 +833,18 @@ pub async fn run_real_graph_worker_files(request: &Path, result: &Path) -> ExitC
         Err(error) => Err(error),
     };
     let envelope = match outcome {
-        Ok(sample) => WorkerEnvelopeV1 {
+        Ok((sample, machine)) => WorkerEnvelopeV1 {
             version: WORKER_PROTOCOL_VERSION,
             ok: true,
             sample: Some(sample),
+            machine: Some(machine),
             error: None,
         },
         Err(error) => WorkerEnvelopeV1 {
             version: WORKER_PROTOCOL_VERSION,
             ok: false,
             sample: None,
+            machine: None,
             error: Some(error.to_string()),
         },
     };
@@ -648,7 +866,9 @@ pub async fn run_real_graph_worker_files(request: &Path, result: &Path) -> ExitC
     }
 }
 
-async fn execute_worker(request: WorkerRequestV1) -> Result<RealGraphRepV1, RealGraphRunError> {
+async fn execute_worker(
+    request: WorkerRequestV1,
+) -> Result<(RealGraphRepV1, MachineIdentityV1), RealGraphRunError> {
     if request.version != WORKER_PROTOCOL_VERSION {
         return Err(RealGraphRunError::new(
             "real_graph_worker_protocol_failed",
@@ -676,6 +896,15 @@ async fn execute_worker(request: WorkerRequestV1) -> Result<RealGraphRepV1, Real
         .snapshot_of(ReadTarget::branch(TARGET_BRANCH))
         .await
         .map_err(engine_worker_error)?;
+    // Capture process-effective facts in the fresh repetition worker after
+    // preparation and immediately before the measured operation. The CLI
+    // parent can have different affinity, cgroup, scheduling, or limits.
+    let machine = capture_machine_identity().map_err(|error| {
+        RealGraphRunError::new(
+            "machine_identity_capture_failed",
+            format!("capture repetition-worker machine identity: {error}"),
+        )
+    })?;
     let probes = MergeWriteProbes::default();
     let started = Instant::now();
     let outcome = with_merge_write_probes(
@@ -737,19 +966,22 @@ async fn execute_worker(request: WorkerRequestV1) -> Result<RealGraphRepV1, Real
     verify_reserved_entities(&db, TARGET_BRANCH, SideExpectation::All).await?;
     verify_merge_commit(&db, &source_before, &target_before, &target_after).await?;
     drop(db);
-    Ok(RealGraphRepV1 {
-        repetition: request.repetition,
-        elapsed_us,
-        outcome: "merged".to_string(),
-        phases,
-        route,
-        before_target_manifest_version: target_before.graph_manifest_version(),
-        after_target_manifest_version: target_after.graph_manifest_version(),
-        inserted_delta_verified: true,
-        existing_rows_in_changed_tables_verified: false,
-        protected_heads_verified: true,
-        untouched_tables_verified,
-    })
+    Ok((
+        RealGraphRepV1 {
+            repetition: request.repetition,
+            elapsed_us,
+            outcome: "merged".to_string(),
+            phases,
+            route,
+            before_target_manifest_version: target_before.graph_manifest_version(),
+            after_target_manifest_version: target_after.graph_manifest_version(),
+            inserted_delta_verified: true,
+            existing_rows_in_changed_tables_verified: false,
+            protected_heads_verified: true,
+            untouched_tables_verified,
+        },
+        machine,
+    ))
 }
 
 fn require_snapshot_unchanged(
@@ -1122,6 +1354,7 @@ fn read_worker_envelope(path: &Path) -> Result<WorkerEnvelopeV1, RealGraphRunErr
     })?;
     if envelope.version != WORKER_PROTOCOL_VERSION
         || envelope.ok != envelope.sample.is_some()
+        || envelope.ok != envelope.machine.is_some()
         || envelope.ok == envelope.error.is_some()
     {
         return Err(RealGraphRunError::new(
@@ -1232,6 +1465,71 @@ mod tests {
         assert!(complete_real_graph_run(Ok(7_u8), Ok(())).is_ok());
     }
 
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_real_graph_profile_remains_apfs_clonefile() {
+        let profile = real_graph_local_profile().unwrap();
+        assert_eq!(profile.filesystem, LocalFilesystem::Apfs);
+        assert_eq!(profile.storage_class, LocalStorageClass::NvmeSsd);
+        assert_eq!(profile.reset, RealGraphReset::Clonefile);
+        assert_eq!(profile.reset_label, "apfs-clonefile-same-active-path");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_real_graph_profile_is_xfs_instance_nvme_plain_copy() {
+        let profile = real_graph_local_profile().unwrap();
+        assert_eq!(profile.filesystem, LocalFilesystem::Xfs);
+        assert_eq!(profile.storage_class, LocalStorageClass::NvmeSsd);
+        assert_eq!(profile.reset, RealGraphReset::PlainCopy);
+        assert_eq!(
+            profile.reset_label,
+            "xfs-plain-copy-syncfs-same-active-path"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_real_graph_plain_copy_syncs_and_restores_the_exact_path() {
+        let directory = tempfile::tempdir().unwrap();
+        let active = directory.path().join("root");
+        let template = directory.path().join("template");
+        fs::create_dir(&active).unwrap();
+        fs::write(active.join("data"), b"prepared graph").unwrap();
+        let frozen = RealGraphTemplate::freeze(
+            real_graph_local_profile().unwrap(),
+            &active,
+            &template,
+            TraversalLimits::default(),
+        )
+        .unwrap();
+        fs::remove_dir_all(&active).unwrap();
+
+        let restored = frozen.restore_active().unwrap();
+        assert_eq!(restored.root(), active);
+        assert_eq!(fs::read(active.join("data")).unwrap(), b"prepared graph");
+        restored.verify_unchanged().unwrap();
+        frozen.verify_unchanged().unwrap();
+        assert!(sync_plain_copy_filesystem(&directory.path().join("missing")).is_err());
+    }
+
+    #[test]
+    fn plain_copy_capacity_is_checked_at_the_exact_boundary() {
+        let prepared_bytes = 42;
+        let required = prepared_bytes + PLAIN_COPY_HEADROOM_BYTES;
+
+        let insufficient =
+            require_plain_copy_capacity(prepared_bytes, required - 1, "/scratch").unwrap_err();
+        assert_eq!(insufficient.code, "insufficient_scratch_capacity");
+        assert_eq!(
+            require_plain_copy_capacity(prepared_bytes, required, "/scratch").unwrap(),
+            required
+        );
+
+        let overflow = require_plain_copy_capacity(u64::MAX, u64::MAX, "/scratch").unwrap_err();
+        assert_eq!(overflow.code, "required_scratch_capacity_overflow");
+    }
+
     #[tokio::test]
     async fn native_finbench_delta_merges_and_verifies_exactly() {
         const SCHEMA: &str = r#"
@@ -1268,7 +1566,7 @@ mod tests {
         drop(db);
 
         prepare_finbench_delta(&root).await.unwrap();
-        let sample = execute_worker(WorkerRequestV1 {
+        let (sample, machine) = execute_worker(WorkerRequestV1 {
             version: WORKER_PROTOCOL_VERSION,
             repetition: 1,
             root,
@@ -1278,9 +1576,26 @@ mod tests {
         .unwrap();
 
         assert_eq!(sample.outcome, "merged");
+        machine.validate().unwrap();
         assert_eq!(sample.route.table_walk_intervals, 2);
         assert!(sample.inserted_delta_verified);
         assert!(!sample.existing_rows_in_changed_tables_verified);
         assert!(sample.protected_heads_verified);
+    }
+
+    #[test]
+    fn worker_machine_identity_is_established_once_and_drift_is_refused() {
+        let first = capture_machine_identity().unwrap();
+        let mut expected = None;
+        accept_worker_machine(&mut expected, first.clone(), 1).unwrap();
+        assert_eq!(expected.as_ref(), Some(&first));
+        accept_worker_machine(&mut expected, first.clone(), 2).unwrap();
+
+        let mut changed = first.clone();
+        changed.machine_label = format!("hostname-sha256:{}", "0".repeat(64));
+        let error = accept_worker_machine(&mut expected, changed, 3).unwrap_err();
+        assert_eq!(error.code, "machine_identity_changed");
+        assert!(error.message.contains("repetition 3"));
+        assert_eq!(expected, Some(first));
     }
 }

--- a/crates/omnigraph-bench/src/real_graph_run.rs
+++ b/crates/omnigraph-bench/src/real_graph_run.rs
@@ -22,7 +22,7 @@ use serde_json::{Value, json};
 use tokio::process::Command;
 use tokio::time::timeout;
 
-use crate::case::{LocalFilesystem, LocalStorageClass};
+use crate::case::{LocalFilesystem, LocalStorageClass, ResetMode};
 use crate::environment::{LocalEnvironmentEvidence, verify_local_environment};
 use crate::fixture_reference::NormalizedFixtureReferenceV1;
 use crate::machine::{MachineIdentityV1, capture_machine_identity};
@@ -229,16 +229,10 @@ struct WorkerEnvelopeV1 {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RealGraphReset {
-    Clonefile,
-    PlainCopy,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct RealGraphLocalProfile {
     filesystem: LocalFilesystem,
     storage_class: LocalStorageClass,
-    reset: RealGraphReset,
+    reset: ResetMode,
     reset_label: &'static str,
 }
 
@@ -247,7 +241,7 @@ fn real_graph_local_profile() -> Result<RealGraphLocalProfile, RealGraphRunError
     Ok(RealGraphLocalProfile {
         filesystem: LocalFilesystem::Apfs,
         storage_class: LocalStorageClass::NvmeSsd,
-        reset: RealGraphReset::Clonefile,
+        reset: ResetMode::LocalClonefile,
         reset_label: "apfs-clonefile-same-active-path",
     })
 }
@@ -257,7 +251,7 @@ fn real_graph_local_profile() -> Result<RealGraphLocalProfile, RealGraphRunError
     Ok(RealGraphLocalProfile {
         filesystem: LocalFilesystem::Xfs,
         storage_class: LocalStorageClass::NvmeSsd,
-        reset: RealGraphReset::PlainCopy,
+        reset: ResetMode::PlainCopy,
         reset_label: "xfs-plain-copy-syncfs-same-active-path",
     })
 }
@@ -283,14 +277,18 @@ impl RealGraphTemplate {
         limits: TraversalLimits,
     ) -> std::io::Result<Self> {
         match profile.reset {
-            RealGraphReset::Clonefile => {
+            ResetMode::LocalClonefile => {
                 freeze_clonefile_template(active, template, limits).map(Self::Clonefile)
             }
-            RealGraphReset::PlainCopy => {
+            ResetMode::PlainCopy => {
                 let frozen = freeze_plain_copy_template(active, template, limits)?;
                 sync_plain_copy_filesystem(frozen.template_root())?;
                 Ok(Self::PlainCopy(frozen))
             }
+            ResetMode::S3Versioning => Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "real-graph execution supports only local reset modes",
+            )),
         }
     }
 
@@ -413,7 +411,7 @@ async fn execute_staged_real_graph_run(
 
     prepare_finbench_delta(&active).await?;
     let limits = TraversalLimits::default();
-    if profile.reset == RealGraphReset::PlainCopy {
+    if profile.reset == ResetMode::PlainCopy {
         let prepared = digest_metadata_tree(&active, limits).map_err(|error| {
             RealGraphRunError::new(
                 "real_graph_capacity_probe_failed",
@@ -1471,7 +1469,7 @@ mod tests {
         let profile = real_graph_local_profile().unwrap();
         assert_eq!(profile.filesystem, LocalFilesystem::Apfs);
         assert_eq!(profile.storage_class, LocalStorageClass::NvmeSsd);
-        assert_eq!(profile.reset, RealGraphReset::Clonefile);
+        assert_eq!(profile.reset, ResetMode::LocalClonefile);
         assert_eq!(profile.reset_label, "apfs-clonefile-same-active-path");
     }
 
@@ -1481,7 +1479,7 @@ mod tests {
         let profile = real_graph_local_profile().unwrap();
         assert_eq!(profile.filesystem, LocalFilesystem::Xfs);
         assert_eq!(profile.storage_class, LocalStorageClass::NvmeSsd);
-        assert_eq!(profile.reset, RealGraphReset::PlainCopy);
+        assert_eq!(profile.reset, ResetMode::PlainCopy);
         assert_eq!(
             profile.reset_label,
             "xfs-plain-copy-syncfs-same-active-path"

--- a/crates/omnigraph-bench/src/reset.rs
+++ b/crates/omnigraph-bench/src/reset.rs
@@ -66,6 +66,11 @@ pub struct PhysicalDigest {
 /// mtime, and ctime) and is only compared against a later observation of the
 /// same tree. Access time is deliberately excluded because read-only cache preparation and
 /// metadata traversal may update it.
+///
+/// Equal metadata is not independent proof of equal contents: same-length
+/// writes can share a filesystem timestamp tick. Callers must retain quiescent
+/// ownership; byte identity comes from [`PhysicalDigest`] and the verified
+/// copy or forced-clone contract.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct MetadataDigest {
@@ -144,8 +149,9 @@ pub fn verify_physical_tree(
 /// Compute a content-free metadata witness for one tree.
 ///
 /// This traverses and stats the complete tree but never opens a regular file.
-/// The witness is suitable for proving that a quiescent tree did not change
-/// between two points in the benchmark protocol. It is not a replacement for
+/// The witness detects observable stat drift between two points in the
+/// benchmark protocol; it does not independently prove unchanged contents.
+/// Callers must keep the tree quiescent. It is not a replacement for
 /// [`PhysicalDigest`]: clone identity additionally relies on a successful
 /// forced `clonefileat(2)` call for every file.
 pub fn digest_metadata_tree(root: &Path, limits: TraversalLimits) -> io::Result<MetadataDigest> {
@@ -388,12 +394,13 @@ impl ClonefileTemplate {
         &self.physical
     }
 
-    /// Metadata witness for proving that the template remains immutable.
+    /// Metadata drift witness for the caller-quiescent template.
     pub fn metadata_digest(&self) -> &MetadataDigest {
         &self.metadata
     }
 
-    /// Prove without reading file contents that the template is unchanged.
+    /// Require unchanged metadata on the caller-quiescent template.
+    /// This does not independently reverify file contents.
     pub fn verify_unchanged(&self) -> io::Result<MetadataDigest> {
         verify_metadata_tree(&self.template_root, &self.metadata, self.limits)
     }
@@ -435,12 +442,13 @@ impl PlainCopyTemplate {
         &self.physical
     }
 
-    /// Metadata witness for proving that the template remains immutable.
+    /// Metadata drift witness for the caller-quiescent template.
     pub fn metadata_digest(&self) -> &MetadataDigest {
         &self.metadata
     }
 
-    /// Prove without reading file contents that the template is unchanged.
+    /// Require unchanged metadata on the caller-quiescent template.
+    /// Restoration separately verifies every source and destination byte.
     pub fn verify_unchanged(&self) -> io::Result<MetadataDigest> {
         verify_metadata_tree(&self.template_root, &self.metadata, self.limits)
     }
@@ -477,8 +485,9 @@ impl PreparedFixtureTree {
         &self.metadata
     }
 
-    /// Prove without reading contents that open and cache preparation did not mutate the
-    /// measured input before the timer starts.
+    /// Require the pre-open metadata witness to remain unchanged.
+    /// The caller must keep the input quiescent; this is not a byte-integrity
+    /// check or protection against arbitrary concurrent writers.
     pub fn verify_unchanged(&self) -> io::Result<MetadataDigest> {
         verify_metadata_tree(&self.root, &self.metadata, self.limits)
     }
@@ -1576,11 +1585,13 @@ mod tests {
     }
 
     #[test]
-    fn metadata_witness_detects_same_length_changes_without_reading_contents() {
+    fn metadata_witness_detects_same_length_changes_with_distinct_timestamps() {
         let fixture = tempfile::tempdir().unwrap();
         fixture_tree(fixture.path());
         let limits = TraversalLimits::default();
         let frozen = digest_metadata_tree(fixture.path(), limits).unwrap();
+        let file = fixture.path().join("a.txt");
+        let original_modified = fs::metadata(&file).unwrap().modified().unwrap();
 
         assert_eq!(frozen.entries, 4);
         assert_eq!(frozen.files, 2);
@@ -1588,7 +1599,15 @@ mod tests {
         assert_eq!(frozen.bytes, 9);
         verify_metadata_tree(fixture.path(), &frozen, limits).unwrap();
 
-        fs::write(fixture.path().join("a.txt"), b"ALPHA").unwrap();
+        fs::write(&file, b"ALPHA").unwrap();
+        // Back-to-back writes can share a timestamp tick. This test owns
+        // observable metadata drift, not a filesystem clock-resolution claim.
+        File::options()
+            .write(true)
+            .open(&file)
+            .unwrap()
+            .set_modified(original_modified + std::time::Duration::from_secs(2))
+            .unwrap();
         let changed = digest_metadata_tree(fixture.path(), limits).unwrap();
         assert_eq!(changed.shape_sha256, frozen.shape_sha256);
         assert_ne!(changed.state_sha256, frozen.state_sha256);
@@ -1654,7 +1673,7 @@ mod tests {
         prepared.verify_unchanged().unwrap();
 
         fs::write(active.join("a.txt"), b"ALPHA").unwrap();
-        assert!(prepared.verify_unchanged().is_err());
+        assert!(verify_physical_tree(&active, frozen.physical_digest(), limits).is_err());
         assert_eq!(fs::read(template.join("a.txt")).unwrap(), b"alpha");
         frozen.verify_unchanged().unwrap();
 

--- a/crates/omnigraph-bench/src/reset.rs
+++ b/crates/omnigraph-bench/src/reset.rs
@@ -91,13 +91,32 @@ pub struct ClonefileTemplate {
     limits: TraversalLimits,
 }
 
-/// One clonefile-restored active tree and its pre-open metadata witness.
+/// A byte-identified plain-copy template that must never be opened as a database.
+///
+/// Like [`ClonefileTemplate`], this remembers the exact absolute path at which
+/// the source fixture was built. Restoring to that lexical path keeps absolute
+/// Lance base paths valid. Unlike clonefile reset, every restore reads and
+/// writes the complete tree; callers must keep that work outside measurement
+/// and must not describe the operating-system page cache as cold.
 #[derive(Debug, Clone)]
-pub struct PreparedClone {
+pub struct PlainCopyTemplate {
+    template_root: PathBuf,
+    active_root: PathBuf,
+    physical: PhysicalDigest,
+    metadata: MetadataDigest,
+    limits: TraversalLimits,
+}
+
+/// One restored active fixture tree and its pre-open metadata witness.
+#[derive(Debug, Clone)]
+pub struct PreparedFixtureTree {
     root: PathBuf,
     metadata: MetadataDigest,
     limits: TraversalLimits,
 }
+
+/// Backward-compatible name for a clonefile-restored fixture tree.
+pub type PreparedClone = PreparedFixtureTree;
 
 /// Compute the physical identity of a quiescent fixture root.
 ///
@@ -205,6 +224,38 @@ pub fn freeze_clonefile_template(
     })
 }
 
+/// Freeze a quiescent active fixture into a never-opened plain-copy template.
+///
+/// Both paths must be stable absolute paths without parent traversal.
+/// `active_root` must be the exact path used to build the database; the
+/// returned template restores only that same path. The caller must remove
+/// `active_root` after this function succeeds and before the first restore.
+///
+/// This is deliberately a byte copy rather than a reflink. It verifies the
+/// complete source and destination contents before returning, so its cost is
+/// proportional to fixture size and can populate the operating-system page
+/// cache.
+pub fn freeze_plain_copy_template(
+    active_root: &Path,
+    template_root: &Path,
+    limits: TraversalLimits,
+) -> io::Result<PlainCopyTemplate> {
+    let active_root = stable_absolute_path("active fixture root", active_root)?;
+    let template_root = stable_absolute_path("plain-copy template root", template_root)?;
+    refuse_destination_below_source(&active_root, &template_root)?;
+    let physical = digest_physical_tree(&active_root, limits)?;
+    copy_verified(&active_root, &template_root, &physical, limits)?;
+    let metadata = digest_metadata_tree(&template_root, limits)?;
+
+    Ok(PlainCopyTemplate {
+        template_root,
+        active_root,
+        physical,
+        metadata,
+        limits,
+    })
+}
+
 /// Accept a clonefile template produced by the contained fixture worker.
 ///
 /// The worker owns the only full byte read and clone operation. The parent
@@ -219,8 +270,51 @@ pub(crate) fn accept_clonefile_template_handoff(
     limits: TraversalLimits,
 ) -> io::Result<ClonefileTemplate> {
     require_clonefile_platform()?;
+    let (active_root, template_root) =
+        retired_template_handoff_paths(active_root, template_root, "clonefile template root")?;
+    validate_handoff_identity(&physical, &metadata)?;
+    verify_metadata_tree(&template_root, &metadata, limits)?;
+    Ok(ClonefileTemplate {
+        template_root,
+        active_root,
+        physical,
+        metadata,
+        limits,
+    })
+}
+
+/// Accept a plain-copy template produced by the contained fixture worker.
+///
+/// Unlike clonefile handoff, the parent re-reads the complete template because
+/// no kernel clone contract connects it to the worker's physical digest.
+pub(crate) fn accept_plain_copy_template_handoff(
+    active_root: &Path,
+    template_root: &Path,
+    physical: PhysicalDigest,
+    metadata: MetadataDigest,
+    limits: TraversalLimits,
+) -> io::Result<PlainCopyTemplate> {
+    let (active_root, template_root) =
+        retired_template_handoff_paths(active_root, template_root, "plain-copy template root")?;
+    validate_handoff_identity(&physical, &metadata)?;
+    verify_physical_tree(&template_root, &physical, limits)?;
+    verify_metadata_tree(&template_root, &metadata, limits)?;
+    Ok(PlainCopyTemplate {
+        template_root,
+        active_root,
+        physical,
+        metadata,
+        limits,
+    })
+}
+
+fn retired_template_handoff_paths(
+    active_root: &Path,
+    template_root: &Path,
+    template_label: &str,
+) -> io::Result<(PathBuf, PathBuf)> {
     let active_root = stable_absolute_path("active fixture root", active_root)?;
-    let template_root = stable_absolute_path("clonefile template root", template_root)?;
+    let template_root = stable_absolute_path(template_label, template_root)?;
     refuse_destination_below_retired_source(&active_root, &template_root)?;
     match fs::symlink_metadata(&active_root) {
         Ok(_) => {
@@ -237,6 +331,13 @@ pub(crate) fn accept_clonefile_template_handoff(
             ));
         }
     }
+    Ok((active_root, template_root))
+}
+
+fn validate_handoff_identity(
+    physical: &PhysicalDigest,
+    metadata: &MetadataDigest,
+) -> io::Result<()> {
     if physical.files != metadata.files || physical.bytes != metadata.bytes {
         return Err(invalid_data(format!(
             "fixture handoff disagrees on template totals: physical files={} bytes={}, metadata files={} bytes={}",
@@ -248,14 +349,7 @@ pub(crate) fn accept_clonefile_template_handoff(
             "fixture handoff physical digest must be exactly 64 lowercase hexadecimal characters",
         ));
     }
-    verify_metadata_tree(&template_root, &metadata, limits)?;
-    Ok(ClonefileTemplate {
-        template_root,
-        active_root,
-        physical,
-        metadata,
-        limits,
-    })
+    Ok(())
 }
 
 fn is_lowercase_sha256(value: &str) -> bool {
@@ -310,14 +404,14 @@ impl ClonefileTemplate {
     /// can leave a partial active tree, which must not be opened. The caller
     /// owns deletion of the previous repetition after all engine handles have
     /// quiesced.
-    pub fn restore_active(&self) -> io::Result<PreparedClone> {
+    pub fn restore_active(&self) -> io::Result<PreparedFixtureTree> {
         let metadata = clonefile_tree_from_witness(
             &self.template_root,
             &self.active_root,
             &self.metadata,
             self.limits,
         )?;
-        Ok(PreparedClone {
+        Ok(PreparedFixtureTree {
             root: self.active_root.clone(),
             metadata,
             limits: self.limits,
@@ -325,7 +419,54 @@ impl ClonefileTemplate {
     }
 }
 
-impl PreparedClone {
+impl PlainCopyTemplate {
+    /// Exact path of the never-opened template tree.
+    pub fn template_root(&self) -> &Path {
+        &self.template_root
+    }
+
+    /// Exact stable path at which every repetition must run.
+    pub fn active_root(&self) -> &Path {
+        &self.active_root
+    }
+
+    /// Full byte identity captured before the template was made.
+    pub fn physical_digest(&self) -> &PhysicalDigest {
+        &self.physical
+    }
+
+    /// Metadata witness for proving that the template remains immutable.
+    pub fn metadata_digest(&self) -> &MetadataDigest {
+        &self.metadata
+    }
+
+    /// Prove without reading file contents that the template is unchanged.
+    pub fn verify_unchanged(&self) -> io::Result<MetadataDigest> {
+        verify_metadata_tree(&self.template_root, &self.metadata, self.limits)
+    }
+
+    /// Restore one repetition to the exact path used to build the fixture.
+    ///
+    /// The active path may be absent or an existing empty directory. This
+    /// verifies every source and destination byte. An error can leave a
+    /// partial active tree, which must not be opened.
+    pub fn restore_active(&self) -> io::Result<PreparedFixtureTree> {
+        copy_verified(
+            &self.template_root,
+            &self.active_root,
+            &self.physical,
+            self.limits,
+        )?;
+        let metadata = digest_metadata_tree(&self.active_root, self.limits)?;
+        Ok(PreparedFixtureTree {
+            root: self.active_root.clone(),
+            metadata,
+            limits: self.limits,
+        })
+    }
+}
+
+impl PreparedFixtureTree {
     /// Exact active path to pass to the engine.
     pub fn root(&self) -> &Path {
         &self.root
@@ -1483,6 +1624,111 @@ mod tests {
         assert_eq!(fs::read(destination.join("a.txt")).unwrap(), b"alpha");
         assert_eq!(fs::read(destination.join("data/b.bin")).unwrap(), b"beta");
         assert!(destination.join("empty").is_dir());
+    }
+
+    #[test]
+    fn plain_copy_template_restores_exact_active_path_with_byte_isolation() {
+        let workspace = tempfile::tempdir().unwrap();
+        let active = workspace.path().join("active");
+        let template = workspace.path().join("template");
+        fs::create_dir(&active).unwrap();
+        fixture_tree(&active);
+        let limits = TraversalLimits::default();
+
+        let frozen = freeze_plain_copy_template(&active, &template, limits).unwrap();
+        assert_eq!(frozen.active_root(), active);
+        assert_eq!(frozen.template_root(), template);
+        assert_eq!(
+            digest_physical_tree(&template, limits).unwrap(),
+            *frozen.physical_digest()
+        );
+        frozen.verify_unchanged().unwrap();
+
+        fs::remove_dir_all(&active).unwrap();
+        let prepared = frozen.restore_active().unwrap();
+        assert_eq!(prepared.root(), active);
+        assert_eq!(
+            digest_physical_tree(&active, limits).unwrap(),
+            *frozen.physical_digest()
+        );
+        prepared.verify_unchanged().unwrap();
+
+        fs::write(active.join("a.txt"), b"ALPHA").unwrap();
+        assert!(prepared.verify_unchanged().is_err());
+        assert_eq!(fs::read(template.join("a.txt")).unwrap(), b"alpha");
+        frozen.verify_unchanged().unwrap();
+
+        fs::remove_dir_all(&active).unwrap();
+        let second = frozen.restore_active().unwrap();
+        assert_eq!(fs::read(active.join("a.txt")).unwrap(), b"alpha");
+        second.verify_unchanged().unwrap();
+        frozen.verify_unchanged().unwrap();
+    }
+
+    #[test]
+    fn changed_plain_copy_template_is_refused_before_restoring_active() {
+        let workspace = tempfile::tempdir().unwrap();
+        let active = workspace.path().join("active");
+        let template = workspace.path().join("template");
+        fs::create_dir(&active).unwrap();
+        fixture_tree(&active);
+        let limits = TraversalLimits::default();
+        let frozen = freeze_plain_copy_template(&active, &template, limits).unwrap();
+        fs::remove_dir_all(&active).unwrap();
+        fs::write(template.join("a.txt"), b"ALPHA").unwrap();
+
+        let error = frozen.restore_active().unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(!active.exists());
+    }
+
+    #[test]
+    fn plain_copy_handoff_requires_retired_active_and_exact_bytes() {
+        let workspace = tempfile::tempdir().unwrap();
+        let active = workspace.path().join("active");
+        let template = workspace.path().join("template");
+        fs::create_dir(&active).unwrap();
+        fixture_tree(&active);
+        let limits = TraversalLimits::default();
+        let frozen = freeze_plain_copy_template(&active, &template, limits).unwrap();
+        let physical = frozen.physical_digest().clone();
+        let metadata = frozen.metadata_digest().clone();
+
+        let left_behind = accept_plain_copy_template_handoff(
+            &active,
+            &template,
+            physical.clone(),
+            metadata.clone(),
+            limits,
+        )
+        .unwrap_err();
+        assert!(
+            left_behind
+                .to_string()
+                .contains("left the active path behind"),
+            "{left_behind}"
+        );
+
+        fs::remove_dir_all(&active).unwrap();
+        let accepted = accept_plain_copy_template_handoff(
+            &active,
+            &template,
+            physical.clone(),
+            metadata.clone(),
+            limits,
+        )
+        .unwrap();
+        let prepared = accepted.restore_active().unwrap();
+        assert_eq!(prepared.root(), active);
+        verify_physical_tree(&active, &physical, limits).unwrap();
+
+        fs::remove_dir_all(&active).unwrap();
+        fs::write(template.join("a.txt"), b"ALPHA").unwrap();
+        let tampered =
+            accept_plain_copy_template_handoff(&active, &template, physical, metadata, limits)
+                .unwrap_err();
+        assert_eq!(tampered.kind(), io::ErrorKind::InvalidData);
     }
 
     #[test]

--- a/crates/omnigraph-bench/src/runner.rs
+++ b/crates/omnigraph-bench/src/runner.rs
@@ -47,10 +47,12 @@ use crate::machine::{MachineIdentityV1, capture_machine_identity};
 use crate::preparation::{PreparationWriteGate, guard_preparation_writes};
 use crate::reset::{
     ClonefileTemplate, MetadataDigest, PHYSICAL_TREE_DIGEST_ALGORITHM, PhysicalDigest,
-    TraversalLimits, accept_clonefile_template_handoff, copy_verified, digest_metadata_tree,
-    digest_physical_tree, freeze_clonefile_template, verify_metadata_shape, verify_metadata_tree,
-    verify_physical_tree,
+    PlainCopyTemplate, TraversalLimits, accept_clonefile_template_handoff,
+    accept_plain_copy_template_handoff, freeze_clonefile_template, freeze_plain_copy_template,
+    verify_metadata_shape,
 };
+#[cfg(test)]
+use crate::reset::{digest_metadata_tree, digest_physical_tree, verify_physical_tree};
 use crate::suite::{MAX_REPETITIONS_PER_CASE, MAX_SUITE_RUNS, MAX_TOTAL_REPETITIONS};
 use crate::supervisor::{SupervisionInput, supervise_repetition};
 use crate::worker_protocol::{
@@ -1607,13 +1609,18 @@ async fn execute_owned_run(
                         RunnerError::new("fixture_handoff_failed", error.to_string())
                     })?,
                 ),
-                ResetMode::PlainCopy => FrozenTemplate::accept_plain_copy_handoff(
-                    &active_root,
-                    &template_root,
-                    handoff.physical.clone(),
-                    handoff.template_metadata,
-                    limits,
-                )?,
+                ResetMode::PlainCopy => FrozenTemplate::PlainCopy(
+                    accept_plain_copy_template_handoff(
+                        &active_root,
+                        &template_root,
+                        handoff.physical.clone(),
+                        handoff.template_metadata,
+                        limits,
+                    )
+                    .map_err(|error| {
+                        RunnerError::new("fixture_handoff_failed", error.to_string())
+                    })?,
+                ),
                 ResetMode::S3Versioning => {
                     return Err(RunnerError::new(
                         "unsupported_runner_axis",
@@ -1644,7 +1651,11 @@ async fn execute_owned_run(
                     )?,
                 )
             } else {
-                FrozenTemplate::freeze_plain_copy(&active_root, &template_root, limits)?
+                FrozenTemplate::PlainCopy(
+                    freeze_plain_copy_template(&active_root, &template_root, limits).map_err(
+                        |error| RunnerError::new("fixture_freeze_failed", error.to_string()),
+                    )?,
+                )
             };
             remove_active_tree(&active_root)?;
             let physical = template.physical_digest().clone();
@@ -2128,93 +2139,28 @@ fn stage_bound_worker(source: BoundWorkerSource, workspace: &Path) -> RunnerResu
 
 enum FrozenTemplate {
     Clonefile(ClonefileTemplate),
-    PlainCopy {
-        template_root: PathBuf,
-        active_root: PathBuf,
-        physical: PhysicalDigest,
-        metadata: MetadataDigest,
-        limits: TraversalLimits,
-    },
+    PlainCopy(PlainCopyTemplate),
 }
 
 impl FrozenTemplate {
-    fn freeze_plain_copy(
-        active_root: &Path,
-        template_root: &Path,
-        limits: TraversalLimits,
-    ) -> RunnerResult<Self> {
-        let physical = digest_physical_tree(active_root, limits)
-            .map_err(|error| RunnerError::new("fixture_digest_failed", error.to_string()))?;
-        copy_verified(active_root, template_root, &physical, limits)
-            .map_err(|error| RunnerError::new("fixture_copy_failed", error.to_string()))?;
-        let metadata = digest_metadata_tree(template_root, limits)
-            .map_err(|error| RunnerError::new("fixture_metadata_failed", error.to_string()))?;
-        Ok(Self::PlainCopy {
-            template_root: template_root.to_path_buf(),
-            active_root: active_root.to_path_buf(),
-            physical,
-            metadata,
-            limits,
-        })
-    }
-
-    fn accept_plain_copy_handoff(
-        active_root: &Path,
-        template_root: &Path,
-        physical: PhysicalDigest,
-        metadata: MetadataDigest,
-        limits: TraversalLimits,
-    ) -> RunnerResult<Self> {
-        match std::fs::symlink_metadata(active_root) {
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Ok(_) => {
-                return Err(RunnerError::new(
-                    "fixture_handoff_failed",
-                    "contained fixture worker left the active path behind",
-                ));
-            }
-            Err(error) => {
-                return Err(RunnerError::new(
-                    "fixture_handoff_failed",
-                    format!("could not inspect retired active path: {error}"),
-                ));
-            }
-        }
-        verify_physical_tree(template_root, &physical, limits)
-            .and_then(|_| verify_metadata_tree(template_root, &metadata, limits))
-            .map_err(|error| RunnerError::new("fixture_handoff_failed", error.to_string()))?;
-        Ok(Self::PlainCopy {
-            template_root: template_root.to_path_buf(),
-            active_root: active_root.to_path_buf(),
-            physical,
-            metadata,
-            limits,
-        })
-    }
-
     fn physical_digest(&self) -> &PhysicalDigest {
         match self {
             Self::Clonefile(template) => template.physical_digest(),
-            Self::PlainCopy { physical, .. } => physical,
+            Self::PlainCopy(template) => template.physical_digest(),
         }
     }
 
     fn active_root(&self) -> &Path {
         match self {
             Self::Clonefile(template) => template.active_root(),
-            Self::PlainCopy { active_root, .. } => active_root,
+            Self::PlainCopy(template) => template.active_root(),
         }
     }
 
     fn verify_unchanged(&self) -> RunnerResult<()> {
         match self {
             Self::Clonefile(template) => template.verify_unchanged().map(|_| ()),
-            Self::PlainCopy {
-                template_root,
-                metadata,
-                limits,
-                ..
-            } => verify_metadata_tree(template_root, metadata, *limits).map(|_| ()),
+            Self::PlainCopy(template) => template.verify_unchanged().map(|_| ()),
         }
         .map_err(|error| {
             RunnerError::new(
@@ -2229,14 +2175,9 @@ impl FrozenTemplate {
             Self::Clonefile(template) => template
                 .restore_active()
                 .map(|prepared| prepared.metadata_digest().clone()),
-            Self::PlainCopy {
-                template_root,
-                active_root,
-                physical,
-                limits,
-                ..
-            } => copy_verified(template_root, active_root, physical, *limits)
-                .and_then(|_| digest_metadata_tree(active_root, *limits)),
+            Self::PlainCopy(template) => template
+                .restore_active()
+                .map(|prepared| prepared.metadata_digest().clone()),
         }
         .map_err(|error| RunnerError::new("reset_failed", error.to_string()))
     }
@@ -3877,14 +3818,16 @@ mod tests {
         let limits = TraversalLimits::default();
         let physical = digest_physical_tree(&template_root, limits).unwrap();
         let metadata = digest_metadata_tree(&template_root, limits).unwrap();
-        let template = FrozenTemplate::accept_plain_copy_handoff(
-            &active_root,
-            &template_root,
-            physical.clone(),
-            metadata,
-            limits,
-        )
-        .unwrap();
+        let template = FrozenTemplate::PlainCopy(
+            accept_plain_copy_template_handoff(
+                &active_root,
+                &template_root,
+                physical.clone(),
+                metadata,
+                limits,
+            )
+            .unwrap(),
+        );
         template.restore_active().unwrap();
         verify_physical_tree(&active_root, &physical, limits).unwrap();
     }

--- a/crates/omnigraph/tests/forbidden_apis.rs
+++ b/crates/omnigraph/tests/forbidden_apis.rs
@@ -244,6 +244,7 @@ write_surfaces! {
 const READ_ONLY_SURFACES: &[(&str, &str)] = &[
     ("db/omnigraph.rs", "open_read_only"),
     ("db/omnigraph.rs", "open_read_only_with_storage"),
+    ("db/omnigraph.rs", "manifest_has_external_base_paths"),
     ("db/omnigraph/export.rs", "capture_served_export_cut"),
     (
         "db/omnigraph/export.rs",
@@ -268,6 +269,7 @@ const READ_ONLY_SURFACES: &[(&str, &str)] = &[
     ("db/omnigraph.rs", "snapshot_at_graph_manifest_version"),
     ("db/omnigraph.rs", "export_jsonl"),
     ("db/omnigraph.rs", "export_jsonl_to_writer"),
+    ("db/omnigraph.rs", "export_jsonl_unordered_to_writer"),
     ("db/omnigraph.rs", "graph_index"),
     ("blob.rs", "read_blob_at"),
     ("db/omnigraph.rs", "branch_list"),

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -153,8 +153,27 @@ cargo run --release --locked -p omnigraph-bench -- \
   suite run benchmarks/suites/local-smoke.suite-v1.yaml
 ```
 
-Do not archive that diagnostic JSON as telemetry. To publish authoritative
-records, first commit the exact source under test, build the release binary from
+The imported-fixture `fixture run-graph` path is separate from durable suite
+execution. Its fixed FinGraph node-and-edge merge adapter supports qualified
+macOS/APFS clonefiles or Linux/XFS directly backed by EC2 instance-store NVMe;
+EBS is refused. The registered source stays quiescent and is never opened as a
+database. Every repetition restores the prepared physical tree at the exact
+same active path. Before freezing, Linux requires free space for one more
+prepared-tree copy plus 1 GiB. Use a dedicated benchmark mount: this path calls
+`syncfs` after freezing and after every restore, outside timing, to finish data
+and directory writeback across that filesystem. It records a distinct
+`xfs-plain-copy-syncfs-same-active-path` reset, not the durable suite's existing
+plain-copy treatment. Fresh workers attest matching process-effective machine
+identities; copying leaves the OS page cache uncontrolled. Reports remain
+`claim_eligible: false` and `durable_record: false`, with no archive publication
+or AWS dispatch. Commands live in the
+[FinGraph diagnostic guide](../../benchmarks/README.md#fingraph-diagnostic-runner).
+Within `omnigraph-bench`, `reset.rs` owns copy/path integrity tests,
+`environment.rs` owns backend qualification, and `real_graph_run.rs` owns the
+platform, capacity, writeback, worker-identity, and native merge regressions.
+
+Do not archive diagnostic JSON as telemetry. To publish authoritative
+`suite run` records, first commit the exact source under test, build the release binary from
 that clean tree, and pass `--archive <DIR>`. The commit records source
 provenance; the executable digest and normalized build/engine facts bind the
 exact SUT bytes. Source revalidation compares raw tracked source bytes without

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -158,10 +158,13 @@ execution. Its fixed FinGraph node-and-edge merge adapter supports qualified
 macOS/APFS clonefiles or Linux/XFS directly backed by EC2 instance-store NVMe;
 EBS is refused. The registered source stays quiescent and is never opened as a
 database. Every repetition restores the prepared physical tree at the exact
-same active path. Before freezing, Linux requires free space for one more
-prepared-tree copy plus 1 GiB. Use a dedicated benchmark mount: this path calls
-`syncfs` after freezing and after every restore, outside timing, to finish data
-and directory writeback across that filesystem. It records a distinct
+same active path. Source and scratch ownership must remain exclusive:
+metadata-only checks detect observable stat drift, not every same-length
+rewrite within a filesystem timestamp tick. Byte identity comes from the
+verified copy or forced-clone contract. Before freezing, Linux requires free
+space for one more prepared-tree copy plus 1 GiB. Use a dedicated benchmark
+mount: this path calls `syncfs` after freezing and after every restore, outside
+timing, to finish data and directory writeback across that filesystem. It records a distinct
 `xfs-plain-copy-syncfs-same-active-path` reset, not the durable suite's existing
 plain-copy treatment. Fresh workers attest matching process-effective machine
 identities; copying leaves the OS page cache uncontrolled. Reports remain

--- a/docs/releases/v0.10.0.md
+++ b/docs/releases/v0.10.0.md
@@ -319,8 +319,10 @@ and GitHub Releases; see the current policy in
   unset and performs no timing clock reads.
 - The benchmark CLI can register, byte-verify, logically validate, and run a
   fixed node-and-edge FinGraph merge diagnostic from declarative fixture and
-  run YAML. This local APFS path is intentionally claim-ineligible and does not
-  publish durable telemetry or dispatch through AWS infrastructure.
+  run YAML. It uses APFS clonefiles on macOS or verified full-copy reset on
+  direct EC2 instance-store NVMe-backed XFS, waits for reset writeback outside
+  timing, and records measured-worker machine and backend evidence. It remains
+  intentionally claim-ineligible without durable telemetry or AWS dispatch.
 
 ## Compatibility
 


### PR DESCRIPTION
## What and why

Connect the verified Linux/XFS backend from #568 to the existing FinGraph diagnostic runner from #570. The existing declarative run YAML and `fixture run-graph --scratch-root` interface stay unchanged.

## Scope

- Extract the existing verified plain-copy reset into a reusable template; the synthetic runner uses the same implementation without changing its durable protocol identity.
- Admit real-graph runs only on qualified macOS/APFS or Linux/XFS directly backed by EC2 instance-store NVMe. EBS remains refused.
- Preserve the exact active path and physical fixture identity between repetitions; check prepared-tree capacity plus 1 GiB before freezing.
- For this diagnostic Linux path, wait for filesystem writeback after freeze and each restore, outside timing. Record the distinct `xfs-plain-copy-syncfs-same-active-path` treatment.
- Capture machine identity in each measured worker, reject drift, and record backend evidence.
- Register the two read-only engine APIs introduced by #570 in the existing API-boundary test registry.

No new engine behavior, YAML schema, CLI, AWS SDK, orchestrator, queue, or telemetry store. Results remain `claim_eligible: false`, `durable_record: false`, with no warm-up and an uncontrolled OS page cache.

## Validation

- Full `omnigraph-bench` package tests, serial: 261 library tests passed (1 ignored), 10 binary tests, 3 provenance tests, and 20 CLI tests.
- Engine API-boundary suite: 22 passed.
- Harness all-target Clippy with warnings denied.
- Formatting, documentation, AGENTS-map, action-pin, and diff checks passed.
- Independent review identified worker-identity and reset-writeback gaps; both are fixed with focused coverage.

## AWS qualification

Passed on exact head `601ed07718917346bb69037af6dc1b3919382f13`, using the standard checked-in release profile on the existing c6id.2xlarge lab (Amazon Linux 2023, dedicated XFS on direct EC2 instance-store NVMe).

- Pinned FinGraph SF10: 5,376,981 nodes + 26,633,151 edges, 18 tables, history depth 3,934; source physical digest and all implemented logical-reference witnesses passed.
- Five successful diagnostic merges: **664.259, 753.964, 745.834, 768.493, 701.485 ms**; **p50 745.834 ms**.
- Every repetition started at target manifest version **3973** and ended at **3974**, with the same frozen prepared-tree identity and active path.
- Each repetition verified the inserted delta, protected heads, 16 untouched tables, and two nonzero TableWalk intervals. Existing rows within the two changed tables remain explicitly unverified.
- Parent-only syscall trace confirmed **6 successful syncfs calls** (freeze + 5 restores); measured child workers were not traced.
- Scratch cleanup passed, source checkout and binary stayed unchanged, and the lab service was restored **active → inactive during measurement → active**.
- Final native standalone reset-owner tests: **15 passed on tmpfs and 15 on XFS**. These are focused owner tests, not a full native Cargo package run.

Binary SHA-256: `88530724061ef1c90bf10a9c158f118b1e56f327a77d0b2ef7151f486a819bb1`  
Original unredacted report SHA-256 (retained privately): `fa1ab78ec24b2909abc48fa7595752c6ac9e88e38493b85f4c6991582de459f1`

Original evidence is retained privately. The qualification comment contains a sanitized public excerpt; timings and verification outcomes are unchanged.

These are **diagnostic measurements, not a performance comparison**: fresh workers, no warm-up, uncontrolled OS page cache, no A/A floor, `claim_eligible: false`, `durable_record: false`. This measures local NVMe operation on an AWS host, not S3 request performance. The workload adapter remains FinGraph-specific; a Monarch workload adapter is not added by this PR.






<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR connects the FinGraph diagnostic runner to qualified Linux/XFS instance-store NVMe while retaining the existing macOS/APFS path.
- Extracts verified plain-copy freezing and restoration into reusable reset primitives.
- Adds Linux backend qualification, capacity checks, filesystem writeback synchronization, stable-path restoration, and worker identity validation.
- Updates the benchmark and developer documentation to describe the supported environments and diagnostic limitations.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/omnigraph-bench/src/real_graph_run.rs | Adds the qualified Linux/XFS execution profile, verified plain-copy resets, capacity enforcement, syncfs writeback barriers, and worker identity evidence. |
| crates/omnigraph-bench/src/reset.rs | Extracts reusable verified plain-copy template freezing, handoff, restoration, and unchanged-template validation. |
| crates/omnigraph-bench/src/fixture_worker.rs | Migrates fixture construction to the reusable plain-copy template implementation while preserving protocol identity. |
| crates/omnigraph-bench/src/runner.rs | Integrates the reset-template refactor and supporting backend behavior into benchmark execution. |
| docs/dev/testing.md | Documents the qualified APFS/XFS boundary, capacity and writeback requirements, stable-path reset behavior, worker identity checks, and diagnostic limitations. |
| crates/omnigraph/tests/forbidden_apis.rs | Registers the two read-only engine APIs in the existing API-boundary test registry. |

</details>

<sub>Reviews (3): Last reviewed commit: ["test(bench): make reset checks independe..."](https://github.com/modernrelay/omnigraph/commit/601ed07718917346bb69037af6dc1b3919382f13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58295141)</sub>

<!-- /greptile_comment -->
