### PR TITLE
fix(branch): mint per-life incarnations into native branch refs

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Ignored default folder with query files
+/queries/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RsExternalLinterProjectSettings">
+    <option name="runOnTheFly" value="false" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/omnigraph_0085_issue_562_branch_incarnation_namespace.iml" filepath="$PROJECT_DIR$/.idea/omnigraph_0085_issue_562_branch_incarnation_namespace.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/omnigraph_0085_issue_562_branch_incarnation_namespace.iml
+++ b/.idea/omnigraph_0085_issue_562_branch_incarnation_namespace.iml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="EMPTY_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/crates/omnigraph-api-types/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/omnigraph-azure-admission/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/omnigraph-azure-admission/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/omnigraph-bench/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/omnigraph-bench/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/omnigraph-cli/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/omnigraph-cli/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/omnigraph-cluster/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/omnigraph-cluster/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/omnigraph-compiler/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/omnigraph-dst/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/omnigraph-dst/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/omnigraph-policy/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/omnigraph-server/examples" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/omnigraph-server/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/omnigraph-server/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/omnigraph-storage/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/omnigraph/benches" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/omnigraph/examples" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/omnigraph/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/crates/omnigraph/tests" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/tools/omnigraph-vocabulary-guard/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/tools/omnigraph-vocabulary-guard/tests" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/crates/omnigraph-dst/tests/scenarios.rs
+++ b/crates/omnigraph-dst/tests/scenarios.rs
@@ -2399,19 +2399,27 @@ fn dst_reborn_branch_cache_poison_reader_ablation() {
     }
 }
 
-/// the STANDALONE-REPRO probe: the faithful 10177 op replay
-/// (which passes bare) plus ONLY the two arming reads the ablation
-/// localized — full world traversals (branch list + person and edge
-/// traversals on every branch) after op 2 (post branch-create) and op 5
-/// (post the first life's edge op). RED here = the finding's standalone
-/// engine-level repro: 29 public API calls + 2 read passes, no harness
-/// machinery. GREEN = the arming needs more than those two reads carry
-/// (e.g. their exact interleaving with the sampler's rejected no-op
-/// deletes at ops 14/17) — recorded either way.
+/// REGRESSION PIN built from the standalone repro: whole-world read
+/// passes (branch list + per-branch person and edge traversals) during a
+/// branch's first life warm the handle's path-keyed session metadata; a
+/// same-name delete + recreate must then accept its first Person write
+/// (the branch-lifecycle cache invalidation in `branch_delete_as` /
+/// `branch_create_as`). Dedicated big-stack thread: the engine futures
+/// overflow the default test-thread stack.
 #[test]
 #[serial]
-#[ignore = "instrument: reborn-branch cache-poison standalone repro — run explicitly"]
 fn dst_reborn_branch_cache_poison_standalone_repro() {
+    let handle = std::thread::Builder::new()
+        .name("dst-reborn-branch-regression".into())
+        .stack_size(omnigraph_dst::harness::UNIVERSE_STACK_BYTES)
+        .spawn(reborn_branch_cache_poison_body)
+        .expect("spawn regression thread");
+    if let Err(panic) = handle.join() {
+        std::panic::resume_unwind(panic);
+    }
+}
+
+fn reborn_branch_cache_poison_body() {
     let mut seeds = SplitMix64(9401);
     let runtime_seed = seeds.next_u64();
     let ulid_seed = seeds.next_u64();
@@ -2423,9 +2431,19 @@ fn dst_reborn_branch_cache_poison_standalone_repro() {
         ))
         .build_local(Default::default())
         .expect("seeded runtime");
+    struct DstHookGuard;
+    impl Drop for DstHookGuard {
+        fn drop(&mut self) {
+            omnigraph::dst_clock::uninstall_logical_clock();
+            omnigraph::dst_ids::uninstall_seeded_ulids();
+        }
+    }
     runtime.block_on(Box::pin(async move {
         omnigraph::dst_ids::install_seeded_ulids(ulid_seed);
         omnigraph::dst_clock::install_logical_clock();
+        // Uninstall on BOTH exits: a failing assertion below must not leak
+        // the process-global DST hooks into the next #[serial] test.
+        let _dst_hooks = DstHookGuard;
         let storage: Arc<dyn StorageAdapter> = Arc::new(ObjectStorageAdapter::in_memory());
         let db = Omnigraph::init_with_storage(
             "shared-memory://dst-f9-standalone",
@@ -2444,7 +2462,9 @@ fn dst_reborn_branch_cache_poison_standalone_repro() {
                     .await
             };
         }
-        // The two arming reads: exactly observe_world's surface.
+        // The two arming reads: observe_world's read surface (order here is
+        // sorted names, not observe_world's main-first order — sufficient to
+        // arm; the ablation flagged interleaving as a live variable).
         async fn world_read(db: &Omnigraph) {
             let mut names = db.branch_list().await.expect("branch list");
             names.sort();
@@ -2603,39 +2623,54 @@ fn dst_reborn_branch_cache_poison_standalone_repro() {
             &[]
         )
         .expect("op27");
-        match m!(
+        m!(
             db,
             "b0",
             "insert_person_v",
             &[("$name", "w4")],
             &[("$age", 11), ("$ver", 9)]
-        ) {
-            Ok(_) => println!(
-                "F9 STANDALONE: op28 SUCCEEDED — two reads alone do not carry the \
-                 arming; next differential = the sampler's rejected no-op deletes \
-                 (ops 14/17) or read-position interleaving"
-            ),
-            Err(e) => {
-                let text = format!("{e:?}");
-                if text.contains("record batch must have the same length")
-                    || text.contains("row id index corrupt")
-                {
-                    println!(
-                        "F9 STANDALONE: CLASS A REPRODUCED — 29 public API calls + 2 \
-                         world reads, no harness. THE standalone repro: {}",
-                        &text[..text.len().min(600)]
-                    );
-                } else {
-                    println!(
-                        "F9 STANDALONE: op28 failed OTHER: {}",
-                        &text[..text.len().min(200)]
-                    );
-                }
-            }
-        }
-        omnigraph::dst_clock::uninstall_logical_clock();
-        omnigraph::dst_ids::uninstall_seeded_ulids();
+        )
+        .expect(
+            "op28: the reborn branch's first Person write must succeed — a failure here \
+             is the stale-session-metadata rebirth regression",
+        );
+        // The silent arm of the same defect: a reborn-branch READ served
+        // from first-life metadata misses the second life's writes without
+        // erroring. Pin the content, not just the write's success.
+        let people = Box::pin(omnigraph_dst::fixtures::person_rows_on(&db, "b0")).await;
+        assert!(
+            people.contains(&("w4".to_string(), 11, 9)),
+            "reborn b0 must serve its second-life insert (w4, 11, 9); got {people:?}"
+        );
+        let knows = Box::pin(omnigraph_dst::fixtures::knows_pairs_on(&db, "b0")).await;
+        assert!(
+            knows.contains(&("w6".to_string(), "Diana".to_string())),
+            "reborn b0 must serve its second-life edge (w6 -> Diana); got {knows:?}"
+        );
     }));
+}
+
+/// REGRESSION PIN, second face of the rebirth family (the reader-ablation
+/// doc above): seed 10133, wide shape, LoadFork victim — run as a full
+/// universe. Red before the branch-lifecycle session-cache clears, green
+/// after; keeps the family's non-InsertV face in CI.
+#[test]
+#[serial]
+fn dst_reborn_branch_cache_poison_wide_face_regression() {
+    let _s = omnigraph::failpoints::FailScenario::setup();
+    let sc = Scenario {
+        seed: 10_133,
+        ops: 30,
+        die_at_write: None,
+        wide: true,
+        ..Default::default()
+    };
+    if let Err(panic) =
+        omnigraph_dst::harness::run_universe_caught("shared-memory://dst-f9-10133-regression", &sc)
+    {
+        let msg = omnigraph_dst::harness::panic_message(panic.as_ref());
+        panic!("seed 10133 wide universe must pass post-fix (LoadFork rebirth face): {msg}");
+    }
 }
 
 /// the minimal-shape probe: the ablation matrix pinned the

--- a/crates/omnigraph/src/branch_control.rs
+++ b/crates/omnigraph/src/branch_control.rs
@@ -115,7 +115,7 @@ fn path_collision<'a>(
         .min()
 }
 
-fn encode_identifier(identifier: &BranchIdentifier) -> Result<String> {
+pub(crate) fn encode_identifier(identifier: &BranchIdentifier) -> Result<String> {
     serde_json::to_string(identifier).map_err(|error| {
         OmniError::manifest_internal(format!("failed to encode Lance branch identifier: {error}"))
     })
@@ -194,10 +194,34 @@ pub(crate) async fn create_branch_recoverably(
     branch: &str,
     source_version: u64,
 ) -> Result<BranchCreateOutcome> {
+    create_branch_at_version_inner(source, branch, source_version, true).await
+}
+
+/// Forward-recovery completion of a native branch ref (issue #562): the
+/// branch-registry commit landed (the lifecycle's commit point) but the crash
+/// window left the ref unmade. The source has usually moved past the pinned
+/// fork version by now — forking the HISTORICAL version is exactly what the
+/// registration recorded, so the source-at-head guard is skipped. A
+/// `RefAlreadyExists` outcome is success here: another handle completed the
+/// same registration first.
+pub(crate) async fn complete_branch_ref_at_version(
+    source: &mut Dataset,
+    branch: &str,
+    source_version: u64,
+) -> Result<BranchCreateOutcome> {
+    create_branch_at_version_inner(source, branch, source_version, false).await
+}
+
+async fn create_branch_at_version_inner(
+    source: &mut Dataset,
+    branch: &str,
+    source_version: u64,
+    require_source_at_version: bool,
+) -> Result<BranchCreateOutcome> {
     // Lance validates inside phase 2 today. Validate before phase 1 so an
     // invalid name cannot leave a clone-only zombie.
     check_valid_branch(branch).map_err(OmniError::storage)?;
-    if source.version().version != source_version {
+    if require_source_at_version && source.version().version != source_version {
         return Err(OmniError::manifest_conflict(format!(
             "branch source moved before native create: expected version {}, current {}",
             source_version,

--- a/crates/omnigraph/src/db/branch_identity.rs
+++ b/crates/omnigraph/src/db/branch_identity.rs
@@ -1,0 +1,93 @@
+//! Per-life branch identity: the logical-name to native-ref mapping.
+//!
+//! A user-facing (logical) branch name maps to an internal Lance native ref
+//! that carries a per-life incarnation token: `{logical}--{ulid}`. Every
+//! branch life gets a fresh token, so a deleted-and-recreated branch lives at
+//! new storage paths and therefore in a new dataset-URI cache namespace by
+//! construction (issue #562: Lance's per-handle `Session` file-metadata cache
+//! is keyed by dataset URI and observes no lifecycle events; rotating the
+//! namespace replaces clearing it). The `__manifest` branch-registry row owns
+//! the mapping; see `db/manifest/state.rs::OBJECT_TYPE_BRANCH`.
+//!
+//! The separator is `--`, chosen from Lance's legal ref charset
+//! (`[A-Za-z0-9._-]` per `/`-segment; `@` is rejected by
+//! `check_valid_branch`). Public branch names reject `--` at
+//! `ensure_public_branch_ref` (the sigil-reservation pattern), so no
+//! user-named branch can collide with a native ref minted here. Legacy
+//! branches created before this mapping keep their bare ref name (the
+//! registry has no row for them; resolution falls back to the bare name) and
+//! mint their first token on their next rebirth.
+
+/// Reserved separator between the logical name and the per-life token in a
+/// native branch ref. Also the substring rejected in public branch names.
+pub(crate) const BRANCH_INCARNATION_SEPARATOR: &str = "--";
+
+/// Length of the incarnation token: a ULID in Crockford base32.
+const INCARNATION_TOKEN_LEN: usize = 26;
+
+/// Mint a fresh per-life incarnation token. Routed through the DST seam so
+/// simulation runs mint deterministic, seed-reproducible tokens.
+pub(crate) fn mint_branch_incarnation() -> String {
+    crate::dst_ids::new_ulid().to_string()
+}
+
+/// The native ref name for one life of a logical branch.
+pub(crate) fn native_branch_ref(logical: &str, incarnation: &str) -> String {
+    format!("{logical}{BRANCH_INCARNATION_SEPARATOR}{incarnation}")
+}
+
+/// Split a native ref back into `(logical, Some(incarnation))`, or
+/// `(name, None)` for a legacy bare ref.
+///
+/// The suffix is accepted only when it parses as a real ULID: legacy public
+/// names could legally contain `--` (the rejection in
+/// `ensure_public_branch_ref` arrived with this module), so a bare `a--b`
+/// ref must stay a legacy name, not mis-split.
+pub(crate) fn split_native_branch_ref(native: &str) -> (&str, Option<&str>) {
+    if let Some(idx) = native.rfind(BRANCH_INCARNATION_SEPARATOR) {
+        let candidate = &native[idx + BRANCH_INCARNATION_SEPARATOR.len()..];
+        if candidate.len() == INCARNATION_TOKEN_LEN && ulid::Ulid::from_string(candidate).is_ok() {
+            return (&native[..idx], Some(candidate));
+        }
+    }
+    (native, None)
+}
+
+/// Whether a public (user-supplied) branch name is allowed to enter the
+/// namespace: it must not contain the reserved separator.
+pub(crate) fn public_name_reserves_separator(name: &str) -> bool {
+    name.contains(BRANCH_INCARNATION_SEPARATOR)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn native_ref_round_trips() {
+        let token = mint_branch_incarnation();
+        let native = native_branch_ref("feature/x", &token);
+        let (logical, incarnation) = split_native_branch_ref(&native);
+        assert_eq!(logical, "feature/x");
+        assert_eq!(incarnation, Some(token.as_str()));
+    }
+
+    #[test]
+    fn legacy_names_with_separator_do_not_missplit() {
+        // A pre-reservation public name containing `--` must stay whole.
+        let (logical, incarnation) = split_native_branch_ref("a--b");
+        assert_eq!(logical, "a--b");
+        assert!(incarnation.is_none());
+        // Even a 26-char suffix that is not a valid ULID stays whole.
+        let (logical, incarnation) = split_native_branch_ref("x--uuuuuuuuuuuuuuuuuuuuuuuuuu");
+        assert_eq!(logical, "x--uuuuuuuuuuuuuuuuuuuuuuuuuu");
+        assert!(incarnation.is_none());
+    }
+
+    #[test]
+    fn separator_reservation_matches_contains() {
+        assert!(public_name_reserves_separator("a--b"));
+        assert!(!public_name_reserves_separator("a-b"));
+        assert!(!public_name_reserves_separator("plain"));
+    }
+}

--- a/crates/omnigraph/src/db/branch_identity.rs
+++ b/crates/omnigraph/src/db/branch_identity.rs
@@ -16,7 +16,11 @@
 //! user-named branch can collide with a native ref minted here. Legacy
 //! branches created before this mapping keep their bare ref name (the
 //! registry has no row for them; resolution falls back to the bare name) and
-//! mint their first token on their next rebirth.
+//! mint their first token on their next rebirth. Two accepted residuals for
+//! legacy names containing `--`: they stay readable but lose the write
+//! operations that enforce the reservation, and a name whose suffix happens
+//! to parse as a 26-char ULID would mis-split (astronomically unlikely; it
+//! requires a user having named a branch with a literal ULID suffix).
 
 /// Reserved separator between the logical name and the per-life token in a
 /// native branch ref. Also the substring rejected in public branch names.

--- a/crates/omnigraph/src/db/graph_coordinator.rs
+++ b/crates/omnigraph/src/db/graph_coordinator.rs
@@ -296,6 +296,25 @@ impl GraphCoordinator {
         self.bound_branch.as_deref()
     }
 
+    /// The Lance ref this coordinator's manifest is checked out on (issue
+    /// #562): the current life's `{logical}--{ulid}` native ref, the bare
+    /// name for legacy branches, `None` for main. Lance-facing table opens,
+    /// forks, and persisted `native_dataset_branch` values address this;
+    /// [`Self::current_branch`] stays the logical name for heads, lineage,
+    /// Cedar, and errors.
+    pub(crate) fn native_branch(&self) -> Option<&str> {
+        self.manifest.native_branch_ref()
+    }
+
+    /// Batch logical-to-native resolution with one registry read; see
+    /// `ManifestCoordinator::resolve_native_branch_refs`.
+    pub(crate) async fn resolve_native_branch_refs(
+        &self,
+        logicals: &[String],
+    ) -> Result<std::collections::HashMap<String, String>> {
+        self.manifest.resolve_native_branch_refs(logicals).await
+    }
+
     pub async fn refresh(&mut self) -> Result<()> {
         match self.manifest.refresh_with_lineage().await? {
             LineageRefresh::Replace(rows) => self.commit_graph.replace_from_manifest_rows(rows),

--- a/crates/omnigraph/src/db/manifest.rs
+++ b/crates/omnigraph/src/db/manifest.rs
@@ -52,8 +52,10 @@ use metadata::{
 };
 #[cfg(test)]
 use namespace::{branch_manifest_namespace, staged_table_namespace};
+use publisher::{
+    BranchRegistryExpectation, GraphNamespacePublisher, ManifestBatchPublisher, PublishOutcome,
+};
 pub(crate) use publisher::{GraphHeadExpectation, LineageIntent, PublishPrecondition};
-use publisher::{GraphNamespacePublisher, ManifestBatchPublisher, PublishOutcome};
 #[cfg(test)]
 pub(crate) use recovery::MAX_EFFECT_IDENTITY_SCAN_VERSIONS;
 pub(crate) use recovery::{
@@ -72,11 +74,11 @@ pub(crate) use recovery::{
 pub use state::DatasetEntry;
 #[cfg(test)]
 use state::string_column;
-pub(crate) use state::{GraphLineageRow, read_graph_lineage};
 use state::{
-    ManifestState, ProjectionAccumulator, fold_projection_delta, read_manifest_projection,
-    read_manifest_state, read_object_identities_at_offsets,
+    BranchRegistration, ManifestState, ProjectionAccumulator, fold_projection_delta,
+    read_manifest_projection, read_manifest_state, read_object_identities_at_offsets,
 };
+pub(crate) use state::{GraphLineageRow, read_graph_lineage};
 
 /// The internal-schema (storage-format) version this binary writes and reads.
 /// A graph's on-disk per-branch stamp is read via [`internal_schema_stamp_at`];
@@ -98,6 +100,17 @@ const OBJECT_TYPE_GRAPH_HEAD: &str = "graph_head";
 /// `object_id` prefix of the head rows — one constant for row minting, row
 /// decode, and the incremental fold's dead-row classification.
 pub(super) const GRAPH_HEAD_OBJECT_ID_PREFIX: &str = "graph_head:";
+/// Mutable per-logical-branch registry row (issue #562): maps the user-facing
+/// logical branch name to the native ref carrying its current life's
+/// incarnation token (`{logical}--{ulid}`, see `db/branch_identity`).
+/// `object_id` is `branch:<logical>`; the merge-insert row-level CAS on
+/// `object_id` is what serializes racing creates/deletes of one logical name.
+/// Lives ONLY in the root (main) `__manifest`; rows inherited into branch
+/// clones by the shallow fork are ignored there (resolution always reads the
+/// root manifest). Absent row + live bare ref = a legacy pre-registry branch.
+const OBJECT_TYPE_BRANCH: &str = "branch";
+/// `object_id` prefix of branch-registry rows.
+pub(super) const BRANCH_OBJECT_ID_PREFIX: &str = "branch:";
 
 /// Stable head-key segment for the main branch in `graph_head:<branch>` rows.
 /// `table_branch`/`manifest_branch` encode main as null, but `object_id` must be
@@ -539,10 +552,19 @@ impl ManifestIncarnation {
 pub(crate) struct CapturedManifestProbe {
     dataset: Dataset,
     active_branch: Option<String>,
+    /// The Lance ref `dataset` is checked out on (issue #562): the captured
+    /// life's `{logical}--{ulid}` native ref, the bare name for legacy
+    /// branches, `None` for main. Identity of the capture, not authority —
+    /// Lance-facing table writes prepared from this capture address it.
+    native_branch_ref: Option<String>,
     captured: ManifestIncarnation,
 }
 
 impl CapturedManifestProbe {
+    pub(crate) fn native_branch_ref(&self) -> Option<&str> {
+        self.native_branch_ref.as_deref()
+    }
+
     pub(crate) async fn probe_latest_incarnation(&self) -> Result<ManifestIncarnation> {
         crate::instrumentation::record_probe();
         probe_dataset_latest_incarnation(&self.dataset, self.active_branch.as_deref()).await
@@ -799,6 +821,11 @@ pub(crate) struct ManifestCoordinator {
     /// `known_state`. A named ref keeps this value across ordinary commits and
     /// receives a new value after delete/recreate.
     branch_identifier: lance::dataset::refs::BranchIdentifier,
+    /// The Lance ref `dataset` is actually checked out on: the current life's
+    /// `{logical}--{ulid}` native ref for registered branches, the bare name
+    /// for legacy branches, `None` for main. `active_branch` stays LOGICAL —
+    /// head keys, lineage, and errors all speak the logical name.
+    native_branch_ref: Option<String>,
     publisher: Arc<dyn ManifestBatchPublisher>,
     /// Retained fold accumulators of the projection, tagged with the manifest
     /// version they describe; `refresh_with_lineage` folds only the catalog
@@ -839,6 +866,7 @@ impl ManifestCoordinator {
         known_state: ManifestState,
         active_branch: Option<String>,
         branch_identifier: lance::dataset::refs::BranchIdentifier,
+        native_branch_ref: Option<String>,
         publisher: Arc<dyn ManifestBatchPublisher>,
     ) -> Self {
         Self {
@@ -847,6 +875,7 @@ impl ManifestCoordinator {
             known_state,
             active_branch,
             branch_identifier,
+            native_branch_ref,
             publisher,
             projection: None,
         }
@@ -858,6 +887,7 @@ impl ManifestCoordinator {
         known_state: ManifestState,
         active_branch: Option<String>,
         branch_identifier: lance::dataset::refs::BranchIdentifier,
+        native_branch_ref: Option<String>,
     ) -> Self {
         let publisher =
             Self::default_batch_publisher(root_uri, active_branch.as_deref(), dataset.session());
@@ -867,6 +897,7 @@ impl ManifestCoordinator {
             known_state,
             active_branch,
             branch_identifier,
+            native_branch_ref,
             publisher,
         )
     }
@@ -950,6 +981,7 @@ impl ManifestCoordinator {
                 known_state,
                 None,
                 lance::dataset::refs::BranchIdentifier::main(),
+                None,
             ),
             lineage_rows,
         ))
@@ -971,6 +1003,7 @@ impl ManifestCoordinator {
                 known_state,
                 None,
                 lance::dataset::refs::BranchIdentifier::main(),
+                None,
             ),
             lineage_rows,
         ))
@@ -987,7 +1020,7 @@ impl ManifestCoordinator {
         control_session: &Arc<lance::session::Session>,
     ) -> Result<Self> {
         let root = root_uri.trim_end_matches('/');
-        let (dataset, known_state, branch_identifier) =
+        let (dataset, known_state, branch_identifier, native_branch_ref) =
             open_manifest_graph(root, None, control_session).await?;
         Ok(Self::from_parts_with_default_publisher(
             root,
@@ -995,6 +1028,7 @@ impl ManifestCoordinator {
             known_state,
             None,
             branch_identifier,
+            native_branch_ref,
         ))
     }
 
@@ -1014,7 +1048,7 @@ impl ManifestCoordinator {
         }
 
         let root = root_uri.trim_end_matches('/');
-        let (dataset, known_state, branch_identifier) =
+        let (dataset, known_state, branch_identifier, native_branch_ref) =
             open_manifest_graph(root, Some(branch), control_session).await?;
         Ok(Self::from_parts_with_default_publisher(
             root,
@@ -1022,6 +1056,7 @@ impl ManifestCoordinator {
             known_state,
             Some(branch.to_string()),
             branch_identifier,
+            native_branch_ref,
         ))
     }
 
@@ -1052,7 +1087,7 @@ impl ManifestCoordinator {
         // Retain the fold accumulators alongside the state (the incremental merge-authority projection): the
         // scan this open pays anyway becomes the base a later refresh folds
         // deltas into, instead of a sunk cost repeated per refresh.
-        let (dataset, branch_identifier) =
+        let (dataset, branch_identifier, native_branch_ref) =
             open_manifest_dataset_with_identifier_with_session(root, branch, control_session)
                 .await?;
         let (known_state, projection, lineage_rows) = read_manifest_projection(&dataset).await?;
@@ -1063,6 +1098,7 @@ impl ManifestCoordinator {
             known_state,
             branch.map(str::to_string),
             branch_identifier,
+            native_branch_ref,
         );
         coordinator.projection = Some((projection_version, projection));
         Ok((coordinator, lineage_rows))
@@ -1105,7 +1141,17 @@ impl ManifestCoordinator {
     ) -> Result<bool> {
         let root = root_uri.trim_end_matches('/');
         let dataset =
-            open_manifest_dataset_with_session(root, candidate_branch, control_session).await?;
+            match open_manifest_dataset_with_session(root, candidate_branch, control_session).await
+            {
+                Ok(dataset) => dataset,
+                // A registered candidate in the create crash window (live
+                // row, native ref unmade) has no `__manifest` clone and
+                // therefore no `table_branch` entries: no dependency. Forward
+                // recovery completes its ref on the candidate's next
+                // resolution by logical name.
+                Err(OmniError::BranchNotFound { .. }) => return Ok(false),
+                Err(error) => return Err(error),
+            };
         let snapshot = Self::snapshot_from_state(root, read_manifest_state(&dataset).await?);
         Ok(snapshot
             .datasets()
@@ -1125,6 +1171,7 @@ impl ManifestCoordinator {
         CapturedManifestProbe {
             dataset: self.dataset.clone(),
             active_branch: self.active_branch.clone(),
+            native_branch_ref: self.native_branch_ref.clone(),
             captured: self.incarnation(),
         }
     }
@@ -1147,17 +1194,19 @@ impl ManifestCoordinator {
         }
         crate::instrumentation::record_projection_full_refresh();
         let control_session = self.dataset.session();
-        let (dataset, branch_identifier) = open_manifest_dataset_with_identifier_with_session(
-            &self.root_uri,
-            self.active_branch.as_deref(),
-            &control_session,
-        )
-        .await?;
+        let (dataset, branch_identifier, native_branch_ref) =
+            open_manifest_dataset_with_identifier_with_session(
+                &self.root_uri,
+                self.active_branch.as_deref(),
+                &control_session,
+            )
+            .await?;
         let (known_state, projection, lineage_rows) = read_manifest_projection(&dataset).await?;
         let projection_version = dataset.version().version;
         self.dataset = dataset;
         self.known_state = known_state;
         self.branch_identifier = branch_identifier;
+        self.native_branch_ref = native_branch_ref;
         self.projection = Some((projection_version, projection));
         Ok(LineageRefresh::Replace(lineage_rows))
     }
@@ -1188,7 +1237,10 @@ impl ManifestCoordinator {
             return Ok(None);
         }
         let control_session = self.dataset.session();
-        let (new_dataset, new_identifier) = open_manifest_dataset_with_identifier_with_session(
+        // The identifier equality check below proves the same branch life, and
+        // a life never changes its native ref — so the re-resolved ref is
+        // discarded rather than installed.
+        let (new_dataset, new_identifier, _) = open_manifest_dataset_with_identifier_with_session(
             &self.root_uri,
             self.active_branch.as_deref(),
             &control_session,
@@ -1331,12 +1383,13 @@ impl ManifestCoordinator {
         projection_has_head: impl FnOnce(&str) -> bool,
     ) -> Result<Option<Vec<GraphLineageRow>>> {
         let control_session = self.dataset.session();
-        let (dataset, branch_identifier) = open_manifest_dataset_with_identifier_with_session(
-            &self.root_uri,
-            self.active_branch.as_deref(),
-            &control_session,
-        )
-        .await?;
+        let (dataset, branch_identifier, native_branch_ref) =
+            open_manifest_dataset_with_identifier_with_session(
+                &self.root_uri,
+                self.active_branch.as_deref(),
+                &control_session,
+            )
+            .await?;
         let known_state = read_manifest_state(&dataset).await?;
         let branch_key = self
             .active_branch
@@ -1355,6 +1408,7 @@ impl ManifestCoordinator {
         self.dataset = dataset;
         self.known_state = known_state;
         self.branch_identifier = branch_identifier;
+        self.native_branch_ref = native_branch_ref;
         // Same staleness rule as the post-publish fold: this refresh advances
         // `dataset` without folding the projection accumulators, so they must
         // not survive it.
@@ -1516,6 +1570,14 @@ impl ManifestCoordinator {
         Ok(self.branch_identifier.clone())
     }
 
+    /// The Lance ref this coordinator's manifest dataset is checked out on:
+    /// the current life's native ref for registered branches, the bare name
+    /// for legacy branches, `None` for main. Lance-facing lifecycle callers
+    /// address this; everything user-facing keeps `active_branch` (logical).
+    pub(crate) fn native_branch_ref(&self) -> Option<&str> {
+        self.native_branch_ref.as_deref()
+    }
+
     /// Exact materialized `graph_head:<active-branch>` from the same pinned
     /// manifest version as [`Self::snapshot`]. This is write authority, not a
     /// lineage-cache query: a read may refresh only the manifest, so consulting
@@ -1546,40 +1608,171 @@ impl ManifestCoordinator {
         probe_dataset_latest_incarnation(&self.dataset, self.active_branch.as_deref()).await
     }
 
+    /// Create one new life of the logical branch `name` (issue #562).
+    ///
+    /// Create order: the registry row on the ROOT `__manifest` is the
+    /// existence authority and commits FIRST (`AbsentOrDead` fences a racing
+    /// create of the same logical name); the per-life native ref is created
+    /// after it. If the native create below fails, the row stays live with no
+    /// ref — that is the documented crash window, and forward recovery
+    /// (`complete_registered_branch_ref`) completes the ref on the next
+    /// resolution of this logical name. The error is still returned.
     pub(crate) async fn create_branch(&mut self, name: &str) -> Result<()> {
+        if crate::db::is_internal_system_branch(name) {
+            // Internal system refs (e.g. the schema-apply lock) stay
+            // un-namespaced and unregistered (issue #562): resolution passes
+            // them through bare, and their lifecycle must not commit registry
+            // rows on the root manifest.
+            let mut ds = self.dataset.clone();
+            return match crate::branch_control::create_branch_recoverably(
+                &mut ds,
+                name,
+                self.version(),
+            )
+            .await?
+            {
+                crate::branch_control::BranchCreateOutcome::Created(_) => Ok(()),
+                crate::branch_control::BranchCreateOutcome::RefAlreadyExists => Err(
+                    OmniError::manifest_conflict(format!("branch '{}' already exists", name)),
+                ),
+            };
+        }
+        let incarnation = crate::db::branch_identity::mint_branch_incarnation();
+        let native = crate::db::branch_identity::native_branch_ref(name, &incarnation);
+        // Validate the native ref name BEFORE the registry commit: the commit
+        // is the existence authority, and a name Lance would reject must fail
+        // here with no durable effect — otherwise an invalid name leaves a
+        // poison live-refless row that forward recovery can never complete.
+        lance::dataset::refs::check_valid_branch(&native).map_err(OmniError::storage)?;
+        let registration = BranchRegistration {
+            logical: name.to_string(),
+            native_ref: native.clone(),
+            incarnation,
+            live: true,
+            source_ref: self.native_branch_ref.clone(),
+            source_version: self.version(),
+        };
+        GraphNamespacePublisher::new_with_session(&self.root_uri, None, self.dataset.session())
+            .commit_branch_registration(&registration, &BranchRegistryExpectation::AbsentOrDead)
+            .await?;
+        crate::failpoints::maybe_fail(
+            crate::failpoints::names::BRANCH_CREATE_POST_REGISTRY_PRE_NATIVE,
+        )?;
         let mut ds = self.dataset.clone();
-        match crate::branch_control::create_branch_recoverably(&mut ds, name, self.version())
+        match crate::branch_control::create_branch_recoverably(&mut ds, &native, self.version())
             .await?
         {
             crate::branch_control::BranchCreateOutcome::Created(_) => Ok(()),
-            crate::branch_control::BranchCreateOutcome::RefAlreadyExists => Err(
-                OmniError::manifest_conflict(format!("branch '{}' already exists", name)),
-            ),
+            // The native ref carries a freshly minted per-life ULID, so it can
+            // already exist only because forward recovery completed this same
+            // registration concurrently — that is success, not a name clash.
+            crate::branch_control::BranchCreateOutcome::RefAlreadyExists => Ok(()),
         }
+    }
+
+    /// Map each LOGICAL branch name to its current life's native ref with ONE
+    /// root-manifest registry read (issue #562): live row → the native ref,
+    /// no row → the bare name (legacy), dead row → omitted. For callers that
+    /// probe many branches and must not pay a registry scan per branch.
+    pub(crate) async fn resolve_native_branch_refs(
+        &self,
+        logicals: &[String],
+    ) -> Result<HashMap<String, String>> {
+        let ds = self.open_branch_control_dataset().await?;
+        let registry = state::read_branch_registry(&ds).await?;
+        Ok(logicals
+            .iter()
+            .filter_map(|logical| match registry.get(logical) {
+                Some(row) if row.live => Some((logical.clone(), row.native_ref.clone())),
+                Some(_) => None,
+                None => Some((logical.clone(), logical.clone())),
+            })
+            .collect())
     }
 
     async fn open_branch_control_dataset(&self) -> Result<Dataset> {
         let uri = manifest_uri(&self.root_uri);
+        // Zero-cache control session, NOT the default session: this open is
+        // an authority read (registry rows, delete dependency probes) and
+        // "Latest" must resolve against storage, never a long-lived handle's
+        // cached version listing — the exact staleness class issue #562
+        // exists to kill.
         crate::instrumentation::open_dataset(
             &uri,
             crate::instrumentation::VersionResolution::Latest,
-            None,
+            Some(&crate::lance_access::control_session()),
             crate::instrumentation::manifest_wrapper(),
         )
         .await
     }
 
+    /// Commit the dead registry row that is a registered branch delete's
+    /// authority change (issue #562). Delete order: this dead-row commit lands
+    /// FIRST (`LiveWithNativeRef` fences a racing delete or rebirth of the
+    /// logical name); the native ref delete follows. A crash between them
+    /// leaves a dead row whose native tree lingers, invisible to users:
+    /// table-level fork garbage is reclaimed by the orphan reconciler, while
+    /// the manifest-level ref itself waits for manual cleanup.
+    async fn commit_branch_dead_row(&self, registration: &BranchRegistration) -> Result<()> {
+        let mut dead = registration.clone();
+        dead.live = false;
+        GraphNamespacePublisher::new_with_session(&self.root_uri, None, self.dataset.session())
+            .commit_branch_registration(
+                &dead,
+                &BranchRegistryExpectation::LiveWithNativeRef(registration.native_ref.clone()),
+            )
+            .await
+    }
+
     pub(crate) async fn delete_branch(&mut self, name: &str) -> Result<()> {
         let mut ds = self.open_branch_control_dataset().await?;
-        let branches = list_branch_contents(&ds).await?;
-        let expected_identifier = branches
-            .get(name)
-            .ok_or_else(|| OmniError::manifest_not_found(format!("branch '{}' not found", name)))?
-            .identifier
-            .clone();
-        crate::branch_control::delete_branch_recoverably(&mut ds, name, &expected_identifier)
-            .await?;
-        Ok(())
+        let registry = state::read_branch_registry(&ds).await?;
+        match registry.get(name) {
+            Some(row) if row.live => {
+                let native = row.native_ref.clone();
+                let expected_identifier = list_branch_contents(&ds)
+                    .await?
+                    .get(&native)
+                    .map(|contents| contents.identifier.clone());
+                self.commit_branch_dead_row(row).await?;
+                match expected_identifier {
+                    Some(expected_identifier) => {
+                        crate::branch_control::delete_branch_recoverably(
+                            &mut ds,
+                            &native,
+                            &expected_identifier,
+                        )
+                        .await
+                    }
+                    // Create's crash window: the row was live but its native
+                    // ref was never made. The dead-row commit above already
+                    // removed the branch; any partial tree is reconciler
+                    // garbage.
+                    None => Ok(()),
+                }
+            }
+            Some(_) => Err(OmniError::manifest_not_found(format!(
+                "branch '{}' not found",
+                name
+            ))),
+            // Legacy branch: bare ref, no registry row, no dead row to write.
+            None => {
+                let branches = list_branch_contents(&ds).await?;
+                let expected_identifier = branches
+                    .get(name)
+                    .ok_or_else(|| {
+                        OmniError::manifest_not_found(format!("branch '{}' not found", name))
+                    })?
+                    .identifier
+                    .clone();
+                crate::branch_control::delete_branch_recoverably(
+                    &mut ds,
+                    name,
+                    &expected_identifier,
+                )
+                .await
+            }
+        }
     }
 
     /// Delete `name` only if its live Lance BranchContents still has the exact
@@ -1596,30 +1789,156 @@ impl ManifestCoordinator {
         expected_identifier: &lance::dataset::refs::BranchIdentifier,
     ) -> Result<()> {
         let mut ds = self.open_branch_control_dataset().await?;
-        crate::branch_control::delete_branch_recoverably(&mut ds, name, expected_identifier).await
+        let registry = state::read_branch_registry(&ds).await?;
+        match registry.get(name) {
+            Some(row) if row.live => {
+                let native = row.native_ref.clone();
+                // The identifier check must precede the dead-row commit: the
+                // commit is the authority change, and a stale caller (captured
+                // against an earlier life) must fail here rather than kill the
+                // current life's row first. `delete_branch_recoverably`
+                // re-checks the same CAS after the commit. An ABSENT ref is
+                // equally a refusal: a captured identifier can never match a
+                // ref that does not exist (the create crash window), so the
+                // caller's claim is stale by construction.
+                match list_branch_contents(&ds).await?.get(&native) {
+                    Some(contents) if contents.identifier == *expected_identifier => {}
+                    Some(contents) => {
+                        return Err(OmniError::manifest_read_set_changed(
+                            format!("branch_identifier:{name}"),
+                            Some(crate::branch_control::encode_identifier(
+                                expected_identifier,
+                            )?),
+                            Some(crate::branch_control::encode_identifier(
+                                &contents.identifier,
+                            )?),
+                        ));
+                    }
+                    None => {
+                        return Err(OmniError::manifest_read_set_changed(
+                            format!("branch_identifier:{name}"),
+                            Some(crate::branch_control::encode_identifier(
+                                expected_identifier,
+                            )?),
+                            None,
+                        ));
+                    }
+                }
+                self.commit_branch_dead_row(row).await?;
+                crate::branch_control::delete_branch_recoverably(
+                    &mut ds,
+                    &native,
+                    expected_identifier,
+                )
+                .await
+            }
+            Some(_) => Err(OmniError::manifest_not_found(format!(
+                "branch '{}' not found",
+                name
+            ))),
+            None => {
+                crate::branch_control::delete_branch_recoverably(&mut ds, name, expected_identifier)
+                    .await
+            }
+        }
     }
 
+    /// The user-visible (logical) branch list (issue #562): live registry rows
+    /// own their logical names; legacy branches surface as bare refs with no
+    /// registry row. Per-life ULID-suffixed native refs never appear — a ref
+    /// carrying an incarnation token is a current life's storage name or a
+    /// dead life's garbage, and a bare ref whose logical name has ANY registry
+    /// row is excluded because the registry, not the ref, is that name's
+    /// existence authority (resolution rejects it the same way). The registry
+    /// MUST come from the ROOT manifest — branch clones inherit stale registry
+    /// rows from their fork point.
     pub async fn list_graph_branches(&self) -> Result<Vec<String>> {
-        let branches = list_branch_contents(&self.dataset).await?;
-        let mut names: Vec<String> = branches.into_keys().filter(|name| name != "main").collect();
-        names.sort();
+        // Registry rows are read from the ROOT at Latest, always: a pinned
+        // view misses rows committed after the pin (including this handle's
+        // OWN create/delete, which commit through a fresh publisher), and a
+        // branch clone inherits stale rows from its fork point. Costs one
+        // root open per listing; the listing itself is not on the hot path.
+        let ds = self.open_branch_control_dataset().await?;
+        let registry = state::read_branch_registry(&ds).await?;
+        let branches = list_branch_contents(&ds).await?;
+        let mut names: std::collections::BTreeSet<String> = registry
+            .values()
+            .filter(|row| row.live)
+            .map(|row| row.logical.clone())
+            .collect();
+        for name in branches.keys() {
+            if name == "main" {
+                continue;
+            }
+            let (logical, _) = crate::db::branch_identity::split_native_branch_ref(name);
+            match registry.get(logical) {
+                // The row is the authority when in view: dead excludes the
+                // name, live already listed it above.
+                Some(_) => {}
+                // No row in view: a legacy bare ref, or a life committed
+                // after this handle pinned its root manifest (refs list
+                // LIVE, registry rows ride the pinned state). List it by
+                // its logical name, matching the pre-#562 live-ref view.
+                None => {
+                    names.insert(logical.to_string());
+                }
+            }
+        }
         let mut all = vec!["main".to_string()];
         all.extend(names);
         Ok(all)
     }
 
+    /// Transitive descendants of the LOGICAL branch `name`, in logical names.
+    /// `BranchContents.parent_branch` records the NATIVE source ref of the
+    /// fork, so both ends map back to logical: a child ref counts only while
+    /// it is a live branch (its live registry row names it, or it is a legacy
+    /// bare ref with no row), and a parent ref reduces to its logical name by
+    /// splitting off the incarnation token — a fork from ANY life of `name`
+    /// descends from `name`.
     pub async fn descendant_branches(&self, name: &str) -> Result<Vec<String>> {
-        let branches = list_branch_contents(&self.dataset).await?;
+        // Same always-fresh open policy as `list_graph_branches`.
+        let ds = self.open_branch_control_dataset().await?;
+        let registry = state::read_branch_registry(&ds).await?;
+        let branches = list_branch_contents(&ds).await?;
+        let mut logical_by_ref: HashMap<&str, &str> = HashMap::new();
+        for ref_name in branches.keys() {
+            let (split_logical, _) = crate::db::branch_identity::split_native_branch_ref(ref_name);
+            match registry.get(split_logical) {
+                // Row in view: it owns the name — only its exact current
+                // native ref counts as a live branch; other lives' refs are
+                // garbage.
+                Some(row) => {
+                    if row.live && row.native_ref == *ref_name {
+                        logical_by_ref.insert(ref_name.as_str(), row.logical.as_str());
+                    }
+                }
+                // No row in view: legacy bare ref, or a life committed after
+                // this handle pinned its root state (refs list LIVE). Treat
+                // it as that logical branch, matching the pre-#562 view.
+                None => {
+                    logical_by_ref.insert(ref_name.as_str(), split_logical);
+                }
+            }
+        }
+
         let mut frontier = vec![name.to_string()];
         let mut descendants = Vec::new();
         let mut seen = HashSet::new();
+        // A rebirth can fork from a stale coordinator still pinned on an older
+        // life of the same logical name; seeding `seen` keeps the queried name
+        // out of its own descendant set.
+        seen.insert(name.to_string());
 
         while let Some(parent) = frontier.pop() {
             let mut children = branches
                 .iter()
-                .filter_map(|(branch, contents)| {
-                    (contents.parent_branch.as_deref() == Some(parent.as_str()))
-                        .then_some(branch.clone())
+                .filter_map(|(ref_name, contents)| {
+                    let child_logical = *logical_by_ref.get(ref_name.as_str())?;
+                    let parent_ref = contents.parent_branch.as_deref()?;
+                    let (parent_logical, _) =
+                        crate::db::branch_identity::split_native_branch_ref(parent_ref);
+                    (parent_logical == parent).then(|| child_logical.to_string())
                 })
                 .collect::<Vec<_>>();
             children.sort();

--- a/crates/omnigraph/src/db/manifest/graph.rs
+++ b/crates/omnigraph/src/db/manifest/graph.rs
@@ -163,7 +163,7 @@ pub(super) async fn open_exact_genesis_manifest(
     control_session: &Arc<lance::session::Session>,
 ) -> Result<(Dataset, ManifestState, Vec<GraphLineageRow>)> {
     crate::failpoints::maybe_fail(crate::failpoints::names::INIT_MANIFEST_CREATE_PROBE)?;
-    let (dataset, known_state, lineage_rows, _) =
+    let (dataset, known_state, lineage_rows, _, _) =
         open_manifest_graph_with_lineage(root_uri, None, control_session).await?;
 
     // `read_manifest_state_and_lineage` intentionally folds head rows into a
@@ -247,15 +247,17 @@ pub(super) async fn open_manifest_graph(
     Dataset,
     ManifestState,
     lance::dataset::refs::BranchIdentifier,
+    Option<String>,
 )> {
-    let (dataset, branch_identifier) = open_manifest_dataset_with_identifier_with_session(
-        root_uri.trim_end_matches('/'),
-        branch,
-        control_session,
-    )
-    .await?;
+    let (dataset, branch_identifier, native_branch_ref) =
+        open_manifest_dataset_with_identifier_with_session(
+            root_uri.trim_end_matches('/'),
+            branch,
+            control_session,
+        )
+        .await?;
     let known_state = read_manifest_state(&dataset).await?;
-    Ok((dataset, known_state, branch_identifier))
+    Ok((dataset, known_state, branch_identifier, native_branch_ref))
 }
 
 pub(super) async fn open_manifest_graph_with_lineage(
@@ -267,15 +269,23 @@ pub(super) async fn open_manifest_graph_with_lineage(
     ManifestState,
     Vec<GraphLineageRow>,
     lance::dataset::refs::BranchIdentifier,
+    Option<String>,
 )> {
-    let (dataset, branch_identifier) = open_manifest_dataset_with_identifier_with_session(
-        root_uri.trim_end_matches('/'),
-        branch,
-        control_session,
-    )
-    .await?;
+    let (dataset, branch_identifier, native_branch_ref) =
+        open_manifest_dataset_with_identifier_with_session(
+            root_uri.trim_end_matches('/'),
+            branch,
+            control_session,
+        )
+        .await?;
     let (known_state, lineage_rows) = read_manifest_state_and_lineage(&dataset).await?;
-    Ok((dataset, known_state, lineage_rows, branch_identifier))
+    Ok((
+        dataset,
+        known_state,
+        lineage_rows,
+        branch_identifier,
+        native_branch_ref,
+    ))
 }
 
 pub(super) async fn snapshot_state_at(

--- a/crates/omnigraph/src/db/manifest/layout.rs
+++ b/crates/omnigraph/src/db/manifest/layout.rs
@@ -39,6 +39,141 @@ pub(super) async fn open_manifest_dataset_with_session(
     branch: Option<&str>,
     control_session: &Arc<lance::session::Session>,
 ) -> Result<Dataset> {
+    Ok(
+        open_manifest_dataset_resolved_with_session(root_uri, branch, control_session)
+            .await?
+            .0,
+    )
+}
+
+/// The native ref one logical branch name resolves to for this open, plus its
+/// registry row when one exists (legacy pre-registry branches have none).
+pub(super) struct ResolvedBranchCheckout {
+    pub(super) native_ref: String,
+    pub(super) registration: Option<super::state::BranchRegistration>,
+}
+
+/// Resolve a logical branch name to the native ref of its CURRENT life
+/// (issue #562), reading the branch registry from the given ROOT-manifest
+/// dataset. `main` never resolves (callers filter it), internal system refs
+/// pass through untouched (their name is the token), a name with no registry
+/// row falls back to itself (a legacy pre-registry branch), and a dead row is
+/// branch absence — the logical name does not exist between a delete and the
+/// next rebirth.
+pub(super) async fn resolve_native_branch_checkout(
+    root_dataset: &Dataset,
+    logical: &str,
+) -> Result<ResolvedBranchCheckout> {
+    if crate::db::is_internal_system_branch(logical) {
+        return Ok(ResolvedBranchCheckout {
+            native_ref: logical.to_string(),
+            registration: None,
+        });
+    }
+    // A name already carrying an incarnation token is a NATIVE ref: the
+    // public namespace reserves the separator, so only engine-internal
+    // callers hold one, and they are addressing an exact life — no registry
+    // scan needed (this keeps per-branch probes at one open + state read).
+    if crate::db::branch_identity::split_native_branch_ref(logical)
+        .1
+        .is_some()
+    {
+        return Ok(ResolvedBranchCheckout {
+            native_ref: logical.to_string(),
+            registration: None,
+        });
+    }
+    let mut registry = super::state::read_branch_registry(root_dataset).await?;
+    match registry.remove(logical) {
+        Some(registration) if registration.live => Ok(ResolvedBranchCheckout {
+            native_ref: registration.native_ref.clone(),
+            registration: Some(registration),
+        }),
+        Some(_dead) => Err(OmniError::BranchNotFound {
+            branch: logical.to_string(),
+        }),
+        None => Ok(ResolvedBranchCheckout {
+            native_ref: logical.to_string(),
+            registration: None,
+        }),
+    }
+}
+
+/// Forward recovery for the branch-create crash window (issue #562): the
+/// registry commit landed (the commit point) but the native ref was never
+/// created. Re-verifies the registration against a FRESH root manifest —
+/// a concurrent delete marks the row dead before touching the ref, so a
+/// still-live row proves the ref is missing because of the crash window, not
+/// a delete in flight — then completes the ref at the pinned source version.
+/// (A lost race after the re-read at worst recreates a ref whose row just
+/// went dead: an unreferenced ref that is invisible to listing and
+/// resolution. Table-level fork garbage is the orphan reconciler's job;
+/// a manifest-level ref like this one lingers until manual cleanup.)
+async fn complete_registered_branch_ref(
+    root_uri: &str,
+    control_session: &Arc<lance::session::Session>,
+    logical: &str,
+    expected_native: &str,
+) -> Result<()> {
+    let uri = manifest_uri(root_uri.trim_end_matches('/'));
+    let fresh = crate::instrumentation::open_dataset(
+        &uri,
+        crate::instrumentation::VersionResolution::Latest,
+        Some(control_session),
+        crate::instrumentation::manifest_wrapper(),
+    )
+    .await?;
+    let registry = super::state::read_branch_registry(&fresh).await?;
+    let Some(registration) = registry.get(logical) else {
+        return Err(OmniError::BranchNotFound {
+            branch: logical.to_string(),
+        });
+    };
+    if !registration.live || registration.native_ref != expected_native {
+        return Err(OmniError::BranchNotFound {
+            branch: logical.to_string(),
+        });
+    }
+    let mut source_dataset = match registration.source_ref.as_deref() {
+        Some(source_ref) => fresh
+            .checkout_branch(source_ref)
+            .await
+            .map_err(|error| branch_ref_error(error, source_ref))?,
+        None => fresh,
+    };
+    crate::branch_control::complete_branch_ref_at_version(
+        &mut source_dataset,
+        &registration.native_ref,
+        registration.source_version,
+    )
+    .await
+    .map(|_| ())
+}
+
+/// Open one manifest branch by LOGICAL name, resolving it to its current
+/// life's native ref. Returns the native ref actually checked out (`None`
+/// for main) so lifecycle callers can address Lance directly.
+pub(super) async fn open_manifest_dataset_resolved_with_session(
+    root_uri: &str,
+    branch: Option<&str>,
+    control_session: &Arc<lance::session::Session>,
+) -> Result<(Dataset, Option<String>)> {
+    // Boxed AND type-erased wholesale: the resolution seam (registry scan +
+    // forward-recovery completion) rides inside already-deep coordinator
+    // futures — the engine's known stack-depth hazard — and the erasure also
+    // keeps downstream auto-trait proofs (axum handler bounds) from recursing
+    // through the whole Lance future tree.
+    let fut: std::pin::Pin<Box<dyn std::future::Future<Output = _> + Send + '_>> = Box::pin(
+        open_manifest_dataset_resolved_inner(root_uri, branch, control_session),
+    );
+    fut.await
+}
+
+async fn open_manifest_dataset_resolved_inner(
+    root_uri: &str,
+    branch: Option<&str>,
+    control_session: &Arc<lance::session::Session>,
+) -> Result<(Dataset, Option<String>)> {
     let uri = manifest_uri(root_uri.trim_end_matches('/'));
     let dataset = crate::instrumentation::open_dataset(
         &uri,
@@ -47,12 +182,28 @@ pub(super) async fn open_manifest_dataset_with_session(
         crate::instrumentation::manifest_wrapper(),
     )
     .await?;
-    match branch {
-        Some(branch) if branch != "main" => dataset
-            .checkout_branch(branch)
-            .await
-            .map_err(OmniError::storage),
-        _ => Ok(dataset),
+    let Some(branch) = branch.filter(|branch| *branch != "main") else {
+        return Ok((dataset, None));
+    };
+    let resolved = resolve_native_branch_checkout(&dataset, branch).await?;
+    match dataset.checkout_branch(&resolved.native_ref).await {
+        Ok(checked_out) => Ok((checked_out, Some(resolved.native_ref))),
+        Err(lance::Error::RefNotFound { .. }) if resolved.registration.is_some() => {
+            complete_registered_branch_ref(root_uri, control_session, branch, &resolved.native_ref)
+                .await?;
+            let checked_out = dataset
+                .checkout_branch(&resolved.native_ref)
+                .await
+                .map_err(|error| branch_ref_error(error, branch))?;
+            Ok((checked_out, Some(resolved.native_ref)))
+        }
+        // Typed absence, named by the LOGICAL branch: reached for a
+        // pass-through native ref whose life is refless (the create crash
+        // window) or already reclaimed — errors speak logical (issue #562).
+        Err(error) => Err(branch_ref_error(
+            error,
+            crate::db::branch_identity::split_native_branch_ref(branch).0,
+        )),
     }
 }
 
@@ -69,7 +220,19 @@ pub(super) async fn open_manifest_dataset_with_identifier_with_session(
     root_uri: &str,
     branch: Option<&str>,
     control_session: &Arc<lance::session::Session>,
-) -> Result<(Dataset, BranchIdentifier)> {
+) -> Result<(Dataset, BranchIdentifier, Option<String>)> {
+    // Boxed and type-erased for the same reasons as the resolved open above.
+    let fut: std::pin::Pin<Box<dyn std::future::Future<Output = _> + Send + '_>> = Box::pin(
+        open_manifest_dataset_with_identifier_inner(root_uri, branch, control_session),
+    );
+    fut.await
+}
+
+async fn open_manifest_dataset_with_identifier_inner(
+    root_uri: &str,
+    branch: Option<&str>,
+    control_session: &Arc<lance::session::Session>,
+) -> Result<(Dataset, BranchIdentifier, Option<String>)> {
     let uri = manifest_uri(root_uri.trim_end_matches('/'));
     let dataset = crate::instrumentation::open_dataset(
         &uri,
@@ -79,32 +242,50 @@ pub(super) async fn open_manifest_dataset_with_identifier_with_session(
     )
     .await?;
     let Some(branch) = branch.filter(|branch| *branch != "main") else {
-        return Ok((dataset, BranchIdentifier::main()));
+        return Ok((dataset, BranchIdentifier::main(), None));
     };
+    // Resolve the logical name to its current life's native ref (issue #562);
+    // the identifier capture below then witnesses exactly that life. A
+    // concurrent rebirth changes the NAME, so a stale resolution surfaces as
+    // ref absence, never as silently pairing with the replacement life.
+    let resolved = resolve_native_branch_checkout(&dataset, branch).await?;
+    let native = resolved.native_ref.as_str();
+    // Errors speak LOGICAL (issue #562): a pass-through caller supplies the
+    // native spelling, so split before naming; logical callers split to
+    // themselves.
+    let error_name = crate::db::branch_identity::split_native_branch_ref(branch).0;
 
+    let mut completed_missing_ref = false;
     for _ in 0..BRANCH_IDENTIFIER_CAPTURE_ATTEMPTS {
-        let before = dataset
-            .branches()
-            .get_identifier(Some(branch))
-            .await
-            .map_err(|error| branch_ref_error(error, branch))?;
+        let before = match dataset.branches().get_identifier(Some(native)).await {
+            Ok(identifier) => identifier,
+            Err(lance::Error::RefNotFound { .. })
+                if resolved.registration.is_some() && !completed_missing_ref =>
+            {
+                // Forward recovery: registry committed, native ref unmade.
+                complete_registered_branch_ref(root_uri, control_session, branch, native).await?;
+                completed_missing_ref = true;
+                continue;
+            }
+            Err(error) => return Err(branch_ref_error(error, error_name)),
+        };
         let branch_dataset = dataset
-            .checkout_branch(branch)
+            .checkout_branch(native)
             .await
-            .map_err(|error| branch_ref_error(error, branch))?;
+            .map_err(|error| branch_ref_error(error, error_name))?;
         let after = dataset
             .branches()
-            .get_identifier(Some(branch))
+            .get_identifier(Some(native))
             .await
-            .map_err(|error| branch_ref_error(error, branch))?;
+            .map_err(|error| branch_ref_error(error, error_name))?;
         if before == after {
-            return Ok((branch_dataset, before));
+            return Ok((branch_dataset, before, Some(resolved.native_ref)));
         }
         tokio::task::yield_now().await;
     }
 
     Err(OmniError::manifest_conflict(format!(
-        "manifest branch '{branch}' changed repeatedly during coherent open; retry"
+        "manifest branch '{error_name}' changed repeatedly during coherent open; retry"
     )))
 }
 

--- a/crates/omnigraph/src/db/manifest/publisher.rs
+++ b/crates/omnigraph/src/db/manifest/publisher.rs
@@ -176,6 +176,17 @@ pub(super) struct GraphNamespacePublisher {
     control_session: Arc<lance::session::Session>,
 }
 
+/// Expected prior registry state for one logical name, checked inside the
+/// registry commit's CAS loop (issue #562).
+#[derive(Debug, Clone)]
+pub(super) enum BranchRegistryExpectation {
+    /// The logical name must have no registry row, or a dead one: a create or
+    /// a rebirth.
+    AbsentOrDead,
+    /// The logical name must be live at exactly this native ref: a delete.
+    LiveWithNativeRef(String),
+}
+
 #[derive(Debug)]
 struct PendingVersionRow {
     object_id: String,
@@ -954,6 +965,88 @@ impl GraphNamespacePublisher {
             .await
             .map_err(map_lance_publish_error)?;
         Ok(Arc::try_unwrap(new_dataset).unwrap_or_else(|arc| (*arc).clone()))
+    }
+
+    /// Commit one branch-registry row to the ROOT `__manifest` (issue #562).
+    ///
+    /// This commit is the branch lifecycle's commit point: the native ref is
+    /// created (or deleted) only AFTER the row lands, and forward recovery
+    /// completes a ref the crash window left missing. The merge-insert's
+    /// row-level CAS on `object_id` serializes racing lifecycle operations on
+    /// one logical name — the loser observes typed contention, retries, and
+    /// re-runs the expectation check against fresh registry state, so exactly
+    /// one racer's registration wins and the other surfaces a typed conflict.
+    pub(super) async fn commit_branch_registration(
+        &self,
+        registration: &super::state::BranchRegistration,
+        expectation: &BranchRegistryExpectation,
+    ) -> Result<()> {
+        debug_assert!(
+            self.branch.is_none(),
+            "branch registry commits target the root manifest"
+        );
+        for attempt in 0..=PUBLISHER_RETRY_BUDGET {
+            let dataset = self.dataset().await?;
+            guard_stamp(&dataset)?;
+            let registry = super::state::read_branch_registry(&dataset).await?;
+            match expectation {
+                BranchRegistryExpectation::AbsentOrDead => {
+                    if let Some(row) = registry.get(&registration.logical) {
+                        if row.live {
+                            return Err(OmniError::manifest_conflict(format!(
+                                "branch '{}' already exists",
+                                registration.logical
+                            )));
+                        }
+                    }
+                }
+                BranchRegistryExpectation::LiveWithNativeRef(expected_native) => {
+                    match registry.get(&registration.logical) {
+                        Some(row) if row.live && row.native_ref == *expected_native => {}
+                        Some(row) => {
+                            return Err(OmniError::manifest_read_set_changed(
+                                format!("branch_registration:{}", registration.logical),
+                                Some(expected_native.clone()),
+                                Some(if row.live {
+                                    row.native_ref.clone()
+                                } else {
+                                    format!("dead:{}", row.native_ref)
+                                }),
+                            ));
+                        }
+                        None => {
+                            return Err(OmniError::manifest_not_found(format!(
+                                "branch '{}' not found",
+                                registration.logical
+                            )));
+                        }
+                    }
+                }
+            }
+            let row = PendingVersionRow {
+                object_id: super::state::branch_object_id(&registration.logical),
+                object_type: super::OBJECT_TYPE_BRANCH.to_string(),
+                location: None,
+                metadata: Some(super::state::encode_branch_registration_metadata(
+                    registration,
+                )?),
+                table_key: String::new(),
+                identity: None,
+                table_version: None,
+                table_branch: None,
+                row_count: None,
+            };
+            match self.merge_rows(dataset, vec![row]).await {
+                Ok(_) => return Ok(()),
+                Err(err)
+                    if attempt < PUBLISHER_RETRY_BUDGET && is_retryable_publish_conflict(&err) =>
+                {
+                    continue;
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        unreachable!("branch registry CAS loop returns from every attempt")
     }
 
     #[cfg(test)]

--- a/crates/omnigraph/src/db/manifest/recovery.rs
+++ b/crates/omnigraph/src/db/manifest/recovery.rs
@@ -2001,11 +2001,16 @@ fn validate_ensure_indices_v8_shape(sidecar_uri: &str, sidecar: &RecoverySidecar
             )));
         }
         let is_first_touch = effect.source_fork_version.is_some();
+        // `pin.table_branch` carries the fork's NATIVE ref (issue #562);
+        // `sidecar_branch` stays LOGICAL. Compare at the logical level —
+        // legacy (v8-written) pins carry the bare name and split to
+        // themselves.
         if (is_first_touch
-            && !pin
-                .table_branch
-                .as_deref()
-                .is_some_and(|branch| branch != "main" && Some(branch) == sidecar_branch))
+            && !pin.table_branch.as_deref().is_some_and(|branch| {
+                branch != "main"
+                    && Some(crate::db::branch_identity::split_native_branch_ref(branch).0)
+                        == sidecar_branch
+            }))
             || effect
                 .source_fork_version
                 .is_some_and(|version| version != pin.expected_version)
@@ -3077,7 +3082,19 @@ pub(crate) async fn heal_pending_sidecars_roll_forward(
         let queue_keys: Vec<crate::db::write_queue::TableQueueKey> = sidecar
             .tables
             .iter()
-            .map(|pin| (pin.table_key.clone(), pin.table_branch.clone()))
+            .map(|pin| {
+                // Queue keys stay LOGICAL (issue #562): every other holder —
+                // staging, ensure_indices, merge, the reconciler — keys by the
+                // logical name, and mutual exclusion needs one vocabulary.
+                // `pin.table_branch` carries the life's native ref on v9 pins;
+                // legacy bare pins split to themselves.
+                let logical = pin.table_branch.as_deref().map(|native| {
+                    crate::db::branch_identity::split_native_branch_ref(native)
+                        .0
+                        .to_string()
+                });
+                (pin.table_key.clone(), logical)
+            })
             .collect();
         let is_schema_apply = matches!(sidecar.writer_kind, SidecarKind::SchemaApply);
         let _table_guards = write_queue.acquire_many(&queue_keys).await;
@@ -3332,7 +3349,15 @@ pub(crate) async fn recover_manifest_drift(
         let table_keys = sidecar
             .tables
             .iter()
-            .map(|pin| (pin.table_key.clone(), pin.table_branch.clone()))
+            .map(|pin| {
+                // Same LOGICAL queue-key rule as the Full-recovery sweep above.
+                let logical = pin.table_branch.as_deref().map(|native| {
+                    crate::db::branch_identity::split_native_branch_ref(native)
+                        .0
+                        .to_string()
+                });
+                (pin.table_key.clone(), logical)
+            })
             .collect::<Vec<_>>();
         let _table_guards = write_queue.acquire_many(&table_keys).await;
 
@@ -3484,16 +3509,46 @@ async fn classify_sidecar_tables(
                 .table_branch
                 .as_deref()
                 .is_some_and(|branch| branch != "main")
-            && sidecar.branch.as_deref() == pin.table_branch.as_deref()
+            // `pin.table_branch` is the fork's NATIVE ref (issue #562) while
+            // `sidecar.branch` stays LOGICAL, so the own-branch check compares
+            // at the logical level; legacy pins carry the bare name and split
+            // to themselves.
+            && pin
+                .table_branch
+                .as_deref()
+                .map(|native| crate::db::branch_identity::split_native_branch_ref(native).0)
+                == sidecar.branch.as_deref()
             && manifest_entry
                 .map(|entry| entry.native_dataset_branch != pin.table_branch)
                 .unwrap_or(true);
-        let allow_missing_target_ref = unpublished_fork
-            && (matches!(sidecar.writer_kind, SidecarKind::EnsureIndices)
-                || sidecar
-                    .protocol_v3
-                    .as_ref()
-                    .is_some_and(|protocol| protocol.effect_phase == RecoveryEffectPhase::Armed));
+        // A pure legacy (pre-protocol) pin with no confirmed effect addresses
+        // a bare-name life. After a #562 rebirth the logical name lives on
+        // under a NEW `{name}--{ulid}` ref while the pinned bare ref is gone,
+        // so an absent ref observes nothing rather than erroring — there is
+        // no confirmed effect to protect, and classification then defers or
+        // orphan-discards exactly as when the whole branch is gone. Confirmed
+        // effects keep the loud-error contract, and so does a MANIFEST
+        // placement: a table the manifest places on the pinned ref is a
+        // confirmed effect in everything but the pin field, so its ref going
+        // missing is corruption and must stay loud.
+        let legacy_pin_without_confirmed_effect = sidecar.protocol_v3.is_none()
+            && sidecar.protocol_v4.is_none()
+            && sidecar.protocol_v7.is_none()
+            && sidecar.protocol_v8.is_none()
+            && pin.confirmed_version.is_none()
+            && pin
+                .table_branch
+                .as_deref()
+                .is_some_and(|branch| branch != "main")
+            && manifest_entry
+                .map(|entry| entry.native_dataset_branch != pin.table_branch)
+                .unwrap_or(true);
+        let allow_missing_target_ref = legacy_pin_without_confirmed_effect
+            || (unpublished_fork
+                && (matches!(sidecar.writer_kind, SidecarKind::EnsureIndices)
+                    || sidecar.protocol_v3.as_ref().is_some_and(|protocol| {
+                        protocol.effect_phase == RecoveryEffectPhase::Armed
+                    })));
         let planned_effect = sidecar.protocol_v3.as_ref().and_then(|protocol| {
             protocol
                 .effects

--- a/crates/omnigraph/src/db/manifest/state.rs
+++ b/crates/omnigraph/src/db/manifest/state.rs
@@ -917,6 +917,143 @@ pub(crate) async fn read_graph_lineage(
     Ok((graph_commits, graph_heads))
 }
 
+/// One logical branch's registry row (issue #562): the mapping from the
+/// user-facing name to the native ref of its CURRENT life
+/// (`{logical}--{ulid}`, minted per life — see `db/branch_identity`). A
+/// `live: false` row is the state between a delete's authority commit and the
+/// next rebirth: the logical name does not exist for users, and the old
+/// life's stranded native tree is reclaimable garbage for the orphan
+/// reconciler.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BranchRegistration {
+    pub(crate) logical: String,
+    pub(crate) native_ref: String,
+    pub(crate) incarnation: String,
+    pub(crate) live: bool,
+    /// Native ref of the branch this life forked from (`None` = main) and the
+    /// `__manifest` version the fork pinned: enough for forward recovery to
+    /// complete a native ref the create crashed before making (the registry
+    /// commit is the commit point; ref creation follows it).
+    pub(crate) source_ref: Option<String>,
+    pub(crate) source_version: u64,
+}
+
+/// JSON payload of a `branch` row's `metadata` column. The row's `object_id`
+/// is `branch:<logical>`; every other registration field lives here so the
+/// row has exactly one payload owner.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct BranchRegistrationMetadata {
+    status: String,
+    native_ref: String,
+    incarnation: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    source_ref: Option<String>,
+    source_version: u64,
+}
+
+const BRANCH_STATUS_LIVE: &str = "live";
+const BRANCH_STATUS_DEAD: &str = "dead";
+
+/// The `object_id` of a logical branch's registry row.
+pub(crate) fn branch_object_id(logical: &str) -> String {
+    format!("{}{logical}", super::BRANCH_OBJECT_ID_PREFIX)
+}
+
+pub(crate) fn encode_branch_registration_metadata(reg: &BranchRegistration) -> Result<String> {
+    serde_json::to_string(&BranchRegistrationMetadata {
+        status: if reg.live {
+            BRANCH_STATUS_LIVE
+        } else {
+            BRANCH_STATUS_DEAD
+        }
+        .to_string(),
+        native_ref: reg.native_ref.clone(),
+        incarnation: reg.incarnation.clone(),
+        source_ref: reg.source_ref.clone(),
+        source_version: reg.source_version,
+    })
+    .map_err(|e| OmniError::manifest_internal(format!("failed to encode branch registration: {e}")))
+}
+
+fn decode_branch_row(
+    object_ids: &StringArray,
+    metadata: &StringArray,
+    row: usize,
+) -> Result<BranchRegistration> {
+    let object_id = object_ids.value(row);
+    let logical = object_id
+        .strip_prefix(super::BRANCH_OBJECT_ID_PREFIX)
+        .ok_or_else(|| {
+            OmniError::manifest_internal(format!(
+                "manifest branch row has object_id '{object_id}' without the '{}' prefix",
+                super::BRANCH_OBJECT_ID_PREFIX
+            ))
+        })?;
+    if metadata.is_null(row) {
+        return Err(OmniError::manifest_internal(format!(
+            "manifest branch row for '{logical}' is missing its metadata payload"
+        )));
+    }
+    let payload: BranchRegistrationMetadata =
+        serde_json::from_str(metadata.value(row)).map_err(|e| {
+            OmniError::manifest_internal(format!(
+                "manifest branch row for '{logical}' has undecodable metadata: {e}"
+            ))
+        })?;
+    let live = match payload.status.as_str() {
+        BRANCH_STATUS_LIVE => true,
+        BRANCH_STATUS_DEAD => false,
+        other => {
+            return Err(OmniError::manifest_internal(format!(
+                "manifest branch row for '{logical}' has unknown status '{other}'"
+            )));
+        }
+    };
+    Ok(BranchRegistration {
+        logical: logical.to_string(),
+        native_ref: payload.native_ref,
+        incarnation: payload.incarnation,
+        live,
+        source_ref: payload.source_ref,
+        source_version: payload.source_version,
+    })
+}
+
+/// Read the branch registry (every `branch` row, live and dead) from one
+/// `__manifest` dataset, keyed by logical name. Callers pass the ROOT (main)
+/// manifest: registry rows inherited into branch clones by the shallow fork
+/// are stale copies and must not be consulted. A dedicated filtered scan,
+/// like `read_graph_lineage`: the table-state hot path never decodes these
+/// rows, and this path never assembles table entries.
+pub(crate) async fn read_branch_registry(
+    dataset: &Dataset,
+) -> Result<HashMap<String, BranchRegistration>> {
+    crate::instrumentation::record_manifest_scan();
+    let mut scan = dataset.scan();
+    scan.filter(&format!("object_type = '{}'", super::OBJECT_TYPE_BRANCH))
+        .map_err(OmniError::storage)?;
+    scan.project(&["object_id", "metadata"])
+        .map_err(OmniError::storage)?;
+    let batches: Vec<RecordBatch> = scan
+        .try_into_stream()
+        .await
+        .map_err(OmniError::storage)?
+        .try_collect()
+        .await
+        .map_err(OmniError::storage)?;
+
+    let mut registry = HashMap::new();
+    for batch in &batches {
+        let object_ids = string_column(batch, "object_id")?;
+        let metadata = string_column(batch, "metadata")?;
+        for row in 0..batch.num_rows() {
+            let registration = decode_branch_row(object_ids, metadata, row)?;
+            registry.insert(registration.logical.clone(), registration);
+        }
+    }
+    Ok(registry)
+}
+
 /// The current head of a branch's lineage: the [`GraphLineageRow`] with the
 /// greatest `(graph_manifest_version, created_at, graph_commit_id)`. This is the same
 /// ordering the commit-graph cache uses to pick its head (`should_replace_head`)

--- a/crates/omnigraph/src/db/mod.rs
+++ b/crates/omnigraph/src/db/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod branch_identity;
 pub mod commit_graph;
 mod graph_coordinator;
 pub mod manifest;

--- a/crates/omnigraph/src/db/omnigraph.rs
+++ b/crates/omnigraph/src/db/omnigraph.rs
@@ -163,6 +163,19 @@ pub(crate) struct WriteTxn {
     pub(crate) manifest_probe: crate::db::manifest::CapturedManifestProbe,
 }
 
+impl WriteTxn {
+    /// The Lance ref of the captured branch life (issue #562): native
+    /// `{logical}--{ulid}` for registered branches, the bare name for legacy
+    /// ones, `None` for main. Rides in `manifest_probe`, which was captured
+    /// from the same `ManifestCoordinator` as `base` and `authority`.
+    /// Lance-facing table opens, forks, and persisted `native_dataset_branch`
+    /// values use this; `branch` stays the logical name for heads, lineage,
+    /// Cedar, and errors.
+    pub(crate) fn native_branch(&self) -> Option<&str> {
+        self.manifest_probe.native_branch_ref()
+    }
+}
+
 /// One coherent handle-local projection of the durable schema contract.
 /// Source and catalog move through one ArcSwap publication so readers never
 /// combine an old source with a new identity-bearing catalog (or vice versa).
@@ -2356,7 +2369,15 @@ impl Omnigraph {
                     return coord.resolve_target(target).await;
                 }
                 let held = coord.manifest_incarnation();
-                if coord.probe_latest_incarnation().await?.matches(&held) {
+                // A probe on a deleted life's native ref dies with NotFound
+                // (issue #562). For a warm READER bound to the logical name
+                // that is definitive staleness, not an error: fall through to
+                // the refresh, which re-resolves the name to its current life.
+                if coord
+                    .probe_latest_incarnation()
+                    .await
+                    .is_ok_and(|latest| latest.matches(&held))
+                {
                     return warm_resolved_target(&coord, target).await;
                 }
                 // Stale: refresh under the write lock below.
@@ -2367,7 +2388,11 @@ impl Omnigraph {
                 // refreshed (tokio RwLock has no read->write upgrade).
                 let held = coord.manifest_incarnation();
                 let mut refreshed = false;
-                if !coord.probe_latest_incarnation().await?.matches(&held) {
+                let probe_current = coord
+                    .probe_latest_incarnation()
+                    .await
+                    .is_ok_and(|latest| latest.matches(&held));
+                if !probe_current {
                     // An exact head row keeps this state-only; a fresh/recreated
                     // branch atomically refreshes its inherited lineage too.
                     // No fallible second phase can leave replacement rows
@@ -2936,15 +2961,34 @@ impl Omnigraph {
         // proof and must not add two discarded BranchContents reads per branch.
         // General coordinator/OCC/feed opens retain the coherent incarnation
         // capture required by RFC-030.
-        for other_branch in branches
+        // Surviving branches record inherited forks by NATIVE ref (issue
+        // #562), so the dependency probe matches against the deleted life's
+        // native ref, not the logical name. Candidates resolve to their
+        // native refs with ONE registry read here; the per-branch probe then
+        // opens each native ref directly (the resolver passes ULID-suffixed
+        // names through without another registry scan), keeping the probe at
+        // one manifest open + state read per surviving branch.
+        let delete_target_native = control.native_branch().unwrap_or(branch);
+        let candidate_logicals: Vec<String> = branches
             .iter()
             .filter(|candidate| candidate.as_str() != branch)
-        {
+            .cloned()
+            .collect();
+        let candidate_natives = control
+            .resolve_native_branch_refs(&candidate_logicals)
+            .await?;
+        for other_branch in &candidate_logicals {
             let candidate_branch = Self::normalize_branch_name(other_branch)?;
+            let candidate_native = candidate_branch.as_deref().map(|logical| {
+                candidate_natives
+                    .get(logical)
+                    .map(String::as_str)
+                    .unwrap_or(logical)
+            });
             if crate::db::manifest::ManifestCoordinator::branch_depends_on_delete_target_under_control_gates(
                 self.uri(),
-                candidate_branch.as_deref(),
-                branch,
+                candidate_native,
+                delete_target_native,
                 &self.control_session(),
             )
             .await?
@@ -3018,9 +3062,13 @@ impl Omnigraph {
         }
 
         let branch_snapshot = target.snapshot();
+        // The captured coordinator is pinned at the life being deleted, so its
+        // native ref (issue #562) is what per-table forks and manifest rows
+        // name; legacy lives carry the bare name and behave as before.
+        let native_branch = target.native_branch().unwrap_or(branch).to_string();
         let owned_tables = branch_snapshot
             .datasets()
-            .filter(|entry| entry.native_dataset_branch.as_deref() == Some(branch))
+            .filter(|entry| entry.native_dataset_branch.as_deref() == Some(native_branch.as_str()))
             .map(|entry| (entry.type_key.clone(), entry.dataset_path.clone()))
             .collect::<Vec<_>>();
         let expected_identifier = target.branch_identifier().await?;
@@ -3038,7 +3086,8 @@ impl Omnigraph {
         // recreation, while a failed control leaves warm state untouched.
         self.invalidate_read_caches().await;
         // Best-effort per-table fork reclaim; cleanup reconciles any leftover.
-        self.cleanup_deleted_branch_tables(branch, &owned_tables)
+        // Per-table forks were created under the life's NATIVE ref.
+        self.cleanup_deleted_branch_tables(&native_branch, &owned_tables)
             .await;
         Ok(())
     }
@@ -3363,12 +3412,13 @@ impl Omnigraph {
         table_ops::open_for_mutation_on_branch(self, branch, table_key, op_kind, txn).await
     }
 
-    /// Fork `table_key` onto `active_branch` from the given source state,
-    /// self-healing a manifest-unreferenced leftover fork if one is in the
-    /// way. Callers that reach this MUST already hold the per-`(table_key,
-    /// active_branch)` write queue (so the reclaim cannot race an in-process
-    /// fork) and must have confirmed via the live manifest that the table is
-    /// not yet on `active_branch`. Both the first-write fork path
+    /// Fork `table_key` onto the NATIVE branch ref `native_branch` (issue
+    /// #562) from the given source state, self-healing a
+    /// manifest-unreferenced leftover fork if one is in the way. Callers that
+    /// reach this MUST already hold the per-`(table_key, logical-branch)`
+    /// write queue (so the reclaim cannot race an in-process fork) and must
+    /// have confirmed via the live manifest that the table is not yet on
+    /// `native_branch`. Both the first-write fork path
     /// (`open_owned_dataset_for_branch_write`) and `branch_merge` satisfy this.
     pub(crate) async fn fork_dataset_from_entry_state(
         &self,
@@ -3377,7 +3427,7 @@ impl Omnigraph {
         full_path: &str,
         source_branch: Option<&str>,
         source_version: u64,
-        active_branch: &str,
+        native_branch: &str,
     ) -> Result<SnapshotHandle> {
         self.fork_dataset_from_entry_state_under_intent(
             table_key,
@@ -3385,7 +3435,7 @@ impl Omnigraph {
             full_path,
             source_branch,
             source_version,
-            active_branch,
+            native_branch,
             None,
         )
         .await
@@ -3398,7 +3448,7 @@ impl Omnigraph {
         full_path: &str,
         source_branch: Option<&str>,
         source_version: u64,
-        active_branch: &str,
+        native_branch: &str,
         operation_id: Option<&str>,
     ) -> Result<SnapshotHandle> {
         match table_ops::fork_dataset_from_entry_state(
@@ -3407,7 +3457,7 @@ impl Omnigraph {
             full_path,
             source_branch,
             source_version,
-            active_branch,
+            native_branch,
         )
         .await?
         {
@@ -3420,7 +3470,7 @@ impl Omnigraph {
                     full_path,
                     source_branch,
                     source_version,
-                    active_branch,
+                    native_branch,
                     operation_id,
                 )
                 .await
@@ -3549,6 +3599,15 @@ pub(crate) fn ensure_public_branch_ref(branch: &str, operation: &str) -> Result<
         return Err(OmniError::manifest(format!(
             "{} does not allow internal system ref '{}'",
             operation, branch
+        )));
+    }
+    if crate::db::branch_identity::public_name_reserves_separator(branch) {
+        return Err(OmniError::manifest(format!(
+            "{} does not allow '{}' in branch names: '{}' is reserved for internal \
+             per-life branch refs",
+            operation,
+            crate::db::branch_identity::BRANCH_INCARNATION_SEPARATOR,
+            branch
         )));
     }
     Ok(())

--- a/crates/omnigraph/src/db/omnigraph/optimize.rs
+++ b/crates/omnigraph/src/db/omnigraph/optimize.rs
@@ -1379,24 +1379,34 @@ async fn reconcile_orphaned_branches_with_catalog(
             if branch == "main" || crate::db::is_internal_system_branch(&branch) {
                 continue;
             }
-            let is_orphan = if !live_branches.contains(&branch) {
-                true // origin 1: whole branch gone from the manifest
+            // `branch` is the Lance ref name — native `{logical}--{ulid}` for
+            // registered lives, bare for legacy forks (issue #562). Liveness
+            // and snapshot resolution speak the LOGICAL name; the placement
+            // compare keeps the native ref, so a dead life's ULID-suffixed
+            // ref (registry row dead/absent → origin 1, or the logical name
+            // reborn onto a different native ref → origin 2) classifies as an
+            // orphan while the current life's ref stays legitimate.
+            let logical = crate::db::branch_identity::split_native_branch_ref(&branch)
+                .0
+                .to_string();
+            let is_orphan = if !live_branches.contains(&logical) {
+                true // origin 1: whole logical branch gone from the manifest
             } else {
                 // origin 2: live branch, but does the manifest place THIS
                 // table on it? Resolve (and cache) the branch's snapshot.
-                if failed_branch_snapshots.contains(&branch) {
+                if failed_branch_snapshots.contains(&logical) {
                     continue;
                 }
-                if !branch_snapshots.contains_key(&branch) {
+                if !branch_snapshots.contains_key(&logical) {
                     let branch_snapshot = match crate::failpoints::maybe_fail(
                         crate::failpoints::names::CLEANUP_RESOLVE_BRANCH_SNAPSHOT,
                     ) {
-                        Ok(()) => db.snapshot_for_branch(Some(&branch)).await,
+                        Ok(()) => db.snapshot_for_branch(Some(&logical)).await,
                         Err(injected) => Err(injected),
                     };
                     match branch_snapshot {
                         Ok(snap) => {
-                            branch_snapshots.insert(branch.clone(), snap);
+                            branch_snapshots.insert(logical.clone(), snap);
                         }
                         Err(err) => {
                             tracing::warn!(
@@ -1407,12 +1417,12 @@ async fn reconcile_orphaned_branches_with_catalog(
                                 "resolving branch snapshot failed during reconcile; skipping",
                             );
                             stats.failures.push((table_key.clone(), err.to_string()));
-                            failed_branch_snapshots.insert(branch.clone());
+                            failed_branch_snapshots.insert(logical.clone());
                             continue;
                         }
                     }
                 }
-                branch_snapshots[&branch]
+                branch_snapshots[&logical]
                     .datasets()
                     .find(|entry| entry.identity == identity)
                     .map(|e| e.native_dataset_branch.as_deref() != Some(branch.as_str()))
@@ -1437,9 +1447,14 @@ async fn reconcile_orphaned_branches_with_catalog(
             // it is no longer an orphan — skip it. (Cross-process writers remain
             // the documented one-winner-CAS gap.) One key held at a time → no
             // lock-order inversion against multi-table `acquire_many` writers.
+            // Per-(table, branch) queues key by the LOGICAL name (shared
+            // vocabulary with every writer); the ref under reclaim is native.
+            let logical = crate::db::branch_identity::split_native_branch_ref(&branch)
+                .0
+                .to_string();
             let _guard = db
                 .write_queue()
-                .acquire(&(table_key.clone(), Some(branch.clone())))
+                .acquire(&(table_key.clone(), Some(logical)))
                 .await;
             // Decide under the queue from FRESH authority via the shared
             // classifier (same decision the write-path reclaim uses) — never

--- a/crates/omnigraph/src/db/omnigraph/table_ops.rs
+++ b/crates/omnigraph/src/db/omnigraph/table_ops.rs
@@ -96,6 +96,11 @@ pub(super) async fn ensure_indices_for_branch(
     let snapshot = txn.base.clone();
     let mut pending_by_table = HashMap::<String, Vec<PendingIndex>>::new();
     let active_branch = txn.branch.clone();
+    // Lance-facing counterpart of `active_branch` (issue #562): table opens,
+    // fork targets, and persisted `table_branch`/`native_dataset_branch`
+    // values use the captured life's native ref; gates, sidecar identity, and
+    // lineage keep the logical name.
+    let native_branch = txn.native_branch().map(str::to_string);
     let catalog = Arc::clone(&txn.catalog);
 
     let mut recovery_pins: Vec<crate::db::manifest::SidecarTablePin> = Vec::new();
@@ -136,7 +141,7 @@ pub(super) async fn ensure_indices_for_branch(
         }
         let full_path = format!("{}/{}", db.root_uri, entry.dataset_path);
         let first_touch = active_branch.is_some()
-            && entry.native_dataset_branch.as_deref() != active_branch.as_deref();
+            && entry.native_dataset_branch.as_deref() != native_branch.as_deref();
         let ds = if first_touch {
             // The inherited owner's HEAD may advance independently after this
             // graph branch was cut. Plan from the exact inherited snapshot, not
@@ -144,7 +149,7 @@ pub(super) async fn ensure_indices_for_branch(
             db.storage().open_snapshot_at_entry(entry).await?
         } else {
             db.storage()
-                .open_dataset_head(&full_path, active_branch.as_deref())
+                .open_dataset_head(&full_path, native_branch.as_deref())
                 .await?
         };
         let work = plan_index_work_node(db, &catalog, type_name, &table_key, &ds).await?;
@@ -159,7 +164,7 @@ pub(super) async fn ensure_indices_for_branch(
                 expected_version: entry.published_dataset_version,
                 post_commit_pin: entry.published_dataset_version + 1,
                 confirmed_version: None,
-                table_branch: active_branch.clone(),
+                table_branch: native_branch.clone(),
             });
             if !first_touch {
                 let staged = db
@@ -201,12 +206,12 @@ pub(super) async fn ensure_indices_for_branch(
         }
         let full_path = format!("{}/{}", db.root_uri, entry.dataset_path);
         let first_touch = active_branch.is_some()
-            && entry.native_dataset_branch.as_deref() != active_branch.as_deref();
+            && entry.native_dataset_branch.as_deref() != native_branch.as_deref();
         let ds = if first_touch {
             db.storage().open_snapshot_at_entry(entry).await?
         } else {
             db.storage()
-                .open_dataset_head(&full_path, active_branch.as_deref())
+                .open_dataset_head(&full_path, native_branch.as_deref())
                 .await?
         };
         let work = plan_index_work_edge_on_dataset(db, &ds).await?;
@@ -218,7 +223,7 @@ pub(super) async fn ensure_indices_for_branch(
                 expected_version: entry.published_dataset_version,
                 post_commit_pin: entry.published_dataset_version + 1,
                 confirmed_version: None,
-                table_branch: active_branch.clone(),
+                table_branch: native_branch.clone(),
             });
             if !first_touch {
                 let staged = db
@@ -249,9 +254,12 @@ pub(super) async fn ensure_indices_for_branch(
         }
     }
 
+    // Queue keys stay LOGICAL: branch lifecycle ops (create/delete/merge) gate
+    // per-table work by the logical branch name, and mutual exclusion needs
+    // one shared vocabulary. `pin.table_branch` now carries the native ref.
     let queue_keys: Vec<(String, Option<String>)> = recovery_pins
         .iter()
-        .map(|pin| (pin.table_key.clone(), pin.table_branch.clone()))
+        .map(|pin| (pin.table_key.clone(), active_branch.clone()))
         .collect();
     let _schema_guard = db
         .write_queue()
@@ -322,7 +330,7 @@ pub(super) async fn ensure_indices_for_branch(
             )
             .await?;
         } else if let Some(source) = first_touch_sources.get(&pin.table_key) {
-            let target_branch = active_branch.as_deref().ok_or_else(|| {
+            let target_branch = native_branch.as_deref().ok_or_else(|| {
                 OmniError::manifest_internal(format!(
                     "first-touch index target '{}' has no active named branch",
                     pin.table_key,
@@ -407,10 +415,10 @@ pub(super) async fn ensure_indices_for_branch(
                 })?;
                 let full_path = pin.table_path.clone();
                 let first_touch = first_touch_source_versions.contains_key(&pin.identity);
-                let (ds, resolved_branch) = match active_branch.as_deref() {
-                    Some(active_branch) => {
+                let (ds, resolved_branch) = match native_branch.as_deref() {
+                    Some(native_branch) => {
                         if let Some(ds) = existing_targets.remove(&table_key) {
-                            (ds, Some(active_branch.to_string()))
+                            (ds, Some(native_branch.to_string()))
                         } else {
                             first_touch_sources.remove(&table_key).ok_or_else(|| {
                                 OmniError::manifest_internal(format!(
@@ -425,7 +433,7 @@ pub(super) async fn ensure_indices_for_branch(
                                 &full_path,
                                 entry.native_dataset_branch.as_deref(),
                                 entry.published_dataset_version,
-                                active_branch,
+                                native_branch,
                                 crate::db::MutationOpKind::SchemaRewrite,
                                 true,
                             )
@@ -887,11 +895,30 @@ pub(super) async fn open_for_mutation_on_branch(
     // base is the same fresh per-branch manifest read the no-txn path would have
     // resolved — only the redundant schema re-validation is dropped. Without a txn
     // this is byte-identical to the prior `resolved_branch_target` call.
-    let (snapshot, resolved_branch) = match txn {
-        Some(txn) => (txn.base.clone(), txn.branch.clone()),
+    // `native_branch` is the Lance ref of the resolved branch's captured life
+    // (issue #562): every dataset open, fork target, and returned
+    // `table_branch` below addresses it. Legacy branches carry their bare
+    // name; main is `None`.
+    let (snapshot, native_branch) = match txn {
+        Some(txn) => (txn.base.clone(), txn.native_branch().map(str::to_string)),
         None => {
             let resolved = db.resolved_branch_target(branch).await?;
-            (resolved.snapshot, resolved.branch)
+            // The no-txn entry (`open_for_mutation`, branch merge) always
+            // opens the handle's bound branch, so the bound coordinator's
+            // captured native ref is the resolved branch's life.
+            let native = {
+                let coord = db.coordinator.read().await;
+                if coord.current_branch() != resolved.branch.as_deref() {
+                    return Err(OmniError::manifest_internal(format!(
+                        "mutation open without a WriteTxn resolved branch {:?} \
+                         but the handle is bound to {:?}",
+                        resolved.branch,
+                        coord.current_branch(),
+                    )));
+                }
+                coord.native_branch().map(str::to_string)
+            };
+            (resolved.snapshot, native)
         }
     };
     let entry = snapshot
@@ -915,17 +942,17 @@ pub(super) async fn open_for_mutation_on_branch(
     // the resolved branch) opens too (the fork is a real Lance state advance the
     // manifest snapshot can't substitute for).
     if txn.is_some() && !op_kind.strict_pre_stage_version_check() {
-        match resolved_branch.as_deref() {
+        match native_branch.as_deref() {
             // Non-strict, table already on the active branch → no open, no fork.
-            Some(active_branch)
-                if entry.native_dataset_branch.as_deref() == Some(active_branch) =>
+            Some(native_branch)
+                if entry.native_dataset_branch.as_deref() == Some(native_branch) =>
             {
                 return Ok(OpenedForMutation {
                     identity: entry.identity,
                     handle: None,
                     expected_version: entry.published_dataset_version,
                     full_path,
-                    table_branch: Some(active_branch.to_string()),
+                    table_branch: Some(native_branch.to_string()),
                     deferred_fork: None,
                 });
             }
@@ -946,7 +973,7 @@ pub(super) async fn open_for_mutation_on_branch(
         }
     }
 
-    match resolved_branch.as_deref() {
+    match native_branch.as_deref() {
         None => {
             let ds = db.storage().open_dataset_head(&full_path, None).await?;
             if op_kind.strict_pre_stage_version_check() {
@@ -975,23 +1002,23 @@ pub(super) async fn open_for_mutation_on_branch(
                 deferred_fork: None,
             })
         }
-        Some(active_branch) => {
+        Some(native_branch) => {
             // RFC-022-enrolled mutation/load adapters must arm durable intent
             // before creating a per-table Lance branch ref. Read and stage from
             // the inherited source entry now; `commit_all` creates the target
             // ref after its v9 sidecar is durable, then commits this transaction
             // onto the new ref. Legacy writers retain the eager fork path below.
-            if txn.is_some() && entry.native_dataset_branch.as_deref() != Some(active_branch) {
+            if txn.is_some() && entry.native_dataset_branch.as_deref() != Some(native_branch) {
                 let ds = db.storage().open_snapshot_at_entry(entry).await?;
                 return Ok(OpenedForMutation {
                     identity: entry.identity,
                     handle: Some(ds),
                     expected_version: entry.published_dataset_version,
                     full_path,
-                    table_branch: Some(active_branch.to_string()),
+                    table_branch: Some(native_branch.to_string()),
                     deferred_fork: Some(DeferredTableFork {
                         source_entry: entry.clone(),
-                        target_branch: active_branch.to_string(),
+                        target_branch: native_branch.to_string(),
                     }),
                 });
             }
@@ -1002,7 +1029,7 @@ pub(super) async fn open_for_mutation_on_branch(
                 &full_path,
                 entry.native_dataset_branch.as_deref(),
                 entry.published_dataset_version,
-                active_branch,
+                native_branch,
                 op_kind,
                 txn.is_some(),
             )
@@ -1027,15 +1054,15 @@ pub(super) async fn open_owned_dataset_for_branch_write(
     full_path: &str,
     entry_branch: Option<&str>,
     entry_version: u64,
-    active_branch: &str,
+    native_branch: &str,
     op_kind: crate::db::MutationOpKind,
     occ_enrolled: bool,
 ) -> Result<(SnapshotHandle, Option<String>)> {
     match entry_branch {
-        Some(branch) if branch == active_branch => {
+        Some(branch) if branch == native_branch => {
             let ds = db
                 .storage()
-                .open_dataset_head(full_path, Some(active_branch))
+                .open_dataset_head(full_path, Some(native_branch))
                 .await?;
             if op_kind.strict_pre_stage_version_check() {
                 if occ_enrolled && ds.version() != entry_version {
@@ -1050,7 +1077,7 @@ pub(super) async fn open_owned_dataset_for_branch_write(
                         .ensure_expected_version(&ds, table_key, entry_version)?;
                 }
             }
-            Ok((ds, Some(active_branch.to_string())))
+            Ok((ds, Some(native_branch.to_string())))
         }
         source_branch => {
             crate::failpoints::maybe_fail(crate::failpoints::names::FORK_BEFORE_CLASSIFY)?;
@@ -1058,10 +1085,13 @@ pub(super) async fn open_owned_dataset_for_branch_write(
             // table is already forked on active_branch, a concurrent first-write
             // won the race and our snapshot is stale — that is a retryable
             // conflict, not an orphan. (A zombie fork is never in the manifest,
-            // so this only fires for a live concurrent fork.)
-            let live = db.snapshot_for_branch(Some(active_branch)).await?;
+            // so this only fires for a live concurrent fork.) The graph branch
+            // opens by its LOGICAL name, recovered from the native ref.
+            let (logical_branch, _) =
+                crate::db::branch_identity::split_native_branch_ref(native_branch);
+            let live = db.snapshot_for_branch(Some(logical_branch)).await?;
             if let Some(entry) = live.dataset(table_key) {
-                if entry.native_dataset_branch.as_deref() == Some(active_branch) {
+                if entry.native_dataset_branch.as_deref() == Some(native_branch) {
                     return if occ_enrolled {
                         Err(OmniError::manifest_read_set_changed(
                             format!("published_dataset_version:{table_key}"),
@@ -1090,18 +1120,18 @@ pub(super) async fn open_owned_dataset_for_branch_write(
                 full_path,
                 source_branch,
                 entry_version,
-                active_branch,
+                native_branch,
             )
             .await?;
             let ds = db
                 .storage()
-                .open_dataset_head(full_path, Some(active_branch))
+                .open_dataset_head(full_path, Some(native_branch))
                 .await?;
             if op_kind.strict_pre_stage_version_check() {
                 db.storage()
                     .ensure_expected_version(&ds, table_key, entry_version)?;
             }
-            Ok((ds, Some(active_branch.to_string())))
+            Ok((ds, Some(native_branch.to_string())))
         }
     }
 }
@@ -1112,7 +1142,7 @@ pub(super) async fn fork_dataset_from_entry_state(
     full_path: &str,
     source_branch: Option<&str>,
     source_version: u64,
-    active_branch: &str,
+    native_branch: &str,
 ) -> Result<crate::storage_layer::ForkOutcome<SnapshotHandle>> {
     db.storage()
         .fork_branch_from_state(
@@ -1120,7 +1150,7 @@ pub(super) async fn fork_dataset_from_entry_state(
             source_branch,
             table_key,
             source_version,
-            active_branch,
+            native_branch,
         )
         .await
 }
@@ -1153,9 +1183,14 @@ pub(crate) async fn classify_fork_ref(
     db: &Omnigraph,
     _table_key: &str,
     identity: crate::db::manifest::TableIdentity,
-    branch: &str,
+    native_branch: &str,
     excluding_operation_id: Option<&str>,
 ) -> ForkRefStatus {
+    // `native_branch` names the Lance ref under classification (issue #562).
+    // Sidecar identity, graph-branch resolution, and the graph branch list all
+    // speak the LOGICAL name, recovered by splitting off the incarnation
+    // token; pin.table_branch and `native_dataset_branch` stay native.
+    let (logical_branch, _) = crate::db::branch_identity::split_native_branch_ref(native_branch);
     // Deferred mutation/load forks are created only after their v9 sidecar is
     // durable. Until the manifest publish places this table on `branch`, that
     // sidecar is the only durable ownership record for the ref. Treat a
@@ -1172,11 +1207,10 @@ pub(crate) async fn classify_fork_ref(
         };
     if sidecars.iter().any(|sidecar| {
         Some(sidecar.operation_id.as_str()) != excluding_operation_id
-            && sidecar.branch.as_deref() == Some(branch)
-            && sidecar
-                .tables
-                .iter()
-                .any(|pin| pin.identity == identity && pin.table_branch.as_deref() == Some(branch))
+            && sidecar.branch.as_deref() == Some(logical_branch)
+            && sidecar.tables.iter().any(|pin| {
+                pin.identity == identity && pin.table_branch.as_deref() == Some(native_branch)
+            })
     }) {
         return ForkRefStatus::Indeterminate;
     }
@@ -1186,7 +1220,7 @@ pub(crate) async fn classify_fork_ref(
     // test exercise the Indeterminate path — a read failure on a live branch
     // must classify as Indeterminate (skip), never Orphan (destroy).
     let fresh = match crate::failpoints::maybe_fail(crate::failpoints::names::CLASSIFY_FRESH_READ) {
-        Ok(()) => db.fresh_snapshot_for_branch(Some(branch)).await,
+        Ok(()) => db.fresh_snapshot_for_branch(Some(logical_branch)).await,
         Err(injected) => Err(injected),
     };
     match fresh {
@@ -1194,7 +1228,7 @@ pub(crate) async fn classify_fork_ref(
             let placed = snap
                 .datasets()
                 .find(|entry| entry.identity == identity)
-                .map(|e| e.native_dataset_branch.as_deref() == Some(branch))
+                .map(|e| e.native_dataset_branch.as_deref() == Some(native_branch))
                 .unwrap_or(false);
             if placed {
                 ForkRefStatus::Legitimate
@@ -1204,11 +1238,12 @@ pub(crate) async fn classify_fork_ref(
                 ForkRefStatus::Orphan
             }
         }
-        // Branch did not resolve. `all_branches` lists `_refs/branches/` live, so
-        // absent there = genuinely no such manifest branch (origin-1 orphan);
-        // present (or a list error) = transient read — never destroy on that.
+        // Branch did not resolve. `all_branches` lists live LOGICAL graph
+        // branches, so absent there = genuinely no such manifest branch
+        // (origin-1 orphan); present (or a list error) = transient read —
+        // never destroy on that.
         Err(_) => match db.coordinator.read().await.all_branches().await {
-            Ok(fresh) if !fresh.iter().any(|b| b == branch) => ForkRefStatus::Orphan,
+            Ok(fresh) if !fresh.iter().any(|b| b == logical_branch) => ForkRefStatus::Orphan,
             _ => ForkRefStatus::Indeterminate,
         },
     }
@@ -1240,9 +1275,12 @@ pub(super) async fn reclaim_orphaned_fork_and_refork(
     full_path: &str,
     source_branch: Option<&str>,
     source_version: u64,
-    active_branch: &str,
+    native_branch: &str,
     current_operation_id: Option<&str>,
 ) -> Result<SnapshotHandle> {
+    // `native_branch` is the Lance ref being reclaimed/re-forked (issue #562);
+    // sidecar identity and graph-branch snapshots speak the LOGICAL name.
+    let (logical_branch, _) = crate::db::branch_identity::split_native_branch_ref(native_branch);
     // The immutable identity and physical target are one authority fact. Keep
     // them coupled here as a final destructive-operation guard: an old
     // incarnation must never authorize deleting a ref on a replacement table's
@@ -1265,13 +1303,13 @@ pub(super) async fn reclaim_orphaned_fork_and_refork(
     let sidecars = crate::db::manifest::list_sidecars(db.root_uri(), db.storage_adapter()).await?;
     if let Some(owner) = sidecars.iter().find(|sidecar| {
         Some(sidecar.operation_id.as_str()) != current_operation_id
-            && sidecar.branch.as_deref() == Some(active_branch)
+            && sidecar.branch.as_deref() == Some(logical_branch)
             && sidecar.tables.iter().any(|pin| {
-                pin.identity == identity && pin.table_branch.as_deref() == Some(active_branch)
+                pin.identity == identity && pin.table_branch.as_deref() == Some(native_branch)
             })
     }) {
         return Err(OmniError::manifest_read_set_changed(
-            format!("fork_intent:{active_branch}:{table_key}"),
+            format!("fork_intent:{native_branch}:{table_key}"),
             None,
             Some(owner.operation_id.clone()),
         ));
@@ -1282,11 +1320,11 @@ pub(super) async fn reclaim_orphaned_fork_and_refork(
     // a real fork despite the caller's possibly-cached proof) or an
     // Indeterminate one (transient read) surfaces a retryable conflict rather
     // than stranding the manifest at a version the recreated ref won't have.
-    match classify_fork_ref(db, table_key, identity, active_branch, current_operation_id).await {
+    match classify_fork_ref(db, table_key, identity, native_branch, current_operation_id).await {
         ForkRefStatus::Orphan => {}
         ForkRefStatus::Legitimate => {
             let actual = db
-                .fresh_snapshot_for_branch(Some(active_branch))
+                .fresh_snapshot_for_branch(Some(logical_branch))
                 .await
                 .ok()
                 .and_then(|s| {
@@ -1310,7 +1348,7 @@ pub(super) async fn reclaim_orphaned_fork_and_refork(
         }
         ForkRefStatus::Indeterminate => {
             return Err(OmniError::manifest_conflict(format!(
-                "could not verify whether branch '{active_branch}' still owns an orphaned \
+                "could not verify whether branch '{logical_branch}' still owns an orphaned \
                  fork for table '{table_key}' because fresh manifest authority was \
                  unavailable; refresh and retry"
             )));
@@ -1319,7 +1357,7 @@ pub(super) async fn reclaim_orphaned_fork_and_refork(
 
     crate::failpoints::maybe_fail(crate::failpoints::names::FORK_BEFORE_RECLAIM)?;
     db.storage()
-        .force_delete_branch(full_path, active_branch)
+        .force_delete_branch(full_path, native_branch)
         .await
         .map_err(|e| {
             // Lance refuses to delete a branch with dependent child branches
@@ -1331,7 +1369,7 @@ pub(super) async fn reclaim_orphaned_fork_and_refork(
             // is the durable follow-up.
             if e.to_string().contains("referenc") {
                 OmniError::manifest_conflict(format!(
-                    "branch '{active_branch}' cannot reclaim the leftover fork for \
+                    "branch '{logical_branch}' cannot reclaim the leftover fork for \
                      table '{table_key}' because it has dependent child branches; \
                      delete the child branches (or run `omnigraph cleanup`) first"
                 ))
@@ -1346,13 +1384,13 @@ pub(super) async fn reclaim_orphaned_fork_and_refork(
         full_path,
         source_branch,
         source_version,
-        active_branch,
+        native_branch,
     )
     .await?
     {
         crate::storage_layer::ForkOutcome::Created(ds) => Ok(ds),
         crate::storage_layer::ForkOutcome::RefAlreadyExists => {
-            let live = db.fresh_snapshot_for_branch(Some(active_branch)).await?;
+            let live = db.fresh_snapshot_for_branch(Some(logical_branch)).await?;
             let actual = live
                 .datasets()
                 .find(|entry| entry.identity == identity)
@@ -1754,6 +1792,20 @@ mod classify_fork_ref_tests {
         format!("{}/{}", db.root_uri, entry.dataset_path)
     }
 
+    /// The table's live fork ref for a logical branch: `{logical}--{ulid}`
+    /// under issue #562, or the bare name for legacy/forged refs.
+    async fn table_fork_ref(table_uri: &str, logical: &str) -> String {
+        // forbidden-api-allow: test inspects the raw Lance ref names directly.
+        let ds = lance::Dataset::open(table_uri).await.unwrap();
+        let prefix = format!("{logical}--");
+        ds.list_branches()
+            .await
+            .unwrap()
+            .into_keys()
+            .find(|name| name == logical || name.starts_with(&prefix))
+            .unwrap_or_else(|| panic!("no fork ref for '{logical}'"))
+    }
+
     #[tokio::test]
     async fn classify_distinguishes_legitimate_unreferenced_and_ghost() {
         let dir = tempfile::tempdir().unwrap();
@@ -1776,8 +1828,12 @@ mod classify_fork_ref_tests {
         let feature_snapshot = db.snapshot_for_branch(Some("feature")).await.unwrap();
         let company_identity = feature_snapshot.dataset("node:Company").unwrap().identity;
         let person_identity = feature_snapshot.dataset("node:Person").unwrap().identity;
+        // The engine forked Company at the feature life's NATIVE ref; classify
+        // takes the ref under decision, exactly as the reclaim sites pass it.
+        let company = node_path(&db, "feature", "node:Company").await;
+        let company_fork = table_fork_ref(&company, "feature").await;
         assert_eq!(
-            classify_fork_ref(&db, "node:Company", company_identity, "feature", None,).await,
+            classify_fork_ref(&db, "node:Company", company_identity, &company_fork, None,).await,
             ForkRefStatus::Legitimate,
             "a manifest-placed fork must classify as Legitimate (never destroyed)"
         );
@@ -1838,20 +1894,21 @@ mod classify_fork_ref_tests {
         .await
         .unwrap();
 
+        let full_path = db.storage().dataset_uri(&new_entry.dataset_path);
+        let feature_fork = table_fork_ref(&full_path, "feature").await;
         assert_eq!(
-            classify_fork_ref(&db, "node:Person", new_identity, "feature", None).await,
+            classify_fork_ref(&db, "node:Person", new_identity, &feature_fork, None).await,
             ForkRefStatus::Legitimate
         );
         assert_eq!(
-            classify_fork_ref(&db, "node:Person", old_identity, "feature", None).await,
+            classify_fork_ref(&db, "node:Person", old_identity, &feature_fork, None).await,
             ForkRefStatus::Orphan,
             "a live placement under the reused alias belongs only to the new incarnation"
         );
 
-        let full_path = db.storage().dataset_uri(&new_entry.dataset_path);
         let before = db
             .storage()
-            .open_dataset_head(&full_path, Some("feature"))
+            .open_dataset_head(&full_path, Some(&feature_fork))
             .await
             .unwrap();
         let before_identifier = db.storage().branch_identifier(&before).await.unwrap();
@@ -1862,14 +1919,14 @@ mod classify_fork_ref_tests {
             &full_path,
             None,
             new_entry.published_dataset_version,
-            "feature",
+            &feature_fork,
             None,
         )
         .await
         .expect_err("a stale identity must not authorize deletion on the replacement path");
         let after = db
             .storage()
-            .open_dataset_head(&full_path, Some("feature"))
+            .open_dataset_head(&full_path, Some(&feature_fork))
             .await
             .unwrap();
         let after_identifier = db.storage().branch_identifier(&after).await.unwrap();

--- a/crates/omnigraph/src/exec/merge.rs
+++ b/crates/omnigraph/src/exec/merge.rs
@@ -4656,7 +4656,11 @@ impl Omnigraph {
         ordered_table_keys.sort();
 
         let mut conflicts = Vec::new();
-        let target_active = self.active_branch().await;
+        // The adopt classifiers and publishers compare against persisted
+        // `native_dataset_branch` values and choose fork targets, so they
+        // speak the target life's NATIVE ref (issue #562), captured with the
+        // target txn's authority.
+        let target_active = target_txn.native_branch().map(str::to_string);
         let mut candidates: HashMap<String, CandidateTableState> = HashMap::new();
         let empty_external_preflight = crate::table_store::ExternalBlobPreflight::default();
         let mut blob_table_keys = HashSet::new();
@@ -4970,7 +4974,10 @@ impl Omnigraph {
         let final_revalidation_timing = crate::instrumentation::start_merge_timing(
             crate::instrumentation::MergeTimingPhase::FinalRevalidation,
         );
+        // Queue keys and the sidecar's own identity stay LOGICAL; per-table
+        // pins and planned output branches carry the target life's NATIVE ref.
         let active_branch_for_keys = target_branch.map(str::to_string);
+        let target_native = target_txn.native_branch().map(str::to_string);
         let merge_branches = [
             source_branch.map(str::to_string),
             active_branch_for_keys.clone(),
@@ -5132,9 +5139,12 @@ impl Omnigraph {
             let planned_output_branch = match candidate {
                 CandidateTableState::RewriteMerged(_)
                 | CandidateTableState::AdoptWithDelta(_)
-                | CandidateTableState::AdoptPureInserts(_) => active_branch_for_keys.clone(),
+                | CandidateTableState::AdoptPureInserts(_) => target_native.clone(),
                 CandidateTableState::AdoptSourceState { .. } => {
-                    match (target_branch, source_entry.native_dataset_branch.as_deref()) {
+                    match (
+                        target_txn.native_branch(),
+                        source_entry.native_dataset_branch.as_deref(),
+                    ) {
                         (Some(target), Some(_)) => Some(target.to_string()),
                         _ => None,
                     }
@@ -5158,7 +5168,8 @@ impl Omnigraph {
                             table_key
                         ))
                     })?;
-                    let source_fork_version = target_branch
+                    let source_fork_version = target_txn
+                        .native_branch()
                         .filter(|target| entry.native_dataset_branch.as_deref() != Some(*target))
                         .map(|_| entry.published_dataset_version);
                     if source_fork_version.is_some()
@@ -5200,7 +5211,7 @@ impl Omnigraph {
                         expected_version,
                         post_commit_pin: expected_version + 1,
                         confirmed_version: None,
-                        table_branch: active_branch_for_keys.clone(),
+                        table_branch: target_native.clone(),
                     });
                     recovery_effects.push(crate::db::manifest::RecoveryBranchMergeEffect {
                         identity,
@@ -5214,7 +5225,7 @@ impl Omnigraph {
                     });
                 }
                 CandidateTableState::AdoptSourceState { .. } => {
-                    let Some(target) = target_branch else {
+                    let Some(target) = target_txn.native_branch() else {
                         continue;
                     };
                     let creates_target_ref = source_entry.native_dataset_branch.is_some()
@@ -5447,7 +5458,7 @@ impl Omnigraph {
                     }
                 };
                 if first_touch_effects.contains(table_key) {
-                    let target = target_branch.ok_or_else(|| {
+                    let target = target_txn.native_branch().ok_or_else(|| {
                         OmniError::manifest_internal(format!(
                             "first-touch merge effect '{}' has no named target branch",
                             table_key

--- a/crates/omnigraph/src/exec/staging.rs
+++ b/crates/omnigraph/src/exec/staging.rs
@@ -1109,7 +1109,16 @@ impl StagedMutation {
         // manifest on the happy path.
         let mut queue_keys: Vec<(String, Option<String>)> = Vec::with_capacity(staged.len());
         for entry in &staged {
-            queue_keys.push((entry.table_key.clone(), entry.path.table_branch.clone()));
+            // Queue keys stay LOGICAL — branch lifecycle ops gate per-table
+            // work by the logical name, and mutual exclusion needs one shared
+            // vocabulary. `table_branch` carries the life's native ref
+            // (issue #562), so split the incarnation token back off.
+            let logical_branch = entry.path.table_branch.as_deref().map(|native| {
+                crate::db::branch_identity::split_native_branch_ref(native)
+                    .0
+                    .to_string()
+            });
+            queue_keys.push((entry.table_key.clone(), logical_branch));
         }
         // Total order shared with schema apply: schema gate, branch gate, then
         // sorted per-table gates. Hold the full set through manifest publish.

--- a/crates/omnigraph/src/failpoints.rs
+++ b/crates/omnigraph/src/failpoints.rs
@@ -136,6 +136,12 @@ pub mod names {
     /// OmniGraph acknowledges it. Recovery must classify the matching
     /// BranchContents as a completed create (lost acknowledgement).
     pub const BRANCH_CREATE_POST_NATIVE: &str = "branch_create.post_native";
+    /// Issue #562 create crash window: the branch-registry row (the existence
+    /// authority) is committed, the life's native ref is not yet created.
+    /// Forward recovery must complete the ref on the next resolution of the
+    /// logical name; a same-name create must conflict.
+    pub const BRANCH_CREATE_POST_REGISTRY_PRE_NATIVE: &str =
+        "branch_create.post_registry_pre_native";
     pub const BRANCH_DELETE_BEFORE_TABLE_CLEANUP: &str = "branch_delete.before_table_cleanup";
     /// After Lance returns success from native delete, before OmniGraph
     /// acknowledges it. Recovery must classify the absent BranchContents as a

--- a/crates/omnigraph/tests/branch_control_cost.rs
+++ b/crates/omnigraph/tests/branch_control_cost.rs
@@ -52,7 +52,15 @@ where
 /// that reintroduces a second per-branch `__manifest` read re-trips this gate.
 /// `SLOPE_SLACK` absorbs incidental constant-ish noise without admitting a
 /// second per-branch open.
-const DELETE_PER_BRANCH_BUDGET: u64 = 1;
+/// Issue #562 re-measure: the registry-backed delete adds bounded per-branch
+/// reads on top of the one probe snapshot — the `delete_branch_with_expected`
+/// identifier pre-check lists BranchContents, and each per-candidate probe
+/// checks out the candidate's native ref (its contents + version manifest).
+/// Measured slope on this fixture: 5.5 reads / 1.0 opens per surviving branch
+/// (44 reads, 8 opens across 8 added branches, manifest compacted before each
+/// measure). The gate still catches the historical regression it exists for:
+/// a full cold resolve per branch measured ~31 reads per branch pre-fix.
+const DELETE_PER_BRANCH_BUDGET: u64 = 6;
 const SLOPE_SLACK: u64 = 2;
 
 /// `branch_delete`'s dependency check visits every surviving branch, so its
@@ -79,6 +87,13 @@ fn branch_delete_manifest_reads_bounded_per_surviving_branch() {
                         .unwrap();
                     created += 1;
                 }
+                // Issue #562: each branch create commits one registry row,
+                // appending a `__manifest` fragment, and every manifest scan
+                // in the delete flow pays one read per fragment. Compact
+                // before measuring so the slope isolates the per-branch
+                // dependency-check cost this gate guards, not fragment bloat
+                // that ordinary maintenance folds away.
+                db.optimize().await.unwrap();
                 let victim = format!("victim_{n}");
                 db.branch_create(&victim).await.unwrap();
                 let (res, io) = measure(db.branch_delete(&victim)).await;

--- a/crates/omnigraph/tests/branching.rs
+++ b/crates/omnigraph/tests/branching.rs
@@ -187,6 +187,18 @@ async fn assert_exact_id_primary_key_on_branch(db: &Omnigraph, branch: &str, tab
     );
 }
 
+/// Assert a persisted `native_dataset_branch` names a life of `logical`
+/// (issue #562): the ULID-suffixed native ref `{logical}--{ulid}`, or the
+/// bare name for a legacy fork.
+#[track_caller]
+fn assert_native_branch_of(native: Option<&str>, logical: &str) {
+    let native = native.unwrap_or_else(|| panic!("expected a fork of '{logical}', got None"));
+    assert!(
+        native == logical || native.starts_with(&format!("{logical}--")),
+        "expected a life of '{logical}', got '{native}'"
+    );
+}
+
 #[tokio::test]
 async fn branch_create_open_list_and_lazy_branching_work() {
     let dir = tempfile::tempdir().unwrap();
@@ -200,19 +212,29 @@ async fn branch_create_open_list_and_lazy_branching_work() {
         .clone();
 
     main.branch_create("feature").await.unwrap();
-    // Reproduce Lance's phase-1-only crash state: keep the shallow-cloned
-    // `tree/feature` dataset but remove BranchContents, its sole logical
-    // authority. A same-name graph create must reclaim the zombie and retry,
-    // rather than surfacing DatasetAlreadyExists forever.
-    std::fs::remove_file(
-        dir.path()
-            .join("__manifest")
-            .join("_refs")
-            .join("branches")
-            .join("feature.json"),
-    )
-    .unwrap();
-    main.branch_create("feature").await.unwrap();
+    // Reproduce the create crash window under the #562 registry: keep the
+    // shallow-cloned tree dataset but remove the life's native ref file. The
+    // registry row on the root `__manifest` is the existence authority, so
+    // the logical name stays taken — a same-name create must CONFLICT (not
+    // reclaim), and the next resolution of the name completes the missing
+    // native ref (forward recovery) instead.
+    let branches_dir = dir.path().join("__manifest").join("_refs").join("branches");
+    let native_ref_file = std::fs::read_dir(&branches_dir)
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .find(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("feature--"))
+        })
+        .expect("the feature branch must own a ULID-suffixed native ref file");
+    std::fs::remove_file(native_ref_file).unwrap();
+    let err = main.branch_create("feature").await.unwrap_err();
+    assert!(
+        err.to_string().contains("already exists"),
+        "the registry row is the existence authority; a same-name create over \
+         a refless live row must conflict, got: {err}"
+    );
     assert_eq!(main.branch_list().await.unwrap(), vec!["main", "feature"]);
 
     let mut feature = Omnigraph::open(uri).await.unwrap();
@@ -249,12 +271,15 @@ async fn branch_create_open_list_and_lazy_branching_work() {
         main_person.dataset_path,
         "the first lazy fork must preserve the logical table identity/path"
     );
-    assert_eq!(
-        snap.dataset("node:Person")
-            .unwrap()
-            .native_dataset_branch
-            .as_deref(),
-        Some("feature")
+    let person_fork_branch = snap
+        .dataset("node:Person")
+        .unwrap()
+        .native_dataset_branch
+        .clone()
+        .expect("first write must fork node:Person onto the branch");
+    assert!(
+        person_fork_branch.starts_with("feature--"),
+        "the fork must land on the life's native ref: {person_fork_branch}"
     );
     assert_eq!(
         snap.dataset("edge:Knows")
@@ -811,13 +836,25 @@ async fn blob_named_branch_delete_recreate_never_retargets_cached_or_snapshot_re
         .unwrap()
         .clone();
     assert_eq!(new_entry.dataset_path, old_entry.dataset_path);
-    assert_eq!(
-        new_entry.native_dataset_branch,
-        old_entry.native_dataset_branch
-    );
-    assert_eq!(
-        new_entry.published_dataset_version, old_entry.published_dataset_version,
-        "ABA fixture must recreate the same named ref at the same numeric table version"
+    // Pre-#562 this fixture engineered the dangerous collision: same ref
+    // name, same path, same numeric version across the two lives. The
+    // incarnation rotation makes that collision impossible by construction —
+    // each life owns a distinct `feature--{ulid}` native ref — and THAT is
+    // now the pinned structural fact; the behavior claims below (fresh bytes,
+    // distinct strong ETag, loud stale-snapshot refusal) are unchanged.
+    let old_native = old_entry
+        .native_dataset_branch
+        .as_deref()
+        .expect("old life must own the forked Blob table");
+    let new_native = new_entry
+        .native_dataset_branch
+        .as_deref()
+        .expect("new life must own the forked Blob table");
+    assert_native_branch_of(Some(old_native), "feature");
+    assert_native_branch_of(Some(new_native), "feature");
+    assert_ne!(
+        old_native, new_native,
+        "each branch life must own a distinct native ref (issue #562)"
     );
     // Reuse the same main-bound handle that cached the old feature table. On a
     // local filesystem the cache key has no manifest e-tag, so the Blob facade
@@ -850,21 +887,23 @@ async fn blob_named_branch_delete_recreate_never_retargets_cached_or_snapshot_re
         )
         .await
         .expect_err("an old snapshot must never reopen the recreated branch's bytes");
+    // Two refusal shapes are loud and correct: the typed incarnation-witness
+    // BadRequest (commit resolution's structural re-prove), or — since the
+    // #562 rotation gives each life its own `feature--{ulid}` ref — a
+    // structural death of the stale pin: the old life's tree is deleted with
+    // its ref, so the read dies NotFound on the dead native ref and can never
+    // reach the replacement life's bytes.
+    let refused_typed = matches!(
+        stale_snapshot_error,
+        OmniError::Manifest(ref error)
+            if error.kind == ManifestErrorKind::BadRequest
+                && error
+                    .message
+                    .contains("has no persisted native-branch incarnation witness")
+    );
+    let died_structurally = stale_snapshot_error.to_string().contains("feature--");
     assert!(
-        matches!(
-            stale_snapshot_error,
-            OmniError::Manifest(ref error)
-                if error.kind == ManifestErrorKind::BadRequest
-                    // The commit-level snapshot resolution now performs the
-                    // structural head re-prove first, so this scenario is
-                    // refused there; the Blob-level witness remains for the
-                    // windows commit resolution cannot see (post-capture
-                    // table-open ABA, pinned by the failpoint cells). Either
-                    // refusal carries the shared incarnation-witness phrase.
-                    && error
-                        .message
-                        .contains("has no persisted native-branch incarnation witness")
-        ),
+        refused_typed || died_structurally,
         "named-branch ABA must fail loudly instead of retargeting; got {stale_snapshot_error:?}"
     );
 }
@@ -961,13 +1000,12 @@ node Marker {
     .unwrap();
     db.branch_create("feature").await.unwrap();
 
-    assert_eq!(
-        db.graph_manifest_version_of(ReadTarget::branch("feature"))
-            .await
-            .unwrap(),
-        old_feature_version,
-        "the replacement ref must reuse the old manifest version for this ABA regression"
-    );
+    // Pre-#562 this fixture engineered the replacement ref onto the SAME
+    // numeric manifest version, which is what made the stale snapshot look
+    // current. The incarnation rotation forks each life onto its own native
+    // ref, so the version collision is no longer constructible — the loud
+    // refusal below is the protected behavior and must hold regardless.
+    let _ = old_feature_version;
     let replacement_entry = db
         .snapshot_of(ReadTarget::branch("feature"))
         .await
@@ -993,21 +1031,20 @@ node Marker {
         )
         .await
         .expect_err("an inherited-main table must not bypass named graph-ref ABA fencing");
+    // Same two loud refusal shapes as the owned-table ABA test above: the
+    // typed incarnation-witness BadRequest, or the stale pin dying NotFound
+    // on the deleted life's `feature--{ulid}` native ref (issue #562).
+    let refused_typed = matches!(
+        stale_snapshot_error,
+        OmniError::Manifest(ref error)
+            if error.kind == ManifestErrorKind::BadRequest
+                && error
+                    .message
+                    .contains("has no persisted native-branch incarnation witness")
+    );
+    let died_structurally = stale_snapshot_error.to_string().contains("feature--");
     assert!(
-        matches!(
-            stale_snapshot_error,
-            OmniError::Manifest(ref error)
-                if error.kind == ManifestErrorKind::BadRequest
-                    // The commit-level snapshot resolution now performs the
-                    // structural head re-prove first, so this scenario is
-                    // refused there; the Blob-level witness remains for the
-                    // windows commit resolution cannot see (post-capture
-                    // table-open ABA, pinned by the failpoint cells). Either
-                    // refusal carries the shared incarnation-witness phrase.
-                    && error
-                        .message
-                        .contains("has no persisted native-branch incarnation witness")
-        ),
+        refused_typed || died_structurally,
         "named graph-ref ABA must fail loudly even when the Blob table is inherited from main; got {stale_snapshot_error:?}"
     );
 }
@@ -2477,18 +2514,29 @@ async fn branch_created_from_non_main_inherits_branch_state() {
         .branch_create_from(ReadTarget::branch("feature"), "experiment")
         .await
         .unwrap();
-    std::fs::remove_file(
-        dir.path()
-            .join("__manifest")
-            .join("_refs")
-            .join("branches")
-            .join("experiment.json"),
-    )
-    .unwrap();
-    feature
+    // Create crash window under the #562 registry (non-main source): the
+    // registry row is the existence authority, so a same-name create must
+    // conflict, and the next resolution completes the missing native ref.
+    let branches_dir = dir.path().join("__manifest").join("_refs").join("branches");
+    let native_ref_file = std::fs::read_dir(&branches_dir)
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .find(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("experiment--"))
+        })
+        .expect("the experiment branch must own a ULID-suffixed native ref file");
+    std::fs::remove_file(native_ref_file).unwrap();
+    let err = feature
         .branch_create_from(ReadTarget::branch("feature"), "experiment")
         .await
-        .expect("non-main create must also reclaim a clone-only target");
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("already exists"),
+        "the registry row is the existence authority; a same-name create over \
+         a refless live row must conflict, got: {err}"
+    );
 
     assert_eq!(
         feature.branch_list().await.unwrap(),
@@ -2543,26 +2591,27 @@ async fn ensure_indices_on_child_branch_keeps_inherited_table_when_no_work_is_ne
 
     let experiment = Omnigraph::open(uri).await.unwrap();
     let experiment_inherited = snapshot_branch(&experiment, "experiment").await.unwrap();
-    assert_eq!(
+    assert_native_branch_of(
         experiment_inherited
             .dataset("node:Person")
             .unwrap()
             .native_dataset_branch
             .as_deref(),
-        Some("feature")
+        "feature",
     );
 
     experiment.ensure_indices_on("experiment").await.unwrap();
 
     let experiment_snap = snapshot_branch(&experiment, "experiment").await.unwrap();
-    assert_eq!(
+    // Index reconciliation must not manufacture a ref-only first-touch
+    // effect: the table stays on the inherited feature-life fork.
+    assert_native_branch_of(
         experiment_snap
             .dataset("node:Person")
             .unwrap()
             .native_dataset_branch
             .as_deref(),
-        Some("feature"),
-        "index reconciliation must not manufacture a ref-only first-touch effect"
+        "feature",
     );
     assert_eq!(
         experiment_snap
@@ -2574,13 +2623,13 @@ async fn ensure_indices_on_child_branch_keeps_inherited_table_when_no_work_is_ne
     );
 
     let feature_snap = snapshot_branch(&feature, "feature").await.unwrap();
-    assert_eq!(
+    assert_native_branch_of(
         feature_snap
             .dataset("node:Person")
             .unwrap()
             .native_dataset_branch
             .as_deref(),
-        Some("feature")
+        "feature",
     );
     assert_eq!(
         count_rows_branch(&feature, "feature", "node:Person").await,
@@ -2599,13 +2648,13 @@ async fn ensure_indices_on_child_branch_keeps_inherited_table_when_no_work_is_ne
         .await
         .unwrap();
     let grandchild = snapshot_branch(&experiment, "grandchild").await.unwrap();
-    assert_eq!(
+    assert_native_branch_of(
         grandchild
             .dataset("node:Person")
             .unwrap()
             .native_dataset_branch
             .as_deref(),
-        Some("feature")
+        "feature",
     );
     experiment.branch_delete("grandchild").await.unwrap();
     experiment.branch_delete("experiment").await.unwrap();
@@ -2637,12 +2686,12 @@ async fn branch_edge_only_write_only_branches_edge_table() {
             .as_deref(),
         None
     );
-    assert_eq!(
+    assert_native_branch_of(
         snap.dataset("edge:Knows")
             .unwrap()
             .native_dataset_branch
             .as_deref(),
-        Some("feature")
+        "feature",
     );
     assert_eq!(
         snap.dataset("edge:WorksAt")
@@ -2739,13 +2788,13 @@ async fn branch_merge_into_non_main_target_works() {
     .unwrap();
     assert_eq!(eve.num_rows(), 1);
     let experiment_snap = snapshot_branch(&experiment, "experiment").await.unwrap();
-    assert_eq!(
+    assert_native_branch_of(
         experiment_snap
             .dataset("node:Person")
             .unwrap()
             .native_dataset_branch
             .as_deref(),
-        Some("experiment")
+        "experiment",
     );
 
     let mut reopened_main = Omnigraph::open(uri).await.unwrap();
@@ -3020,7 +3069,10 @@ async fn branch_api_rejects_reserved_main_and_same_source_target_merge() {
     db.branch_create("feature").await.unwrap();
     db.sync_branch("feature").await.unwrap();
     let err = db.branch_delete("feature").await.unwrap_err();
-    assert!(err.to_string().contains("currently active branch"));
+    assert!(
+        err.to_string().contains("currently active branch"),
+        "expected active-branch rejection, got: {err}"
+    );
 }
 
 #[tokio::test]

--- a/crates/omnigraph/tests/changes.rs
+++ b/crates/omnigraph/tests/changes.rs
@@ -2881,16 +2881,28 @@ async fn change_feed_cursor_scope_mismatches_are_typed() {
     );
     db.branch_delete("warm-aba").await.unwrap();
     db.branch_create("warm-aba").await.unwrap();
-    assert_rejected(
-        warm_reader
-            .poll_change_feed(feed_request(
-                Some("warm-aba"),
-                ChangeFeedPosition::Cursor(warm_cursor),
-            ))
-            .await
-            .unwrap_err(),
-        "different branch incarnation",
-    );
+    // Post-#562 the stale warm cut usually dies structurally first: its
+    // pinned dataset addresses the dead life's `warm-aba--{ulid}` tree,
+    // which is removed with the life. Either shape is loud, and neither can
+    // serve the replacement life's rows.
+    let warm_err = warm_reader
+        .poll_change_feed(feed_request(
+            Some("warm-aba"),
+            ChangeFeedPosition::Cursor(warm_cursor),
+        ))
+        .await
+        .unwrap_err();
+    match warm_err {
+        omnigraph::error::OmniError::ChangeCursorRejected { reason } => assert!(
+            reason.contains("different branch incarnation"),
+            "reason '{reason}' should mention 'different branch incarnation'"
+        ),
+        other => assert!(
+            other.to_string().contains("warm-aba--"),
+            "expected a typed rejection or structural death on the dead \
+             life's native ref, got: {other:?}"
+        ),
+    }
 
     // Another graph entirely (fresh identity domain and genesis).
     let other_dir = tempfile::tempdir().unwrap();

--- a/crates/omnigraph/tests/failpoints.rs
+++ b/crates/omnigraph/tests/failpoints.rs
@@ -318,11 +318,55 @@ async fn native_branch_controls_reclassify_lost_acknowledgements() {
             .expect("absent BranchContents must classify a lost delete acknowledgement");
     }
     assert_eq!(db.branch_list().await.unwrap(), vec!["main".to_string()]);
-    assert_eq!(version_main(&db).await.unwrap(), before_version);
+    // Issue #562: branch lifecycle now commits its registry rows on the root
+    // `__manifest` — one live-row commit for the create, one dead-row commit
+    // for the delete — so main's manifest version advances by exactly two.
+    // The unchanged claim is below: no graph LINEAGE is manufactured.
+    assert_eq!(version_main(&db).await.unwrap(), before_version + 2);
     assert_eq!(
         db.list_commits(Some("main")).await.unwrap().len(),
         before_commits,
         "native branch controls must not manufacture graph lineage"
+    );
+}
+
+// Issue #562 create crash window: the branch-registry row (the existence
+// authority) commits, then the process dies before the life's native ref is
+// created. The logical name exists — a same-name create must conflict — and
+// the next resolution of the name completes the missing native ref (forward
+// recovery), after which the branch is fully readable.
+#[tokio::test]
+#[serial]
+async fn branch_create_registry_committed_ref_missing_forward_recovers() {
+    let _scenario = FailScenario::setup();
+    let dir = tempfile::tempdir().unwrap();
+    let db = helpers::init_and_load(&dir).await;
+
+    {
+        let _fp = ScopedFailPoint::new(names::BRANCH_CREATE_POST_REGISTRY_PRE_NATIVE, "return");
+        db.branch_create("feature")
+            .await
+            .expect_err("create must surface the injected failure after the registry commit");
+    }
+    let err = db.branch_create("feature").await.unwrap_err();
+    assert!(
+        err.to_string().contains("already exists"),
+        "the registry row is the existence authority; a same-name create over \
+         a refless live row must conflict, got: {err}"
+    );
+    assert!(
+        db.branch_list()
+            .await
+            .unwrap()
+            .iter()
+            .any(|branch| branch == "feature"),
+        "a live refless registration still lists as an existing branch"
+    );
+    assert_eq!(
+        helpers::count_rows_branch(&db, "feature", "node:Person").await,
+        4,
+        "resolution must forward-complete the missing native ref and read the \
+         pinned source state"
     );
 }
 
@@ -356,7 +400,7 @@ async fn branch_delete_partial_failure_converges_via_cleanup() {
     {
         let ds = lance::Dataset::open(&person_uri).await.unwrap();
         assert!(
-            ds.list_branches().await.unwrap().contains_key("feature"),
+            helpers::native_ref_for(&ds, "feature").await.is_some(),
             "precondition: the owned table fork exists before delete"
         );
     }
@@ -378,7 +422,7 @@ async fn branch_delete_partial_failure_converges_via_cleanup() {
     {
         let ds = lance::Dataset::open(&person_uri).await.unwrap();
         assert!(
-            ds.list_branches().await.unwrap().contains_key("feature"),
+            helpers::native_ref_for(&ds, "feature").await.is_some(),
             "failed eager reclaim should leave the orphan for cleanup to reconcile"
         );
     }
@@ -393,7 +437,7 @@ async fn branch_delete_partial_failure_converges_via_cleanup() {
     {
         let ds = lance::Dataset::open(&person_uri).await.unwrap();
         assert!(
-            !ds.list_branches().await.unwrap().contains_key("feature"),
+            helpers::native_ref_for(&ds, "feature").await.is_none(),
             "cleanup should reconcile the orphaned fork away"
         );
     }
@@ -487,10 +531,13 @@ async fn recreate_over_orphaned_fork_reports_indeterminate_authority_read() {
     db.branch_create("feature").await.unwrap();
 
     let person_uri = node_table_uri(&db, "Person").await;
+    // Forge the orphan at the branch's NATIVE ref (issue #562): the engine's
+    // fork targets that name, so only a same-named forged ref collides.
+    let feature_native = helpers::graph_native_ref(&uri, "feature").await;
     {
         let mut ds = lance::Dataset::open(&person_uri).await.unwrap();
         let base = ds.version().version;
-        ds.create_branch("feature", base, None).await.unwrap();
+        ds.create_branch(&feature_native, base, None).await.unwrap();
     }
 
     let row = r#"{"type":"Person","data":{"name":"Grace","age":37}}"#;
@@ -519,7 +566,10 @@ async fn recreate_over_orphaned_fork_reports_indeterminate_authority_read() {
 
         let ds = lance::Dataset::open(&person_uri).await.unwrap();
         assert!(
-            ds.list_branches().await.unwrap().contains_key("feature"),
+            ds.list_branches()
+                .await
+                .unwrap()
+                .contains_key(feature_native.as_str()),
             "ambiguous orphan status must leave the fork for a later retry"
         );
     }
@@ -807,12 +857,8 @@ async fn cross_handle_reclaim_never_deletes_live_intent_owned_fork() {
     rendezvous.wait_until_reached().await;
 
     let person_uri = node_table_uri(&db_b, "Person").await;
-    let fork_before = lance::Dataset::open(&person_uri)
+    let fork_before = helpers::open_dataset_head(&person_uri, Some("feature"))
         .await
-        .unwrap()
-        .checkout_branch("feature")
-        .await
-        .unwrap()
         .branch_identifier()
         .await
         .unwrap();
@@ -835,12 +881,8 @@ async fn cross_handle_reclaim_never_deletes_live_intent_owned_fork() {
         "the second handle must wait on A's root-scoped effect gates"
     );
 
-    let fork_after = lance::Dataset::open(&person_uri)
+    let fork_after = helpers::open_dataset_head(&person_uri, Some("feature"))
         .await
-        .unwrap()
-        .checkout_branch("feature")
-        .await
-        .unwrap()
         .branch_identifier()
         .await
         .unwrap();
@@ -903,37 +945,37 @@ async fn armed_first_touch_recovery_accepts_missing_target_ref() {
     }
     let operation_id = single_sidecar_operation_id(dir.path());
     let person_uri = node_table_uri(&db, "Person").await;
-    assert!(
-        !lance::Dataset::open(&person_uri)
-            .await
-            .unwrap()
-            .list_branches()
-            .await
-            .unwrap()
-            .contains_key("feature"),
-        "precondition: crash happened before the target ref was created"
-    );
+    {
+        let ds = lance::Dataset::open(&person_uri).await.unwrap();
+        assert!(
+            helpers::native_ref_for(&ds, "feature").await.is_none(),
+            "precondition: crash happened before the target ref was created"
+        );
+    }
 
     // Materialize the narrower Lance crash window underneath the already-
     // durable writer intent: shallow clone present, BranchContents absent.
     // Full recovery must not equate "not listed" with "no physical fork".
+    // The intent targets the branch life's NATIVE ref (issue #562), so the
+    // forged clone-only state must live at that name.
+    let feature_native = helpers::graph_native_ref(&uri, "feature").await;
     let mut person = lance::Dataset::open(&person_uri).await.unwrap();
     let person_version = person.version().version;
     person
-        .create_branch("feature", person_version, None)
+        .create_branch(&feature_native, person_version, None)
         .await
         .unwrap();
     std::fs::remove_file(
         std::path::Path::new(&person_uri)
             .join("_refs")
             .join("branches")
-            .join("feature.json"),
+            .join(format!("{feature_native}.json")),
     )
     .unwrap();
     assert!(
         std::path::Path::new(&person_uri)
             .join("tree")
-            .join("feature")
+            .join(&feature_native)
             .exists(),
         "precondition: clone-only target tree exists"
     );
@@ -1094,12 +1136,13 @@ async fn armed_first_touch_recovery_defers_legacy_path_overlap_until_leaf_delete
             .join("feature.json"),
     )
     .unwrap();
+    // The production-created leaf forked at its life's NATIVE ref
+    // (`feature/child--{ulid}`); the forged ancestor stays the bare legacy
+    // name. Both nest under the same `tree/feature/` physical prefix.
     assert!(
-        person
-            .list_branches()
+        helpers::native_ref_for(&person, "feature/child")
             .await
-            .unwrap()
-            .contains_key("feature/child"),
+            .is_some(),
         "precondition: live leaf table branch exists"
     );
     assert!(
@@ -1181,7 +1224,21 @@ async fn partial_first_touch_recovery_fails_closed_on_legacy_path_overlap() {
         })
         .collect::<Vec<_>>();
 
-    db.branch_create("feature").await.unwrap();
+    // Forge a LEGACY graph-branch admission (bare ref, no registry row):
+    // this scenario models an old store, where the path-overlapping child
+    // could legally exist. A #562-registered branch would fork at its native
+    // `feature--{ulid}` ref and never share the forged child's path prefix,
+    // so the legacy shape is the only one that still reproduces the overlap.
+    {
+        let mut manifest = lance::Dataset::open(&format!("{uri}/__manifest"))
+            .await
+            .unwrap();
+        let manifest_version = manifest.version().version;
+        manifest
+            .create_branch("feature", manifest_version, None)
+            .await
+            .unwrap();
+    }
     let operation_id = {
         let _failpoint = ScopedFailPoint::new(names::MUTATION_POST_TABLE_COMMIT, "return");
         let error = db
@@ -1416,16 +1473,13 @@ async fn armed_first_touch_recovery_reclaims_exact_no_effect_fork() {
     }
     let operation_id = single_sidecar_operation_id(dir.path());
     let person_uri = node_table_uri(&db, "Person").await;
-    assert!(
-        lance::Dataset::open(&person_uri)
-            .await
-            .unwrap()
-            .list_branches()
-            .await
-            .unwrap()
-            .contains_key("feature"),
-        "precondition: intent-owned target ref exists without a committed effect"
-    );
+    {
+        let ds = lance::Dataset::open(&person_uri).await.unwrap();
+        assert!(
+            helpers::native_ref_for(&ds, "feature").await.is_some(),
+            "precondition: intent-owned target ref exists without a committed effect"
+        );
+    }
     drop(db);
 
     let recovered = Omnigraph::open(&uri).await.unwrap();
@@ -1434,16 +1488,13 @@ async fn armed_first_touch_recovery_reclaims_exact_no_effect_fork() {
         main_rows,
         "recovery must leave the feature table inherited"
     );
-    assert!(
-        !lance::Dataset::open(&person_uri)
-            .await
-            .unwrap()
-            .list_branches()
-            .await
-            .unwrap()
-            .contains_key("feature"),
-        "full recovery must reclaim the exact unpublished no-effect ref"
-    );
+    {
+        let ds = lance::Dataset::open(&person_uri).await.unwrap();
+        assert!(
+            helpers::native_ref_for(&ds, "feature").await.is_none(),
+            "full recovery must reclaim the exact unpublished no-effect ref"
+        );
+    }
     assert!(
         !dir.path()
             .join("__recovery")
@@ -1783,16 +1834,13 @@ async fn full_recovery_converges_multiple_no_effect_claims_for_one_fork() {
         "precondition: both no-effect claims are durable"
     );
     let person_uri = node_table_uri(&writer_b_db, "Person").await;
-    assert!(
-        lance::Dataset::open(&person_uri)
-            .await
-            .unwrap()
-            .list_branches()
-            .await
-            .unwrap()
-            .contains_key("feature"),
-        "precondition: A's exact no-effect target ref exists"
-    );
+    {
+        let ds = lance::Dataset::open(&person_uri).await.unwrap();
+        assert!(
+            helpers::native_ref_for(&ds, "feature").await.is_some(),
+            "precondition: A's exact no-effect target ref exists"
+        );
+    }
     drop(writer_b_db);
 
     let recovered = Omnigraph::open(&uri)
@@ -1803,16 +1851,13 @@ async fn full_recovery_converges_multiple_no_effect_claims_for_one_fork() {
         main_rows
     );
     assert!(helpers::recovery::sidecar_operation_ids(dir.path()).is_empty());
-    assert!(
-        !lance::Dataset::open(&person_uri)
-            .await
-            .unwrap()
-            .list_branches()
-            .await
-            .unwrap()
-            .contains_key("feature"),
-        "the last no-effect claim must reclaim the exact unpublished ref"
-    );
+    {
+        let ds = lance::Dataset::open(&person_uri).await.unwrap();
+        assert!(
+            helpers::native_ref_for(&ds, "feature").await.is_none(),
+            "the last no-effect claim must reclaim the exact unpublished ref"
+        );
+    }
 }
 
 /// A no-effect Armed intent must not delete a ref while a competing confirmed
@@ -3995,13 +4040,14 @@ async fn recovery_rolls_forward_ensure_indices_on_feature_branch_inner() {
     // publisher deliberately skips the normal index-rebuild preparation;
     // the failed writer below is still the real `ensure_indices_on`.
     let person_uri = node_table_uri(&db, "Person").await;
+    let feature_native = helpers::graph_native_ref(&uri, "feature").await;
     let mut ds = helpers::open_dataset_head(&person_uri, Some("feature")).await;
     ds.drop_index("id_idx").await.unwrap();
     let dropped_index_head = ds.version().version;
     db.failpoint_publish_table_head_without_index_rebuild_for_test(
         "feature",
         "node:Person",
-        Some("feature"),
+        Some(feature_native.as_str()),
     )
     .await
     .unwrap();
@@ -4088,7 +4134,7 @@ async fn recovery_rolls_forward_ensure_indices_on_feature_branch_inner() {
     db.failpoint_publish_table_head_without_index_rebuild_for_test(
         "feature",
         "node:Person",
-        Some("feature"),
+        Some(feature_native.as_str()),
     )
     .await
     .unwrap();
@@ -4516,14 +4562,25 @@ async fn ensure_indices_first_touch_crash_before_ref_recovers_cleanly() {
     // state, never something a new loose sidecar may claim.
     let person_uri = node_table_uri(&db, "Person").await;
     let mut person = lance::Dataset::open(&person_uri).await.unwrap();
+    // The engine addresses fork refs by each life's NATIVE name (issue #562),
+    // so the foreign ref must be forged at the experiment life's native ref
+    // from the feature life's native fork to collide with the index target.
+    let feature_fork_native = helpers::native_ref_for(&person, "feature")
+        .await
+        .expect("feature's table fork exists");
+    let experiment_native = helpers::graph_native_ref(&uri, "experiment").await;
     let feature_head = person
-        .checkout_branch("feature")
+        .checkout_branch(&feature_fork_native)
         .await
         .unwrap()
         .version()
         .version;
     person
-        .create_branch("experiment", ("feature", feature_head), None)
+        .create_branch(
+            &experiment_native,
+            (feature_fork_native.as_str(), feature_head),
+            None,
+        )
         .await
         .unwrap();
     let orphan_error = db
@@ -4537,14 +4594,19 @@ async fn ensure_indices_first_touch_crash_before_ref_recovers_cleanly() {
         "unexpected orphan-ref refusal: {orphan_error}"
     );
     assert!(helpers::recovery::sidecar_operation_ids(dir.path()).is_empty());
-    person.delete_branch("experiment").await.unwrap();
+    person.delete_branch(&experiment_native).await.unwrap();
 
     {
         let _failpoint =
             ScopedFailPoint::new(names::ENSURE_INDICES_POST_SIDECAR_PRE_FORK, "return");
-        db.ensure_indices_on("experiment")
+        let error = db
+            .ensure_indices_on("experiment")
             .await
             .expect_err("failpoint must fire after sidecar and before target ref creation");
+        assert!(
+            matches!(error, OmniError::RecoveryRequired { .. }),
+            "expected the injected post-sidecar failure, got: {error}"
+        );
     }
     let operation_id = single_sidecar_operation_id(dir.path());
     drop(db);
@@ -4562,13 +4624,13 @@ async fn ensure_indices_first_touch_crash_before_ref_recovers_cleanly() {
         .snapshot_of(omnigraph::db::ReadTarget::branch("experiment"))
         .await
         .unwrap();
-    assert_eq!(
+    helpers::assert_native_branch_of(
         inherited
             .dataset("node:Person")
             .unwrap()
             .native_dataset_branch
             .as_deref(),
-        Some("feature")
+        "feature",
     );
 
     recovered.ensure_indices_on("experiment").await.unwrap();
@@ -4576,13 +4638,13 @@ async fn ensure_indices_first_touch_crash_before_ref_recovers_cleanly() {
         .snapshot_of(omnigraph::db::ReadTarget::branch("experiment"))
         .await
         .unwrap();
-    assert_eq!(
+    helpers::assert_native_branch_of(
         owned
             .dataset("node:Person")
             .unwrap()
             .native_dataset_branch
             .as_deref(),
-        Some("experiment")
+        "experiment",
     );
 }
 
@@ -5603,7 +5665,19 @@ async fn orphaned_branch_discard_is_idempotent_across_delete_failure() {
     )
     .await
     .unwrap();
-    db.branch_create("feature").await.unwrap();
+    // Forge a LEGACY graph branch (bare ref, no #562 registry row): the raw
+    // substrate ref delete below must leave the branch GENUINELY gone, and a
+    // registered branch's live row would instead trigger forward recovery.
+    {
+        let mut manifest = lance::Dataset::open(&format!("{uri}/__manifest"))
+            .await
+            .unwrap();
+        let manifest_version = manifest.version().version;
+        manifest
+            .create_branch("feature", manifest_version, None)
+            .await
+            .unwrap();
+    }
     helpers::mutate_branch(
         &mut db,
         "feature",
@@ -5977,7 +6051,19 @@ async fn orphaned_branch_discard_converges_across_audit_append_failure() {
     )
     .await
     .unwrap();
-    db.branch_create("feature").await.unwrap();
+    // Forge a LEGACY graph branch (bare ref, no #562 registry row): the raw
+    // substrate ref delete below must leave the branch GENUINELY gone, and a
+    // registered branch's live row would instead trigger forward recovery.
+    {
+        let mut manifest = lance::Dataset::open(&format!("{uri}/__manifest"))
+            .await
+            .unwrap();
+        let manifest_version = manifest.version().version;
+        manifest
+            .create_branch("feature", manifest_version, None)
+            .await
+            .unwrap();
+    }
     helpers::mutate_branch(
         &mut db,
         "feature",
@@ -8996,18 +9082,14 @@ async fn branch_merge_post_effect_target_advance_requires_recovery_and_preserves
     // still advances, invalidating the merge's coarse target authority token.
     // The test-only seam deliberately bypasses the process-local queues.
     let company_uri = node_table_uri(&target_winner, "Company").await;
-    let mut raw_company = lance::Dataset::open(&company_uri)
-        .await
-        .unwrap()
-        .checkout_branch("target")
-        .await
-        .unwrap();
+    let mut raw_company = helpers::open_dataset_head(&company_uri, Some("target")).await;
     helpers::lance_delete_inline(&mut raw_company, "1 = 2").await;
+    let target_native = helpers::graph_native_ref(&uri, "target").await;
     target_winner
         .failpoint_publish_table_head_without_index_rebuild_for_test(
             "target",
             "node:Company",
-            Some("target"),
+            Some(target_native.as_str()),
         )
         .await
         .unwrap();
@@ -9089,19 +9171,15 @@ async fn branch_merge_post_effect_same_table_advance_fails_closed() {
     merge_rv.wait_until_reached().await;
 
     let person_uri = node_table_uri(&target_winner, "Person").await;
-    let mut raw_target = lance::Dataset::open(&person_uri)
-        .await
-        .unwrap()
-        .checkout_branch("target")
-        .await
-        .unwrap();
+    let mut raw_target = helpers::open_dataset_head(&person_uri, Some("target")).await;
     helpers::lance_delete_inline(&mut raw_target, "1 = 2").await;
     let winner_lance_head = raw_target.version().version;
+    let target_native = helpers::graph_native_ref(&uri, "target").await;
     target_winner
         .failpoint_publish_table_head_without_index_rebuild_for_test(
             "target",
             "node:Person",
-            Some("target"),
+            Some(target_native.as_str()),
         )
         .await
         .unwrap();
@@ -9141,12 +9219,8 @@ async fn branch_merge_post_effect_same_table_advance_fails_closed() {
         winner_manifest_version,
         "failed recovery must not move the winning target manifest"
     );
-    let lance_after_failed_recovery = lance::Dataset::open(&person_uri)
+    let lance_after_failed_recovery = helpers::open_dataset_head(&person_uri, Some("target"))
         .await
-        .unwrap()
-        .checkout_branch("target")
-        .await
-        .unwrap()
         .version()
         .version;
     assert_eq!(
@@ -9200,30 +9274,22 @@ async fn branch_merge_rollback_restarts_after_restore_before_publish() {
     assert!(sidecar_path.exists());
 
     let company_uri = node_table_uri(&target_winner, "Company").await;
-    let mut raw_company = lance::Dataset::open(&company_uri)
-        .await
-        .unwrap()
-        .checkout_branch("target")
-        .await
-        .unwrap();
+    let mut raw_company = helpers::open_dataset_head(&company_uri, Some("target")).await;
     helpers::lance_delete_inline(&mut raw_company, "1 = 2").await;
+    let target_native = helpers::graph_native_ref(&uri, "target").await;
     target_winner
         .failpoint_publish_table_head_without_index_rebuild_for_test(
             "target",
             "node:Company",
-            Some("target"),
+            Some(target_native.as_str()),
         )
         .await
         .unwrap();
     let winner_head = branch_head_commit_id(dir.path(), "target").await.unwrap();
 
     let person_uri = node_table_uri(&db, "Person").await;
-    let person_before_restore = lance::Dataset::open(&person_uri)
+    let person_before_restore = helpers::open_dataset_head(&person_uri, Some("target"))
         .await
-        .unwrap()
-        .checkout_branch("target")
-        .await
-        .unwrap()
         .version()
         .version;
     drop(db);
@@ -9256,12 +9322,8 @@ async fn branch_merge_rollback_restarts_after_restore_before_publish() {
         recovery_audit_kinds(dir.path()).await.is_empty(),
         "an interrupted rollback must not claim a completed audit outcome"
     );
-    let person_after_interrupted_restore = lance::Dataset::open(&person_uri)
+    let person_after_interrupted_restore = helpers::open_dataset_head(&person_uri, Some("target"))
         .await
-        .unwrap()
-        .checkout_branch("target")
-        .await
-        .unwrap()
         .version()
         .version;
     assert!(
@@ -9273,12 +9335,8 @@ async fn branch_merge_rollback_restarts_after_restore_before_publish() {
         .await
         .expect("the next open must recognize and finish the interrupted compensation");
     assert!(!sidecar_path.exists());
-    let person_after_recovery = lance::Dataset::open(&person_uri)
+    let person_after_recovery = helpers::open_dataset_head(&person_uri, Some("target"))
         .await
-        .unwrap()
-        .checkout_branch("target")
-        .await
-        .unwrap()
         .version()
         .version;
     assert_eq!(
@@ -9312,12 +9370,8 @@ async fn branch_merge_rollback_restarts_after_restore_before_publish() {
 
     drop(recovered);
     let _reopened = Omnigraph::open(&uri).await.unwrap();
-    let person_after_second_open = lance::Dataset::open(&person_uri)
+    let person_after_second_open = helpers::open_dataset_head(&person_uri, Some("target"))
         .await
-        .unwrap()
-        .checkout_branch("target")
-        .await
-        .unwrap()
         .version()
         .version;
     assert_eq!(person_after_second_open, person_after_recovery);
@@ -10442,12 +10496,14 @@ async fn branch_merge_sidecar_pins_table_branch_to_active_branch() {
                      got pin {pin:?}"
                 )
             });
-        assert_eq!(
-            table_branch, "target_branch",
-            "sidecar pin must record `table_branch` as the merge target branch (where \
-             commits actually land via publish_rewritten_merge_table → open_for_mutation), \
-             NOT entry.native_dataset_branch from the target snapshot. See merge.rs filter_map and \
-             the rationale comment at table_ops.rs:115-120. Got pin: {pin:?}"
+        // Issue #562: the pin records the merge target's NATIVE ref (where
+        // commits actually land via publish_rewritten_merge_table →
+        // open_for_mutation), never entry.native_dataset_branch from the
+        // target snapshot. The native ref is a life of the logical target.
+        assert!(
+            table_branch.starts_with("target_branch--"),
+            "sidecar pin must record `table_branch` as the merge target's native ref \
+             (a `target_branch--{{ulid}}` life). Got pin: {pin:?}"
         );
     }
 }
@@ -11124,16 +11180,13 @@ async fn first_touch_post_create_open_error_keeps_recovery_ownership() {
         "ambiguous post-create failure must retain its ownership sidecar"
     );
     let person_uri = node_table_uri(&db, "Person").await;
-    assert!(
-        lance::Dataset::open(&person_uri)
-            .await
-            .unwrap()
-            .list_branches()
-            .await
-            .unwrap()
-            .contains_key("feature"),
-        "test seam fires only after the target ref is durable"
-    );
+    {
+        let ds = lance::Dataset::open(&person_uri).await.unwrap();
+        assert!(
+            helpers::native_ref_for(&ds, "feature").await.is_some(),
+            "test seam fires only after the target ref is durable"
+        );
+    }
 
     drop(db);
     let recovered = Omnigraph::open(&uri).await.unwrap();
@@ -11142,16 +11195,13 @@ async fn first_touch_post_create_open_error_keeps_recovery_ownership() {
         4,
         "failed first touch must not publish its row"
     );
-    assert!(
-        !lance::Dataset::open(&person_uri)
-            .await
-            .unwrap()
-            .list_branches()
-            .await
-            .unwrap()
-            .contains_key("feature"),
-        "Full recovery must reclaim the sidecar-owned untouched ref"
-    );
+    {
+        let ds = lance::Dataset::open(&person_uri).await.unwrap();
+        assert!(
+            helpers::native_ref_for(&ds, "feature").await.is_none(),
+            "Full recovery must reclaim the sidecar-owned untouched ref"
+        );
+    }
 }
 
 /// A branch delete's first recovery probe is not its authority boundary. A data
@@ -11300,28 +11350,46 @@ node Document {
     let new_snapshot = replacement.expect("delete/recreate replacement must complete");
     let new_entry = new_snapshot.dataset("node:Document").unwrap();
     assert_eq!(new_entry.dataset_path, old_entry.dataset_path);
-    assert_eq!(
-        new_entry.native_dataset_branch,
-        old_entry.native_dataset_branch
-    );
-    assert_eq!(
-        new_entry.published_dataset_version, old_entry.published_dataset_version,
-        "the regression must exercise same-path/same-version branch ABA"
+    // Pre-#562 this fixture engineered same-native-ref/same-version ABA. The
+    // rotation makes that collision impossible — each life owns a distinct
+    // `feature--{ulid}` fork, which is now the pinned structural fact; the
+    // protected behavior below (stale capture never serves replacement
+    // bytes) is unchanged.
+    let old_native = old_entry
+        .native_dataset_branch
+        .as_deref()
+        .expect("old life must own the forked Blob table");
+    let new_native = new_entry
+        .native_dataset_branch
+        .as_deref()
+        .expect("new life must own the forked Blob table");
+    assert_ne!(
+        old_native, new_native,
+        "each branch life must own a distinct native ref (issue #562)"
     );
 
     let error = read_task
         .await
         .unwrap()
         .expect_err("the stale live-branch capture must never return replacement bytes");
+    // Two loud refusal shapes: the typed incarnation-witness BadRequest, or
+    // the stale pin dying structurally on the deleted life's native ref
+    // (its tree is removed with the life, so the read can never reach the
+    // replacement's bytes).
+    let refused_typed = matches!(
+        error,
+        OmniError::Manifest(ref manifest)
+            if manifest.kind == ManifestErrorKind::BadRequest
+                && manifest.message
+                    == "Blob property 'Document.content' has no persisted native-branch incarnation witness at the selected target"
+    );
+    let died_structurally = error.to_string().contains("feature--");
+    // A reclaimed historical version is equally loud: the stale capture's
+    // pinned version belongs to the deleted life and no longer resolves.
+    let version_reclaimed = matches!(error, OmniError::HistoricalVersionReclaimed { .. });
     assert!(
-        matches!(
-            error,
-            OmniError::Manifest(ref manifest)
-                if manifest.kind == ManifestErrorKind::BadRequest
-                    && manifest.message
-                        == "Blob property 'Document.content' has no persisted native-branch incarnation witness at the selected target"
-        ),
-        "live branch ABA must fail with the exact incarnation refusal, got {error:?}"
+        refused_typed || died_structurally || version_reclaimed,
+        "live branch ABA must fail loudly instead of retargeting, got {error:?}"
     );
     assert_eq!(
         read_managed_blob_bytes(&control, ReadTarget::branch("feature"), cell).await,
@@ -11412,25 +11480,32 @@ node Document {
 
     let new_snapshot = replacement.expect("delete/recreate replacement must complete");
     let new_entry = new_snapshot.dataset("node:Document").unwrap();
-    assert_eq!(
-        new_entry.published_dataset_version, old_entry.published_dataset_version,
-        "the regression must exercise same-version branch ABA"
+    // Pre-#562 the fixture pinned same-version ABA; the rotation gives each
+    // life its own native ref, so pin the distinct-lives fact instead.
+    assert_ne!(
+        new_entry.native_dataset_branch, old_entry.native_dataset_branch,
+        "each branch life must own a distinct native ref (issue #562)"
     );
 
     let error = poll_task
         .await
         .unwrap()
         .expect_err("the stale cut must never emit the replacement branch's rows");
+    // Loud refusal shapes: the typed incarnation witness, a ChangeFeedGap
+    // (the feed's designed unreadable-history signal — carries no rows), or
+    // the stale pin dying structurally on the deleted life's native ref.
+    let refused = matches!(
+        error,
+        OmniError::Manifest(ref manifest)
+            if manifest.kind == ManifestErrorKind::BadRequest
+                && manifest
+                    .message
+                    .contains("has no persisted native-branch incarnation witness")
+    ) || matches!(error, OmniError::ChangeFeedGap { .. })
+        || error.to_string().contains("feature--");
     assert!(
-        matches!(
-            error,
-            OmniError::Manifest(ref manifest)
-                if manifest.kind == ManifestErrorKind::BadRequest
-                    && manifest
-                        .message
-                        .contains("has no persisted native-branch incarnation witness")
-        ),
-        "in-poll branch ABA must fail with the incarnation refusal, got {error:?}"
+        refused,
+        "in-poll branch ABA must fail loudly instead of retargeting, got {error:?}"
     );
 }
 
@@ -11524,25 +11599,32 @@ node Document {
 
     let new_snapshot = replacement.expect("delete/recreate replacement must complete");
     let new_entry = new_snapshot.dataset("node:Document").unwrap();
-    assert_eq!(
-        new_entry.published_dataset_version, old_entry.published_dataset_version,
-        "the regression must exercise same-version branch ABA"
+    // Pre-#562 the fixture pinned same-version ABA; the rotation gives each
+    // life its own native ref, so pin the distinct-lives fact instead.
+    assert_ne!(
+        new_entry.native_dataset_branch, old_entry.native_dataset_branch,
+        "each branch life must own a distinct native ref (issue #562)"
     );
 
     let error = poll_task
         .await
         .unwrap()
         .expect_err("the retargeted table open must not emit the replacement branch's rows");
+    // Loud refusal shapes: the typed incarnation witness, a ChangeFeedGap
+    // (the feed's designed unreadable-history signal — carries no rows), or
+    // the stale pin dying structurally on the deleted life's native ref.
+    let refused = matches!(
+        error,
+        OmniError::Manifest(ref manifest)
+            if manifest.kind == ManifestErrorKind::BadRequest
+                && manifest
+                    .message
+                    .contains("has no persisted native-branch incarnation witness")
+    ) || matches!(error, OmniError::ChangeFeedGap { .. })
+        || error.to_string().contains("feature--");
     assert!(
-        matches!(
-            error,
-            OmniError::Manifest(ref manifest)
-                if manifest.kind == ManifestErrorKind::BadRequest
-                    && manifest
-                        .message
-                        .contains("has no persisted native-branch incarnation witness")
-        ),
-        "in-poll table-open ABA must fail with the incarnation refusal, got {error:?}"
+        refused,
+        "in-poll table-open ABA must fail loudly instead of retargeting, got {error:?}"
     );
 }
 
@@ -11630,16 +11712,21 @@ node Document {
         .await
         .unwrap()
         .expect_err("without an e_tag witness the logical post-open re-prove must still refuse");
+    // Loud refusal shapes: the post-open logical witness, a ChangeFeedGap
+    // (the feed's unreadable-history signal — carries no rows), or the stale
+    // pin dying structurally on the deleted life's native ref (issue #562).
+    let refused = matches!(
+        error,
+        OmniError::Manifest(ref manifest)
+            if manifest.kind == ManifestErrorKind::BadRequest
+                && manifest
+                    .message
+                    .contains("after the per-table opens")
+    ) || matches!(error, OmniError::ChangeFeedGap { .. })
+        || error.to_string().contains("feature--");
     assert!(
-        matches!(
-            error,
-            OmniError::Manifest(ref manifest)
-                if manifest.kind == ManifestErrorKind::BadRequest
-                    && manifest
-                        .message
-                        .contains("after the per-table opens")
-        ),
-        "the logical post-open witness must produce the incarnation refusal, got {error:?}"
+        refused,
+        "the logical post-open witness must fail the poll loudly, got {error:?}"
     );
 }
 
@@ -11832,13 +11919,13 @@ async fn branch_merge_fences_target_delete_recreate_aba() {
     // version; BranchIdentifier is the incarnation component that prevents
     // that pair from masquerading as the authority captured by the merge.
     let person_uri = node_table_uri(merge_db.as_ref(), "Person").await;
-    let old_target = lance::Dataset::open(&person_uri)
-        .await
-        .unwrap()
-        .checkout_branch("target")
-        .await
-        .unwrap();
-    let old_target_version = old_target.version().version;
+    let old_target = helpers::open_dataset_head(&person_uri, Some("target")).await;
+    let old_target_native = {
+        let ds = lance::Dataset::open(&person_uri).await.unwrap();
+        helpers::native_ref_for(&ds, "target")
+            .await
+            .expect("target's table fork exists")
+    };
     let old_target_identifier = old_target.branch_identifier().await.unwrap();
 
     let merge_rv =
@@ -11874,12 +11961,8 @@ async fn branch_merge_fences_target_delete_recreate_aba() {
         tokio::time::timeout(std::time::Duration::from_millis(250), &mut control_task)
             .await
             .is_err();
-    let target_unchanged_while_parked = lance::Dataset::open(&person_uri)
+    let target_unchanged_while_parked = helpers::open_dataset_head(&person_uri, Some("target"))
         .await
-        .unwrap()
-        .checkout_branch("target")
-        .await
-        .unwrap()
         .branch_identifier()
         .await
         .unwrap()
@@ -11921,21 +12004,25 @@ async fn branch_merge_fences_target_delete_recreate_aba() {
             && !target_names.iter().any(|name| name == "old-target-only"),
         "recreated target leaked state from the deleted target incarnation: {target_names:?}"
     );
-    let new_target = lance::Dataset::open(&person_uri)
-        .await
-        .unwrap()
-        .checkout_branch("target")
-        .await
-        .unwrap();
+    let new_target = helpers::open_dataset_head(&person_uri, Some("target")).await;
     assert_ne!(
         new_target.branch_identifier().await.unwrap(),
         old_target_identifier,
         "delete+recreate must mint a new target incarnation"
     );
-    assert_eq!(
-        new_target.version().version,
-        old_target_version,
-        "the regression fixture must exercise same-name/same-version ABA"
+    // Pre-#562 this fixture pinned same-name/same-version ABA. The rotation
+    // makes that collision impossible by construction: the recreated life
+    // owns a distinct `target--{ulid}` native ref, which is the pinned
+    // structural fact now.
+    let new_target_native = {
+        let ds = lance::Dataset::open(&person_uri).await.unwrap();
+        helpers::native_ref_for(&ds, "target")
+            .await
+            .expect("recreated target's table fork exists")
+    };
+    assert_ne!(
+        new_target_native, old_target_native,
+        "each target life must own a distinct native ref (issue #562)"
     );
 }
 
@@ -12010,18 +12097,14 @@ async fn branch_merge_rejects_fresh_target_manifest_change_before_effects() {
     // `graph_head`; the merge handle's cached target snapshot remains at
     // `before`.
     let person_uri = node_table_uri(&target_writer, "Person").await;
-    let mut raw_target = lance::Dataset::open(&person_uri)
-        .await
-        .unwrap()
-        .checkout_branch("target")
-        .await
-        .unwrap();
+    let mut raw_target = helpers::open_dataset_head(&person_uri, Some("target")).await;
     helpers::lance_delete_inline(&mut raw_target, "1 = 2").await;
+    let target_native = helpers::graph_native_ref(&uri, "target").await;
     let publish_result = target_writer
         .failpoint_publish_table_head_without_index_rebuild_for_test(
             "target",
             "node:Person",
-            Some("target"),
+            Some(target_native.as_str()),
         )
         .await;
     let after_result = helpers::version_branch(&target_writer, "target").await;
@@ -12164,18 +12247,14 @@ async fn branch_merge_source_advance_keeps_captured_source_parent() {
     // source table HEAD with a no-op delete, then publish it through the
     // queue-bypassing seam. The source branch incarnation remains unchanged.
     let person_uri = node_table_uri(&source_writer, "Person").await;
-    let mut raw_source = lance::Dataset::open(&person_uri)
-        .await
-        .unwrap()
-        .checkout_branch("source")
-        .await
-        .unwrap();
+    let mut raw_source = helpers::open_dataset_head(&person_uri, Some("source")).await;
     helpers::lance_delete_inline(&mut raw_source, "1 = 2").await;
+    let source_native = helpers::graph_native_ref(&uri, "source").await;
     source_writer
         .failpoint_publish_table_head_without_index_rebuild_for_test(
             "source",
             "node:Person",
-            Some("source"),
+            Some(source_native.as_str()),
         )
         .await
         .unwrap();
@@ -12230,12 +12309,11 @@ async fn branch_merge_pure_insert_rejects_source_table_ref_aba_before_arm() {
     .unwrap();
 
     let person_uri = node_table_uri(&db, "Person").await;
-    let old_source = lance::Dataset::open(&person_uri)
-        .await
-        .unwrap()
-        .checkout_branch("source")
-        .await
-        .unwrap();
+    // The raw ABA is forged at the source life's NATIVE ref (issue #562): the
+    // graph branch stays the same life, only the table-level ref is replaced
+    // out-of-band, and the final identifier check must catch exactly that.
+    let source_native = helpers::graph_native_ref(&uri, "source").await;
+    let old_source = helpers::open_dataset_head(&person_uri, Some("source")).await;
     let old_source_version = old_source.version().version;
     let old_source_identifier = old_source.branch_identifier().await.unwrap();
     let merge_db = std::sync::Arc::new(db);
@@ -12255,22 +12333,22 @@ async fn branch_merge_pure_insert_rejects_source_table_ref_aba_before_arm() {
             .await
             .map_err(OmniError::storage)?;
         let main_version = root.version().version;
-        root.force_delete_branch("source")
+        root.force_delete_branch(&source_native)
             .await
             .map_err(OmniError::storage)?;
         if let Err(error) = std::fs::remove_dir_all(
             std::path::Path::new(&person_uri)
                 .join("tree")
-                .join("source"),
+                .join(&source_native),
         ) && error.kind() != std::io::ErrorKind::NotFound
         {
             return Err(error.into());
         }
-        root.create_branch("source", main_version, None)
+        root.create_branch(&source_native, main_version, None)
             .await
             .map_err(OmniError::storage)?;
         let mut replacement = root
-            .checkout_branch("source")
+            .checkout_branch(&source_native)
             .await
             .map_err(OmniError::storage)?;
         // The manifest publisher refuses to register the same table version a
@@ -12283,7 +12361,7 @@ async fn branch_merge_pure_insert_rejects_source_table_ref_aba_before_arm() {
             .failpoint_publish_table_head_without_index_rebuild_for_test(
                 "source",
                 "node:Person",
-                Some("source"),
+                Some(source_native.as_str()),
             )
             .await?;
         Ok::<_, OmniError>((
@@ -12380,10 +12458,13 @@ async fn branch_merge_pure_insert_rejects_target_table_ref_aba_before_arm() {
         .await
         .unwrap();
     let target_entry = target_snapshot.dataset("node:Person").unwrap();
-    assert_eq!(
-        target_entry.native_dataset_branch.as_deref(),
-        Some("target"),
-        "fixture requires an already-owned target table ref"
+    let target_native = target_entry
+        .native_dataset_branch
+        .clone()
+        .expect("fixture requires an already-owned target table ref");
+    assert!(
+        target_native.starts_with("target--"),
+        "the owned fork must live at the target life's native ref: {target_native}"
     );
     assert_eq!(target_entry.entity_count, main_rows as u64);
     let expected_target_version = target_entry.published_dataset_version;
@@ -12391,12 +12472,7 @@ async fn branch_merge_pure_insert_rejects_target_table_ref_aba_before_arm() {
     let source_head_before = branch_head_commit_id(dir.path(), "source").await.unwrap();
 
     let person_uri = node_table_uri(&db, "Person").await;
-    let old_target = lance::Dataset::open(&person_uri)
-        .await
-        .unwrap()
-        .checkout_branch("target")
-        .await
-        .unwrap();
+    let old_target = helpers::open_dataset_head(&person_uri, Some("target")).await;
     assert_eq!(old_target.version().version, expected_target_version);
     let old_target_identifier = old_target.branch_identifier().await.unwrap();
 
@@ -12419,7 +12495,7 @@ async fn branch_merge_pure_insert_rejects_target_table_ref_aba_before_arm() {
     let target_ref_path = std::path::Path::new(&person_uri)
         .join("_refs")
         .join("branches")
-        .join("target.json");
+        .join(format!("{target_native}.json"));
     let replacement_result = (|| {
         let bytes = std::fs::read(&target_ref_path)?;
         let mut contents: lance::dataset::refs::BranchContents = serde_json::from_slice(&bytes)
@@ -12447,12 +12523,7 @@ async fn branch_merge_pure_insert_rejects_target_table_ref_aba_before_arm() {
         replacement_identifier, old_target_identifier,
         "raw ref replacement must mint a distinct native target-table incarnation"
     );
-    let replacement_target = lance::Dataset::open(&person_uri)
-        .await
-        .unwrap()
-        .checkout_branch("target")
-        .await
-        .unwrap();
+    let replacement_target = helpers::open_dataset_head(&person_uri, Some("target")).await;
     assert_eq!(
         replacement_target.version().version,
         expected_target_version,
@@ -12516,12 +12587,7 @@ async fn branch_merge_pure_insert_rejects_target_table_ref_aba_before_arm() {
         !target_names.iter().any(|name| name == "source-only"),
         "source-only row leaked into rejected target merge: {target_names:?}"
     );
-    let final_target = lance::Dataset::open(&person_uri)
-        .await
-        .unwrap()
-        .checkout_branch("target")
-        .await
-        .unwrap();
+    let final_target = helpers::open_dataset_head(&person_uri, Some("target")).await;
     assert_eq!(final_target.version().version, expected_target_version);
     assert_eq!(
         final_target.branch_identifier().await.unwrap(),
@@ -12560,7 +12626,7 @@ async fn assert_branch_merge_first_touch_ref_is_recovered(
     let person_uri = node_table_uri(&db, "Person").await;
     let person = lance::Dataset::open(&person_uri).await.unwrap();
     assert!(
-        !person.list_branches().await.unwrap().contains_key("target"),
+        helpers::native_ref_for(&person, "target").await.is_none(),
         "fixture requires the target table ref to be lazy"
     );
 
@@ -12586,7 +12652,7 @@ async fn assert_branch_merge_first_touch_ref_is_recovered(
 
     let person = lance::Dataset::open(&person_uri).await.unwrap();
     assert_eq!(
-        person.list_branches().await.unwrap().contains_key("target"),
+        helpers::native_ref_for(&person, "target").await.is_some(),
         ref_exists_before_recovery,
         "fixture must stop at the intended sidecar/ref boundary"
     );
@@ -12596,7 +12662,7 @@ async fn assert_branch_merge_first_touch_ref_is_recovered(
     assert!(!sidecar_path.exists());
     let person = lance::Dataset::open(&person_uri).await.unwrap();
     assert!(
-        !person.list_branches().await.unwrap().contains_key("target"),
+        helpers::native_ref_for(&person, "target").await.is_none(),
         "Full recovery must reclaim an unpublished first-touch target ref"
     );
     assert_eq!(

--- a/crates/omnigraph/tests/forbidden_apis.rs
+++ b/crates/omnigraph/tests/forbidden_apis.rs
@@ -268,6 +268,11 @@ const READ_ONLY_SURFACES: &[(&str, &str)] = &[
     ("db/omnigraph.rs", "snapshot_at_graph_manifest_version"),
     ("db/omnigraph.rs", "export_jsonl"),
     ("db/omnigraph.rs", "export_jsonl_to_writer"),
+    // Added by #570 without registration (pre-existing red at 12e23d81):
+    // unordered export delegates to the same export read path; the base-paths
+    // probe is a relocation-audit read of the manifest dataset.
+    ("db/omnigraph.rs", "export_jsonl_unordered_to_writer"),
+    ("db/omnigraph.rs", "manifest_has_external_base_paths"),
     ("db/omnigraph.rs", "graph_index"),
     ("blob.rs", "read_blob_at"),
     ("db/omnigraph.rs", "branch_list"),
@@ -292,6 +297,18 @@ const LOW_LEVEL_READ_ONLY_SURFACES: &[(&str, &str, &str)] = &[
         "db/graph_coordinator.rs",
         "GraphCoordinator",
         "open_exact_genesis_with_storage",
+    ),
+    // Issue #562: batch logical-to-native resolution — one registry READ from
+    // a fresh root open; commits nothing.
+    (
+        "db/graph_coordinator.rs",
+        "GraphCoordinator",
+        "resolve_native_branch_refs",
+    ),
+    (
+        "db/manifest.rs",
+        "ManifestCoordinator",
+        "resolve_native_branch_refs",
     ),
     ("db/graph_coordinator.rs", "GraphCoordinator", "open"),
     (
@@ -652,6 +669,12 @@ gateway_surfaces! {
     "db/manifest/publisher.rs" => "GraphNamespacePublisher" => GatewayDisposition::ReadOrPure => [
         "new_with_session",
     ],
+    // Issue #562: the branch-registry row commit is the branch lifecycle's
+    // existence authority; row-level CAS on `object_id` via the same
+    // merge-insert gateway the version publisher uses.
+    "db/manifest/publisher.rs" => "GraphNamespacePublisher" => GatewayDisposition::Durable(WriteProtocol::Composed("branch registry CAS commit")) => [
+        "commit_branch_registration",
+    ],
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -681,7 +704,7 @@ durable_calls! {
     // (A `table_version_management` config key is deliberately not written:
     // neither the pinned Lance substrate nor this crate reads it.)
     ("db/manifest/graph.rs", "Dataset::write(", 2, WriteProtocol::Bootstrap),
-    ("db/manifest/publisher.rs", ".dataset()", 2, WriteProtocol::ReadOnlyAccess),
+    ("db/manifest/publisher.rs", ".dataset()", 3, WriteProtocol::ReadOnlyAccess),
     ("db/manifest/publisher.rs", ".publish_with_precondition(", 1, WriteProtocol::Exact("manifest publisher trait forwarding")),
     ("db/manifest/publisher.rs", "MergeInsertBuilder::try_new(", 1, WriteProtocol::Exact("lowest manifest publisher gateway")),
     ("db/manifest/publisher.rs", ".execute_reader(", 1, WriteProtocol::Exact("lowest manifest publisher gateway")),

--- a/crates/omnigraph/tests/forbidden_apis.rs
+++ b/crates/omnigraph/tests/forbidden_apis.rs
@@ -268,11 +268,6 @@ const READ_ONLY_SURFACES: &[(&str, &str)] = &[
     ("db/omnigraph.rs", "snapshot_at_graph_manifest_version"),
     ("db/omnigraph.rs", "export_jsonl"),
     ("db/omnigraph.rs", "export_jsonl_to_writer"),
-    // Added by #570 without registration (pre-existing red at 12e23d81):
-    // unordered export delegates to the same export read path; the base-paths
-    // probe is a relocation-audit read of the manifest dataset.
-    ("db/omnigraph.rs", "export_jsonl_unordered_to_writer"),
-    ("db/omnigraph.rs", "manifest_has_external_base_paths"),
     ("db/omnigraph.rs", "graph_index"),
     ("blob.rs", "read_blob_at"),
     ("db/omnigraph.rs", "branch_list"),

--- a/crates/omnigraph/tests/helpers/mod.rs
+++ b/crates/omnigraph/tests/helpers/mod.rs
@@ -117,9 +117,64 @@ pub async fn open_dataset_head(uri: &str, branch: Option<&str>) -> lance::Datase
         .await
         .unwrap();
     match branch {
-        Some(branch) if branch != "main" => ds.checkout_branch(branch).await.unwrap(),
+        Some(branch) if branch != "main" => {
+            // Callers name branches LOGICALLY; the on-disk ref is the current
+            // life's `{logical}--{ulid}` native ref (issue #562), or the bare
+            // name for legacy/hand-forged fixtures.
+            let native = native_ref_for(&ds, branch)
+                .await
+                .unwrap_or_else(|| branch.to_string());
+            ds.checkout_branch(&native).await.unwrap()
+        }
         _ => ds,
     }
+}
+
+/// The Lance ref on `ds` that is a life of the LOGICAL branch name (issue
+/// #562): the ULID-suffixed native ref when one exists, else the bare name if
+/// present, else `None`. More than one listed life is a fixture bug — fail
+/// loudly rather than pick one.
+pub async fn native_ref_for(ds: &lance::Dataset, logical: &str) -> Option<String> {
+    let branches = ds.list_branches().await.unwrap();
+    let prefix = format!("{logical}--");
+    let mut lives: Vec<String> = branches
+        .keys()
+        .filter(|name| name.as_str() == logical || name.starts_with(&prefix))
+        .cloned()
+        .collect();
+    assert!(
+        lives.len() <= 1,
+        "ambiguous lives for logical branch '{logical}': {lives:?}"
+    );
+    lives.pop()
+}
+
+/// Assert a persisted `native_dataset_branch` names a life of `logical`
+/// (issue #562): the ULID-suffixed native ref `{logical}--{ulid}`, or the
+/// bare name for a legacy fork.
+#[track_caller]
+pub fn assert_native_branch_of(native: Option<&str>, logical: &str) {
+    let native = native.unwrap_or_else(|| panic!("expected a fork of '{logical}', got None"));
+    assert!(
+        native == logical || native.starts_with(&format!("{logical}--")),
+        "expected a life of '{logical}', got '{native}'"
+    );
+}
+
+/// The current life's native ref of a LOGICAL graph branch, read from the
+/// `__manifest` dataset's live refs (issue #562). Fixtures that forge or
+/// inspect per-table state colliding with the engine's own fork targets must
+/// address this name, not the logical one.
+pub async fn graph_native_ref(root_uri: &str, logical: &str) -> String {
+    let manifest_uri = format!("{}/__manifest", root_uri.trim_end_matches('/'));
+    let ds = lance::dataset::builder::DatasetBuilder::from_uri(&manifest_uri)
+        .with_session(test_session())
+        .load()
+        .await
+        .unwrap();
+    native_ref_for(&ds, logical)
+        .await
+        .unwrap_or_else(|| panic!("no live ref for logical branch '{logical}'"))
 }
 
 /// Init a graph and load the standard test data.

--- a/crates/omnigraph/tests/maintenance.rs
+++ b/crates/omnigraph/tests/maintenance.rs
@@ -1640,11 +1640,13 @@ async fn cleanup_reconciles_live_branch_orphan_fork_but_keeps_legitimate_fork() 
             "cleanup must reclaim the manifest-unreferenced Person fork on the live branch"
         );
     }
-    // ...but the legitimate Company fork on the same live branch is kept.
+    // ...but the legitimate Company fork on the same live branch is kept
+    // (the engine forked it at the feature life's `feature--{ulid}` native
+    // ref, issue #562).
     {
         let ds = Dataset::open(&company_uri).await.unwrap();
         assert!(
-            ds.list_branches().await.unwrap().contains_key("feature"),
+            helpers::native_ref_for(&ds, "feature").await.is_some(),
             "cleanup must NOT reclaim a legitimately-forked table on a live branch"
         );
     }

--- a/crates/omnigraph/tests/merge_cost.rs
+++ b/crates/omnigraph/tests/merge_cost.rs
@@ -125,8 +125,20 @@ fn merge_validation_is_delta_scoped() {
              Pre-#5 it opened every catalog table (~6) via a whole-graph validation scan.",
             io.data_open_count
         );
-        const COMMON_MERGE_MANIFEST_OPEN_CEILING: u64 = 3;
-        const COMMON_MERGE_MANIFEST_SCAN_CEILING: u64 = 3;
+        // Issue #562 re-measure: branch listings are authority reads now
+        // (always-fresh root open + registry scan; a pinned listing serves
+        // ghost branches on long-lived handles — caught by parity), and the
+        // merge's commit resolutions hit the listing fallback. Measured 11.
+        // Batching the per-merge listings is noted follow-up; the ceiling
+        // still forbids O(catalog)/O(history) open regressions.
+        const COMMON_MERGE_MANIFEST_OPEN_CEILING: u64 = 12;
+        // Issue #562 re-measure: every branch-bound `__manifest` open now
+        // performs one small filtered registry scan (object_type='branch') to
+        // resolve the logical name to its life's native ref. Measured 12 on
+        // this fixture (was <=3); the scan count stays FLAT across history
+        // depth, so the ceiling still forbids O(history) scan regressions.
+        // Batching resolution per merge is noted follow-up.
+        const COMMON_MERGE_MANIFEST_SCAN_CEILING: u64 = 13;
         assert!(
             io.internal_open_count <= COMMON_MERGE_MANIFEST_OPEN_CEILING,
             "common one-table fast-forward merge opened internal tables {} times; expected <= \
@@ -245,8 +257,13 @@ fn merge_manifest_cost_grows_with_history() {
             // each of the fixed-count coherent scans folds the uncompacted
             // append-only journal.
             assert_grows(&curve, |c| c.manifest_reads, 1, "merge __manifest scan");
-            const DIVERGED_MERGE_MANIFEST_OPEN_CEILING: u64 = 4;
-            const DIVERGED_MERGE_MANIFEST_SCAN_CEILING: u64 = 4;
+            // Issue #562: same always-fresh listing cost as the common-merge
+            // ceiling above (measured 12, flat across depth).
+            const DIVERGED_MERGE_MANIFEST_OPEN_CEILING: u64 = 13;
+            // Issue #562: one filtered registry-resolution scan per
+            // branch-bound open (measured 13 at every depth — flat, so the
+            // O(history) guard this ceiling exists for still holds).
+            const DIVERGED_MERGE_MANIFEST_SCAN_CEILING: u64 = 14;
             for (depth, io) in &curve {
                 assert!(
                     io.internal_open_count <= DIVERGED_MERGE_MANIFEST_OPEN_CEILING,

--- a/crates/omnigraph/tests/merge_fast_forward.rs
+++ b/crates/omnigraph/tests/merge_fast_forward.rs
@@ -409,12 +409,7 @@ async fn append_only_fast_forward_merge_uses_bounded_fenced_insert_chain() {
         base_entry.dataset_path.trim_start_matches('/')
     );
     let base_table = Dataset::open(&person_uri).await.unwrap();
-    let source_table = Dataset::open(&person_uri)
-        .await
-        .unwrap()
-        .checkout_branch("feature")
-        .await
-        .unwrap();
+    let source_table = helpers::open_dataset_head(&person_uri, Some("feature")).await;
     let base_identifier = base_table.branch_identifier().await.unwrap();
     let source_identifier = source_table.branch_identifier().await.unwrap();
     assert_eq!(
@@ -506,12 +501,8 @@ async fn nested_source_lineage_merges_without_false_read_set_conflict() {
         .branch_identifier()
         .await
         .unwrap();
-    let source_identifier = Dataset::open(&person_uri)
+    let source_identifier = helpers::open_dataset_head(&person_uri, Some("experiment"))
         .await
-        .unwrap()
-        .checkout_branch("experiment")
-        .await
-        .unwrap()
         .branch_identifier()
         .await
         .unwrap();
@@ -556,12 +547,7 @@ async fn missing_source_transaction_history_falls_back_to_ordered_diff() {
         main.uri().trim_end_matches('/'),
         base_entry.dataset_path.trim_start_matches('/')
     );
-    let source = Dataset::open(&person_uri)
-        .await
-        .unwrap()
-        .checkout_branch("feature")
-        .await
-        .unwrap();
+    let source = helpers::open_dataset_head(&person_uri, Some("feature")).await;
     let missing_version = source
         .version()
         .version
@@ -571,9 +557,16 @@ async fn missing_source_transaction_history_falls_back_to_ordered_diff() {
         missing_version > base_entry.published_dataset_version,
         "fixture needs at least two source transactions above the merge base"
     );
+    // The fork's tree lives at the feature life's NATIVE ref (issue #562).
+    let feature_fork = {
+        let root = Dataset::open(&person_uri).await.unwrap();
+        helpers::native_ref_for(&root, "feature")
+            .await
+            .expect("feature's table fork exists")
+    };
     let versions_dir = std::path::Path::new(&person_uri)
         .join("tree")
-        .join("feature")
+        .join(&feature_fork)
         .join("_versions");
     let v1_path = versions_dir.join(format!("{missing_version}.manifest"));
     let v2_path = versions_dir.join(format!("{:020}.manifest", u64::MAX - missing_version));

--- a/crates/omnigraph/tests/merge_net_zero.rs
+++ b/crates/omnigraph/tests/merge_net_zero.rs
@@ -293,11 +293,17 @@ query set_note($title: String, $note: String) {
         .dataset("node:Document")
         .expect("feature Document entry");
     assert_eq!(source_entry.dataset_path, base_entry.dataset_path);
-    assert_eq!(
-        source_entry.native_dataset_branch.as_deref(),
-        Some("feature")
+    // The fork lives at the feature life's native ref (issue #562); the tree
+    // path below addresses that exact ref.
+    let source_native = source_entry
+        .native_dataset_branch
+        .as_deref()
+        .expect("feature must own the forked Document table");
+    assert!(
+        source_native == "feature" || source_native.starts_with("feature--"),
+        "expected a life of 'feature', got '{source_native}'"
     );
-    let source_table_uri = format!("{base_table_uri}/tree/feature");
+    let source_table_uri = format!("{base_table_uri}/tree/{source_native}");
     let source_dataset = Dataset::open(&source_table_uri).await.unwrap();
     assert_ne!(source_dataset.uri(), base_dataset.uri());
     let mut scanner = source_dataset.scan();

--- a/crates/omnigraph/tests/merge_projection_cache.rs
+++ b/crates/omnigraph/tests/merge_projection_cache.rs
@@ -160,8 +160,14 @@ fn repeated_merge_refreshes_projection_incrementally() {
             // structural physical-take guard above. The ceiling leaves room
             // for Lance metadata layout changes without allowing a hidden
             // full coordinator reopen to multiply the measured reads.
+            // Issue #562 re-measure: branch-bound opens now read the branch
+            // registry from the root manifest, adding a bounded number of
+            // object reads per open (measured 79 on this fixture, was <=32
+            // pre-registry). Batching resolution per operation is noted
+            // follow-up; the ceiling still forbids an unbounded full-scan
+            // regression.
             assert!(
-                io.manifest_reads <= 32,
+                io.manifest_reads <= 96,
                 "incremental repeated merge used {} manifest object reads; hidden full scans must not ride the measured path",
                 io.manifest_reads,
             );

--- a/crates/omnigraph/tests/warm_read_cost.rs
+++ b/crates/omnigraph/tests/warm_read_cost.rs
@@ -247,8 +247,10 @@ async fn warm_branch_read_uses_one_ref_witness_without_manifest_scan() {
         let reads = last_manifest_reads();
         assert_eq!(reads.len(), 1);
         assert!(
-            reads[0].contains("_refs/branches/feature.json"),
-            "the sole warm named-branch read must be BranchContents, not a manifest body: {reads:#?}"
+            reads[0].contains("_refs/branches/feature--")
+                || reads[0].contains("_refs/branches/feature.json"),
+            "the sole warm named-branch read must be BranchContents of the \
+             branch life's native ref (issue #562), not a manifest body: {reads:#?}"
         );
         assert_eq!(
             io.version_probes, 1,
@@ -300,9 +302,12 @@ async fn cold_other_branch_resolution_uses_one_coherent_manifest_open() {
             io.internal_open_count, 1,
             "cold branch resolution must derive snapshot + lineage from one manifest open"
         );
+        // Issue #562: +1 filtered branch-registry scan resolves the logical
+        // name to its life's native ref before the state scan.
         assert_eq!(
-            io.manifest_scan_count, 1,
-            "cold branch resolution must derive snapshot + lineage in one manifest row scan"
+            io.manifest_scan_count, 2,
+            "cold branch resolution must derive snapshot + lineage in one manifest row scan \
+             plus the one registry-resolution scan (issue #562)"
         );
     })
     .await;
@@ -323,32 +328,50 @@ async fn native_branch_controls_use_one_post_gate_manifest_capture() {
 
         let (created, create_io) = measure(db.branch_create("feature")).await;
         created.unwrap();
+        // Issue #562 re-measure: create = the coherent post-gate source
+        // capture (1 open, 1 state scan) PLUS the registry authority commit
+        // (its own root open + CAS pre-check registry scan + publish-state
+        // loads) PLUS the always-fresh namespace-safety listings.
+        // Measured (5, 5) on this fixture.
         assert_eq!(
             (create_io.internal_open_count, create_io.manifest_scan_count),
-            (1, 1),
-            "branch create must use one coherent post-gate source capture"
+            (5, 5),
+            "branch create = one coherent post-gate source capture + the registry \
+             commit + the always-fresh namespace-safety listings"
         );
 
         let (deleted, delete_io) = measure(db.branch_delete("feature")).await;
         deleted.unwrap();
+        // Issue #562 re-measure: delete adds the registry work on top of the
+        // pre-existing captures — the batch candidate resolution, the
+        // branch-list and descendants authority reads (always-fresh), the
+        // dead-row CAS commit's own open + pre-check scan, and the
+        // with-expected identifier listing. Measured (9, 10) on this
+        // one-survivor fixture; the per-surviving-branch SLOPE is bounded
+        // separately by branch_control_cost.
         assert_eq!(
             (delete_io.internal_open_count, delete_io.manifest_scan_count),
-            (3, 2),
-            "branch delete needs one coherent target capture, one fresh manifest-only \
-             snapshot for surviving main, and one native-ref opener"
+            (9, 10),
+            "branch delete = the coherent captures + the registry authority work \
+             + the always-fresh listings"
         );
 
         db.branch_create("feature").await.unwrap();
         let (created_from, create_from_io) =
             measure(db.branch_create_from("feature", "review")).await;
         created_from.unwrap();
+        // Issue #562 re-measure: create-from = the coherent post-gate source
+        // capture plus the registry authority commit plus the always-fresh
+        // listings; the non-main source adds one resolved open over plain
+        // create. Measured (5, 6).
         assert_eq!(
             (
                 create_from_io.internal_open_count,
                 create_from_io.manifest_scan_count,
             ),
-            (1, 1),
-            "branch create-from must use one coherent post-gate source capture"
+            (5, 6),
+            "branch create-from = the coherent source capture + the registry commit \
+             + the always-fresh listings"
         );
     })
     .await;
@@ -419,10 +442,12 @@ async fn warm_read_on_recreated_branch_observes_new_incarnation() {
         .graph_manifest_version_of(ReadTarget::branch("feature"))
         .await
         .unwrap();
-    assert_eq!(
-        new_version, old_version,
-        "test setup must exercise branch incarnation reuse at one Lance version"
-    );
+    // Pre-#562 this fixture engineered the recreation at the SAME numeric
+    // manifest version (the dangerous collision). The registry authority
+    // commits now advance the version across lives, so the collision is no
+    // longer constructible; the protected claims below (replacement rows,
+    // replaced head, no old-life leakage) hold structurally instead.
+    let _ = (new_version, old_version);
 
     let (new_feature, io) = measure(reader.query_with_head(
         ReadTarget::branch("feature"),
@@ -525,7 +550,7 @@ async fn recreated_branch_owned_table_handle_uses_table_etag() {
         .dataset("node:Person")
         .unwrap()
         .clone();
-    assert_eq!(old_entry.native_dataset_branch.as_deref(), Some("feature"));
+    helpers::assert_native_branch_of(old_entry.native_dataset_branch.as_deref(), "feature");
 
     writer.branch_delete("feature").await.unwrap();
     writer.branch_create("feature").await.unwrap();
@@ -546,13 +571,13 @@ async fn recreated_branch_owned_table_handle_uses_table_etag() {
         .unwrap()
         .clone();
     assert_eq!(new_entry.dataset_path, old_entry.dataset_path);
-    assert_eq!(
-        new_entry.native_dataset_branch,
-        old_entry.native_dataset_branch
-    );
-    assert_eq!(
-        new_entry.published_dataset_version, old_entry.published_dataset_version,
-        "test setup must force table handle identity to differ only by e_tag"
+    // Pre-#562 this fixture forced the handle-cache key to differ ONLY by
+    // e_tag (same path, branch name, version) — the documented e_tag-less
+    // hazard. The rotation puts the life's native ref in the key, so the two
+    // lives differ structurally; pin that instead.
+    assert_ne!(
+        new_entry.native_dataset_branch, old_entry.native_dataset_branch,
+        "each branch life must own a distinct native ref (issue #562)"
     );
 
     let (new_person, io) = measure(reader.query(
@@ -646,9 +671,9 @@ async fn recreated_branch_traversal_uses_graph_index_incarnation() {
             .dataset("edge:Knows")
             .unwrap()
             .clone();
-        assert_eq!(
+        helpers::assert_native_branch_of(
             old_edge_entry.native_dataset_branch.as_deref(),
-            Some("feature")
+            "feature",
         );
 
         writer.branch_delete("feature").await.unwrap();
@@ -673,13 +698,13 @@ async fn recreated_branch_traversal_uses_graph_index_incarnation() {
             .unwrap()
             .clone();
         assert_eq!(new_edge_entry.dataset_path, old_edge_entry.dataset_path);
-        assert_eq!(
-            new_edge_entry.native_dataset_branch,
-            old_edge_entry.native_dataset_branch
-        );
-        assert_eq!(
-            new_edge_entry.published_dataset_version, old_edge_entry.published_dataset_version,
-            "test setup must force graph-index identity to differ only by snapshot incarnation"
+        // Pre-#562 this fixture forced the graph-index cache key to collide
+        // across lives (same path, branch name, version). The rotation keys
+        // the fork by the life's native ref, so the lives differ
+        // structurally; pin that instead.
+        assert_ne!(
+            new_edge_entry.native_dataset_branch, old_edge_entry.native_dataset_branch,
+            "each branch life must own a distinct native ref (issue #562)"
         );
 
         let (new_friends, io) = measure(reader.query(

--- a/docs/releases/v0.10.0.md
+++ b/docs/releases/v0.10.0.md
@@ -207,6 +207,17 @@ and GitHub Releases; see the current policy in
   instead of risking same-name/same-version branch ABA. Genuine inherited-main
   history remains eligible after the graph-snapshot proof; property/schema
   checks still apply.
+- **Branch names reject the reserved `--` substring.** Each life of a branch
+  now owns an internal native ref named `{name}--{ulid}`, so a deleted and
+  recreated branch never shares storage paths or cache entries with its dead
+  predecessor (the delete/recreate staleness class of #562). To keep the
+  internal namespace collision-free, `--` is rejected in branch names on
+  create, mutate, load, and delete. Existing branches keep their current
+  names and paths untouched; a pre-existing name containing `--` remains
+  readable and mergeable but loses write operations and cannot be recreated
+  after deletion. A failed `branch_create` may still have registered the
+  name: the retry reports `already exists` and the branch completes on next
+  use.
 - **Blob property-lifetime fencing.** Physical user fields newly initialized,
   added, or schema-rebuilt by 0.10 persist `omnigraph.stable_property_id`. A
   schema-preserving Append, Merge, or mutation write after upgrade retains an

--- a/docs/user/branching/index.md
+++ b/docs/user/branching/index.md
@@ -40,6 +40,12 @@ Branch names may contain `/`, but live names must not be path prefixes of one
 another. For example, `review` and `review/alice` cannot coexist. `main` is
 reserved. A branch with descendants must be deleted leaf-first.
 
+The substring `--` is reserved for internal per-life branch identity and is
+rejected in branch names on create, mutate, load, and delete. A branch created
+before this reservation whose name contains `--` stays readable and mergeable,
+but can no longer be written to and cannot be recreated after deletion; migrate
+it by merging or exporting its content into a branch without `--` in the name.
+
 Branch-control operations are safe across handles in one writer process. Do not
 run branch create/delete control concurrently from separate writer processes
 against the same graph.


### PR DESCRIPTION
## What & why

Closes #562. A reborn branch (delete then create of the same logical name) reuses the same storage paths: manifest versions restart at 1, so `tree/b0/_versions/1.manifest` names different bytes across lives, and Lance's per-URI session file-metadata cache serves the dead life's entries to the new one, failing warm reads with `all columns in a record batch must have the same length` or silently returning stale rows. This PR closes it structurally: the user-facing logical branch name now maps to an internal native ref `{name}--{ulid}` with a per-life ULID minted at branch_create, so a rebirth is a new storage subtree and a new cache namespace by construction. No cache is ever cleared, and the staleness classes clearing cannot reach (a third in-process handle, a long-lived handle in another process, an in-flight cache loader inserting after a clear) close in the same move.

- Registry as authority: a branch registry row in the root `__manifest` (logical name, native ref, incarnation, liveness) is the existence authority; its CAS commit serializes racing creates of the same name (the Lance ref layer has no atomic create primitive) and the loser gets a typed Conflict.
- Crash safety: create commits the live row then creates the ref; delete commits the dead row then deletes the ref; forward recovery completes a missing ref in the create crash window (a live row with an absent ref proves it).
- Resolution freshness: branch-bound opens resolve the logical name through the pinned root manifest snapshot; a writer from an earlier life dies structurally, since its captured branch identifier can never match the current life's ref.
- Namespace guard: `--` is rejected in public branch names, so no user-chosen name can collide with an internal ref.
- Lazy migration: existing branches keep their bare ref names (resolution falls back when no registry row exists) and the first rebirth mints the ULID; no format stamp bump.
- Lance is unchanged: it treats the ref name as opaque and derives dataset paths, hence cache keys, from it. This is the `table_incarnation_id` precedent (identity embedded in paths makes staleness unrepresentable) applied to branches.

## Backing issue / RFC

- [x] Fixes an **accepted** issue: Closes #562

## Checklist

- [x] Change is focused (one logical change: per-life branch identity in the native ref, plus the registry and resolution seam it requires)
- [x] Tests added/updated for behavior changes (two DST repro pins green with a red control reproducing the exact #562 signature when resolution is neutered; new failpoint pinning forward recovery between registry commit and ref create; branching, failpoints, recovery, and cost suites extended to the per-life model)
- [ ] Public docs updated if user-facing surface changed (owed: `--` is now rejected in public branch names, and pre-existing branch names containing `--` lose mutate/load; doc lines land before merge)
- [x] Reviewed against docs/dev/invariants.md — no Hard Invariant weakened, no deny-list item hit (nearest miss: two new root-manifest commits per branch create+delete pair; the internal schema-apply lock branch is exempted and stays un-namespaced)

## Local verification

- `cargo test -p omnigraph-engine --test branching` — 40/40 (one skip: pre-existing stack-overflow test)
- `cargo test -p omnigraph-engine --test failpoints --features failpoints` — 151/151
- `cargo test -p omnigraph-engine` per suite — forbidden_apis 22/22, recovery 20/20, changes 46/46, maintenance 33/33, warm_read_cost 16/16, merge_cost 2/2, merge_projection_cache 5/5, merge_fast_forward 16/16, merge_net_zero 11/11, branch_control_cost 1/1; parity_branch_merge green against a freshly built server binary
- `cd crates/omnigraph-dst && cargo test --test scenarios dst_reborn_branch_cache_poison` — 2/2; red control: neutering native-ref resolution turns both pins red with the #562 signature
- `cargo test --workspace` — green except 3 known pre-existing reds (blob sandbox policy test, two stack-overflow tests) and 2 main-only `write_cost` accounting tests under baseline verification against clean upstream
- `cargo clippy --workspace --all-targets` — clean; `cargo fmt --all` — applied
- DST cost golden — not regenerated: drift measured and attributed (registry commits plus one resolution scan per branch-bound open), regen lands after review

## Notes for reviewers

- Engine footprint: branch_create and branch_delete each add one root `__manifest` registry commit; every branch-bound open pays one filtered registry-resolution scan, flat across history depth. The scan reads all manifest fragments, so per-open resolution caching and registry-fragment compaction are the first follow-up optimizations.
- Mixed-version sharp edge: an old binary deleting a branch leaves the registry row live, and a new binary's forward recovery then resurrects the branch empty at its fork point; upgrade guidance should land branch lifecycle ops on new binaries first.
- Native refs are user-addressable on reads (a `name--ulid` string resolves as itself), so Cedar policy sees the native name on that path.
- A dead life's manifest-level ref tree left by a delete crash has no automatic sweeper (it is unreachable via the registry; table-level forks are swept by the existing reconciler); dead-tree cleanup is a documented follow-up.
- A registry-row rewrite degrades one incremental refresh to a full scan, once per lifecycle op.
- Known corner: a live but refless child registration (create crash window) is not counted as a descendant by parent delete; the remedy is `branch_delete(child)`.
- No kill switch: the mechanism is structural and unconditioned; legacy stores keep working via the bare-name fallback.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR assigns every new branch lifetime a unique native Lance reference while preserving logical branch names as the public interface.
- Adds a root-manifest branch registry as lifecycle authority, with CAS-based create/delete serialization and forward recovery for interrupted creation.
- Resolves logical names to per-incarnation native references throughout manifest, table, staging, merge, maintenance, and recovery paths.
- Adds regression and failpoint coverage for stale-cache rebirths, lifecycle races, recovery, merge behavior, and operation costs.
- Documents the reserved `--` namespace, legacy-name compatibility restrictions, and migration options.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/omnigraph/src/db/branch_identity.rs | Defines the reserved namespace, per-life ULID minting, native-reference construction, and legacy-reference parsing. |
| crates/omnigraph/src/db/manifest.rs | Implements registry-authoritative branch creation, deletion, listing, logical-to-native resolution, and interrupted-create recovery. |
| crates/omnigraph/src/db/manifest/state.rs | Adds durable branch-registration rows and projection logic for current lifecycle authority. |
| crates/omnigraph/src/db/manifest/publisher.rs | Adds conditional registry publication used to serialize branch lifecycle transitions. |
| crates/omnigraph/src/db/manifest/layout.rs | Resolves logical branch checkouts to the native reference recorded for the current incarnation. |
| crates/omnigraph/src/db/manifest/recovery.rs | Completes live registrations whose native references were not created before interruption. |
| crates/omnigraph/src/db/omnigraph.rs | Integrates public-name validation and incarnation-aware branch lifecycle behavior into engine operations. |
| crates/omnigraph/tests/branching.rs | Covers namespace restrictions, lifecycle rebirth, legacy compatibility, and concurrent branch operations. |
| crates/omnigraph/tests/failpoints.rs | Exercises interruption windows and validates forward convergence of registry and native-reference state. |
| docs/user/branching/index.md | Documents the reserved separator, affected operations, legacy behavior, and migration path. |
| docs/releases/v0.10.0.md | Records the user-visible namespace restriction and branch-incarnation behavior for the release. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Create[Create logical branch] --> Register[Commit live registry row with native name--ULID]
    Register --> NativeCreate[Create native Lance ref]
    NativeCreate --> Use[Resolve logical name through registry]
    Register -->|Interrupted before ref creation| Recover[Forward recovery creates recorded native ref]
    Recover --> Use
    Use --> Delete[Delete logical branch]
    Delete --> Dead[Commit dead registry row]
    Dead --> NativeDelete[Delete native Lance ref]
    NativeDelete --> Recreate[Recreate same logical name]
    Recreate --> Fresh[Mint a new ULID and storage namespace]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into branch-incarnat..."](https://github.com/modernrelay/omnigraph/commit/67d75afbac73b39fbee129db5e2772a333b14cda) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58400146)</sub>

<!-- /greptile_comment -->