### PR TITLE
feat(bench): register, verify, and run real FinGraph fixture graphs

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -14,9 +14,12 @@ records, fixtures, or result storage.
   resolved relative to the suite file that contains it, and its canonical
   target must remain under the same catalog's `cases/` directory. Suite and
   referenced-case symlinks cannot escape the catalog.
-- `*.fixture-reference-v1.yaml` is the future logical contract for an imported
-  node-and-edge graph. No FinBench reference is checked in until its complete
-  logical content is independently digested and its physical root is frozen.
+- `fixtures/*.fixture-reference-v1.yaml` is the path-free logical contract for
+  an imported node-and-edge graph: builder provenance, logical data shape,
+  declared physical state, and expected schema/content digests.
+- `real-graph/*.run-v1.yaml` selects one registered fixture, the fixed
+  real-graph workload, repetition count, and operation deadline. This narrow
+  diagnostic path is separate from CaseV1 suites and durable run records.
 
 The `version` field selects the document schema. Keep identifiers and enum
 values in kebab-case. The scenario and fixture-builder versions identify the
@@ -152,13 +155,56 @@ target/release/omnigraph-bench fixture preflight-copy \
 These commands prove only physical byte identity and copy preflight. Physical
 identity is audit/reset evidence, not `point_id` input. They do not add the
 fixture to a CaseV1 suite or run a benchmark; CaseV1 remains the synthetic
-builder contract. No copied tree remains after preflight success. The strict
-logical reference declaration is available through `fixture reference
-validate`, but that command only checks the document. Graph-level validation,
-a non-vacuous node/edge workload adapter, and a Lance relocation preflight are
-still required. `ID=BUNDLE` preflight only reports its adjacent physical-source
-descriptor and observed bytes. See the crate README for both small schemas and
-the intentional boundary.
+builder contract. No copied tree remains after preflight success.
+
+### Observe and validate a registered graph
+
+`fixture observe-graph` copies and byte-verifies the bundle into disposable
+scratch, opens only that copy read-only, and computes the implemented logical
+witnesses:
+
+```bash
+target/release/omnigraph-bench fixture observe-graph \
+  --fixture finbench-2026-08-21-sf10-v1=/path/to/finbench-2026-08-21-sf10-v1 \
+  --scratch-root /path/to/existing-apfs-scratch --json
+```
+
+The observation includes accepted schema shape, complete per-type node and
+edge counts, a canonical logical-content digest, logical payload bytes,
+engine-managed index observations, main history depth, branch inventory, and a
+relocation-self-contained witness. The command rechecks the copied physical
+tree after observation and removes it. It never opens the registered source as
+an OmniGraph database and does not mutate that source.
+
+The declarative expectations for the frozen FinGraph fixture live in
+`benchmarks/fixtures/finbench-2026-08-21-sf10-v1.fixture-reference-v1.yaml`.
+Validate the YAML structure first, then recompute its implemented witnesses
+against the registered bytes:
+
+```bash
+target/release/omnigraph-bench fixture reference validate \
+  benchmarks/fixtures/finbench-2026-08-21-sf10-v1.fixture-reference-v1.yaml \
+  --json
+
+target/release/omnigraph-bench fixture validate-graph \
+  benchmarks/fixtures/finbench-2026-08-21-sf10-v1.fixture-reference-v1.yaml \
+  --fixture finbench-2026-08-21-sf10-v1=/path/to/finbench-2026-08-21-sf10-v1 \
+  --scratch-root /path/to/existing-apfs-scratch --json
+```
+
+`fixture reference validate` parses and normalizes the strict document only;
+it does not inspect a graph or prove a supplied digest. `fixture
+validate-graph` binds that declaration to one byte-verified disposable copy and
+fails when an implemented witness differs. Aging, deletion-history,
+compaction-recency, unknown raw Lance indexes, and per-index FTS/ANN freshness
+still lack exact substrate-owned witnesses and remain explicit in
+`unverified_state_fields`. Accordingly, graph inspection and validation always
+report `claim_eligible: false`.
+
+The logical reference and run file deliberately contain no local path, S3 URI,
+account, or credentials. The `ID=BUNDLE` argument is invocation-local transport
+configuration; replacing both bundle entries changes the observed physical
+receipt and the logical validation must still pass.
 
 Validation loads every referenced case and checks cross-field rules, including
 checked scale budgets, table bounds, cache-condition declarations, and
@@ -174,6 +220,8 @@ RustFS images in their point identity, but they are not executable by this
 runner slice.
 
 ## Run locally
+
+### CaseV1 suite runner
 
 Wall-clock execution is available only from a release-profile binary:
 
@@ -284,6 +332,62 @@ protected-head capture still occur and `page_cache: uncontrolled` states the
 OS cache limitation explicitly. A true page-cache-cold point remains refused
 until a named platform/backend eviction control has a post-control witness;
 storage-cold is also unsupported and unrepresentable.
+
+### FinGraph diagnostic runner
+
+The real-graph run is declared independently from the synthetic CaseV1 suite.
+The checked-in run file has this strict shape:
+
+```yaml
+version: 1
+fixture_id: finbench-2026-08-21-sf10-v1
+workload: finbench-disjoint-insert-merge
+repetitions: 5
+operation_deadline_seconds: 600
+```
+
+`repetitions` must be from 1 through 20 and
+`operation_deadline_seconds` from 1 through 3600. Unknown fields are refused.
+The logical reference path and local bundle path stay outside the run file so
+neither a checkout location nor an operator's storage location becomes
+experiment identity.
+
+Build the CLI in release mode and run the checked-in FinGraph declaration and
+logical reference against a local registered bundle:
+
+```bash
+cargo build --release --locked -p omnigraph-bench
+
+target/release/omnigraph-bench fixture run-graph \
+  benchmarks/real-graph/finbench-2026-08-21-sf10-v1.run-v1.yaml \
+  --reference \
+    benchmarks/fixtures/finbench-2026-08-21-sf10-v1.fixture-reference-v1.yaml \
+  --fixture finbench-2026-08-21-sf10-v1=/path/to/finbench-2026-08-21-sf10-v1 \
+  --scratch-root /path/to/existing-apfs-scratch --json
+```
+
+`run-graph` refuses a debug build. It is currently a local APFS diagnostic:
+the harness copies and validates the registered graph, prepares two branches
+whose disjoint changes each contain two `Account` nodes and one
+`AccountTransferAccount` edge, and freezes that prepared input. Each repetition
+restores the same path with APFS clonefiles and runs only the branch merge in a
+fresh worker process. The registered source is never opened as an OmniGraph
+database and remains unchanged.
+The result includes raw elapsed samples, p50, merge route/phases, the prepared
+physical digest, and verification evidence for the inserted delta, protected
+heads, and untouched tables. Pre-existing rows in the two changed tables are
+not yet fully re-read and are reported as unverified rather than implied to be
+proved.
+
+This path deliberately does not make a publishable performance claim. Every
+result says `claim_eligible: false` and `durable_record: false`; it has no
+warm-up program, and although each measurement uses a fresh process, the
+operating-system page cache is uncontrolled. `run-graph` does not accept
+`--archive`, publish durable telemetry, calculate a noise floor, download an
+S3 fixture, or dispatch work through the AWS benchmark infrastructure. AWS may
+hold the source snapshot, but an operator must first provide the verified local
+two-entry bundle used above. AWS orchestration and durable-record integration
+are later connector work, not behavior hidden behind this command.
 
 ## Telemetry and delivery boundary
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -14,6 +14,9 @@ records, fixtures, or result storage.
   resolved relative to the suite file that contains it, and its canonical
   target must remain under the same catalog's `cases/` directory. Suite and
   referenced-case symlinks cannot escape the catalog.
+- `*.fixture-reference-v1.yaml` is the future logical contract for an imported
+  node-and-edge graph. No FinBench reference is checked in until its complete
+  logical content is independently digested and its physical root is frozen.
 
 The `version` field selects the document schema. Keep identifiers and enum
 values in kebab-case. The scenario and fixture-builder versions identify the
@@ -109,6 +112,9 @@ cargo run --locked -p omnigraph-bench -- \
 
 cargo run --locked -p omnigraph-bench -- \
   suite plan benchmarks/suites/local-smoke.suite-v1.yaml
+
+cargo run --locked -p omnigraph-bench -- \
+  fixture reference validate /path/to/graph.fixture-reference-v1.yaml
 ```
 
 Each command accepts `--json` for machine-readable output. `suite plan` also
@@ -146,13 +152,13 @@ target/release/omnigraph-bench fixture preflight-copy \
 These commands prove only physical byte identity and copy preflight. Physical
 identity is audit/reset evidence, not `point_id` input. They do not add the
 fixture to a CaseV1 suite or run a benchmark; CaseV1 remains the synthetic
-builder contract. No copied tree remains after preflight success. Next is a
-versioned real-graph case/reference contract, graph-level logical validation,
-a non-vacuous node/edge workload adapter, and a Lance relocation preflight.
-That case/reference must independently pin the expected validated logical
-fixture stamp; `ID=BUNDLE` preflight only reports its adjacent physical-source
-descriptor and observed bytes. See the crate README for the small descriptor
-schema and the intentional boundary.
+builder contract. No copied tree remains after preflight success. The strict
+logical reference declaration is available through `fixture reference
+validate`, but that command only checks the document. Graph-level validation,
+a non-vacuous node/edge workload adapter, and a Lance relocation preflight are
+still required. `ID=BUNDLE` preflight only reports its adjacent physical-source
+descriptor and observed bytes. See the crate README for both small schemas and
+the intentional boundary.
 
 Validation loads every referenced case and checks cross-field rules, including
 checked scale budgets, table bounds, cache-condition declarations, and

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -373,6 +373,9 @@ whose disjoint changes each contain two `Account` nodes and one
 restores the same path with APFS clonefiles and runs only the branch merge in a
 fresh worker process. The registered source is never opened as an OmniGraph
 database and remains unchanged.
+Before returning either success or failure, the command explicitly attempts to
+remove its disposable workspace. A cleanup failure is reported, and a run plus
+cleanup double failure retains both causes.
 The result includes raw elapsed samples, p50, merge route/phases, the prepared
 physical digest, and verification evidence for the inserted delta, protected
 heads, and untouched tables. Pre-existing rows in the two changed tables are

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -114,6 +114,46 @@ cargo run --locked -p omnigraph-bench -- \
 Each command accepts `--json` for machine-readable output. `suite plan` also
 accepts `--case <ID>` to select one case from a suite.
 
+An operator-quiesced external snapshot tree uses a location-free two-entry
+bundle:
+
+```text
+BUNDLE/
+  fixture-source.json
+  root/
+```
+
+Create the physical copy-source descriptor from a quiescent local copy, then
+verify any later copy:
+
+```bash
+target/release/omnigraph-bench fixture fingerprint \
+  --id monarch-main-20260829 --root /mnt/nvme/fixtures/monarch/root \
+  > /path/to/fixture-source.json
+target/release/omnigraph-bench fixture verify /path/to/fixture-source.json \
+  --root /mnt/nvme/fixtures/monarch/root --json
+```
+
+The harness can also resolve `ID=BUNDLE`, copy the source into private
+disposable scratch, verify the copy, and clean it in the same invocation:
+
+```bash
+target/release/omnigraph-bench fixture preflight-copy \
+  --fixture monarch-main-20260829=/mnt/nvme/fixtures/monarch \
+  --scratch-root /mnt/nvme/omnigraph-bench-scratch --json
+```
+
+These commands prove only physical byte identity and copy preflight. Physical
+identity is audit/reset evidence, not `point_id` input. They do not add the
+fixture to a CaseV1 suite or run a benchmark; CaseV1 remains the synthetic
+builder contract. No copied tree remains after preflight success. Next is a
+versioned real-graph case/reference contract, graph-level logical validation,
+a non-vacuous node/edge workload adapter, and a Lance relocation preflight.
+That case/reference must independently pin the expected validated logical
+fixture stamp; `ID=BUNDLE` preflight only reports its adjacent physical-source
+descriptor and observed bytes. See the crate README for the small descriptor
+schema and the intentional boundary.
+
 Validation loads every referenced case and checks cross-field rules, including
 checked scale budgets, table bounds, cache-condition declarations, and
 reset/backend compatibility. Planning expands the suite into ordered run

--- a/benchmarks/fixtures/finbench-2026-08-21-sf10-v1.fixture-reference-v1.yaml
+++ b/benchmarks/fixtures/finbench-2026-08-21-sf10-v1.fixture-reference-v1.yaml
@@ -1,0 +1,126 @@
+version: 1
+fixture_id: finbench-2026-08-21-sf10-v1
+logical:
+  builder:
+    id: finbench-import
+    version: 1
+    recipe_sha256: 93810507ac01300e9ec8bc4d4052a9ebae1fbaa596a5892d2a7d030344c915da
+    parameters:
+      - { name: optimize-every, value: 200 }
+      - { name: scale-factor, value: 10 }
+      - { name: shard-lines, value: 8192 }
+    inputs:
+      - role: graph-schema
+        sha256: e2d8cd2430a4b79792c1a8b271c24add98862a367bcb54a500226e5a175d9116
+      - role: transformed-manifest
+        sha256: 5e0b3d93716055e5238d70ef9fb6edea592c49500cf9b99b0e8c84790860d835
+  data:
+    provenance: corpus-derived
+    schema_shape:
+      algorithm: omnigraph-schema-shape-v1
+      sha256: 51653ed5394949b966869c0194310a3d05d8a12096f2b7681eebbc413d8b27bc
+    node_tables:
+      - { name: Account, rows: 1534180 }
+      - { name: Company, rows: 291235 }
+      - { name: Loan, rows: 1028775 }
+      - { name: Medium, rows: 1940119 }
+      - { name: Person, rows: 582672 }
+    edge_tables:
+      - { name: AccountRepayLoan, rows: 1964476 }
+      - { name: AccountTransferAccount, rows: 6219881 }
+      - { name: AccountWithdrawAccount, rows: 6766001 }
+      - { name: CompanyApplyLoan, rows: 343454 }
+      - { name: CompanyGuaranteeCompany, rows: 141653 }
+      - { name: CompanyInvestCompany, rows: 512922 }
+      - { name: CompanyOwnAccount, rows: 511266 }
+      - { name: LoanDepositAccount, rows: 2024665 }
+      - { name: MediumSignInAccount, rows: 5127913 }
+      - { name: PersonApplyLoan, rows: 685321 }
+      - { name: PersonGuaranteePerson, rows: 284060 }
+      - { name: PersonInvestCompany, rows: 1028625 }
+      - { name: PersonOwnAccount, rows: 1022914 }
+    payload:
+      kind: variable
+      algorithm: omnigraph-logical-properties-v1
+      total_bytes: 4223187890
+    column_shape: scalars
+    topology_skew: source-defined
+  state:
+    aging: small-commits
+    indexes:
+      - { table: "edge:AccountRepayLoan", column: dst, kind: btree, freshness: optimized }
+      - { table: "edge:AccountRepayLoan", column: id, kind: btree, freshness: optimized }
+      - { table: "edge:AccountRepayLoan", column: src, kind: btree, freshness: optimized }
+      - { table: "edge:AccountTransferAccount", column: dst, kind: btree, freshness: optimized }
+      - { table: "edge:AccountTransferAccount", column: id, kind: btree, freshness: optimized }
+      - { table: "edge:AccountTransferAccount", column: src, kind: btree, freshness: optimized }
+      - { table: "edge:AccountWithdrawAccount", column: dst, kind: btree, freshness: optimized }
+      - { table: "edge:AccountWithdrawAccount", column: id, kind: btree, freshness: optimized }
+      - { table: "edge:AccountWithdrawAccount", column: src, kind: btree, freshness: optimized }
+      - { table: "edge:CompanyApplyLoan", column: dst, kind: btree, freshness: optimized }
+      - { table: "edge:CompanyApplyLoan", column: id, kind: btree, freshness: optimized }
+      - { table: "edge:CompanyApplyLoan", column: src, kind: btree, freshness: optimized }
+      - { table: "edge:CompanyGuaranteeCompany", column: dst, kind: btree, freshness: optimized }
+      - { table: "edge:CompanyGuaranteeCompany", column: id, kind: btree, freshness: optimized }
+      - { table: "edge:CompanyGuaranteeCompany", column: src, kind: btree, freshness: optimized }
+      - { table: "edge:CompanyInvestCompany", column: dst, kind: btree, freshness: optimized }
+      - { table: "edge:CompanyInvestCompany", column: id, kind: btree, freshness: optimized }
+      - { table: "edge:CompanyInvestCompany", column: src, kind: btree, freshness: optimized }
+      - { table: "edge:CompanyOwnAccount", column: dst, kind: btree, freshness: optimized }
+      - { table: "edge:CompanyOwnAccount", column: id, kind: btree, freshness: optimized }
+      - { table: "edge:CompanyOwnAccount", column: src, kind: btree, freshness: optimized }
+      - { table: "edge:LoanDepositAccount", column: dst, kind: btree, freshness: optimized }
+      - { table: "edge:LoanDepositAccount", column: id, kind: btree, freshness: optimized }
+      - { table: "edge:LoanDepositAccount", column: src, kind: btree, freshness: optimized }
+      - { table: "edge:MediumSignInAccount", column: dst, kind: btree, freshness: optimized }
+      - { table: "edge:MediumSignInAccount", column: id, kind: btree, freshness: optimized }
+      - { table: "edge:MediumSignInAccount", column: src, kind: btree, freshness: optimized }
+      - { table: "edge:PersonApplyLoan", column: dst, kind: btree, freshness: optimized }
+      - { table: "edge:PersonApplyLoan", column: id, kind: btree, freshness: optimized }
+      - { table: "edge:PersonApplyLoan", column: src, kind: btree, freshness: optimized }
+      - { table: "edge:PersonGuaranteePerson", column: dst, kind: btree, freshness: optimized }
+      - { table: "edge:PersonGuaranteePerson", column: id, kind: btree, freshness: optimized }
+      - { table: "edge:PersonGuaranteePerson", column: src, kind: btree, freshness: optimized }
+      - { table: "edge:PersonInvestCompany", column: dst, kind: btree, freshness: optimized }
+      - { table: "edge:PersonInvestCompany", column: id, kind: btree, freshness: optimized }
+      - { table: "edge:PersonInvestCompany", column: src, kind: btree, freshness: optimized }
+      - { table: "edge:PersonOwnAccount", column: dst, kind: btree, freshness: optimized }
+      - { table: "edge:PersonOwnAccount", column: id, kind: btree, freshness: optimized }
+      - { table: "edge:PersonOwnAccount", column: src, kind: btree, freshness: optimized }
+      - { table: "node:Account", column: accountId, kind: fts, freshness: optimized }
+      - { table: "node:Account", column: accountLevel, kind: btree, freshness: optimized }
+      - { table: "node:Account", column: accountType, kind: btree, freshness: optimized }
+      - { table: "node:Account", column: createTime, kind: btree, freshness: optimized }
+      - { table: "node:Account", column: id, kind: btree, freshness: optimized }
+      - { table: "node:Account", column: isBlocked, kind: btree, freshness: optimized }
+      - { table: "node:Company", column: city, kind: fts, freshness: optimized }
+      - { table: "node:Company", column: companyId, kind: fts, freshness: optimized }
+      - { table: "node:Company", column: companyName, kind: fts, freshness: optimized }
+      - { table: "node:Company", column: country, kind: fts, freshness: optimized }
+      - { table: "node:Company", column: createTime, kind: btree, freshness: optimized }
+      - { table: "node:Company", column: id, kind: btree, freshness: optimized }
+      - { table: "node:Company", column: isBlocked, kind: btree, freshness: optimized }
+      - { table: "node:Loan", column: createTime, kind: btree, freshness: optimized }
+      - { table: "node:Loan", column: id, kind: btree, freshness: optimized }
+      - { table: "node:Loan", column: loanAmount, kind: btree, freshness: optimized }
+      - { table: "node:Loan", column: loanId, kind: fts, freshness: optimized }
+      - { table: "node:Medium", column: createTime, kind: btree, freshness: optimized }
+      - { table: "node:Medium", column: id, kind: btree, freshness: optimized }
+      - { table: "node:Medium", column: isBlocked, kind: btree, freshness: optimized }
+      - { table: "node:Medium", column: mediumId, kind: fts, freshness: optimized }
+      - { table: "node:Medium", column: mediumType, kind: btree, freshness: optimized }
+      - { table: "node:Medium", column: riskLevel, kind: btree, freshness: optimized }
+      - { table: "node:Person", column: city, kind: fts, freshness: optimized }
+      - { table: "node:Person", column: country, kind: fts, freshness: optimized }
+      - { table: "node:Person", column: createTime, kind: btree, freshness: optimized }
+      - { table: "node:Person", column: id, kind: btree, freshness: optimized }
+      - { table: "node:Person", column: isBlocked, kind: btree, freshness: optimized }
+      - { table: "node:Person", column: personId, kind: fts, freshness: optimized }
+      - { table: "node:Person", column: personName, kind: fts, freshness: optimized }
+    deletion_history: none
+    compaction_recency: not-optimized
+    history_depth: 3934
+expected:
+  logical_content:
+    algorithm: omnigraph-logical-graph-multiset-v1
+    sha256: cf3115b85de3bf06ff68017f0bc65c9735640131be9ae04403e2081894209f96

--- a/benchmarks/real-graph/finbench-2026-08-21-sf10-v1.run-v1.yaml
+++ b/benchmarks/real-graph/finbench-2026-08-21-sf10-v1.run-v1.yaml
@@ -1,0 +1,5 @@
+version: 1
+fixture_id: finbench-2026-08-21-sf10-v1
+workload: finbench-disjoint-insert-merge
+repetitions: 5
+operation_deadline_seconds: 600

--- a/crates/omnigraph-bench/README.md
+++ b/crates/omnigraph-bench/README.md
@@ -109,6 +109,92 @@ measurement protocol and identity vocabulary.
   is stable across rebuilt Lance ids, timestamps, and encodings; a separate
   physical tree digest pins the exact bytes restored for every repetition.
 
+## Logical references for real graphs
+
+An externally built graph first needs a strict logical declaration. A
+`fixture-reference-v1.yaml` records only rebuild-stable identity:
+
+- the imported-graph builder version, digest-pinned recipe and inputs, and
+  typed parameters;
+- Data as canonical schema shape, non-empty node and edge inventories with
+  exact row counts, payload/column shape, provenance, and topology skew;
+- State as aging, structured index inventory, deletion history, compaction
+  recency, and history depth; and
+- the full logical-content digest that a later graph validator is expected to
+  reproduce.
+
+The authoring shape is deliberately location-free and scalar:
+
+```yaml
+version: 1
+fixture_id: finbench-sf10-main
+logical:
+  builder:
+    id: finbench-import
+    version: 1
+    recipe_sha256: "<64 lowercase hex characters>"
+    parameters:
+      - { name: scale-factor, value: 10 }
+    inputs:
+      - role: source-snapshot
+        sha256: "<64 lowercase hex characters>"
+  data:
+    provenance: corpus-derived
+    schema_shape:
+      algorithm: future-schema-shape-v1
+      sha256: "<64 lowercase hex characters>"
+    node_tables:
+      - { name: Person, rows: 582672 }
+    edge_tables:
+      - { name: PersonOwnAccount, rows: 1022914 }
+    payload:
+      kind: variable
+      algorithm: future-logical-payload-v1
+      total_bytes: 4096
+    column_shape: scalars
+    topology_skew: source-defined
+  state:
+    aging: small-commits
+    indexes: []
+    deletion_history: none
+    compaction_recency: optimized
+    history_depth: 3972
+expected:
+  logical_content:
+    algorithm: future-logical-graph-v1
+    sha256: "<64 lowercase hex characters>"
+```
+
+Builder parameters are limited to `null`, booleans, and unsigned integers;
+arbitrary strings cannot store literal paths, URIs, or credentials. Parameter
+names and numeric meanings are still trusted builder-contract input that a
+future builder adapter must validate. Input roles are path-free semantic labels
+and each input's content is pinned by SHA-256; this slice does not resolve that
+content.
+
+Validate the declaration with:
+
+```bash
+target/debug/omnigraph-bench fixture reference validate \
+  /path/to/graph.fixture-reference-v1.yaml --json
+```
+
+The result reports `reference_sha256`, an audit hash of the complete normalized,
+versioned declaration. It is not a point id. A future real-graph case must
+materialize builder, Data, and State into its typed run spec; the fixture id,
+reference path/hash, expected digest, graph commits, timestamps, and every
+physical/source location remain outside point identity.
+
+This command validates and normalizes the document only. Any 64-hex expected
+digest is still an unverified expectation: the command does not open a store or
+turn the supplied value into evidence. No executable real-graph reference is
+checked in until it has a canonical full-content digest and a frozen registered
+root. The next slice must define and implement the named canonical schema,
+payload, and graph hashing algorithms, with golden vectors, then compare the
+result on a disposable verified copy before any case can consume the reference.
+Algorithm ids in this document are explicit future contracts; validation does
+not claim to implement them.
+
 ## Registered fixture byte verification
 
 Large graph snapshots can be registered without putting a machine path, S3
@@ -193,12 +279,13 @@ anything.
 This interface is deliberately physical-only. It neither downloads from S3
 nor opens or mutates the source graph, proves graph-level logical Data/State or
 Lance relocation safety, prepares branches, or makes the registered fixture
-runnable by the synthetic CaseV1 executor. Next is an RFC-backed, versioned
-real-graph case/reference contract, graph-level logical validation of the
-registered node/edge fixture, a scenario adapter that prepares and verifies
-non-vacuous node/edge work, and a Lance relocation preflight. That later runner
-must keep its existing run-owned workspace alive and open only its copied
-`root/`, never the bundle source.
+runnable by the synthetic CaseV1 executor. The logical reference format above
+is now the independent expectation, but it is not yet bound to these copied
+bytes. Next is read-only graph-level validation of the copied node/edge
+fixture, then a scenario adapter that prepares and verifies non-vacuous work
+and a Lance relocation preflight. That later runner must keep its existing
+run-owned workspace alive and open only its copied `root/`, never the bundle
+source.
 
 The local source namespace is a trusted-input boundary: the operator must keep
 it quiescent for the command. Digest/copy verification detects ordinary drift

--- a/crates/omnigraph-bench/README.md
+++ b/crates/omnigraph-bench/README.md
@@ -120,80 +120,42 @@ An externally built graph first needs a strict logical declaration. A
   exact row counts, payload/column shape, provenance, and topology skew;
 - State as aging, structured index inventory, deletion history, compaction
   recency, and history depth; and
-- the full logical-content digest that a later graph validator is expected to
-  reproduce.
+- the full logical-content digest that `fixture validate-graph` recomputes
+  against a byte-verified disposable copy.
 
-The authoring shape is deliberately location-free and scalar:
-
-```yaml
-version: 1
-fixture_id: finbench-sf10-main
-logical:
-  builder:
-    id: finbench-import
-    version: 1
-    recipe_sha256: "<64 lowercase hex characters>"
-    parameters:
-      - { name: scale-factor, value: 10 }
-    inputs:
-      - role: source-snapshot
-        sha256: "<64 lowercase hex characters>"
-  data:
-    provenance: corpus-derived
-    schema_shape:
-      algorithm: future-schema-shape-v1
-      sha256: "<64 lowercase hex characters>"
-    node_tables:
-      - { name: Person, rows: 582672 }
-    edge_tables:
-      - { name: PersonOwnAccount, rows: 1022914 }
-    payload:
-      kind: variable
-      algorithm: future-logical-payload-v1
-      total_bytes: 4096
-    column_shape: scalars
-    topology_skew: source-defined
-  state:
-    aging: small-commits
-    indexes: []
-    deletion_history: none
-    compaction_recency: optimized
-    history_depth: 3972
-expected:
-  logical_content:
-    algorithm: future-logical-graph-v1
-    sha256: "<64 lowercase hex characters>"
-```
+The checked-in FinGraph declaration is
+`benchmarks/fixtures/finbench-2026-08-21-sf10-v1.fixture-reference-v1.yaml`.
+Its implemented algorithms are `omnigraph-schema-shape-v1`,
+`omnigraph-logical-properties-v1`, and
+`omnigraph-logical-graph-multiset-v1`. The document remains deliberately
+location-free and scalar.
 
 Builder parameters are limited to `null`, booleans, and unsigned integers;
 arbitrary strings cannot store literal paths, URIs, or credentials. Parameter
 names and numeric meanings are still trusted builder-contract input that a
-future builder adapter must validate. Input roles are path-free semantic labels
-and each input's content is pinned by SHA-256; this slice does not resolve that
-content.
+builder contract must define. Input roles are path-free semantic labels and
+each input's content is pinned by SHA-256. The current validator verifies the
+resulting graph facts; it does not replay the import recipe or resolve its
+inputs.
 
 Validate the declaration with:
 
 ```bash
-target/debug/omnigraph-bench fixture reference validate \
-  /path/to/graph.fixture-reference-v1.yaml --json
+target/release/omnigraph-bench fixture reference validate \
+  benchmarks/fixtures/finbench-2026-08-21-sf10-v1.fixture-reference-v1.yaml \
+  --json
 ```
 
 The result reports `reference_sha256`, an audit hash of the complete normalized,
-versioned declaration. It is not a point id. A future real-graph case must
-materialize builder, Data, and State into its typed run spec; the fixture id,
-reference path/hash, expected digest, graph commits, timestamps, and every
-physical/source location remain outside point identity.
-
-This command validates and normalizes the document only. Any 64-hex expected
-digest is still an unverified expectation: the command does not open a store or
-turn the supplied value into evidence. No executable real-graph reference is
-checked in until it has a canonical full-content digest and a frozen registered
-root. The next slice must define and implement the named canonical schema,
-payload, and graph hashing algorithms, with golden vectors, then compare the
-result on a disposable verified copy before any case can consume the reference.
-Algorithm ids in this document are explicit future contracts; validation does
-not claim to implement them.
+versioned declaration. It is not a point id. This command validates and
+normalizes the document only; it does not open a store or prove a supplied
+digest. `fixture observe-graph` derives the implemented witnesses, and `fixture
+validate-graph` compares all of them with the declaration while also requiring
+a relocation-self-contained graph. Aging, deletion history, compaction
+recency, unknown raw Lance index metadata, and per-index FTS/ANN freshness
+remain explicitly unverified, so the result is claim-ineligible. See the
+[benchmark catalog](../../benchmarks/README.md#observe-and-validate-a-registered-graph)
+for the exact observation and validation commands.
 
 ## Registered fixture byte verification
 
@@ -268,24 +230,27 @@ a time, so peak scratch usage is bounded by the largest fixture rather than
 their sum. Because this is a copy preflight, no staged tree remains after
 success.
 
-`ID=BUNDLE` is not yet an authoritative benchmark binding: this command reads
-the adjacent source descriptor and returns its canonical digest, but has no
-independent expected logical fixture stamp to compare it with. Replacing both
-`fixture-source.json` and `root/` under the same id therefore produces a
-different successful preflight receipt. The future case/runner contract must
-supply and enforce the expected logical fixture stamp before it can measure
-anything.
+`fixture preflight-copy` remains physical-only: it has no independent logical
+expectation, so replacing both `fixture-source.json` and `root/` under the same
+id produces a different successful physical receipt. `fixture observe-graph`
+and `fixture validate-graph` build on this seam. They retain the verified
+disposable copy, open only that copy read-only, compute the canonical schema,
+payload, and full node/edge content witnesses, check table/index/history
+observations and relocation safety, recheck its physical bytes, and then clean
+it up. They neither download from S3 nor open or mutate the registered source
+as an OmniGraph database.
 
-This interface is deliberately physical-only. It neither downloads from S3
-nor opens or mutates the source graph, proves graph-level logical Data/State or
-Lance relocation safety, prepares branches, or makes the registered fixture
-runnable by the synthetic CaseV1 executor. The logical reference format above
-is now the independent expectation, but it is not yet bound to these copied
-bytes. Next is read-only graph-level validation of the copied node/edge
-fixture, then a scenario adapter that prepares and verifies non-vacuous work
-and a Lance relocation preflight. That later runner must keep its existing
-run-owned workspace alive and open only its copied `root/`, never the bundle
-source.
+`fixture run-graph` is the narrow runnable adapter for the checked-in FinGraph
+reference and strict real-graph run YAML. From a release binary on local APFS,
+it validates the copied graph, prepares a deterministic disjoint node-and-edge
+delta on two branches, freezes that prepared state, and restores identical
+clonefile inputs for fresh-process merge repetitions. This path is deliberately
+diagnostic: its output always records `claim_eligible: false` and
+`durable_record: false`, has no warm-up, leaves the OS page cache uncontrolled,
+and cannot publish through `--archive`. It also does not dispatch through the
+AWS benchmark infrastructure or publish durable telemetry. See the
+[FinGraph diagnostic instructions](../../benchmarks/README.md#fingraph-diagnostic-runner)
+for the declarative run shape and exact command.
 
 The local source namespace is a trusted-input boundary: the operator must keep
 it quiescent for the command. Digest/copy verification detects ordinary drift

--- a/crates/omnigraph-bench/README.md
+++ b/crates/omnigraph-bench/README.md
@@ -109,6 +109,102 @@ measurement protocol and identity vocabulary.
   is stable across rebuilt Lance ids, timestamps, and encodings; a separate
   physical tree digest pins the exact bytes restored for every repetition.
 
+## Registered fixture byte verification
+
+Large graph snapshots can be registered without putting a machine path, S3
+URI, account, or credentials into their identity. A strict
+`fixture-source.json` describes only a format version, a path-free id, and the
+physical tree identity:
+
+```json
+{
+  "format_version": 1,
+  "fixture_id": "monarch-main-20260829",
+  "physical": {
+    "digest_algorithm": "omnigraph-bench-physical-tree-v1",
+    "tree_sha256": "<64 lowercase hex characters>",
+    "files": 16279,
+    "bytes": 3893489669
+  }
+}
+```
+
+Keep the descriptor beside, not inside, the graph root. The local bundle
+convention is deliberately small:
+
+```text
+BUNDLE/
+  fixture-source.json
+  root/
+```
+
+After an operator has quiesced a local snapshot tree, fingerprint its complete
+bytes into the small descriptor:
+
+```bash
+target/release/omnigraph-bench fixture fingerprint \
+  --id monarch-main-20260829 \
+  --root /mnt/nvme/fixtures/monarch/root \
+  > /mnt/nvme/fixtures/monarch/fixture-source.json
+```
+
+The command only prints JSON; it does not modify the tree or write a registry.
+Bind any later local copy to that descriptor and re-read its complete bytes with:
+
+```bash
+target/release/omnigraph-bench fixture verify fixture-source.json \
+  --root /mnt/nvme/fixtures/monarch/root --json
+```
+
+Success returns the canonical typed `source_descriptor_sha256`, the canonical
+local path, and the observed physical identity. The local path and descriptor
+digest are transport/audit evidence, not the harness's stamped logical fixture
+manifest and, per RFC 0039, must not become `point_id` input.
+
+Exercise the same-invocation binding and copy seam with a repeatable
+`ID=BUNDLE` mapping:
+
+```bash
+target/release/omnigraph-bench fixture preflight-copy \
+  --fixture monarch-main-20260829=/mnt/nvme/fixtures/monarch \
+  --scratch-root /mnt/nvme/omnigraph-bench-scratch \
+  --json
+```
+
+The command resolves the two required direct bundle entries, checks that the
+binding id matches the typed source descriptor, verifies the source while
+copying it into a private disposable workspace, re-digests the copy, and
+explicitly removes the workspace. Duplicate/malformed mappings, symlinked required
+entries, source drift, copy failure or drift, and cleanup failure all fail
+closed. Paths are invocation-only and do not appear in the success result.
+Unrelated bundle siblings are ignored. Bindings are copied and removed one at
+a time, so peak scratch usage is bounded by the largest fixture rather than
+their sum. Because this is a copy preflight, no staged tree remains after
+success.
+
+`ID=BUNDLE` is not yet an authoritative benchmark binding: this command reads
+the adjacent source descriptor and returns its canonical digest, but has no
+independent expected logical fixture stamp to compare it with. Replacing both
+`fixture-source.json` and `root/` under the same id therefore produces a
+different successful preflight receipt. The future case/runner contract must
+supply and enforce the expected logical fixture stamp before it can measure
+anything.
+
+This interface is deliberately physical-only. It neither downloads from S3
+nor opens or mutates the source graph, proves graph-level logical Data/State or
+Lance relocation safety, prepares branches, or makes the registered fixture
+runnable by the synthetic CaseV1 executor. Next is an RFC-backed, versioned
+real-graph case/reference contract, graph-level logical validation of the
+registered node/edge fixture, a scenario adapter that prepares and verifies
+non-vacuous node/edge work, and a Lance relocation preflight. That later runner
+must keep its existing run-owned workspace alive and open only its copied
+`root/`, never the bundle source.
+
+The local source namespace is a trusted-input boundary: the operator must keep
+it quiescent for the command. Digest/copy verification detects ordinary drift
+and prevents a mismatching copy from succeeding, but this path traversal is
+not a sandbox for an adversary racing file types or path entries.
+
 ## Durable records and archive
 
 Passing `--archive <DIR>` changes successful `suite run` finalization from a

--- a/crates/omnigraph-bench/src/bin/omnigraph-bench.rs
+++ b/crates/omnigraph-bench/src/bin/omnigraph-bench.rs
@@ -17,6 +17,9 @@ use omnigraph_bench::record::{
     AcquisitionTerminalStageV1, AcquisitionTerminalV1, InvocationIdentityV1, ObservedBackendV1,
     RecordInputV1, build_censored_run_record, build_run_record, sut_identity_for_execution,
 };
+use omnigraph_bench::registered_fixture::{
+    fingerprint_registered_fixture, preflight_copy_fixture_bindings, verify_registered_fixture,
+};
 use omnigraph_bench::{
     Diagnostic, PLAN_FORMAT_VERSION, RUNNER_OUTPUT_VERSION, ResolvedRun, ResolvedSuite,
     RunExecution, RunOptions, RunnerError, ValidatedCase, ValidationOutcome, execute_run,
@@ -46,6 +49,11 @@ enum Command {
     Case {
         #[command(subcommand)]
         command: CaseCommand,
+    },
+    /// Verify registered frozen fixture trees before benchmark preparation.
+    Fixture {
+        #[command(subcommand)]
+        command: FixtureCommand,
     },
     /// Inspect suites of benchmark cases.
     Suite {
@@ -83,6 +91,41 @@ enum CaseCommand {
     List {
         directory: PathBuf,
         /// Emit a machine-readable array.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum FixtureCommand {
+    /// Print a location-free JSON manifest for one stable local tree.
+    Fingerprint {
+        /// Path-free identity assigned to this exact physical snapshot.
+        #[arg(long)]
+        id: String,
+        /// Local graph-root directory to read completely.
+        #[arg(long)]
+        root: PathBuf,
+    },
+    /// Verify a local frozen tree against a location-free copy-source descriptor.
+    Verify {
+        source: PathBuf,
+        /// Local graph-root directory whose complete bytes must match.
+        #[arg(long)]
+        root: PathBuf,
+        /// Emit a machine-readable verification result.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Verify bundles while copying them through disposable harness scratch.
+    PreflightCopy {
+        /// Repeatable invocation-local fixture mapping in ID=BUNDLE form.
+        #[arg(long = "fixture", value_name = "ID=BUNDLE", required = true)]
+        fixtures: Vec<String>,
+        /// Create the disposable staging workspace below this existing directory.
+        #[arg(long)]
+        scratch_root: Option<PathBuf>,
+        /// Emit a machine-readable verification result after cleanup.
         #[arg(long)]
         json: bool,
     },
@@ -239,6 +282,7 @@ struct PlanRun<'a> {
 async fn main() -> ExitCode {
     match Cli::parse().command {
         Command::Case { command } => run_case(command),
+        Command::Fixture { command } => run_fixture(command),
         Command::Suite { command } => run_suite(command).await,
         Command::Archive { command } => run_archive(command),
         Command::Projection { command } => run_projection(command).await,
@@ -521,6 +565,67 @@ fn run_case(command: CaseCommand) -> ExitCode {
             }
         }
         CaseCommand::List { directory, json } => list_cases(&directory, json),
+    }
+}
+
+fn run_fixture(command: FixtureCommand) -> ExitCode {
+    match command {
+        FixtureCommand::Fingerprint { id, root } => {
+            match fingerprint_registered_fixture(id, &root).into_result() {
+                Ok(fixture) => print_json_success(&fixture),
+                Err(diagnostics) => print_diagnostics(&diagnostics),
+            }
+        }
+        FixtureCommand::Verify { source, root, json } => {
+            let outcome = verify_registered_fixture(&source, &root);
+            if json {
+                print_json(&outcome)
+            } else {
+                match outcome.into_result() {
+                    Ok(verified) => {
+                        println!(
+                            "verified fixture {} source_descriptor_sha256={} root={} files={} bytes={} tree_sha256={}",
+                            verified.fixture_id,
+                            verified.source_descriptor_sha256,
+                            verified.canonical_root.display(),
+                            verified.physical.files,
+                            verified.physical.bytes,
+                            verified.physical.tree_sha256,
+                        );
+                        ExitCode::SUCCESS
+                    }
+                    Err(diagnostics) => print_diagnostics(&diagnostics),
+                }
+            }
+        }
+        FixtureCommand::PreflightCopy {
+            fixtures,
+            scratch_root,
+            json,
+        } => {
+            let outcome = preflight_copy_fixture_bindings(&fixtures, scratch_root.as_deref());
+            if json {
+                print_json(&outcome)
+            } else {
+                match outcome.into_result() {
+                    Ok(fixtures) => {
+                        for fixture in fixtures {
+                            println!(
+                                "preflight-copied fixture {} source_descriptor_sha256={} files={} bytes={} tree_sha256={}",
+                                fixture.fixture_id,
+                                fixture.source_descriptor_sha256,
+                                fixture.physical.files,
+                                fixture.physical.bytes,
+                                fixture.physical.tree_sha256,
+                            );
+                        }
+                        println!("disposable scratch removed");
+                        ExitCode::SUCCESS
+                    }
+                    Err(diagnostics) => print_diagnostics(&diagnostics),
+                }
+            }
+        }
     }
 }
 

--- a/crates/omnigraph-bench/src/bin/omnigraph-bench.rs
+++ b/crates/omnigraph-bench/src/bin/omnigraph-bench.rs
@@ -14,12 +14,19 @@ use omnigraph_bench::projection::{
     DEFAULT_PROJECTION_PAGE_SIZE, ProjectionCursorV1, ProjectionError, ProjectionPageV1,
     list_points_page, list_runs_for_point_page, rebuild_projection,
 };
+use omnigraph_bench::real_graph::{
+    RealGraphObservationV1, observe_real_graph, validate_real_graph_reference,
+};
+use omnigraph_bench::real_graph_run::{
+    execute_real_graph_run, load_real_graph_run_spec, run_real_graph_worker_files,
+};
 use omnigraph_bench::record::{
     AcquisitionTerminalStageV1, AcquisitionTerminalV1, InvocationIdentityV1, ObservedBackendV1,
     RecordInputV1, build_censored_run_record, build_run_record, sut_identity_for_execution,
 };
 use omnigraph_bench::registered_fixture::{
-    fingerprint_registered_fixture, preflight_copy_fixture_bindings, verify_registered_fixture,
+    FixtureCopyPreflightReceiptV1, fingerprint_registered_fixture, preflight_copy_fixture_bindings,
+    stage_registered_fixture_binding, verify_registered_fixture,
 };
 use omnigraph_bench::{
     Diagnostic, PLAN_FORMAT_VERSION, RUNNER_OUTPUT_VERSION, ResolvedRun, ResolvedSuite,
@@ -77,6 +84,9 @@ enum Command {
     /// Private bounded fixture-builder endpoint used by the supervising runner.
     #[command(name = "__fixture-worker-v1", hide = true)]
     FixtureWorkerV1 { request: PathBuf, result: PathBuf },
+    /// Private real-graph diagnostic worker endpoint.
+    #[command(name = "__real-graph-worker-v1", hide = true)]
+    RealGraphWorkerV1 { request: PathBuf, result: PathBuf },
 }
 
 #[derive(Debug, Subcommand)]
@@ -132,6 +142,46 @@ enum FixtureCommand {
         #[arg(long)]
         scratch_root: Option<PathBuf>,
         /// Emit a machine-readable verification result after cleanup.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Inspect the logical node-and-edge content of one copied registered fixture.
+    ObserveGraph {
+        /// Invocation-local fixture mapping in ID=BUNDLE form.
+        #[arg(long = "fixture", value_name = "ID=BUNDLE")]
+        fixture: String,
+        /// Create the disposable staging workspace below this existing directory.
+        #[arg(long)]
+        scratch_root: Option<PathBuf>,
+        /// Emit a machine-readable observation.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Validate one copied registered fixture against a logical reference.
+    ValidateGraph {
+        reference: PathBuf,
+        /// Invocation-local fixture mapping in ID=BUNDLE form.
+        #[arg(long = "fixture", value_name = "ID=BUNDLE")]
+        fixture: String,
+        /// Create the disposable staging workspace below this existing directory.
+        #[arg(long)]
+        scratch_root: Option<PathBuf>,
+        /// Emit machine-readable validation evidence.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Run the fixed FinGraph-native diagnostic workload from a strict YAML spec.
+    RunGraph {
+        spec: PathBuf,
+        #[arg(long)]
+        reference: PathBuf,
+        /// Invocation-local fixture mapping in ID=BUNDLE form.
+        #[arg(long = "fixture", value_name = "ID=BUNDLE")]
+        fixture: String,
+        /// Place all disposable graph copies below this existing directory.
+        #[arg(long)]
+        scratch_root: Option<PathBuf>,
+        /// Emit machine-readable diagnostic results.
         #[arg(long)]
         json: bool,
     },
@@ -299,13 +349,16 @@ struct PlanRun<'a> {
 async fn main() -> ExitCode {
     match Cli::parse().command {
         Command::Case { command } => run_case(command),
-        Command::Fixture { command } => run_fixture(command),
+        Command::Fixture { command } => run_fixture(command).await,
         Command::Suite { command } => run_suite(command).await,
         Command::Archive { command } => run_archive(command),
         Command::Projection { command } => run_projection(command).await,
         Command::WorkerV1 => omnigraph_bench::worker::run_worker_stdio_v1().await,
         Command::FixtureWorkerV1 { request, result } => {
             omnigraph_bench::fixture_worker::run_fixture_worker_files_v1(&request, &result).await
+        }
+        Command::RealGraphWorkerV1 { request, result } => {
+            run_real_graph_worker_files(&request, &result).await
         }
     }
 }
@@ -585,7 +638,18 @@ fn run_case(command: CaseCommand) -> ExitCode {
     }
 }
 
-fn run_fixture(command: FixtureCommand) -> ExitCode {
+#[derive(Debug, Serialize)]
+#[serde(deny_unknown_fields)]
+struct RealGraphInspectionV1 {
+    version: u32,
+    fixture: FixtureCopyPreflightReceiptV1,
+    reference_sha256: Option<String>,
+    implemented_witnesses_match: bool,
+    claim_eligible: bool,
+    observation: RealGraphObservationV1,
+}
+
+async fn run_fixture(command: FixtureCommand) -> ExitCode {
     match command {
         FixtureCommand::Reference { command } => match command {
             FixtureReferenceCommand::Validate { file, json } => {
@@ -662,6 +726,159 @@ fn run_fixture(command: FixtureCommand) -> ExitCode {
                 }
             }
         }
+        FixtureCommand::ObserveGraph {
+            fixture,
+            scratch_root,
+            json,
+        } => inspect_real_graph_fixture(&fixture, scratch_root.as_deref(), None, json).await,
+        FixtureCommand::ValidateGraph {
+            reference,
+            fixture,
+            scratch_root,
+            json,
+        } => {
+            let reference = match load_fixture_reference(&reference).into_result() {
+                Ok(reference) => reference,
+                Err(diagnostics) => return print_cli_failures(diagnostics, json),
+            };
+            inspect_real_graph_fixture(&fixture, scratch_root.as_deref(), Some(&reference), json)
+                .await
+        }
+        FixtureCommand::RunGraph {
+            spec,
+            reference,
+            fixture,
+            scratch_root,
+            json,
+        } => {
+            let spec = match load_real_graph_run_spec(&spec).into_result() {
+                Ok(spec) => spec,
+                Err(diagnostics) => return print_cli_failures(diagnostics, json),
+            };
+            let reference = match load_fixture_reference(&reference).into_result() {
+                Ok(reference) => reference,
+                Err(diagnostics) => return print_cli_failures(diagnostics, json),
+            };
+            match execute_real_graph_run(&spec, &reference, &fixture, scratch_root.as_deref()).await
+            {
+                Ok(report) => {
+                    if json {
+                        print_json_success(&report)
+                    } else {
+                        println!(
+                            "FinGraph diagnostic: p50={}us over {} repetitions; claim-eligible=false, durable-record=false",
+                            report.p50_us, report.repetitions
+                        );
+                        ExitCode::SUCCESS
+                    }
+                }
+                Err(error) => {
+                    print_cli_failure(Diagnostic::error(error.code, "$", error.message), json)
+                }
+            }
+        }
+    }
+}
+
+async fn inspect_real_graph_fixture(
+    fixture: &str,
+    scratch_root: Option<&Path>,
+    reference: Option<&omnigraph_bench::fixture_reference::NormalizedFixtureReferenceV1>,
+    json: bool,
+) -> ExitCode {
+    let staged = match stage_registered_fixture_binding(fixture, scratch_root).into_result() {
+        Ok(staged) => staged,
+        Err(diagnostics) => return print_cli_failures(diagnostics, json),
+    };
+    if let Some(reference) = reference
+        && reference.definition.fixture_id != staged.receipt().fixture_id
+    {
+        let diagnostic = Diagnostic::error(
+            "fixture_reference_id_mismatch",
+            "--fixture",
+            format!(
+                "logical reference identifies fixture {:?}, but the registered bundle identifies {:?}",
+                reference.definition.fixture_id,
+                staged.receipt().fixture_id
+            ),
+        );
+        let cleanup = staged.finish();
+        return match cleanup {
+            Ok(_) => print_cli_failure(diagnostic, json),
+            Err(cleanup) => print_cli_failures(vec![diagnostic, cleanup], json),
+        };
+    }
+    let observation = match observe_real_graph(staged.root()).await {
+        Ok(observation) => observation,
+        Err(error) => {
+            let diagnostic =
+                Diagnostic::error("real_graph_observation_failed", "$", error.to_string());
+            let cleanup = staged.finish();
+            return match cleanup {
+                Ok(_) => print_cli_failure(diagnostic, json),
+                Err(cleanup) => print_cli_failures(vec![diagnostic, cleanup], json),
+            };
+        }
+    };
+    if let Some(reference) = reference
+        && let Err(error) = validate_real_graph_reference(reference, &observation)
+    {
+        let diagnostic = Diagnostic::error(
+            "real_graph_reference_mismatch",
+            "reference",
+            error.to_string(),
+        );
+        let cleanup = staged.finish();
+        return match cleanup {
+            Ok(_) => print_cli_failure(diagnostic, json),
+            Err(cleanup) => print_cli_failures(vec![diagnostic, cleanup], json),
+        };
+    }
+    if let Err(diagnostic) = staged.verify_unchanged() {
+        let cleanup = staged.finish();
+        return match cleanup {
+            Ok(_) => print_cli_failure(diagnostic, json),
+            Err(cleanup) => print_cli_failures(vec![diagnostic, cleanup], json),
+        };
+    }
+    let receipt = match staged.finish() {
+        Ok(receipt) => receipt,
+        Err(diagnostic) => return print_cli_failure(diagnostic, json),
+    };
+    let inspection = RealGraphInspectionV1 {
+        version: 1,
+        fixture: receipt,
+        reference_sha256: reference.map(|reference| reference.reference_sha256.clone()),
+        implemented_witnesses_match: reference.is_some(),
+        claim_eligible: false,
+        observation,
+    };
+    if json {
+        print_json_success(&inspection)
+    } else {
+        println!(
+            "observed real graph fixture {}: {} node rows, {} edge rows, history depth {}; claim-eligible=false{}",
+            inspection.fixture.fixture_id,
+            inspection
+                .observation
+                .node_tables
+                .iter()
+                .map(|table| table.rows)
+                .sum::<u64>(),
+            inspection
+                .observation
+                .edge_tables
+                .iter()
+                .map(|table| table.rows)
+                .sum::<u64>(),
+            inspection.observation.history_depth,
+            if inspection.implemented_witnesses_match {
+                " (implemented reference witnesses match; declared state remains partially unverified)"
+            } else {
+                ""
+            },
+        );
+        ExitCode::SUCCESS
     }
 }
 

--- a/crates/omnigraph-bench/src/bin/omnigraph-bench.rs
+++ b/crates/omnigraph-bench/src/bin/omnigraph-bench.rs
@@ -9,6 +9,7 @@ use omnigraph_bench::archive::{
     iter_archive, preflight_archive_publication, publish_record, reconcile_archive_publication,
 };
 use omnigraph_bench::case::Backend;
+use omnigraph_bench::fixture_reference::load_fixture_reference;
 use omnigraph_bench::projection::{
     DEFAULT_PROJECTION_PAGE_SIZE, ProjectionCursorV1, ProjectionError, ProjectionPageV1,
     list_points_page, list_runs_for_point_page, rebuild_projection,
@@ -98,6 +99,11 @@ enum CaseCommand {
 
 #[derive(Debug, Subcommand)]
 enum FixtureCommand {
+    /// Inspect logical references for externally built node-and-edge fixtures.
+    Reference {
+        #[command(subcommand)]
+        command: FixtureReferenceCommand,
+    },
     /// Print a location-free JSON manifest for one stable local tree.
     Fingerprint {
         /// Path-free identity assigned to this exact physical snapshot.
@@ -126,6 +132,17 @@ enum FixtureCommand {
         #[arg(long)]
         scratch_root: Option<PathBuf>,
         /// Emit a machine-readable verification result after cleanup.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum FixtureReferenceCommand {
+    /// Strictly parse and validate one fixture-reference-v1 YAML file.
+    Validate {
+        file: PathBuf,
+        /// Emit a machine-readable validation result.
         #[arg(long)]
         json: bool,
     },
@@ -570,6 +587,25 @@ fn run_case(command: CaseCommand) -> ExitCode {
 
 fn run_fixture(command: FixtureCommand) -> ExitCode {
     match command {
+        FixtureCommand::Reference { command } => match command {
+            FixtureReferenceCommand::Validate { file, json } => {
+                let outcome = load_fixture_reference(&file);
+                if json {
+                    print_json(&outcome)
+                } else {
+                    match outcome.into_result() {
+                        Ok(reference) => {
+                            println!(
+                                "valid fixture reference {} reference_sha256={}",
+                                reference.definition.fixture_id, reference.reference_sha256,
+                            );
+                            ExitCode::SUCCESS
+                        }
+                        Err(diagnostics) => print_diagnostics(&diagnostics),
+                    }
+                }
+            }
+        },
         FixtureCommand::Fingerprint { id, root } => {
             match fingerprint_registered_fixture(id, &root).into_result() {
                 Ok(fixture) => print_json_success(&fixture),

--- a/crates/omnigraph-bench/src/fixture_reference.rs
+++ b/crates/omnigraph-bench/src/fixture_reference.rs
@@ -1,0 +1,889 @@
+//! Logical declarations for externally built node-and-edge fixtures.
+//!
+//! This module only validates and normalizes a declaration. It does not open a
+//! graph or certify that the declared digest is true. Dedicated location,
+//! credential, commit, timestamp, and physical-tree fields are absent, and
+//! builder parameters deliberately have no arbitrary string value.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::model::{
+    Diagnostic, ValidationOutcome, declared_version, read_yaml_file, strict_yaml, typed_sha256,
+    valid_kebab_id,
+};
+
+pub const FIXTURE_REFERENCE_FORMAT_VERSION: u32 = 1;
+
+const MAX_ID_BYTES: usize = 128;
+const MAX_PARAMETERS: usize = 128;
+const MAX_INPUTS: usize = 256;
+const MAX_GRAPH_TYPES: usize = 10_000;
+const MAX_INDEXES: usize = 100_000;
+const MAX_BUILDER_VERSION: u32 = 1_000_000;
+const MAX_ROWS_PER_GRAPH_TYPE: u64 = 1_000_000_000_000;
+const MAX_TOTAL_GRAPH_ROWS: u64 = 10_000_000_000_000;
+const MAX_PAYLOAD_BYTES_PER_ROW: u64 = 64 * 1024 * 1024;
+const MAX_TOTAL_LOGICAL_PAYLOAD_BYTES: u64 = 1 << 60;
+const MAX_HISTORY_DEPTH: u64 = 10_000_000;
+
+/// A strict V1 declaration of one externally built logical fixture.
+///
+/// `fixture_id`, the reference digest, and `expected` are linkage/evidence,
+/// not future point identity. A future case must materialize `logical` into its
+/// versioned run spec rather than hashing a path or this reference as an opaque
+/// value.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FixtureReferenceV1 {
+    pub version: u32,
+    pub fixture_id: String,
+    pub logical: RealGraphLogicalDeclarationV1,
+    pub expected: ExpectedLogicalContentV1,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RealGraphLogicalDeclarationV1 {
+    pub builder: ImportedGraphBuilderV1,
+    pub data: RealGraphDataV1,
+    pub state: RealGraphStateV1,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ImportedGraphBuilderV1 {
+    pub id: String,
+    pub version: u32,
+    pub recipe_sha256: String,
+    pub parameters: Vec<BuilderParameterV1>,
+    pub inputs: Vec<BuilderInputV1>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BuilderParameterV1 {
+    pub name: String,
+    pub value: BuilderParameterValueV1,
+}
+
+/// V1 deliberately has no arbitrary string values, so paths, URIs, and
+/// credentials cannot be stored here. Parameter names and numeric meanings are
+/// trusted builder-contract input that the future builder adapter must check.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum BuilderParameterValueV1 {
+    Null(()),
+    Bool(bool),
+    U64(u64),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BuilderInputV1 {
+    /// Path-free semantic role for one content-addressed builder input.
+    pub role: String,
+    pub sha256: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DigestReferenceV1 {
+    /// Versioned canonical byte-projection identifier.
+    pub algorithm: String,
+    pub sha256: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RealGraphDataV1 {
+    pub provenance: RealGraphDataProvenance,
+    pub schema_shape: DigestReferenceV1,
+    pub node_tables: Vec<GraphTableCountV1>,
+    pub edge_tables: Vec<GraphTableCountV1>,
+    pub payload: RealGraphPayloadV1,
+    pub column_shape: RealGraphColumnShape,
+    pub topology_skew: RealGraphTopologySkew,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RealGraphDataProvenance {
+    Synthetic,
+    CorpusDerived,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GraphTableCountV1 {
+    pub name: String,
+    pub rows: u64,
+}
+
+/// Exact payload-size factor. Variable-width data records an exact total; its
+/// bytes-per-row level is the rational `total_bytes / total graph rows`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case", deny_unknown_fields)]
+pub enum RealGraphPayloadV1 {
+    Fixed {
+        /// Versioned rule defining which logical bytes each row includes.
+        algorithm: String,
+        bytes_per_row: u64,
+    },
+    Variable {
+        /// Versioned rule defining which logical bytes the total includes.
+        algorithm: String,
+        total_bytes: u64,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RealGraphColumnShape {
+    Scalars,
+    ScalarsVector,
+    ScalarsBlob,
+    Mixed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RealGraphTopologySkew {
+    Uniform,
+    PowerLaw,
+    SourceDefined,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RealGraphStateV1 {
+    pub aging: RealGraphAgingV1,
+    pub indexes: Vec<RealGraphIndexV1>,
+    pub deletion_history: RealGraphDeletionHistoryV1,
+    pub compaction_recency: RealGraphCompactionRecencyV1,
+    pub history_depth: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RealGraphAgingV1 {
+    BulkLoaded,
+    SmallCommits,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RealGraphIndexV1 {
+    pub table: String,
+    pub column: String,
+    pub kind: RealGraphIndexKindV1,
+    pub freshness: RealGraphIndexFreshnessV1,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RealGraphIndexKindV1 {
+    Btree,
+    Fts,
+    Ann,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RealGraphIndexFreshnessV1 {
+    Optimized,
+    RowsStale,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RealGraphDeletionHistoryV1 {
+    None,
+    Heavy,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RealGraphCompactionRecencyV1 {
+    Optimized,
+    NotOptimized,
+}
+
+/// Expected output of the future graph-level validator. This is a required
+/// declaration, not proof: only recomputation against a copied graph can turn
+/// it into validation evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ExpectedLogicalContentV1 {
+    pub logical_content: DigestReferenceV1,
+}
+
+/// A normalized declaration and its complete, version-bearing audit digest.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct NormalizedFixtureReferenceV1 {
+    pub definition: FixtureReferenceV1,
+    /// Audit/linkage only. A future point id hashes its typed run spec instead.
+    pub reference_sha256: String,
+}
+
+pub fn load_fixture_reference(path: &Path) -> ValidationOutcome<NormalizedFixtureReferenceV1> {
+    let source = match read_yaml_file(path, "fixture_reference") {
+        Ok(source) => source,
+        Err(diagnostic) => return ValidationOutcome::failure(vec![diagnostic]),
+    };
+    parse_fixture_reference(&source)
+}
+
+pub fn parse_fixture_reference(source: &str) -> ValidationOutcome<NormalizedFixtureReferenceV1> {
+    let version = match declared_version(source, "fixture_reference") {
+        Ok(version) => version,
+        Err(diagnostic) => return ValidationOutcome::failure(vec![diagnostic]),
+    };
+    if version != FIXTURE_REFERENCE_FORMAT_VERSION {
+        return ValidationOutcome::failure(vec![Diagnostic::error(
+            "unsupported_fixture_reference_version",
+            "version",
+            format!(
+                "expected fixture reference version {FIXTURE_REFERENCE_FORMAT_VERSION}, observed {version}"
+            ),
+        )]);
+    }
+    let reference = match strict_yaml(source, "fixture_reference") {
+        Ok(reference) => reference,
+        Err(diagnostic) => return ValidationOutcome::failure(vec![diagnostic]),
+    };
+    normalize_fixture_reference(reference)
+}
+
+pub fn normalize_fixture_reference(
+    mut reference: FixtureReferenceV1,
+) -> ValidationOutcome<NormalizedFixtureReferenceV1> {
+    let mut diagnostics = Vec::new();
+    if reference.version != FIXTURE_REFERENCE_FORMAT_VERSION {
+        diagnostics.push(Diagnostic::error(
+            "unsupported_fixture_reference_version",
+            "version",
+            format!(
+                "expected fixture reference version {FIXTURE_REFERENCE_FORMAT_VERSION}, observed {}",
+                reference.version
+            ),
+        ));
+    }
+    validate_kebab_id(
+        &reference.fixture_id,
+        "fixture_id",
+        "invalid_fixture_reference_id",
+        &mut diagnostics,
+    );
+    validate_builder(&mut reference.logical.builder, &mut diagnostics);
+    validate_data(&mut reference.logical.data, &mut diagnostics);
+    validate_state(
+        &mut reference.logical.state,
+        &reference.logical.data,
+        &mut diagnostics,
+    );
+    validate_digest_reference(
+        &reference.expected.logical_content,
+        "expected.logical_content",
+        &mut diagnostics,
+    );
+    if !diagnostics.is_empty() {
+        return ValidationOutcome::failure(diagnostics);
+    }
+    let reference_sha256 = match typed_sha256(&reference) {
+        Ok(digest) => digest,
+        Err(diagnostic) => return ValidationOutcome::failure(vec![diagnostic]),
+    };
+    ValidationOutcome::success(NormalizedFixtureReferenceV1 {
+        definition: reference,
+        reference_sha256,
+    })
+}
+
+fn validate_builder(builder: &mut ImportedGraphBuilderV1, diagnostics: &mut Vec<Diagnostic>) {
+    validate_kebab_id(
+        &builder.id,
+        "logical.builder.id",
+        "invalid_fixture_builder_id",
+        diagnostics,
+    );
+    if !(1..=MAX_BUILDER_VERSION).contains(&builder.version) {
+        diagnostics.push(Diagnostic::error(
+            "invalid_fixture_builder_version",
+            "logical.builder.version",
+            format!("builder version must be in 1..={MAX_BUILDER_VERSION}"),
+        ));
+    }
+    validate_sha256(
+        &builder.recipe_sha256,
+        "logical.builder.recipe_sha256",
+        diagnostics,
+    );
+    if builder.parameters.len() > MAX_PARAMETERS {
+        diagnostics.push(Diagnostic::error(
+            "fixture_builder_parameter_budget_exceeded",
+            "logical.builder.parameters",
+            format!("at most {MAX_PARAMETERS} builder parameters are allowed"),
+        ));
+    }
+    let mut parameter_names = BTreeSet::new();
+    for (index, parameter) in builder.parameters.iter().enumerate() {
+        validate_kebab_id(
+            &parameter.name,
+            &format!("logical.builder.parameters[{index}].name"),
+            "invalid_fixture_builder_parameter",
+            diagnostics,
+        );
+        if !parameter_names.insert(parameter.name.as_str()) {
+            diagnostics.push(Diagnostic::error(
+                "duplicate_fixture_builder_parameter",
+                format!("logical.builder.parameters[{index}].name"),
+                format!(
+                    "builder parameter '{}' appears more than once",
+                    parameter.name
+                ),
+            ));
+        }
+    }
+    builder.parameters.sort();
+
+    if builder.inputs.is_empty() || builder.inputs.len() > MAX_INPUTS {
+        diagnostics.push(Diagnostic::error(
+            "invalid_fixture_builder_inputs",
+            "logical.builder.inputs",
+            format!("an imported graph requires 1..={MAX_INPUTS} digest-pinned inputs"),
+        ));
+    }
+    let mut input_roles = BTreeSet::new();
+    for (index, input) in builder.inputs.iter().enumerate() {
+        validate_kebab_id(
+            &input.role,
+            &format!("logical.builder.inputs[{index}].role"),
+            "invalid_fixture_builder_input_role",
+            diagnostics,
+        );
+        validate_sha256(
+            &input.sha256,
+            &format!("logical.builder.inputs[{index}].sha256"),
+            diagnostics,
+        );
+        if !input_roles.insert(input.role.as_str()) {
+            diagnostics.push(Diagnostic::error(
+                "duplicate_fixture_builder_input",
+                format!("logical.builder.inputs[{index}].role"),
+                format!("builder input role '{}' appears more than once", input.role),
+            ));
+        }
+    }
+    builder.inputs.sort();
+}
+
+fn validate_data(data: &mut RealGraphDataV1, diagnostics: &mut Vec<Diagnostic>) {
+    validate_digest_reference(&data.schema_shape, "logical.data.schema_shape", diagnostics);
+    let node_rows = validate_table_inventory(&mut data.node_tables, "node", diagnostics);
+    let edge_rows = validate_table_inventory(&mut data.edge_tables, "edge", diagnostics);
+    if data
+        .node_tables
+        .len()
+        .saturating_add(data.edge_tables.len())
+        > MAX_GRAPH_TYPES
+    {
+        diagnostics.push(Diagnostic::error(
+            "fixture_graph_type_budget_exceeded",
+            "logical.data",
+            format!("at most {MAX_GRAPH_TYPES} total node and edge types are allowed"),
+        ));
+    }
+    let total_rows = node_rows
+        .and_then(|node_rows| edge_rows.and_then(|edge_rows| node_rows.checked_add(edge_rows)));
+    if total_rows.is_none_or(|total| total > MAX_TOTAL_GRAPH_ROWS) {
+        diagnostics.push(Diagnostic::error(
+            "fixture_total_row_budget_exceeded",
+            "logical.data",
+            format!("total node and edge rows must be <= {MAX_TOTAL_GRAPH_ROWS}"),
+        ));
+    }
+    match &data.payload {
+        RealGraphPayloadV1::Fixed {
+            algorithm,
+            bytes_per_row,
+        } => {
+            validate_algorithm_id(algorithm, "logical.data.payload.algorithm", diagnostics);
+            if *bytes_per_row > MAX_PAYLOAD_BYTES_PER_ROW {
+                diagnostics.push(Diagnostic::error(
+                    "fixture_payload_budget_exceeded",
+                    "logical.data.payload.bytes_per_row",
+                    format!("payload bytes per row must be <= {MAX_PAYLOAD_BYTES_PER_ROW}"),
+                ));
+            }
+            if total_rows
+                .and_then(|rows| rows.checked_mul(*bytes_per_row))
+                .is_none_or(|total| total > MAX_TOTAL_LOGICAL_PAYLOAD_BYTES)
+            {
+                diagnostics.push(Diagnostic::error(
+                    "fixture_payload_budget_exceeded",
+                    "logical.data.payload",
+                    format!(
+                        "total logical payload bytes must be <= {MAX_TOTAL_LOGICAL_PAYLOAD_BYTES}"
+                    ),
+                ));
+            }
+        }
+        RealGraphPayloadV1::Variable {
+            algorithm,
+            total_bytes,
+        } => {
+            validate_algorithm_id(algorithm, "logical.data.payload.algorithm", diagnostics);
+            let average_budget = total_rows
+                .and_then(|rows| rows.checked_mul(MAX_PAYLOAD_BYTES_PER_ROW))
+                .unwrap_or(u64::MAX);
+            if *total_bytes > MAX_TOTAL_LOGICAL_PAYLOAD_BYTES || *total_bytes > average_budget {
+                diagnostics.push(Diagnostic::error(
+                    "fixture_payload_budget_exceeded",
+                    "logical.data.payload.total_bytes",
+                    format!(
+                        "total logical payload bytes must be <= {MAX_TOTAL_LOGICAL_PAYLOAD_BYTES} and average <= {MAX_PAYLOAD_BYTES_PER_ROW} bytes per row"
+                    ),
+                ));
+            }
+        }
+    }
+}
+
+fn validate_table_inventory(
+    tables: &mut [GraphTableCountV1],
+    kind: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<u64> {
+    let base = format!("logical.data.{kind}_tables");
+    if tables.is_empty() {
+        diagnostics.push(Diagnostic::error(
+            "empty_fixture_graph_inventory",
+            &base,
+            format!("a real graph fixture must declare at least one {kind} type"),
+        ));
+    }
+    let mut names = BTreeSet::new();
+    let mut total = Some(0u64);
+    for (index, table) in tables.iter().enumerate() {
+        if !valid_type_name(&table.name) {
+            diagnostics.push(Diagnostic::error(
+                "invalid_fixture_graph_type",
+                format!("{base}[{index}].name"),
+                "graph type names must match OmniGraph's uppercase ASCII type grammar",
+            ));
+        }
+        if table.rows > MAX_ROWS_PER_GRAPH_TYPE {
+            diagnostics.push(Diagnostic::error(
+                "fixture_table_row_budget_exceeded",
+                format!("{base}[{index}].rows"),
+                format!("rows per graph type must be <= {MAX_ROWS_PER_GRAPH_TYPE}"),
+            ));
+        }
+        if !names.insert(table.name.as_str()) {
+            diagnostics.push(Diagnostic::error(
+                "duplicate_fixture_graph_type",
+                format!("{base}[{index}].name"),
+                format!("{kind} type '{}' appears more than once", table.name),
+            ));
+        }
+        total = total.and_then(|current| current.checked_add(table.rows));
+    }
+    if total == Some(0) {
+        diagnostics.push(Diagnostic::error(
+            "empty_fixture_graph_rows",
+            &base,
+            format!("declared {kind} types must contain at least one row in aggregate"),
+        ));
+    }
+    if total.is_none() {
+        diagnostics.push(Diagnostic::error(
+            "fixture_row_count_overflow",
+            &base,
+            format!("total {kind} row count overflows u64"),
+        ));
+    }
+    tables.sort();
+    total
+}
+
+fn validate_state(
+    state: &mut RealGraphStateV1,
+    data: &RealGraphDataV1,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    if !(1..=MAX_HISTORY_DEPTH).contains(&state.history_depth) {
+        diagnostics.push(Diagnostic::error(
+            "invalid_fixture_history_depth",
+            "logical.state.history_depth",
+            format!("history depth must be in 1..={MAX_HISTORY_DEPTH}"),
+        ));
+    }
+    if state.indexes.len() > MAX_INDEXES {
+        diagnostics.push(Diagnostic::error(
+            "fixture_index_budget_exceeded",
+            "logical.state.indexes",
+            format!("at most {MAX_INDEXES} index declarations are allowed"),
+        ));
+    }
+    let tables = data
+        .node_tables
+        .iter()
+        .map(|table| format!("node:{}", table.name))
+        .chain(
+            data.edge_tables
+                .iter()
+                .map(|table| format!("edge:{}", table.name)),
+        )
+        .collect::<BTreeSet<_>>();
+    let mut indexes = BTreeSet::new();
+    for (index, entry) in state.indexes.iter().enumerate() {
+        if !tables.contains(&entry.table) {
+            diagnostics.push(Diagnostic::error(
+                "unknown_fixture_index_table",
+                format!("logical.state.indexes[{index}].table"),
+                "index table must exactly name a declared `node:Type` or `edge:Type`",
+            ));
+        }
+        if !valid_property_name(&entry.column) {
+            diagnostics.push(Diagnostic::error(
+                "invalid_fixture_index_column",
+                format!("logical.state.indexes[{index}].column"),
+                "index columns must match OmniGraph's lowercase ASCII property grammar",
+            ));
+        }
+        if !indexes.insert((entry.table.as_str(), entry.column.as_str(), entry.kind)) {
+            diagnostics.push(Diagnostic::error(
+                "duplicate_fixture_index",
+                format!("logical.state.indexes[{index}]"),
+                "the same table, column, and kind appears more than once; freshness is one state",
+            ));
+        }
+        if matches!(
+            data.column_shape,
+            RealGraphColumnShape::Scalars | RealGraphColumnShape::ScalarsBlob
+        ) && entry.kind == RealGraphIndexKindV1::Ann
+        {
+            diagnostics.push(Diagnostic::error(
+                "impossible_fixture_index_inventory",
+                format!("logical.state.indexes[{index}].kind"),
+                "ANN indexes require a column shape that includes vectors",
+            ));
+        }
+    }
+    state.indexes.sort();
+}
+
+fn validate_kebab_id(value: &str, path: &str, code: &str, diagnostics: &mut Vec<Diagnostic>) {
+    if !valid_kebab_id(value) || value.len() > MAX_ID_BYTES {
+        diagnostics.push(Diagnostic::error(
+            code,
+            path,
+            "value must be 1..=128 characters of path-free kebab-case ASCII",
+        ));
+    }
+}
+
+fn validate_sha256(value: &str, path: &str, diagnostics: &mut Vec<Diagnostic>) {
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        diagnostics.push(Diagnostic::error(
+            "invalid_fixture_sha256",
+            path,
+            "SHA-256 must contain exactly 64 lowercase hexadecimal characters",
+        ));
+    }
+}
+
+fn validate_digest_reference(
+    reference: &DigestReferenceV1,
+    path: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    validate_algorithm_id(
+        &reference.algorithm,
+        &format!("{path}.algorithm"),
+        diagnostics,
+    );
+    validate_sha256(&reference.sha256, &format!("{path}.sha256"), diagnostics);
+}
+
+fn validate_algorithm_id(value: &str, path: &str, diagnostics: &mut Vec<Diagnostic>) {
+    validate_kebab_id(value, path, "invalid_fixture_digest_algorithm", diagnostics);
+    let version_is_canonical = value.rsplit_once("-v").is_some_and(|(name, version)| {
+        !name.is_empty()
+            && !version.is_empty()
+            && !version.starts_with('0')
+            && version.bytes().all(|byte| byte.is_ascii_digit())
+            && version.parse::<u32>().is_ok()
+    });
+    if !version_is_canonical {
+        diagnostics.push(Diagnostic::error(
+            "unversioned_fixture_digest_algorithm",
+            path,
+            "digest algorithm ids must end in a canonical positive `-vN` version",
+        ));
+    }
+}
+
+fn valid_type_name(value: &str) -> bool {
+    valid_ascii_identifier(value, |byte| byte.is_ascii_uppercase())
+}
+
+fn valid_property_name(value: &str) -> bool {
+    valid_ascii_identifier(value, |byte| byte.is_ascii_lowercase() || byte == b'_')
+}
+
+fn valid_ascii_identifier(value: &str, valid_first: impl Fn(u8) -> bool) -> bool {
+    if value.is_empty() || value.len() > MAX_ID_BYTES {
+        return false;
+    }
+    let mut bytes = value.bytes();
+    let Some(first) = bytes.next() else {
+        return false;
+    };
+    valid_first(first) && bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reference_yaml() -> String {
+        format!(
+            r#"version: 1
+fixture_id: finbench-sf10-main
+logical:
+  builder:
+    id: finbench-import
+    version: 1
+    recipe_sha256: "{}"
+    parameters:
+      - {{ name: scale-factor, value: 10 }}
+      - {{ name: optimize-every, value: 200 }}
+    inputs:
+      - role: source-snapshot
+        sha256: "{}"
+      - role: labels
+        sha256: "{}"
+  data:
+    provenance: corpus-derived
+    schema_shape:
+      algorithm: future-schema-shape-v1
+      sha256: "{}"
+    node_tables:
+      - {{ name: Person, rows: 582672 }}
+      - {{ name: Account, rows: 1534180 }}
+    edge_tables:
+      - {{ name: PersonOwnAccount, rows: 1022914 }}
+      - {{ name: AccountTransferAccount, rows: 6219881 }}
+    payload:
+      kind: variable
+      algorithm: future-logical-payload-v1
+      total_bytes: 4096
+    column_shape: scalars
+    topology_skew: source-defined
+  state:
+    aging: small-commits
+    indexes:
+      - table: node:Account
+        column: accountId
+        kind: btree
+        freshness: optimized
+      - table: node:Person
+        column: name
+        kind: fts
+        freshness: rows-stale
+    deletion_history: none
+    compaction_recency: optimized
+    history_depth: 3972
+expected:
+  logical_content:
+    algorithm: future-logical-graph-v1
+    sha256: "{}"
+"#,
+            "1".repeat(64),
+            "2".repeat(64),
+            "5".repeat(64),
+            "3".repeat(64),
+            "4".repeat(64),
+        )
+    }
+
+    #[test]
+    fn strict_reference_normalizes_every_order_free_inventory() {
+        let first = parse_fixture_reference(&reference_yaml())
+            .into_result()
+            .unwrap();
+        assert_eq!(first.definition.logical.data.node_tables[0].name, "Account");
+        assert_eq!(
+            first.definition.logical.builder.parameters[0].name,
+            "optimize-every"
+        );
+        assert_eq!(first.reference_sha256.len(), 64);
+
+        let reordered = reference_yaml()
+            .replace(
+                "      - { name: scale-factor, value: 10 }\n      - { name: optimize-every, value: 200 }",
+                "      - { name: optimize-every, value: 200 }\n      - { name: scale-factor, value: 10 }",
+            )
+            .replace(
+                "      - { name: Person, rows: 582672 }\n      - { name: Account, rows: 1534180 }",
+                "      - { name: Account, rows: 1534180 }\n      - { name: Person, rows: 582672 }",
+            )
+            .replace(
+                &format!(
+                    "      - role: source-snapshot\n        sha256: \"{}\"\n      - role: labels\n        sha256: \"{}\"",
+                    "2".repeat(64),
+                    "5".repeat(64)
+                ),
+                &format!(
+                    "      - role: labels\n        sha256: \"{}\"\n      - role: source-snapshot\n        sha256: \"{}\"",
+                    "5".repeat(64),
+                    "2".repeat(64)
+                ),
+            )
+            .replace(
+                "      - { name: PersonOwnAccount, rows: 1022914 }\n      - { name: AccountTransferAccount, rows: 6219881 }",
+                "      - { name: AccountTransferAccount, rows: 6219881 }\n      - { name: PersonOwnAccount, rows: 1022914 }",
+            )
+            .replace(
+                "      - table: node:Account\n        column: accountId\n        kind: btree\n        freshness: optimized\n      - table: node:Person\n        column: name\n        kind: fts\n        freshness: rows-stale",
+                "      - table: node:Person\n        column: name\n        kind: fts\n        freshness: rows-stale\n      - table: node:Account\n        column: accountId\n        kind: btree\n        freshness: optimized",
+            );
+        assert_eq!(
+            first,
+            parse_fixture_reference(&reordered).into_result().unwrap()
+        );
+    }
+
+    #[test]
+    fn document_shape_does_not_accept_physical_facts_or_missing_expectation() {
+        let physical = reference_yaml().replace(
+            "fixture_id: finbench-sf10-main",
+            "fixture_id: finbench-sf10-main\nsource_uri: s3://bucket/root",
+        );
+        assert!(!parse_fixture_reference(&physical).ok);
+
+        let missing =
+            reference_yaml().replace(&format!("    sha256: \"{}\"\n", "4".repeat(64)), "");
+        assert!(!parse_fixture_reference(&missing).ok);
+
+        let string_parameter = reference_yaml().replace("value: 10", "value: /tmp/graph");
+        assert!(!parse_fixture_reference(&string_parameter).ok);
+
+        let duplicate_key = reference_yaml().replace(
+            "fixture_id: finbench-sf10-main",
+            "fixture_id: finbench-sf10-main\nfixture_id: duplicate",
+        );
+        assert!(!parse_fixture_reference(&duplicate_key).ok);
+
+        let cross_variant_field = reference_yaml().replace(
+            "total_bytes: 4096",
+            "total_bytes: 4096\n      bytes_per_row: 1",
+        );
+        assert!(!parse_fixture_reference(&cross_variant_field).ok);
+    }
+
+    #[test]
+    fn duplicate_and_impossible_identity_entries_fail_closed() {
+        let duplicate_parameter = reference_yaml().replace(
+            "      - { name: optimize-every, value: 200 }",
+            "      - { name: scale-factor, value: 99 }",
+        );
+        let duplicate_index = reference_yaml().replace(
+            "    deletion_history: none",
+            "      - table: node:Account\n        column: accountId\n        kind: btree\n        freshness: rows-stale\n    deletion_history: none",
+        );
+        let scalar_ann = reference_yaml().replace("kind: btree", "kind: ann");
+        for (source, expected_code) in [
+            (duplicate_parameter, "duplicate_fixture_builder_parameter"),
+            (duplicate_index, "duplicate_fixture_index"),
+            (scalar_ann, "impossible_fixture_index_inventory"),
+        ] {
+            assert!(
+                parse_fixture_reference(&source)
+                    .diagnostics
+                    .iter()
+                    .any(|diagnostic| diagnostic.code == expected_code),
+                "missing {expected_code}"
+            );
+        }
+    }
+
+    #[test]
+    fn grammar_versions_and_resource_bounds_are_checked() {
+        let semantic = reference_yaml()
+            .replace("name: Person", "name: person")
+            .replace("column: accountId", "column: AccountId")
+            .replace("rows: 582672", "rows: 1000000000001")
+            .replace("total_bytes: 4096", "total_bytes: 1152921504606846977");
+        let codes = parse_fixture_reference(&semantic)
+            .diagnostics
+            .into_iter()
+            .map(|diagnostic| diagnostic.code)
+            .collect::<BTreeSet<_>>();
+        assert!(codes.contains("invalid_fixture_graph_type"));
+        assert!(codes.contains("invalid_fixture_index_column"));
+        assert!(codes.contains("fixture_table_row_budget_exceeded"));
+        assert!(codes.contains("fixture_payload_budget_exceeded"));
+
+        let oversized_fixed = reference_yaml()
+            .replace("rows: 582672", "rows: 1000000000000")
+            .replace("rows: 1534180", "rows: 1000000000000")
+            .replace("rows: 1022914", "rows: 1000000000000")
+            .replace("rows: 6219881", "rows: 1000000000000")
+            .replace(
+                "kind: variable\n      algorithm: future-logical-payload-v1\n      total_bytes: 4096",
+                "kind: fixed\n      algorithm: future-logical-payload-v1\n      bytes_per_row: 67108864",
+            );
+        assert!(
+            parse_fixture_reference(&oversized_fixed)
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "fixture_payload_budget_exceeded")
+        );
+
+        let oversized_variable_average = reference_yaml()
+            .replace("rows: 582672", "rows: 1")
+            .replace("rows: 1534180", "rows: 1")
+            .replace("rows: 1022914", "rows: 1")
+            .replace("rows: 6219881", "rows: 1")
+            .replace("total_bytes: 4096", "total_bytes: 268435457");
+        assert!(
+            parse_fixture_reference(&oversized_variable_average)
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "fixture_payload_budget_exceeded")
+        );
+
+        for invalid in ["schema-shape", "schema-shape-v0", "schema-shape-v01"] {
+            let unversioned_algorithm = reference_yaml().replace(
+                "algorithm: future-schema-shape-v1",
+                &format!("algorithm: {invalid}"),
+            );
+            assert!(
+                parse_fixture_reference(&unversioned_algorithm)
+                    .diagnostics
+                    .iter()
+                    .any(|diagnostic| {
+                        diagnostic.code == "unversioned_fixture_digest_algorithm"
+                    }),
+                "accepted non-canonical algorithm id {invalid}"
+            );
+        }
+
+        assert_eq!(
+            parse_fixture_reference(&reference_yaml().replace("version: 1", "version: 2"))
+                .diagnostics[0]
+                .code,
+            "unsupported_fixture_reference_version"
+        );
+    }
+}

--- a/crates/omnigraph-bench/src/lib.rs
+++ b/crates/omnigraph-bench/src/lib.rs
@@ -18,6 +18,7 @@ pub mod model;
 mod preparation;
 pub mod projection;
 pub mod record;
+pub mod registered_fixture;
 pub mod reset;
 pub mod runner;
 #[doc(hidden)]

--- a/crates/omnigraph-bench/src/lib.rs
+++ b/crates/omnigraph-bench/src/lib.rs
@@ -11,6 +11,7 @@ pub mod branch_merge;
 pub mod case;
 pub mod counting;
 pub mod environment;
+pub mod fixture_reference;
 #[doc(hidden)]
 pub mod fixture_worker;
 pub mod machine;
@@ -31,6 +32,10 @@ pub mod worker;
 pub mod worker_protocol;
 
 pub use case::{CaseV1, PointIdentityV1, ValidatedCase, load_case, parse_case, validate_case};
+pub use fixture_reference::{
+    FixtureReferenceV1, NormalizedFixtureReferenceV1, load_fixture_reference,
+    normalize_fixture_reference, parse_fixture_reference,
+};
 pub use model::{Diagnostic, DiagnosticSeverity, ValidationOutcome};
 pub use runner::{
     BuildEvidence, RUNNER_OUTPUT_VERSION, RunExecution, RunOptions, RunnerError, SuiteExecution,

--- a/crates/omnigraph-bench/src/lib.rs
+++ b/crates/omnigraph-bench/src/lib.rs
@@ -18,6 +18,8 @@ pub mod machine;
 pub mod model;
 mod preparation;
 pub mod projection;
+pub mod real_graph;
+pub mod real_graph_run;
 pub mod record;
 pub mod registered_fixture;
 pub mod reset;

--- a/crates/omnigraph-bench/src/real_graph.rs
+++ b/crates/omnigraph-bench/src/real_graph.rs
@@ -1,0 +1,931 @@
+//! Read-only logical validation for registered node-and-edge graph fixtures.
+//!
+//! Physical registration proves copied bytes. This module opens only that
+//! disposable copy, captures one coherent `main` snapshot, checks its complete
+//! table inventory, and derives rebuild-stable logical evidence. Generated
+//! storage ids are deliberately excluded: keyed node properties remain in the
+//! row image, while edge endpoints and declared properties identify edge
+//! content (including duplicate parallel edges through multiset cardinality).
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+use std::io::{self, Write};
+use std::path::Path;
+
+use arrow_schema::Schema as ArrowSchema;
+use omnigraph::IndexCoverage;
+use omnigraph::db::{Omnigraph, ReadTarget, SnapshotDataset};
+use omnigraph_compiler::schema_shape_hash_from_ir;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::fixture_reference::{
+    DigestReferenceV1, GraphTableCountV1, NormalizedFixtureReferenceV1, RealGraphIndexFreshnessV1,
+    RealGraphIndexKindV1, RealGraphIndexV1, RealGraphPayloadV1,
+};
+
+pub const REAL_GRAPH_OBSERVATION_VERSION: u32 = 1;
+pub const SCHEMA_SHAPE_ALGORITHM: &str = "omnigraph-schema-shape-v1";
+pub const LOGICAL_PAYLOAD_ALGORITHM: &str = "omnigraph-logical-properties-v1";
+pub const LOGICAL_GRAPH_ALGORITHM: &str = "omnigraph-logical-graph-multiset-v1";
+
+const ROW_HASH_DOMAIN_A: &[u8] = b"omnigraph-logical-row-v1/a\0";
+const ROW_HASH_DOMAIN_B: &[u8] = b"omnigraph-logical-row-v1/b\0";
+const TABLE_HASH_DOMAIN: &[u8] = b"omnigraph-logical-table-multiset-v1\0";
+const GRAPH_HASH_DOMAIN: &[u8] = b"omnigraph-logical-graph-multiset-v1\0";
+const MAX_EXPORT_LINE_BYTES: usize = 128 * 1024 * 1024;
+const STABLE_PROPERTY_ID_METADATA_KEY: &str = "omnigraph.stable_property_id";
+
+pub type RealGraphResult<T> = Result<T, RealGraphError>;
+
+#[derive(Debug)]
+pub struct RealGraphError(String);
+
+impl RealGraphError {
+    fn new(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
+
+impl Display for RealGraphError {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl Error for RealGraphError {}
+
+impl From<io::Error> for RealGraphError {
+    fn from(error: io::Error) -> Self {
+        Self::new(error.to_string())
+    }
+}
+
+/// Path-free evidence derived from one immutable copied graph.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RealGraphObservationV1 {
+    pub version: u32,
+    pub graph_manifest_version: u64,
+    pub main_commit_id: Option<String>,
+    pub schema_shape: DigestReferenceV1,
+    pub logical_content: DigestReferenceV1,
+    pub node_tables: Vec<GraphTableCountV1>,
+    pub edge_tables: Vec<GraphTableCountV1>,
+    pub logical_payload_bytes: u64,
+    pub indexes: Vec<RealGraphIndexV1>,
+    pub history_depth: u64,
+    pub relocation_self_contained: bool,
+    pub branches: Vec<String>,
+    /// These declaration fields do not yet have a substrate-owned exact
+    /// witness. Keeping them explicit prevents this diagnostic validator from
+    /// silently upgrading itself into claim-grade fixture certification.
+    pub unverified_state_fields: Vec<String>,
+}
+
+/// Compare every currently implemented logical witness to one normalized
+/// fixture declaration.
+pub fn validate_real_graph_reference(
+    reference: &NormalizedFixtureReferenceV1,
+    observed: &RealGraphObservationV1,
+) -> RealGraphResult<()> {
+    let expected = &reference.definition;
+    require_equal(
+        "logical.data.schema_shape",
+        &expected.logical.data.schema_shape,
+        &observed.schema_shape,
+    )?;
+    require_equal(
+        "logical.data.node_tables",
+        &expected.logical.data.node_tables,
+        &observed.node_tables,
+    )?;
+    require_equal(
+        "logical.data.edge_tables",
+        &expected.logical.data.edge_tables,
+        &observed.edge_tables,
+    )?;
+    match &expected.logical.data.payload {
+        RealGraphPayloadV1::Variable {
+            algorithm,
+            total_bytes,
+        } if algorithm == LOGICAL_PAYLOAD_ALGORITHM
+            && *total_bytes == observed.logical_payload_bytes => {}
+        RealGraphPayloadV1::Variable {
+            algorithm,
+            total_bytes,
+        } => {
+            return Err(RealGraphError::new(format!(
+                "logical.data.payload differs: expected algorithm={algorithm:?}, total_bytes={total_bytes}; observed algorithm={LOGICAL_PAYLOAD_ALGORITHM:?}, total_bytes={}",
+                observed.logical_payload_bytes
+            )));
+        }
+        RealGraphPayloadV1::Fixed { .. } => {
+            return Err(RealGraphError::new(
+                "logical.data.payload differs: this validator observes an exact variable-width logical property total",
+            ));
+        }
+    }
+    require_equal(
+        "logical.state.indexes",
+        &expected.logical.state.indexes,
+        &observed.indexes,
+    )?;
+    require_equal(
+        "logical.state.history_depth",
+        &expected.logical.state.history_depth,
+        &observed.history_depth,
+    )?;
+    require_equal(
+        "expected.logical_content",
+        &expected.expected.logical_content,
+        &observed.logical_content,
+    )?;
+    if !observed.relocation_self_contained {
+        return Err(RealGraphError::new(
+            "copied graph retains external Lance base paths and is not relocation self-contained",
+        ));
+    }
+    Ok(())
+}
+
+fn require_equal<T: PartialEq + std::fmt::Debug>(
+    path: &str,
+    expected: &T,
+    observed: &T,
+) -> RealGraphResult<()> {
+    if expected == observed {
+        Ok(())
+    } else {
+        Err(RealGraphError::new(format!(
+            "{path} differs: expected {expected:?}, observed {observed:?}"
+        )))
+    }
+}
+
+/// Inspect a private, quiescent graph copy without mutating it.
+pub async fn observe_real_graph(root: &Path) -> RealGraphResult<RealGraphObservationV1> {
+    let root = root
+        .to_str()
+        .ok_or_else(|| RealGraphError::new("real graph root must be valid UTF-8"))?;
+    let db = Omnigraph::open_read_only(root)
+        .await
+        .map_err(|error| RealGraphError::new(format!("open copied graph read-only: {error}")))?;
+    let mut branches = db
+        .branch_list()
+        .await
+        .map_err(|error| RealGraphError::new(format!("list copied graph branches: {error}")))?;
+    branches.sort();
+    if branches.iter().any(|branch| branch != "main") {
+        return Err(RealGraphError::new(format!(
+            "registered real graph must be a main-only base; observed branches {branches:?}"
+        )));
+    }
+
+    let catalog = db.catalog();
+    let accepted_ir = catalog.bound_schema_ir().ok_or_else(|| {
+        RealGraphError::new("copied graph catalog is not bound to accepted schema identity")
+    })?;
+    for node in &accepted_ir.nodes {
+        let catalog_node = catalog.node_types.get(&node.name).ok_or_else(|| {
+            RealGraphError::new(format!(
+                "accepted node {} is absent from catalog",
+                node.name
+            ))
+        })?;
+        if catalog_node.key.as_ref().is_none_or(Vec::is_empty) {
+            return Err(RealGraphError::new(format!(
+                "node {} has no deterministic @key; logical id normalization is unsupported",
+                node.name
+            )));
+        }
+    }
+    let shape_hash = schema_shape_hash_from_ir(accepted_ir)
+        .map_err(|error| RealGraphError::new(format!("hash accepted schema shape: {error}")))?;
+    let schema_sha256 = shape_hash.strip_prefix("sha256:").ok_or_else(|| {
+        RealGraphError::new("schema shape hash did not use the expected sha256 prefix")
+    })?;
+
+    let snapshot = db
+        .snapshot_of(ReadTarget::branch("main"))
+        .await
+        .map_err(|error| RealGraphError::new(format!("capture copied graph main: {error}")))?;
+    let graph_manifest_version = snapshot.graph_manifest_version();
+    let main_commit_id = snapshot.graph_head(None).map(str::to_owned);
+    let expected_table_keys = accepted_ir
+        .nodes
+        .iter()
+        .map(|node| format!("node:{}", node.name))
+        .chain(
+            accepted_ir
+                .edges
+                .iter()
+                .map(|edge| format!("edge:{}", edge.name)),
+        )
+        .collect::<BTreeSet<_>>();
+    let observed_table_keys = snapshot
+        .datasets()
+        .map(|entry| entry.type_key.clone())
+        .collect::<BTreeSet<_>>();
+    if observed_table_keys != expected_table_keys {
+        return Err(RealGraphError::new(format!(
+            "accepted schema and main snapshot table inventories differ: schema={expected_table_keys:?}, snapshot={observed_table_keys:?}"
+        )));
+    }
+
+    let mut node_tables = Vec::new();
+    let mut edge_tables = Vec::new();
+    let mut indexes = Vec::new();
+    let mut expected_logical_rows = BTreeMap::new();
+    let mut relocation_self_contained =
+        !db.manifest_has_external_base_paths(None)
+            .await
+            .map_err(|error| {
+                RealGraphError::new(format!(
+                    "inspect graph-manifest relocation metadata: {error}"
+                ))
+            })?;
+    for table_key in &expected_table_keys {
+        let entry = snapshot
+            .dataset(table_key)
+            .expect("table-key equality proved every accepted table is present");
+        let dataset = snapshot.open_dataset(table_key).await.map_err(|error| {
+            RealGraphError::new(format!("open pinned dataset {table_key}: {error}"))
+        })?;
+        let physical_rows = dataset.count_rows(None).await.map_err(|error| {
+            RealGraphError::new(format!("count pinned dataset {table_key}: {error}"))
+        })?;
+        let physical_rows = u64::try_from(physical_rows)
+            .map_err(|_| RealGraphError::new(format!("row count for {table_key} exceeds u64")))?;
+        if physical_rows != entry.entity_count {
+            return Err(RealGraphError::new(format!(
+                "main snapshot row count for {table_key} differs: manifest={}, physical={physical_rows}",
+                entry.entity_count
+            )));
+        }
+        expected_logical_rows.insert(table_key.clone(), physical_rows);
+        relocation_self_contained &= !dataset.has_external_base_paths();
+
+        let (name, expected_schema, node_declared_indexes) =
+            if let Some(name) = table_key.strip_prefix("node:") {
+                let ty = catalog.node_types.get(name).ok_or_else(|| {
+                    RealGraphError::new(format!("catalog is missing accepted node {name}"))
+                })?;
+                (name, ty.arrow_schema.as_ref(), Some(ty.indices.as_slice()))
+            } else if let Some(name) = table_key.strip_prefix("edge:") {
+                let ty = catalog.edge_types.get(name).ok_or_else(|| {
+                    RealGraphError::new(format!("catalog is missing accepted edge {name}"))
+                })?;
+                (name, ty.arrow_schema.as_ref(), None)
+            } else {
+                return Err(RealGraphError::new(format!(
+                    "main snapshot contains invalid graph table key {table_key}"
+                )));
+            };
+        let physical_schema = ArrowSchema::from(dataset.schema());
+        require_compatible_physical_schema(table_key, expected_schema, &physical_schema)?;
+
+        // This inventories the indexes the current engine owns: every node id,
+        // each declared node property (probing its actual physical kind), and
+        // edge id/src/dst. Unknown raw Lance metadata remains explicitly
+        // unverified below rather than being presented as a complete inventory.
+        let mut index_columns = BTreeSet::from(["id".to_string()]);
+        if let Some(declared_indexes) = node_declared_indexes {
+            for fields in declared_indexes {
+                let [column] = fields.as_slice() else {
+                    return Err(RealGraphError::new(format!(
+                        "{table_key} declares a composite index; real-graph validator v1 supports single-column indexes only"
+                    )));
+                };
+                index_columns.insert(column.clone());
+            }
+        } else {
+            index_columns.extend(["src".to_string(), "dst".to_string()]);
+        }
+        let table_has_stale_index = dataset.has_unindexed_fragments().await.map_err(|error| {
+            RealGraphError::new(format!("inspect index freshness for {table_key}: {error}"))
+        })?;
+        for column in index_columns {
+            observe_engine_index(
+                &dataset,
+                table_key,
+                &column,
+                table_has_stale_index,
+                &mut indexes,
+            )
+            .await?;
+        }
+        let row_count = GraphTableCountV1 {
+            name: name.to_string(),
+            rows: physical_rows,
+        };
+        if table_key.starts_with("node:") {
+            node_tables.push(row_count);
+        } else {
+            edge_tables.push(row_count);
+        }
+    }
+    node_tables.sort();
+    edge_tables.sort();
+    indexes.sort();
+
+    let history_depth = u64::try_from(
+        db.list_commits(Some("main"))
+            .await
+            .map_err(|error| RealGraphError::new(format!("list main history: {error}")))?
+            .len(),
+    )
+    .map_err(|_| RealGraphError::new("main history depth exceeds u64"))?;
+    let mut sink = LogicalGraphSink::default();
+    db.export_jsonl_unordered_to_writer("main", &[], &mut sink)
+        .await
+        .map_err(|error| RealGraphError::new(format!("stream copied graph content: {error}")))?;
+    sink.verify_table_counts(&expected_logical_rows)?;
+    let content = sink.finish(schema_sha256)?;
+    let closing_snapshot = db
+        .snapshot_of(ReadTarget::branch("main"))
+        .await
+        .map_err(|error| RealGraphError::new(format!("recapture copied graph main: {error}")))?;
+    if closing_snapshot.graph_manifest_version() != graph_manifest_version
+        || closing_snapshot.graph_head(None) != main_commit_id.as_deref()
+    {
+        return Err(RealGraphError::new(
+            "copied graph main changed while logical evidence was being observed",
+        ));
+    }
+    drop(db);
+
+    Ok(RealGraphObservationV1 {
+        version: REAL_GRAPH_OBSERVATION_VERSION,
+        graph_manifest_version,
+        main_commit_id,
+        schema_shape: DigestReferenceV1 {
+            algorithm: SCHEMA_SHAPE_ALGORITHM.to_string(),
+            sha256: schema_sha256.to_string(),
+        },
+        logical_content: DigestReferenceV1 {
+            algorithm: LOGICAL_GRAPH_ALGORITHM.to_string(),
+            sha256: content.logical_content_sha256,
+        },
+        node_tables,
+        edge_tables,
+        logical_payload_bytes: content.logical_payload_bytes,
+        indexes,
+        history_depth,
+        relocation_self_contained,
+        branches,
+        unverified_state_fields: vec![
+            "aging".to_string(),
+            "deletion-history".to_string(),
+            "compaction-recency".to_string(),
+            "per-index-fts-ann-freshness".to_string(),
+            "unknown-index-metadata".to_string(),
+        ],
+    })
+}
+
+fn require_compatible_physical_schema(
+    table_key: &str,
+    expected: &ArrowSchema,
+    observed: &ArrowSchema,
+) -> RealGraphResult<()> {
+    if expected.fields().len() != observed.fields().len()
+        || expected.metadata() != observed.metadata()
+    {
+        return Err(RealGraphError::new(format!(
+            "physical schema for {table_key} differs from the accepted catalog"
+        )));
+    }
+    for (expected, observed) in expected.fields().iter().zip(observed.fields()) {
+        if expected.name() != observed.name()
+            || expected.data_type() != observed.data_type()
+            || expected.is_nullable() != observed.is_nullable()
+        {
+            return Err(RealGraphError::new(format!(
+                "physical field {table_key}.{} differs from the accepted catalog",
+                expected.name()
+            )));
+        }
+        let mut observed_metadata = observed.metadata().clone();
+        if !observed_metadata.contains_key(STABLE_PROPERTY_ID_METADATA_KEY) {
+            if let Some(stable_id) = expected.metadata().get(STABLE_PROPERTY_ID_METADATA_KEY) {
+                // Supported v6 graphs created before stable property markers
+                // were added lack this one annotation. The engine accepts
+                // those tables by exact pinned version; every other physical
+                // field property and every present marker must still match.
+                observed_metadata.insert(
+                    STABLE_PROPERTY_ID_METADATA_KEY.to_string(),
+                    stable_id.clone(),
+                );
+            }
+        }
+        if &observed_metadata != expected.metadata() {
+            return Err(RealGraphError::new(format!(
+                "physical metadata for {table_key}.{} differs from the accepted catalog",
+                expected.name()
+            )));
+        }
+    }
+    Ok(())
+}
+
+async fn observe_engine_index(
+    dataset: &SnapshotDataset,
+    table_key: &str,
+    column: &str,
+    table_has_stale_index: bool,
+    output: &mut Vec<RealGraphIndexV1>,
+) -> RealGraphResult<()> {
+    if dataset.has_btree_index(column).await.map_err(|error| {
+        RealGraphError::new(format!("inspect BTREE {table_key}.{column}: {error}"))
+    })? {
+        let freshness = match dataset.index_coverage(column).await.map_err(|error| {
+            RealGraphError::new(format!(
+                "inspect BTREE coverage {table_key}.{column}: {error}"
+            ))
+        })? {
+            IndexCoverage::Indexed => RealGraphIndexFreshnessV1::Optimized,
+            IndexCoverage::Degraded { .. } => RealGraphIndexFreshnessV1::RowsStale,
+        };
+        output.push(RealGraphIndexV1 {
+            table: table_key.to_string(),
+            column: column.to_string(),
+            kind: RealGraphIndexKindV1::Btree,
+            freshness,
+        });
+    }
+    for (present, kind) in [
+        (
+            dataset.has_fts_index(column).await.map_err(|error| {
+                RealGraphError::new(format!("inspect FTS {table_key}.{column}: {error}"))
+            })?,
+            RealGraphIndexKindV1::Fts,
+        ),
+        (
+            dataset.has_vector_index(column).await.map_err(|error| {
+                RealGraphError::new(format!("inspect ANN {table_key}.{column}: {error}"))
+            })?,
+            RealGraphIndexKindV1::Ann,
+        ),
+    ] {
+        if present {
+            output.push(RealGraphIndexV1 {
+                table: table_key.to_string(),
+                column: column.to_string(),
+                kind,
+                freshness: if table_has_stale_index {
+                    RealGraphIndexFreshnessV1::RowsStale
+                } else {
+                    RealGraphIndexFreshnessV1::Optimized
+                },
+            });
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Default)]
+struct TableAccumulator {
+    rows: u64,
+    sum_a: [u8; 32],
+    sum_b: [u8; 32],
+}
+
+#[derive(Debug, Default)]
+struct LogicalGraphSink {
+    pending: Vec<u8>,
+    tables: BTreeMap<String, TableAccumulator>,
+    logical_payload_bytes: u64,
+}
+
+struct LogicalContentSummary {
+    logical_content_sha256: String,
+    logical_payload_bytes: u64,
+}
+
+impl LogicalGraphSink {
+    fn verify_table_counts(&self, expected: &BTreeMap<String, u64>) -> RealGraphResult<()> {
+        let observed = expected
+            .keys()
+            .map(|table| {
+                (
+                    table.clone(),
+                    self.tables.get(table).map_or(0, |value| value.rows),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        let unexpected = self
+            .tables
+            .keys()
+            .filter(|table| !expected.contains_key(*table))
+            .cloned()
+            .collect::<Vec<_>>();
+        if &observed != expected || !unexpected.is_empty() {
+            return Err(RealGraphError::new(format!(
+                "canonical export table counts differ from the pinned graph: expected={expected:?}, observed={observed:?}, unexpected={unexpected:?}"
+            )));
+        }
+        Ok(())
+    }
+
+    fn consume_pending_lines(&mut self, max_line_bytes: usize) -> io::Result<()> {
+        while let Some(newline) = self.pending.iter().position(|byte| *byte == b'\n') {
+            if newline > max_line_bytes {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "canonical export row exceeds the validator line budget",
+                ));
+            }
+            let line = self.pending.drain(..=newline).collect::<Vec<_>>();
+            self.consume_line(&line[..line.len() - 1])
+                .map_err(io::Error::other)?;
+        }
+        if self.pending.len() > max_line_bytes {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "canonical export row exceeds the validator line budget",
+            ));
+        }
+        Ok(())
+    }
+
+    fn consume_line(&mut self, line: &[u8]) -> RealGraphResult<()> {
+        if line.is_empty() {
+            return Ok(());
+        }
+        let mut row: Value = serde_json::from_slice(line)
+            .map_err(|error| RealGraphError::new(format!("parse canonical export row: {error}")))?;
+        let object = row
+            .as_object_mut()
+            .ok_or_else(|| RealGraphError::new("canonical export row is not an object"))?;
+        let node_type = object
+            .get("type")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+        let edge_type = object
+            .get("edge")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+        let (table_key, canonical_row, payload_bytes) = if let Some(node) = node_type {
+            let mut data = object
+                .remove("data")
+                .and_then(|value| value.as_object().cloned())
+                .ok_or_else(|| RealGraphError::new("node export row has no data object"))?;
+            data.remove("id");
+            let payload = canonical_json_bytes(&Value::Object(data.clone()))?;
+            let mut canonical = Vec::new();
+            frame(&mut canonical, b"node");
+            frame(&mut canonical, node.as_bytes());
+            frame(&mut canonical, &payload);
+            (format!("node:{node}"), canonical, payload.len())
+        } else if let Some(edge) = edge_type {
+            let from = object
+                .get("from")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+                .ok_or_else(|| RealGraphError::new("edge export row has no string from"))?;
+            let to = object
+                .get("to")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+                .ok_or_else(|| RealGraphError::new("edge export row has no string to"))?;
+            let mut data = object
+                .remove("data")
+                .and_then(|value| value.as_object().cloned())
+                .ok_or_else(|| RealGraphError::new("edge export row has no data object"))?;
+            data.remove("id");
+            let payload = canonical_json_bytes(&Value::Object(data.clone()))?;
+            let mut canonical = Vec::new();
+            frame(&mut canonical, b"edge");
+            frame(&mut canonical, edge.as_bytes());
+            frame(&mut canonical, from.as_bytes());
+            frame(&mut canonical, to.as_bytes());
+            frame(&mut canonical, &payload);
+            (format!("edge:{edge}"), canonical, payload.len())
+        } else {
+            return Err(RealGraphError::new(
+                "canonical export row is neither a node nor an edge",
+            ));
+        };
+        self.logical_payload_bytes = self
+            .logical_payload_bytes
+            .checked_add(u64::try_from(payload_bytes).map_err(|_| {
+                RealGraphError::new("one canonical logical payload length exceeds u64")
+            })?)
+            .ok_or_else(|| RealGraphError::new("logical payload byte total exceeds u64"))?;
+        let table = self.tables.entry(table_key).or_default();
+        table.rows = table
+            .rows
+            .checked_add(1)
+            .ok_or_else(|| RealGraphError::new("logical table row count exceeds u64"))?;
+        add_mod_256(
+            &mut table.sum_a,
+            &domain_hash(ROW_HASH_DOMAIN_A, &canonical_row),
+        );
+        add_mod_256(
+            &mut table.sum_b,
+            &domain_hash(ROW_HASH_DOMAIN_B, &canonical_row),
+        );
+        Ok(())
+    }
+
+    fn finish(self, schema_sha256: &str) -> RealGraphResult<LogicalContentSummary> {
+        if !self.pending.is_empty() {
+            return Err(RealGraphError::new(
+                "canonical export ended with an unterminated JSONL row",
+            ));
+        }
+        let schema = decode_sha256(schema_sha256)?;
+        let mut graph = Sha256::new();
+        graph.update(GRAPH_HASH_DOMAIN);
+        frame_digest(&mut graph, b"schema-sha256", &schema);
+        for (table_key, table) in self.tables {
+            let mut table_digest = Sha256::new();
+            table_digest.update(TABLE_HASH_DOMAIN);
+            frame_digest(&mut table_digest, b"table", table_key.as_bytes());
+            frame_digest(&mut table_digest, b"rows-u64-le", &table.rows.to_le_bytes());
+            frame_digest(&mut table_digest, b"sum-a", &table.sum_a);
+            frame_digest(&mut table_digest, b"sum-b", &table.sum_b);
+            frame_digest(&mut graph, b"table-sha256", &table_digest.finalize());
+        }
+        Ok(LogicalContentSummary {
+            logical_content_sha256: format!("{:x}", graph.finalize()),
+            logical_payload_bytes: self.logical_payload_bytes,
+        })
+    }
+}
+
+impl Write for LogicalGraphSink {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.pending.extend_from_slice(bytes);
+        self.consume_pending_lines(MAX_EXPORT_LINE_BYTES)?;
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn canonical_json_bytes(value: &Value) -> RealGraphResult<Vec<u8>> {
+    let mut bytes = Vec::new();
+    write_canonical_json(value, &mut bytes)?;
+    Ok(bytes)
+}
+
+fn write_canonical_json(value: &Value, output: &mut Vec<u8>) -> RealGraphResult<()> {
+    match value {
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {
+            serde_json::to_writer(&mut *output, value).map_err(|error| {
+                RealGraphError::new(format!("serialize canonical scalar: {error}"))
+            })?;
+        }
+        Value::Array(values) => {
+            output.push(b'[');
+            for (index, value) in values.iter().enumerate() {
+                if index > 0 {
+                    output.push(b',');
+                }
+                write_canonical_json(value, output)?;
+            }
+            output.push(b']');
+        }
+        Value::Object(values) => {
+            output.push(b'{');
+            let mut keys = values.keys().collect::<Vec<_>>();
+            keys.sort();
+            for (index, key) in keys.into_iter().enumerate() {
+                if index > 0 {
+                    output.push(b',');
+                }
+                serde_json::to_writer(&mut *output, key).map_err(|error| {
+                    RealGraphError::new(format!("serialize canonical object key: {error}"))
+                })?;
+                output.push(b':');
+                write_canonical_json(
+                    values
+                        .get(key)
+                        .expect("canonical object key came from this object"),
+                    output,
+                )?;
+            }
+            output.push(b'}');
+        }
+    }
+    Ok(())
+}
+
+fn frame(output: &mut Vec<u8>, value: &[u8]) {
+    output.extend_from_slice(&(value.len() as u64).to_le_bytes());
+    output.extend_from_slice(value);
+}
+
+fn frame_digest(digest: &mut Sha256, label: &[u8], value: &[u8]) {
+    digest.update((label.len() as u64).to_le_bytes());
+    digest.update(label);
+    digest.update((value.len() as u64).to_le_bytes());
+    digest.update(value);
+}
+
+fn domain_hash(domain: &[u8], value: &[u8]) -> [u8; 32] {
+    let mut digest = Sha256::new();
+    digest.update(domain);
+    digest.update((value.len() as u64).to_le_bytes());
+    digest.update(value);
+    digest.finalize().into()
+}
+
+fn add_mod_256(sum: &mut [u8; 32], value: &[u8; 32]) {
+    let mut carry = 0u16;
+    for (left, right) in sum.iter_mut().zip(value) {
+        let total = u16::from(*left) + u16::from(*right) + carry;
+        *left = total as u8;
+        carry = total >> 8;
+    }
+}
+
+fn decode_sha256(value: &str) -> RealGraphResult<[u8; 32]> {
+    if value.len() != 64 {
+        return Err(RealGraphError::new("schema SHA-256 is not 64 hex digits"));
+    }
+    let mut output = [0u8; 32];
+    for (index, byte) in output.iter_mut().enumerate() {
+        let offset = index * 2;
+        let pair = &value.as_bytes()[offset..offset + 2];
+        let high = decode_hex_digit(pair[0])?;
+        let low = decode_hex_digit(pair[1])?;
+        *byte = (high << 4) | low;
+    }
+    Ok(output)
+}
+
+fn decode_hex_digit(value: u8) -> RealGraphResult<u8> {
+    match value {
+        b'0'..=b'9' => Ok(value - b'0'),
+        b'a'..=b'f' => Ok(value - b'a' + 10),
+        b'A'..=b'F' => Ok(value - b'A' + 10),
+        _ => Err(RealGraphError::new(
+            "schema SHA-256 contains a non-hex digit",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_schema::{DataType, Field};
+    use lance::datatypes::LANCE_UNENFORCED_PRIMARY_KEY;
+    use omnigraph::loader::{LoadMode, load_jsonl};
+
+    fn export_rows(rows: &[&str]) -> LogicalContentSummary {
+        let mut sink = LogicalGraphSink::default();
+        for row in rows {
+            sink.write_all(row.as_bytes()).unwrap();
+            sink.write_all(b"\n").unwrap();
+        }
+        sink.finish(&"a".repeat(64)).unwrap()
+    }
+
+    fn physical_schema(stable_property_id: Option<&str>, primary_key: bool) -> ArrowSchema {
+        let mut id_metadata = std::collections::HashMap::new();
+        if primary_key {
+            id_metadata.insert(LANCE_UNENFORCED_PRIMARY_KEY.to_string(), "true".to_string());
+        }
+        let mut name_metadata = std::collections::HashMap::new();
+        if let Some(stable_property_id) = stable_property_id {
+            name_metadata.insert(
+                STABLE_PROPERTY_ID_METADATA_KEY.to_string(),
+                stable_property_id.to_string(),
+            );
+        }
+        ArrowSchema::new(vec![
+            Field::new("id", DataType::Utf8, false).with_metadata(id_metadata),
+            Field::new("name", DataType::Utf8, true).with_metadata(name_metadata),
+        ])
+    }
+
+    #[test]
+    fn physical_schema_allows_only_absent_legacy_stable_property_marker() {
+        let expected = physical_schema(Some("42"), true);
+        let legacy = physical_schema(None, true);
+        require_compatible_physical_schema("node:Person", &expected, &legacy).unwrap();
+
+        let wrong_stable_id = physical_schema(Some("41"), true);
+        assert!(
+            require_compatible_physical_schema("node:Person", &expected, &wrong_stable_id)
+                .unwrap_err()
+                .to_string()
+                .contains("physical metadata")
+        );
+
+        let missing_primary_key = physical_schema(None, false);
+        assert!(
+            require_compatible_physical_schema("node:Person", &expected, &missing_primary_key)
+                .unwrap_err()
+                .to_string()
+                .contains("physical metadata")
+        );
+    }
+
+    #[test]
+    fn logical_multiset_omits_generated_ids_preserves_duplicates_and_ignores_order() {
+        let edge_a =
+            r#"{"edge":"Transfer","from":"a","to":"b","data":{"id":"generated-a","amount":1}}"#;
+        let edge_b =
+            r#"{"edge":"Transfer","from":"a","to":"b","data":{"id":"generated-b","amount":1}}"#;
+        let edge_other =
+            r#"{"edge":"Transfer","from":"b","to":"a","data":{"id":"generated-c","amount":2}}"#;
+        let left = export_rows(&[edge_a, edge_other]);
+        let rebuilt = export_rows(&[edge_other, edge_b]);
+        assert_eq!(left.logical_content_sha256, rebuilt.logical_content_sha256);
+        let duplicate = export_rows(&[edge_a, edge_b, edge_other]);
+        assert_ne!(
+            left.logical_content_sha256,
+            duplicate.logical_content_sha256
+        );
+    }
+
+    #[test]
+    fn canonical_property_order_and_redundant_node_id_do_not_change_content() {
+        let first = export_rows(&[
+            r#"{"type":"Person","data":{"id":"physical-a","personId":"p1","active":true}}"#,
+        ]);
+        let second = export_rows(&[
+            r#"{"type":"Person","data":{"active":true,"personId":"p1","id":"physical-b"}}"#,
+        ]);
+        assert_eq!(first.logical_content_sha256, second.logical_content_sha256);
+        assert_eq!(first.logical_payload_bytes, second.logical_payload_bytes);
+    }
+
+    #[test]
+    fn newline_terminated_rows_still_obey_the_line_budget() {
+        let mut sink = LogicalGraphSink::default();
+        sink.pending.extend_from_slice(b"12345\n");
+        let error = sink.consume_pending_lines(4).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn partial_export_cannot_mint_a_logical_digest() {
+        let mut sink = LogicalGraphSink::default();
+        sink.write_all(
+            br#"{"type":"Person","data":{"id":"p1","personId":"p1"}}
+"#,
+        )
+        .unwrap();
+        let expected = BTreeMap::from([("node:Person".to_string(), 2)]);
+        assert!(sink.verify_table_counts(&expected).is_err());
+    }
+
+    #[tokio::test]
+    async fn observes_a_complete_node_and_edge_graph_without_writing_it() {
+        const SCHEMA: &str = r#"
+            node Person {
+                personId: String @key
+                active: Bool
+            }
+            edge Knows: Person -> Person {
+                since: I64
+            }
+        "#;
+        const DATA: &str = r#"{"type":"Person","data":{"personId":"p1","active":true}}
+{"type":"Person","data":{"personId":"p2","active":false}}
+{"edge":"Knows","from":"p1","to":"p2","data":{"since":2026}}"#;
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("graph");
+        let uri = root.to_str().unwrap();
+        let db = Omnigraph::init(uri, SCHEMA).await.unwrap();
+        load_jsonl(&db, DATA, LoadMode::Overwrite).await.unwrap();
+        drop(db);
+
+        let before =
+            crate::reset::digest_physical_tree(&root, crate::reset::TraversalLimits::default())
+                .unwrap();
+        let observed = observe_real_graph(&root).await.unwrap();
+        let after =
+            crate::reset::digest_physical_tree(&root, crate::reset::TraversalLimits::default())
+                .unwrap();
+
+        assert_eq!(before, after);
+        assert_eq!(
+            observed.node_tables,
+            vec![GraphTableCountV1 {
+                name: "Person".to_string(),
+                rows: 2,
+            }]
+        );
+        assert_eq!(
+            observed.edge_tables,
+            vec![GraphTableCountV1 {
+                name: "Knows".to_string(),
+                rows: 1,
+            }]
+        );
+        assert!(observed.relocation_self_contained);
+        assert!(observed.logical_payload_bytes > 0);
+        assert_eq!(observed.logical_content.sha256.len(), 64);
+        assert!(observed.history_depth > 0);
+    }
+}

--- a/crates/omnigraph-bench/src/real_graph_run.rs
+++ b/crates/omnigraph-bench/src/real_graph_run.rs
@@ -1,0 +1,1215 @@
+//! Claim-ineligible execution against a registered real graph fixture.
+//!
+//! V1 deliberately supports one FinGraph-native branch-merge probe. The
+//! imported graph supplies realistic catalog size, history, fragments, and
+//! indexes; each side inserts two `Account` nodes and one transfer edge. The
+//! prepared tree is frozen once, every repetition is restored with APFS
+//! clonefiles, and the measured merge runs in a fresh process. Results are
+//! diagnostic JSON only and cannot enter the durable benchmark archive.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{ExitCode, Stdio};
+use std::time::{Duration, Instant};
+
+use omnigraph::db::{MergeOutcome, Omnigraph, ReadTarget, Snapshot};
+use omnigraph::instrumentation::{MergeWriteProbes, with_merge_write_probes};
+use omnigraph::loader::LoadMode;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use tokio::process::Command;
+use tokio::time::timeout;
+
+use crate::fixture_reference::NormalizedFixtureReferenceV1;
+use crate::model::{
+    Diagnostic, ValidationOutcome, declared_version, read_yaml_file, strict_yaml, valid_kebab_id,
+};
+use crate::real_graph::{observe_real_graph, validate_real_graph_reference};
+use crate::registered_fixture::{FixtureCopyPreflightReceiptV1, stage_registered_fixture_binding};
+use crate::reset::{PhysicalDigest, TraversalLimits, freeze_clonefile_template};
+use crate::runner::{
+    MergePhaseEvidenceForm, MergeRouteObservation, PhaseObservation,
+    configure_benchmark_worker_environment, phase_observations,
+    validate_successful_merge_phase_topology,
+};
+
+pub const REAL_GRAPH_RUN_SPEC_VERSION: u32 = 1;
+const WORKER_PROTOCOL_VERSION: u32 = 1;
+const MAX_REPETITIONS: u32 = 20;
+const MAX_DEADLINE_SECONDS: u64 = 3_600;
+const MAX_WORKER_FILE_BYTES: u64 = 1024 * 1024;
+const WORKER_VERIFY_GRACE_SECONDS: u64 = 120;
+const SOURCE_BRANCH: &str = "bench-source";
+const TARGET_BRANCH: &str = "bench-target";
+const ACCOUNT_TABLE: &str = "node:Account";
+const TRANSFER_TABLE: &str = "edge:AccountTransferAccount";
+
+const SOURCE_A: &str = "omnigraph-bench-fin-v1-src-a";
+const SOURCE_B: &str = "omnigraph-bench-fin-v1-src-b";
+const SOURCE_EDGE: &str = "omnigraph-bench-fin-v1-src-transfer";
+const TARGET_A: &str = "omnigraph-bench-fin-v1-tgt-a";
+const TARGET_B: &str = "omnigraph-bench-fin-v1-tgt-b";
+const TARGET_EDGE: &str = "omnigraph-bench-fin-v1-tgt-transfer";
+
+const SOURCE_BATCH: &str = r#"{"type":"Account","data":{"accountId":"omnigraph-bench-fin-v1-src-a","createTime":"2020-01-01T00:00:00Z","isBlocked":false,"accountType":"internet_account","freqLoginType":"ipv4","accountLevel":"basic"}}
+{"type":"Account","data":{"accountId":"omnigraph-bench-fin-v1-src-b","createTime":"2020-01-01T00:00:00Z","isBlocked":false,"accountType":"internet_account","freqLoginType":"ipv4","accountLevel":"basic"}}
+{"edge":"AccountTransferAccount","from":"omnigraph-bench-fin-v1-src-a","to":"omnigraph-bench-fin-v1-src-b","data":{"id":"omnigraph-bench-fin-v1-src-transfer","amount":1.25,"createTime":"2020-01-01T00:00:00Z","orderNum":"omnigraph-bench-fin-v1-src-order","payType":"bank_transfer","goodsType":"bank_transfer"}}"#;
+
+const TARGET_BATCH: &str = r#"{"type":"Account","data":{"accountId":"omnigraph-bench-fin-v1-tgt-a","createTime":"2020-01-01T00:00:01Z","isBlocked":false,"accountType":"internet_account","freqLoginType":"ipv4","accountLevel":"basic"}}
+{"type":"Account","data":{"accountId":"omnigraph-bench-fin-v1-tgt-b","createTime":"2020-01-01T00:00:01Z","isBlocked":false,"accountType":"internet_account","freqLoginType":"ipv4","accountLevel":"basic"}}
+{"edge":"AccountTransferAccount","from":"omnigraph-bench-fin-v1-tgt-a","to":"omnigraph-bench-fin-v1-tgt-b","data":{"id":"omnigraph-bench-fin-v1-tgt-transfer","amount":2.5,"createTime":"2020-01-01T00:00:01Z","orderNum":"omnigraph-bench-fin-v1-tgt-order","payType":"bank_transfer","goodsType":"bank_transfer"}}"#;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RealGraphWorkloadV1 {
+    FinbenchDisjointInsertMerge,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RealGraphRunSpecV1 {
+    pub version: u32,
+    pub fixture_id: String,
+    pub workload: RealGraphWorkloadV1,
+    pub repetitions: u32,
+    pub operation_deadline_seconds: u64,
+}
+
+pub fn load_real_graph_run_spec(path: &Path) -> ValidationOutcome<RealGraphRunSpecV1> {
+    let source = match read_yaml_file(path, "real_graph_run") {
+        Ok(source) => source,
+        Err(diagnostic) => return ValidationOutcome::failure(vec![diagnostic]),
+    };
+    let version = match declared_version(&source, "real_graph_run") {
+        Ok(version) => version,
+        Err(diagnostic) => return ValidationOutcome::failure(vec![diagnostic]),
+    };
+    if version != REAL_GRAPH_RUN_SPEC_VERSION {
+        return ValidationOutcome::failure(vec![Diagnostic::error(
+            "unsupported_real_graph_run_version",
+            "version",
+            format!(
+                "unsupported real-graph run version {version}; expected {REAL_GRAPH_RUN_SPEC_VERSION}"
+            ),
+        )]);
+    }
+    let spec: RealGraphRunSpecV1 = match strict_yaml(&source, "real_graph_run") {
+        Ok(spec) => spec,
+        Err(diagnostic) => return ValidationOutcome::failure(vec![diagnostic]),
+    };
+    let mut diagnostics = Vec::new();
+    if !valid_kebab_id(&spec.fixture_id) || spec.fixture_id.len() > 128 {
+        diagnostics.push(Diagnostic::error(
+            "invalid_real_graph_fixture_id",
+            "fixture_id",
+            "fixture_id must be 1..=128 characters of path-free kebab-case ASCII",
+        ));
+    }
+    if !(1..=MAX_REPETITIONS).contains(&spec.repetitions) {
+        diagnostics.push(Diagnostic::error(
+            "invalid_real_graph_repetitions",
+            "repetitions",
+            format!("repetitions must be in 1..={MAX_REPETITIONS}"),
+        ));
+    }
+    if !(1..=MAX_DEADLINE_SECONDS).contains(&spec.operation_deadline_seconds) {
+        diagnostics.push(Diagnostic::error(
+            "invalid_real_graph_deadline",
+            "operation_deadline_seconds",
+            format!("operation_deadline_seconds must be in 1..={MAX_DEADLINE_SECONDS}"),
+        ));
+    }
+    if diagnostics.is_empty() {
+        ValidationOutcome::success(spec)
+    } else {
+        ValidationOutcome::failure(diagnostics)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TablePointerV1 {
+    pub type_key: String,
+    pub dataset_path: String,
+    pub published_dataset_version: u64,
+    pub native_dataset_branch: Option<String>,
+    pub entity_count: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RealGraphRepV1 {
+    pub repetition: u32,
+    pub elapsed_us: u64,
+    pub outcome: String,
+    pub phases: Vec<PhaseObservation>,
+    pub route: MergeRouteObservation,
+    pub before_target_manifest_version: u64,
+    pub after_target_manifest_version: u64,
+    pub inserted_delta_verified: bool,
+    pub existing_rows_in_changed_tables_verified: bool,
+    pub protected_heads_verified: bool,
+    pub untouched_tables_verified: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RealGraphRunReportV1 {
+    pub version: u32,
+    pub fixture_id: String,
+    pub workload: RealGraphWorkloadV1,
+    pub fixture: FixtureCopyPreflightReceiptV1,
+    pub reference_sha256: String,
+    pub prepared_input_physical: PhysicalDigest,
+    pub reset: String,
+    pub process_state: String,
+    pub page_cache_state: String,
+    pub warmup: String,
+    pub claim_eligible: bool,
+    pub durable_record: bool,
+    pub repetitions: u32,
+    pub operation_deadline_seconds: u64,
+    pub p50_us: u64,
+    pub samples: Vec<RealGraphRepV1>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RealGraphRunError {
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl RealGraphRunError {
+    fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for RealGraphRunError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for RealGraphRunError {}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WorkerRequestV1 {
+    version: u32,
+    repetition: u32,
+    root: PathBuf,
+    operation_deadline_seconds: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WorkerEnvelopeV1 {
+    version: u32,
+    ok: bool,
+    sample: Option<RealGraphRepV1>,
+    error: Option<String>,
+}
+
+pub async fn execute_real_graph_run(
+    spec: &RealGraphRunSpecV1,
+    reference: &NormalizedFixtureReferenceV1,
+    fixture_binding: &str,
+    scratch_root: Option<&Path>,
+) -> Result<RealGraphRunReportV1, RealGraphRunError> {
+    if cfg!(debug_assertions) {
+        return Err(RealGraphRunError::new(
+            "release_build_required",
+            "real-graph timing requires the checked-in Cargo release profile",
+        ));
+    }
+    if spec.fixture_id != reference.definition.fixture_id {
+        return Err(RealGraphRunError::new(
+            "real_graph_fixture_id_mismatch",
+            format!(
+                "run spec identifies {:?}, but the logical reference identifies {:?}",
+                spec.fixture_id, reference.definition.fixture_id
+            ),
+        ));
+    }
+    let staged = stage_registered_fixture_binding(fixture_binding, scratch_root)
+        .into_result()
+        .map_err(|diagnostics| diagnostics_error("real_graph_staging_failed", diagnostics))?;
+    if staged.receipt().fixture_id != spec.fixture_id {
+        let observed = staged.receipt().fixture_id.clone();
+        let _ = staged.finish();
+        return Err(RealGraphRunError::new(
+            "real_graph_fixture_id_mismatch",
+            format!(
+                "run spec identifies {:?}, but the registered fixture identifies {observed:?}",
+                spec.fixture_id
+            ),
+        ));
+    }
+    let observation = observe_real_graph(staged.root()).await.map_err(|error| {
+        RealGraphRunError::new("real_graph_observation_failed", error.to_string())
+    })?;
+    validate_real_graph_reference(reference, &observation).map_err(|error| {
+        RealGraphRunError::new("real_graph_reference_mismatch", error.to_string())
+    })?;
+    staged.verify_unchanged().map_err(|diagnostic| {
+        RealGraphRunError::new("staged_fixture_changed", diagnostic.message)
+    })?;
+
+    let active = staged.root().to_path_buf();
+    let workspace = active.parent().ok_or_else(|| {
+        RealGraphRunError::new(
+            "real_graph_scratch_failed",
+            "staged graph root has no run-owned parent",
+        )
+    })?;
+    let template = workspace.join("template");
+    let fixture_receipt = staged.receipt().clone();
+
+    prepare_finbench_delta(&active).await?;
+    let frozen = freeze_clonefile_template(&active, &template, TraversalLimits::default())
+        .map_err(|error| {
+            RealGraphRunError::new(
+                "real_graph_freeze_failed",
+                format!("freeze prepared graph with APFS clonefiles: {error}"),
+            )
+        })?;
+    remove_active(&active, workspace)?;
+
+    let executable = std::env::current_exe().map_err(|error| {
+        RealGraphRunError::new(
+            "real_graph_worker_unavailable",
+            format!("resolve current benchmark executable: {error}"),
+        )
+    })?;
+    let mut samples = Vec::with_capacity(spec.repetitions as usize);
+    for repetition in 1..=spec.repetitions {
+        frozen.verify_unchanged().map_err(|error| {
+            RealGraphRunError::new(
+                "real_graph_template_changed",
+                format!("prepared template changed before repetition {repetition}: {error}"),
+            )
+        })?;
+        let prepared = frozen.restore_active().map_err(|error| {
+            RealGraphRunError::new(
+                "real_graph_reset_failed",
+                format!("restore repetition {repetition}: {error}"),
+            )
+        })?;
+        prepared.verify_unchanged().map_err(|error| {
+            RealGraphRunError::new(
+                "real_graph_reset_changed",
+                format!("restored input changed before repetition {repetition}: {error}"),
+            )
+        })?;
+        let request_path = workspace.join(format!("request-{repetition}.json"));
+        let result_path = workspace.join(format!("result-{repetition}.json"));
+        let worker_scratch = workspace.join(format!("worker-{repetition}"));
+        fs::create_dir(&worker_scratch).map_err(|error| {
+            RealGraphRunError::new(
+                "real_graph_worker_protocol_failed",
+                format!("create repetition worker scratch: {error}"),
+            )
+        })?;
+        let request = WorkerRequestV1 {
+            version: WORKER_PROTOCOL_VERSION,
+            repetition,
+            root: prepared.root().to_path_buf(),
+            operation_deadline_seconds: spec.operation_deadline_seconds,
+        };
+        fs::write(
+            &request_path,
+            serde_json::to_vec(&request).map_err(|error| {
+                RealGraphRunError::new(
+                    "real_graph_worker_protocol_failed",
+                    format!("serialize worker request: {error}"),
+                )
+            })?,
+        )
+        .map_err(|error| {
+            RealGraphRunError::new(
+                "real_graph_worker_protocol_failed",
+                format!("write worker request: {error}"),
+            )
+        })?;
+        let sample = invoke_worker(
+            &executable,
+            &request_path,
+            &result_path,
+            &worker_scratch,
+            spec.operation_deadline_seconds,
+        )
+        .await;
+        remove_active(&active, workspace)?;
+        samples.push(sample?);
+    }
+    frozen.verify_unchanged().map_err(|error| {
+        RealGraphRunError::new(
+            "real_graph_template_changed",
+            format!("prepared template changed after execution: {error}"),
+        )
+    })?;
+
+    let mut elapsed = samples
+        .iter()
+        .map(|sample| sample.elapsed_us)
+        .collect::<Vec<_>>();
+    elapsed.sort_unstable();
+    let p50_us = elapsed[(elapsed.len() - 1) / 2];
+    let prepared_input_physical = frozen.physical_digest().clone();
+    staged.finish().map_err(|diagnostic| {
+        RealGraphRunError::new("fixture_cleanup_failed", diagnostic.message)
+    })?;
+    Ok(RealGraphRunReportV1 {
+        version: REAL_GRAPH_RUN_SPEC_VERSION,
+        fixture_id: spec.fixture_id.clone(),
+        workload: spec.workload,
+        fixture: fixture_receipt,
+        reference_sha256: reference.reference_sha256.clone(),
+        prepared_input_physical,
+        reset: "apfs-clonefile-same-active-path".to_string(),
+        process_state: "fresh-process-per-repetition".to_string(),
+        page_cache_state: "uncontrolled".to_string(),
+        warmup: "none".to_string(),
+        claim_eligible: false,
+        durable_record: false,
+        repetitions: spec.repetitions,
+        operation_deadline_seconds: spec.operation_deadline_seconds,
+        p50_us,
+        samples,
+    })
+}
+
+fn diagnostics_error(code: &'static str, diagnostics: Vec<Diagnostic>) -> RealGraphRunError {
+    RealGraphRunError::new(
+        code,
+        diagnostics
+            .into_iter()
+            .map(|diagnostic| {
+                format!(
+                    "{} at {}: {}",
+                    diagnostic.code, diagnostic.path, diagnostic.message
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("; "),
+    )
+}
+
+async fn prepare_finbench_delta(root: &Path) -> Result<(), RealGraphRunError> {
+    let uri = path_utf8(root)?;
+    let db = Omnigraph::open(uri).await.map_err(|error| {
+        RealGraphRunError::new(
+            "real_graph_prepare_failed",
+            format!("open disposable FinGraph copy: {error}"),
+        )
+    })?;
+    let mut branches = db.branch_list().await.map_err(engine_prepare_error)?;
+    branches.sort();
+    if branches != ["main"] {
+        return Err(RealGraphRunError::new(
+            "real_graph_prepare_failed",
+            format!("FinGraph base must contain only main; observed {branches:?}"),
+        ));
+    }
+    verify_reserved_entities(&db, "main", SideExpectation::None).await?;
+    let main = db
+        .snapshot_of(ReadTarget::branch("main"))
+        .await
+        .map_err(engine_prepare_error)?;
+    require_finbench_tables(&main)?;
+    db.branch_create_from(ReadTarget::branch("main"), SOURCE_BRANCH)
+        .await
+        .map_err(engine_prepare_error)?;
+    db.branch_create_from(ReadTarget::branch("main"), TARGET_BRANCH)
+        .await
+        .map_err(engine_prepare_error)?;
+    let source = db
+        .load_graph_batch_as_with_receipt(SOURCE_BRANCH, None, SOURCE_BATCH, LoadMode::Append, None)
+        .await
+        .map_err(engine_prepare_error)?;
+    require_load_receipt(&source.result, SOURCE_BRANCH)?;
+    let target = db
+        .load_graph_batch_as_with_receipt(TARGET_BRANCH, None, TARGET_BATCH, LoadMode::Append, None)
+        .await
+        .map_err(engine_prepare_error)?;
+    require_load_receipt(&target.result, TARGET_BRANCH)?;
+    verify_reserved_entities(&db, "main", SideExpectation::None).await?;
+    verify_reserved_entities(&db, SOURCE_BRANCH, SideExpectation::SourceOnly).await?;
+    verify_reserved_entities(&db, TARGET_BRANCH, SideExpectation::TargetOnly).await?;
+    verify_prepared_counts(&db, &main).await?;
+    drop(db);
+    Ok(())
+}
+
+fn require_load_receipt(
+    result: &omnigraph::loader::LoadResult,
+    branch: &str,
+) -> Result<(), RealGraphRunError> {
+    if result.branch != branch
+        || result.branch_created
+        || result.nodes_loaded.get("Account") != Some(&2)
+        || result.edges_loaded.get("AccountTransferAccount") != Some(&1)
+        || result.nodes_loaded.len() != 1
+        || result.edges_loaded.len() != 1
+    {
+        return Err(RealGraphRunError::new(
+            "real_graph_prepare_failed",
+            format!("unexpected strict load receipt on {branch}: {result:?}"),
+        ));
+    }
+    Ok(())
+}
+
+fn require_finbench_tables(snapshot: &Snapshot) -> Result<(), RealGraphRunError> {
+    for table in [ACCOUNT_TABLE, TRANSFER_TABLE] {
+        if snapshot.dataset(table).is_none() {
+            return Err(RealGraphRunError::new(
+                "real_graph_prepare_failed",
+                format!("registered graph is missing required FinGraph table {table}"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+async fn verify_prepared_counts(db: &Omnigraph, main: &Snapshot) -> Result<(), RealGraphRunError> {
+    for branch in [SOURCE_BRANCH, TARGET_BRANCH] {
+        let snapshot = db
+            .snapshot_of(ReadTarget::branch(branch))
+            .await
+            .map_err(engine_prepare_error)?;
+        require_count_delta(main, &snapshot, ACCOUNT_TABLE, 2)?;
+        require_count_delta(main, &snapshot, TRANSFER_TABLE, 1)?;
+    }
+    Ok(())
+}
+
+fn require_count_delta(
+    before: &Snapshot,
+    after: &Snapshot,
+    table: &str,
+    delta: u64,
+) -> Result<(), RealGraphRunError> {
+    let before = before.dataset(table).ok_or_else(|| {
+        RealGraphRunError::new("real_graph_verification_failed", format!("missing {table}"))
+    })?;
+    let after = after.dataset(table).ok_or_else(|| {
+        RealGraphRunError::new("real_graph_verification_failed", format!("missing {table}"))
+    })?;
+    if after.entity_count != before.entity_count.saturating_add(delta) {
+        return Err(RealGraphRunError::new(
+            "real_graph_verification_failed",
+            format!(
+                "{table} count mismatch: before={}, expected delta={delta}, after={}",
+                before.entity_count, after.entity_count
+            ),
+        ));
+    }
+    Ok(())
+}
+
+async fn invoke_worker(
+    executable: &Path,
+    request: &Path,
+    result: &Path,
+    worker_scratch: &Path,
+    deadline_seconds: u64,
+) -> Result<RealGraphRepV1, RealGraphRunError> {
+    let mut command = Command::new(executable);
+    configure_benchmark_worker_environment(command.as_std_mut(), worker_scratch);
+    command
+        .arg("__real-graph-worker-v1")
+        .arg(request)
+        .arg(result)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
+    let mut child = command.spawn().map_err(|error| {
+        RealGraphRunError::new(
+            "real_graph_worker_failed",
+            format!("spawn fresh benchmark worker: {error}"),
+        )
+    })?;
+    let hard_seconds = deadline_seconds
+        .checked_add(WORKER_VERIFY_GRACE_SECONDS)
+        .ok_or_else(|| RealGraphRunError::new("real_graph_worker_failed", "deadline overflow"))?;
+    let status = match timeout(Duration::from_secs(hard_seconds), child.wait()).await {
+        Ok(status) => status.map_err(|error| {
+            RealGraphRunError::new(
+                "real_graph_worker_failed",
+                format!("wait for fresh benchmark worker: {error}"),
+            )
+        })?,
+        Err(_) => {
+            child.start_kill().map_err(|error| {
+                RealGraphRunError::new(
+                    "real_graph_worker_timeout",
+                    format!("terminate worker after {hard_seconds}s: {error}"),
+                )
+            })?;
+            child.wait().await.map_err(|error| {
+                RealGraphRunError::new(
+                    "real_graph_worker_timeout",
+                    format!("reap terminated worker: {error}"),
+                )
+            })?;
+            return Err(RealGraphRunError::new(
+                "real_graph_worker_timeout",
+                format!("fresh worker exceeded the {hard_seconds}s hard deadline"),
+            ));
+        }
+    };
+    let envelope = read_worker_envelope(result)?;
+    if !status.success() || !envelope.ok {
+        return Err(RealGraphRunError::new(
+            "real_graph_worker_failed",
+            envelope
+                .error
+                .unwrap_or_else(|| format!("worker exited {status}")),
+        ));
+    }
+    envelope.sample.ok_or_else(|| {
+        RealGraphRunError::new(
+            "real_graph_worker_protocol_failed",
+            "successful worker returned no sample",
+        )
+    })
+}
+
+pub async fn run_real_graph_worker_files(request: &Path, result: &Path) -> ExitCode {
+    let outcome = match read_worker_request(request) {
+        Ok(request) => execute_worker(request).await,
+        Err(error) => Err(error),
+    };
+    let envelope = match outcome {
+        Ok(sample) => WorkerEnvelopeV1 {
+            version: WORKER_PROTOCOL_VERSION,
+            ok: true,
+            sample: Some(sample),
+            error: None,
+        },
+        Err(error) => WorkerEnvelopeV1 {
+            version: WORKER_PROTOCOL_VERSION,
+            ok: false,
+            sample: None,
+            error: Some(error.to_string()),
+        },
+    };
+    let serialized = match serde_json::to_vec(&envelope) {
+        Ok(serialized) => serialized,
+        Err(error) => {
+            eprintln!("serialize real-graph worker result: {error}");
+            return ExitCode::FAILURE;
+        }
+    };
+    if let Err(error) = write_new(result, &serialized) {
+        eprintln!("write real-graph worker result: {error}");
+        return ExitCode::FAILURE;
+    }
+    if envelope.ok {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    }
+}
+
+async fn execute_worker(request: WorkerRequestV1) -> Result<RealGraphRepV1, RealGraphRunError> {
+    if request.version != WORKER_PROTOCOL_VERSION {
+        return Err(RealGraphRunError::new(
+            "real_graph_worker_protocol_failed",
+            format!("unsupported worker protocol {}", request.version),
+        ));
+    }
+    if !(1..=MAX_DEADLINE_SECONDS).contains(&request.operation_deadline_seconds) {
+        return Err(RealGraphRunError::new(
+            "real_graph_worker_protocol_failed",
+            "worker operation deadline is out of range",
+        ));
+    }
+    let db = Omnigraph::open(path_utf8(&request.root)?)
+        .await
+        .map_err(engine_worker_error)?;
+    let main_before = db
+        .snapshot_of(ReadTarget::branch("main"))
+        .await
+        .map_err(engine_worker_error)?;
+    let source_before = db
+        .snapshot_of(ReadTarget::branch(SOURCE_BRANCH))
+        .await
+        .map_err(engine_worker_error)?;
+    let target_before = db
+        .snapshot_of(ReadTarget::branch(TARGET_BRANCH))
+        .await
+        .map_err(engine_worker_error)?;
+    let probes = MergeWriteProbes::default();
+    let started = Instant::now();
+    let outcome = with_merge_write_probes(
+        probes.clone(),
+        db.branch_merge(SOURCE_BRANCH, TARGET_BRANCH),
+    )
+    .await
+    .map_err(engine_worker_error)?;
+    let elapsed = started.elapsed();
+    let elapsed_us = u64::try_from(elapsed.as_micros()).map_err(|_| {
+        RealGraphRunError::new("real_graph_worker_failed", "elapsed time exceeds u64")
+    })?;
+    if elapsed > Duration::from_secs(request.operation_deadline_seconds) {
+        return Err(RealGraphRunError::new(
+            "real_graph_operation_deadline_exceeded",
+            format!(
+                "measured merge took {elapsed_us}us, exceeding the declared {}s deadline",
+                request.operation_deadline_seconds
+            ),
+        ));
+    }
+    if outcome != MergeOutcome::Merged {
+        return Err(RealGraphRunError::new(
+            "real_graph_vacuous_merge",
+            format!("expected Merged, observed {outcome:?}"),
+        ));
+    }
+    let phases = phase_observations(probes.merge_timing_snapshot());
+    let route = MergeRouteObservation::from_probes(&probes);
+    validate_successful_merge_phase_topology(
+        &phases,
+        &route,
+        2,
+        MergePhaseEvidenceForm::RawSnapshot,
+    )
+    .map_err(|error| {
+        RealGraphRunError::new(
+            error.code(),
+            format!("invalid merge phase evidence: {error}"),
+        )
+    })?;
+    let main_after = db
+        .snapshot_of(ReadTarget::branch("main"))
+        .await
+        .map_err(engine_worker_error)?;
+    let source_after = db
+        .snapshot_of(ReadTarget::branch(SOURCE_BRANCH))
+        .await
+        .map_err(engine_worker_error)?;
+    let target_after = db
+        .snapshot_of(ReadTarget::branch(TARGET_BRANCH))
+        .await
+        .map_err(engine_worker_error)?;
+    require_snapshot_unchanged("main", &main_before, &main_after)?;
+    require_snapshot_unchanged(SOURCE_BRANCH, &source_before, &source_after)?;
+    let untouched_tables_verified = verify_target_delta(&target_before, &target_after)?;
+    verify_reserved_entities(&db, "main", SideExpectation::None).await?;
+    verify_reserved_entities(&db, SOURCE_BRANCH, SideExpectation::SourceOnly).await?;
+    verify_reserved_entities(&db, TARGET_BRANCH, SideExpectation::All).await?;
+    verify_merge_commit(&db, &source_before, &target_before, &target_after).await?;
+    drop(db);
+    Ok(RealGraphRepV1 {
+        repetition: request.repetition,
+        elapsed_us,
+        outcome: "merged".to_string(),
+        phases,
+        route,
+        before_target_manifest_version: target_before.graph_manifest_version(),
+        after_target_manifest_version: target_after.graph_manifest_version(),
+        inserted_delta_verified: true,
+        existing_rows_in_changed_tables_verified: false,
+        protected_heads_verified: true,
+        untouched_tables_verified,
+    })
+}
+
+fn require_snapshot_unchanged(
+    name: &str,
+    before: &Snapshot,
+    after: &Snapshot,
+) -> Result<(), RealGraphRunError> {
+    if before.graph_head(Some(name).filter(|name| *name != "main"))
+        != after.graph_head(Some(name).filter(|name| *name != "main"))
+        || snapshot_pointers(before) != snapshot_pointers(after)
+    {
+        return Err(RealGraphRunError::new(
+            "real_graph_verification_failed",
+            format!("protected {name} head or table pointers changed during target merge"),
+        ));
+    }
+    Ok(())
+}
+
+fn verify_target_delta(before: &Snapshot, after: &Snapshot) -> Result<u32, RealGraphRunError> {
+    if before.graph_head(Some(TARGET_BRANCH)) == after.graph_head(Some(TARGET_BRANCH)) {
+        return Err(RealGraphRunError::new(
+            "real_graph_verification_failed",
+            "target head did not advance",
+        ));
+    }
+    let before_pointers = snapshot_pointers(before);
+    let after_pointers = snapshot_pointers(after);
+    if before_pointers.len() != after_pointers.len() {
+        return Err(RealGraphRunError::new(
+            "real_graph_verification_failed",
+            "target table inventory changed during merge",
+        ));
+    }
+    let mut untouched = 0u32;
+    for (table, old) in &before_pointers {
+        let new = after_pointers.get(table).ok_or_else(|| {
+            RealGraphRunError::new(
+                "real_graph_verification_failed",
+                format!("target lost table {table}"),
+            )
+        })?;
+        let expected_delta = match table.as_str() {
+            ACCOUNT_TABLE => Some(2),
+            TRANSFER_TABLE => Some(1),
+            _ => None,
+        };
+        if let Some(delta) = expected_delta {
+            if new.dataset_path != old.dataset_path
+                || new.native_dataset_branch != old.native_dataset_branch
+                || new.published_dataset_version <= old.published_dataset_version
+                || new.entity_count != old.entity_count.saturating_add(delta)
+            {
+                return Err(RealGraphRunError::new(
+                    "real_graph_verification_failed",
+                    format!("target changed {table} outside the declared count/version delta"),
+                ));
+            }
+        } else if new != old {
+            return Err(RealGraphRunError::new(
+                "real_graph_verification_failed",
+                format!("untouched imported table {table} changed during merge"),
+            ));
+        } else {
+            untouched = untouched.saturating_add(1);
+        }
+    }
+    Ok(untouched)
+}
+
+fn snapshot_pointers(snapshot: &Snapshot) -> BTreeMap<String, TablePointerV1> {
+    snapshot
+        .datasets()
+        .map(|entry| {
+            (
+                entry.type_key.clone(),
+                TablePointerV1 {
+                    type_key: entry.type_key.clone(),
+                    dataset_path: entry.dataset_path.clone(),
+                    published_dataset_version: entry.published_dataset_version,
+                    native_dataset_branch: entry.native_dataset_branch.clone(),
+                    entity_count: entry.entity_count,
+                },
+            )
+        })
+        .collect()
+}
+
+async fn verify_merge_commit(
+    db: &Omnigraph,
+    source_before: &Snapshot,
+    target_before: &Snapshot,
+    target_after: &Snapshot,
+) -> Result<(), RealGraphRunError> {
+    let source_head = source_before
+        .graph_head(Some(SOURCE_BRANCH))
+        .ok_or_else(|| {
+            RealGraphRunError::new(
+                "real_graph_verification_failed",
+                "source has no prepared head",
+            )
+        })?;
+    let target_head = target_before
+        .graph_head(Some(TARGET_BRANCH))
+        .ok_or_else(|| {
+            RealGraphRunError::new(
+                "real_graph_verification_failed",
+                "target has no prepared head",
+            )
+        })?;
+    let merged_head = target_after
+        .graph_head(Some(TARGET_BRANCH))
+        .ok_or_else(|| {
+            RealGraphRunError::new(
+                "real_graph_verification_failed",
+                "target has no merged head",
+            )
+        })?;
+    let commits = db
+        .list_commits(Some(TARGET_BRANCH))
+        .await
+        .map_err(engine_worker_error)?;
+    let merge = commits
+        .iter()
+        .find(|commit| commit.graph_commit_id == merged_head)
+        .ok_or_else(|| {
+            RealGraphRunError::new(
+                "real_graph_verification_failed",
+                "merged target head is absent from target lineage",
+            )
+        })?;
+    if merge.parent_commit_id.as_deref() != Some(target_head)
+        || merge.merged_parent_commit_id.as_deref() != Some(source_head)
+    {
+        return Err(RealGraphRunError::new(
+            "real_graph_verification_failed",
+            "merge commit parent provenance does not match prepared source and target heads",
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy)]
+enum SideExpectation {
+    None,
+    SourceOnly,
+    TargetOnly,
+    All,
+}
+
+async fn verify_reserved_entities(
+    db: &Omnigraph,
+    branch: &str,
+    expectation: SideExpectation,
+) -> Result<(), RealGraphRunError> {
+    let source_present = matches!(
+        expectation,
+        SideExpectation::SourceOnly | SideExpectation::All
+    );
+    let target_present = matches!(
+        expectation,
+        SideExpectation::TargetOnly | SideExpectation::All
+    );
+    for (id, present) in [
+        (SOURCE_A, source_present),
+        (SOURCE_B, source_present),
+        (TARGET_A, target_present),
+        (TARGET_B, target_present),
+    ] {
+        let entity = db
+            .entity_at_target(ReadTarget::branch(branch), ACCOUNT_TABLE, id)
+            .await
+            .map_err(engine_worker_error)?;
+        verify_account(id, present, entity.as_ref())?;
+    }
+    for (id, source, target, amount, present) in [
+        (SOURCE_EDGE, SOURCE_A, SOURCE_B, 1.25, source_present),
+        (TARGET_EDGE, TARGET_A, TARGET_B, 2.5, target_present),
+    ] {
+        let entity = db
+            .entity_at_target(ReadTarget::branch(branch), TRANSFER_TABLE, id)
+            .await
+            .map_err(engine_worker_error)?;
+        verify_transfer(id, source, target, amount, present, entity.as_ref())?;
+    }
+    Ok(())
+}
+
+fn verify_account(
+    id: &str,
+    present: bool,
+    entity: Option<&Value>,
+) -> Result<(), RealGraphRunError> {
+    if !present {
+        if entity.is_some() {
+            return Err(verification_error(format!(
+                "reserved Account {id} unexpectedly exists"
+            )));
+        }
+        return Ok(());
+    }
+    let entity = entity.ok_or_else(|| verification_error(format!("missing Account {id}")))?;
+    if entity.as_object().map(serde_json::Map::len) != Some(11) {
+        return Err(verification_error(format!(
+            "Account {id} does not contain exactly the accepted schema fields"
+        )));
+    }
+    for (field, expected) in [
+        ("id", json!(id)),
+        ("accountId", json!(id)),
+        ("isBlocked", json!(false)),
+        ("accountType", json!("internet_account")),
+        ("freqLoginType", json!("ipv4")),
+        ("accountLevel", json!("basic")),
+        ("nickname", Value::Null),
+        ("phonenum", Value::Null),
+        ("email", Value::Null),
+        ("lastLoginTime", Value::Null),
+    ] {
+        if entity.get(field) != Some(&expected) {
+            return Err(verification_error(format!(
+                "Account {id}.{field} differs: expected {expected}, observed {:?}",
+                entity.get(field)
+            )));
+        }
+    }
+    let expected_time_ms = if id.starts_with("omnigraph-bench-fin-v1-src-") {
+        1_577_836_800_000
+    } else {
+        1_577_836_801_000
+    };
+    verify_datetime_millis(entity.get("createTime"), expected_time_ms, "Account", id)?;
+    Ok(())
+}
+
+fn verify_transfer(
+    id: &str,
+    source: &str,
+    target: &str,
+    amount: f64,
+    present: bool,
+    entity: Option<&Value>,
+) -> Result<(), RealGraphRunError> {
+    if !present {
+        if entity.is_some() {
+            return Err(verification_error(format!(
+                "reserved transfer {id} unexpectedly exists"
+            )));
+        }
+        return Ok(());
+    }
+    let entity = entity.ok_or_else(|| verification_error(format!("missing transfer {id}")))?;
+    if entity.as_object().map(serde_json::Map::len) != Some(9) {
+        return Err(verification_error(format!(
+            "transfer {id} does not contain exactly the accepted schema fields"
+        )));
+    }
+    let source_side = id == SOURCE_EDGE;
+    for (field, expected) in [
+        ("id", json!(id)),
+        ("src", json!(source)),
+        ("dst", json!(target)),
+        ("amount", json!(amount)),
+        ("payType", json!("bank_transfer")),
+        ("goodsType", json!("bank_transfer")),
+        ("comment", Value::Null),
+        (
+            "orderNum",
+            json!(if source_side {
+                "omnigraph-bench-fin-v1-src-order"
+            } else {
+                "omnigraph-bench-fin-v1-tgt-order"
+            }),
+        ),
+    ] {
+        if entity.get(field) != Some(&expected) {
+            return Err(verification_error(format!(
+                "transfer {id}.{field} differs: expected {expected}, observed {:?}",
+                entity.get(field)
+            )));
+        }
+    }
+    verify_datetime_millis(
+        entity.get("createTime"),
+        if source_side {
+            1_577_836_800_000
+        } else {
+            1_577_836_801_000
+        },
+        "transfer",
+        id,
+    )?;
+    Ok(())
+}
+
+fn verify_datetime_millis(
+    observed: Option<&Value>,
+    expected: i64,
+    kind: &str,
+    id: &str,
+) -> Result<(), RealGraphRunError> {
+    let observed = observed
+        .and_then(Value::as_i64)
+        .ok_or_else(|| verification_error(format!("{kind} {id}.createTime is not an integer")))?;
+    if observed != expected {
+        return Err(verification_error(format!(
+            "{kind} {id}.createTime differs: expected epoch-ms {expected}, observed {observed}"
+        )));
+    }
+    Ok(())
+}
+
+fn verification_error(message: impl Into<String>) -> RealGraphRunError {
+    RealGraphRunError::new("real_graph_verification_failed", message)
+}
+
+fn engine_prepare_error(error: impl std::fmt::Display) -> RealGraphRunError {
+    RealGraphRunError::new("real_graph_prepare_failed", error.to_string())
+}
+
+fn engine_worker_error(error: impl std::fmt::Display) -> RealGraphRunError {
+    RealGraphRunError::new("real_graph_worker_failed", error.to_string())
+}
+
+fn path_utf8(path: &Path) -> Result<&str, RealGraphRunError> {
+    path.to_str().ok_or_else(|| {
+        RealGraphRunError::new("real_graph_path_invalid", "graph path must be valid UTF-8")
+    })
+}
+
+fn remove_active(active: &Path, workspace: &Path) -> Result<(), RealGraphRunError> {
+    if active.parent() != Some(workspace)
+        || active.file_name().and_then(|name| name.to_str()) != Some("root")
+    {
+        return Err(RealGraphRunError::new(
+            "real_graph_cleanup_refused",
+            "refused to remove a path outside the staged run-owned root slot",
+        ));
+    }
+    match fs::remove_dir_all(active) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(RealGraphRunError::new(
+            "real_graph_cleanup_failed",
+            format!(
+                "remove disposable active graph {}: {error}",
+                active.display()
+            ),
+        )),
+    }
+}
+
+fn read_worker_request(path: &Path) -> Result<WorkerRequestV1, RealGraphRunError> {
+    let bytes = read_bounded(path)?;
+    serde_json::from_slice(&bytes).map_err(|error| {
+        RealGraphRunError::new(
+            "real_graph_worker_protocol_failed",
+            format!("parse worker request: {error}"),
+        )
+    })
+}
+
+fn read_worker_envelope(path: &Path) -> Result<WorkerEnvelopeV1, RealGraphRunError> {
+    let bytes = read_bounded(path)?;
+    let envelope: WorkerEnvelopeV1 = serde_json::from_slice(&bytes).map_err(|error| {
+        RealGraphRunError::new(
+            "real_graph_worker_protocol_failed",
+            format!("parse worker result: {error}"),
+        )
+    })?;
+    if envelope.version != WORKER_PROTOCOL_VERSION
+        || envelope.ok != envelope.sample.is_some()
+        || envelope.ok == envelope.error.is_some()
+    {
+        return Err(RealGraphRunError::new(
+            "real_graph_worker_protocol_failed",
+            "worker result envelope is inconsistent",
+        ));
+    }
+    Ok(envelope)
+}
+
+fn read_bounded(path: &Path) -> Result<Vec<u8>, RealGraphRunError> {
+    let metadata = fs::metadata(path).map_err(|error| {
+        RealGraphRunError::new(
+            "real_graph_worker_protocol_failed",
+            format!("inspect worker file {}: {error}", path.display()),
+        )
+    })?;
+    if metadata.len() > MAX_WORKER_FILE_BYTES {
+        return Err(RealGraphRunError::new(
+            "real_graph_worker_protocol_failed",
+            "worker protocol file exceeds 1 MiB",
+        ));
+    }
+    fs::read(path).map_err(|error| {
+        RealGraphRunError::new(
+            "real_graph_worker_protocol_failed",
+            format!("read worker file {}: {error}", path.display()),
+        )
+    })
+}
+
+fn write_new(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    use std::io::Write;
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)?;
+    file.write_all(bytes)?;
+    file.sync_all()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use omnigraph::loader::load_jsonl;
+
+    #[test]
+    fn run_spec_is_strict_and_bounded() {
+        let directory = tempfile::tempdir().unwrap();
+        let valid = directory.path().join("run.yaml");
+        fs::write(
+            &valid,
+            "version: 1\nfixture_id: finbench-sf10-v1\nworkload: finbench-disjoint-insert-merge\nrepetitions: 2\noperation_deadline_seconds: 60\n",
+        )
+        .unwrap();
+        assert!(load_real_graph_run_spec(&valid).ok);
+
+        fs::write(
+            &valid,
+            "version: 1\nfixture_id: finbench-sf10-v1\nworkload: finbench-disjoint-insert-merge\nrepetitions: 0\noperation_deadline_seconds: 60\n",
+        )
+        .unwrap();
+        assert_eq!(
+            load_real_graph_run_spec(&valid).diagnostics[0].code,
+            "invalid_real_graph_repetitions"
+        );
+    }
+
+    #[tokio::test]
+    async fn native_finbench_delta_merges_and_verifies_exactly() {
+        const SCHEMA: &str = r#"
+            node Account {
+                accountId: String @key
+                createTime: DateTime
+                isBlocked: Bool
+                accountType: enum(internet_account)
+                nickname: String?
+                phonenum: String?
+                email: String?
+                freqLoginType: enum(ipv4)
+                lastLoginTime: DateTime?
+                accountLevel: enum(basic)
+            }
+            edge AccountTransferAccount: Account -> Account {
+                amount: F64
+                createTime: DateTime
+                orderNum: String
+                comment: String?
+                payType: enum(bank_transfer)
+                goodsType: enum(bank_transfer)
+            }
+        "#;
+        const BASE: &str = r#"{"type":"Account","data":{"accountId":"existing-a","createTime":"2019-01-01T00:00:00Z","isBlocked":false,"accountType":"internet_account","freqLoginType":"ipv4","accountLevel":"basic"}}
+{"type":"Account","data":{"accountId":"existing-b","createTime":"2019-01-01T00:00:00Z","isBlocked":false,"accountType":"internet_account","freqLoginType":"ipv4","accountLevel":"basic"}}
+{"edge":"AccountTransferAccount","from":"existing-a","to":"existing-b","data":{"id":"existing-transfer","amount":9.0,"createTime":"2019-01-01T00:00:00Z","orderNum":"existing-order","payType":"bank_transfer","goodsType":"bank_transfer"}}"#;
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("active");
+        let db = Omnigraph::init(root.to_str().unwrap(), SCHEMA)
+            .await
+            .unwrap();
+        load_jsonl(&db, BASE, LoadMode::Overwrite).await.unwrap();
+        drop(db);
+
+        prepare_finbench_delta(&root).await.unwrap();
+        let sample = execute_worker(WorkerRequestV1 {
+            version: WORKER_PROTOCOL_VERSION,
+            repetition: 1,
+            root,
+            operation_deadline_seconds: 60,
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(sample.outcome, "merged");
+        assert_eq!(sample.route.table_walk_intervals, 2);
+        assert!(sample.inserted_delta_verified);
+        assert!(!sample.existing_rows_in_changed_tables_verified);
+        assert!(sample.protected_heads_verified);
+    }
+}

--- a/crates/omnigraph-bench/src/real_graph_run.rs
+++ b/crates/omnigraph-bench/src/real_graph_run.rs
@@ -26,7 +26,9 @@ use crate::model::{
     Diagnostic, ValidationOutcome, declared_version, read_yaml_file, strict_yaml, valid_kebab_id,
 };
 use crate::real_graph::{observe_real_graph, validate_real_graph_reference};
-use crate::registered_fixture::{FixtureCopyPreflightReceiptV1, stage_registered_fixture_binding};
+use crate::registered_fixture::{
+    FixtureCopyPreflightReceiptV1, StagedRegisteredFixtureV1, stage_registered_fixture_binding,
+};
 use crate::reset::{PhysicalDigest, TraversalLimits, freeze_clonefile_template};
 use crate::runner::{
     MergePhaseEvidenceForm, MergeRouteObservation, PhaseObservation,
@@ -239,9 +241,18 @@ pub async fn execute_real_graph_run(
     let staged = stage_registered_fixture_binding(fixture_binding, scratch_root)
         .into_result()
         .map_err(|diagnostics| diagnostics_error("real_graph_staging_failed", diagnostics))?;
+    let outcome = execute_staged_real_graph_run(spec, reference, &staged).await;
+    let cleanup = staged.finish().map(|_| ());
+    complete_real_graph_run(outcome, cleanup)
+}
+
+async fn execute_staged_real_graph_run(
+    spec: &RealGraphRunSpecV1,
+    reference: &NormalizedFixtureReferenceV1,
+    staged: &StagedRegisteredFixtureV1,
+) -> Result<RealGraphRunReportV1, RealGraphRunError> {
     if staged.receipt().fixture_id != spec.fixture_id {
         let observed = staged.receipt().fixture_id.clone();
-        let _ = staged.finish();
         return Err(RealGraphRunError::new(
             "real_graph_fixture_id_mismatch",
             format!(
@@ -361,9 +372,6 @@ pub async fn execute_real_graph_run(
     elapsed.sort_unstable();
     let p50_us = elapsed[(elapsed.len() - 1) / 2];
     let prepared_input_physical = frozen.physical_digest().clone();
-    staged.finish().map_err(|diagnostic| {
-        RealGraphRunError::new("fixture_cleanup_failed", diagnostic.message)
-    })?;
     Ok(RealGraphRunReportV1 {
         version: REAL_GRAPH_RUN_SPEC_VERSION,
         fixture_id: spec.fixture_id.clone(),
@@ -382,6 +390,27 @@ pub async fn execute_real_graph_run(
         p50_us,
         samples,
     })
+}
+
+fn complete_real_graph_run<T>(
+    outcome: Result<T, RealGraphRunError>,
+    cleanup: Result<(), Diagnostic>,
+) -> Result<T, RealGraphRunError> {
+    match (outcome, cleanup) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Err(error), Ok(())) => Err(error),
+        (Ok(_), Err(cleanup)) => Err(RealGraphRunError::new(
+            "fixture_cleanup_failed",
+            format!("{} at {}: {}", cleanup.code, cleanup.path, cleanup.message),
+        )),
+        (Err(error), Err(cleanup)) => Err(RealGraphRunError::new(
+            "real_graph_run_and_cleanup_failed",
+            format!(
+                "run failed with {}: {}; cleanup also failed with {} at {}: {}",
+                error.code, error.message, cleanup.code, cleanup.path, cleanup.message
+            ),
+        )),
+    }
 }
 
 fn diagnostics_error(code: &'static str, diagnostics: Vec<Diagnostic>) -> RealGraphRunError {
@@ -1159,6 +1188,48 @@ mod tests {
             load_real_graph_run_spec(&valid).diagnostics[0].code,
             "invalid_real_graph_repetitions"
         );
+    }
+
+    #[test]
+    fn cleanup_failure_is_never_hidden_by_the_run_outcome() {
+        let cleanup = || {
+            Diagnostic::error(
+                "fixture_preflight_cleanup_failed",
+                "$",
+                "could not remove staged fixture",
+            )
+        };
+
+        let cleanup_only = complete_real_graph_run::<()>(Ok(()), Err(cleanup())).unwrap_err();
+        assert_eq!(cleanup_only.code, "fixture_cleanup_failed");
+        assert!(
+            cleanup_only
+                .message
+                .contains("fixture_preflight_cleanup_failed")
+        );
+
+        let both = complete_real_graph_run::<()>(
+            Err(RealGraphRunError::new(
+                "real_graph_worker_failed",
+                "worker failed",
+            )),
+            Err(cleanup()),
+        )
+        .unwrap_err();
+        assert_eq!(both.code, "real_graph_run_and_cleanup_failed");
+        assert!(both.message.contains("real_graph_worker_failed"));
+        assert!(both.message.contains("fixture_preflight_cleanup_failed"));
+
+        let primary = complete_real_graph_run::<()>(
+            Err(RealGraphRunError::new(
+                "real_graph_worker_failed",
+                "worker failed",
+            )),
+            Ok(()),
+        )
+        .unwrap_err();
+        assert_eq!(primary.code, "real_graph_worker_failed");
+        assert!(complete_real_graph_run(Ok(7_u8), Ok(())).is_ok());
     }
 
     #[tokio::test]

--- a/crates/omnigraph-bench/src/record.rs
+++ b/crates/omnigraph-bench/src/record.rs
@@ -24,10 +24,11 @@ use crate::case::{
 use crate::counting::LogicalCallCounts;
 use crate::machine::MachineIdentityV1;
 use crate::model::typed_sha256;
+use crate::reset::PHYSICAL_TREE_DIGEST_ALGORITHM;
 use crate::runner::{
     ControlCallObservation, EffectiveEnvironmentValue, MergePhaseEvidenceForm,
-    MergeRouteObservation, PHYSICAL_TREE_DIGEST_ALGORITHM, PhaseObservation, RepObservation,
-    RunExecution, VerificationObservation, validate_successful_merge_phase_topology,
+    MergeRouteObservation, PhaseObservation, RepObservation, RunExecution, VerificationObservation,
+    validate_successful_merge_phase_topology,
 };
 use crate::suite::MAX_REPETITIONS_PER_CASE;
 use crate::{CASE_FORMAT_VERSION, POINT_IDENTITY_VERSION, ResolvedRun, validate_case};

--- a/crates/omnigraph-bench/src/registered_fixture.rs
+++ b/crates/omnigraph-bench/src/registered_fixture.rs
@@ -1,0 +1,1172 @@
+//! Physical registration, binding, and disposable staging of frozen fixtures.
+//!
+//! This deliberately does not open an OmniGraph graph, download from object
+//! storage, validate logical Data/State, prepare a workload, or make a fixture
+//! executable by CaseV1. Physical identity is audit/reset evidence; RFC 0039
+//! keeps it out of benchmark point identity.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{self, OpenOptions};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::model::{Diagnostic, ValidationOutcome, typed_sha256, valid_kebab_id};
+use crate::reset::{
+    PHYSICAL_TREE_DIGEST_ALGORITHM, PhysicalDigest, TraversalLimits, copy_verified,
+    digest_physical_tree, verify_physical_tree,
+};
+
+pub const REGISTERED_FIXTURE_SOURCE_FORMAT_VERSION: u32 = 1;
+const MAX_SOURCE_DESCRIPTOR_BYTES: u64 = 1024 * 1024;
+const MAX_FIXTURE_ID_BYTES: usize = 128;
+const MAX_FIXTURE_BINDINGS: usize = 64;
+
+/// A location-free declaration of one exact physical tree.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RegisteredFixtureSourceV1 {
+    pub format_version: u32,
+    pub fixture_id: String,
+    pub physical: RegisteredPhysicalTreeV1,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RegisteredPhysicalTreeV1 {
+    pub digest_algorithm: String,
+    pub tree_sha256: String,
+    pub files: u64,
+    pub bytes: u64,
+}
+
+#[derive(Deserialize)]
+struct RegisteredFixtureSourceVersionHeader {
+    format_version: u32,
+    #[serde(flatten)]
+    _remaining: BTreeMap<String, serde::de::IgnoredAny>,
+}
+
+/// One invocation-local path proven to contain the registered bytes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct VerifiedRegisteredFixtureSourceV1 {
+    pub fixture_id: String,
+    pub source_descriptor_sha256: String,
+    pub canonical_root: PathBuf,
+    pub physical: RegisteredPhysicalTreeV1,
+}
+
+/// One invocation-local `ID=BUNDLE` mapping.
+///
+/// `bundle` is transport/configuration, never fixture or benchmark identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FixtureBundleBinding {
+    fixture_id: String,
+    bundle: PathBuf,
+}
+
+/// A bundle whose required direct entries and typed source were resolved.
+///
+/// The source tree is not trusted after this step. The copy preflight
+/// re-reads and verifies every source byte while copying it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedFixtureBundleV1 {
+    fixture_id: String,
+    source_descriptor_sha256: String,
+    canonical_bundle: PathBuf,
+    canonical_root: PathBuf,
+    source: RegisteredFixtureSourceV1,
+}
+
+/// Path-free evidence that one bundle was copied and re-verified in scratch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct FixtureCopyPreflightReceiptV1 {
+    pub fixture_id: String,
+    pub source_descriptor_sha256: String,
+    pub physical: RegisteredPhysicalTreeV1,
+}
+
+/// Harness-owned disposable staging workspace.
+///
+/// Dropping this value attempts best-effort deletion. Call [`Self::finish`] when
+/// cleanup success must be reported to a user or orchestration layer.
+#[derive(Debug)]
+struct StagedFixtureBundlesV1 {
+    workspace: Option<tempfile::TempDir>,
+    fixtures: BTreeMap<String, FixtureCopyPreflightReceiptV1>,
+}
+
+impl StagedFixtureBundlesV1 {
+    /// Delete the disposable workspace and return path-free staging evidence.
+    fn finish(mut self) -> Result<Vec<FixtureCopyPreflightReceiptV1>, Diagnostic> {
+        let fixtures = self.fixtures.values().cloned().collect();
+        let workspace = self
+            .workspace
+            .take()
+            .expect("staging workspace is present until finish");
+        workspace.close().map_err(|error| {
+            Diagnostic::error(
+                "fixture_preflight_cleanup_failed",
+                "$",
+                format!("could not remove disposable fixture staging workspace: {error}"),
+            )
+        })?;
+        Ok(fixtures)
+    }
+}
+
+/// Read one stable local tree and return its location-free copy-source descriptor.
+pub fn fingerprint_registered_fixture(
+    fixture_id: String,
+    root: &Path,
+) -> ValidationOutcome<RegisteredFixtureSourceV1> {
+    if !valid_kebab_id(&fixture_id) || fixture_id.len() > MAX_FIXTURE_ID_BYTES {
+        return ValidationOutcome::failure(vec![Diagnostic::error(
+            "invalid_registered_fixture_id",
+            "fixture_id",
+            "fixture_id must be 1..=128 characters of path-free kebab-case ASCII",
+        )]);
+    }
+    let canonical_root = match canonical_fixture_root(root) {
+        Ok(root) => root,
+        Err(diagnostic) => return ValidationOutcome::failure(vec![diagnostic]),
+    };
+    let observed = match digest_physical_tree(&canonical_root, TraversalLimits::default()) {
+        Ok(observed) => observed,
+        Err(error) => {
+            return ValidationOutcome::failure(vec![Diagnostic::error(
+                "registered_fixture_fingerprint_failed",
+                root.to_string_lossy(),
+                format!("could not fingerprint fixture bytes: {error}"),
+            )]);
+        }
+    };
+    let source = RegisteredFixtureSourceV1 {
+        format_version: REGISTERED_FIXTURE_SOURCE_FORMAT_VERSION,
+        fixture_id,
+        physical: registered_physical(&observed),
+    };
+    match seal_source_descriptor(&source) {
+        Ok(_) => ValidationOutcome::success(source),
+        Err(diagnostics) => ValidationOutcome::failure(diagnostics),
+    }
+}
+
+/// Re-read every byte and bind a local directory to one registered source.
+pub fn verify_registered_fixture(
+    source_path: &Path,
+    root: &Path,
+) -> ValidationOutcome<VerifiedRegisteredFixtureSourceV1> {
+    let (source, source_descriptor_sha256) = match load_source_descriptor(source_path) {
+        Ok(loaded) => loaded,
+        Err(diagnostics) => return ValidationOutcome::failure(diagnostics),
+    };
+    let canonical_root = match canonical_fixture_root(root) {
+        Ok(root) => root,
+        Err(diagnostic) => return ValidationOutcome::failure(vec![diagnostic]),
+    };
+    let canonical_source = match fs::canonicalize(source_path) {
+        Ok(path) => path,
+        Err(error) => {
+            return ValidationOutcome::failure(vec![Diagnostic::error(
+                "fixture_source_read_error",
+                source_path.to_string_lossy(),
+                format!("could not canonicalize fixture source descriptor: {error}"),
+            )]);
+        }
+    };
+    if canonical_source.starts_with(&canonical_root) {
+        return ValidationOutcome::failure(vec![Diagnostic::error(
+            "fixture_source_inside_root",
+            source_path.to_string_lossy(),
+            "fixture source descriptor must live outside the graph root it identifies",
+        )]);
+    }
+
+    let expected = PhysicalDigest {
+        files: source.physical.files,
+        bytes: source.physical.bytes,
+        digest_sha256: source.physical.tree_sha256.clone(),
+    };
+    if let Err(error) = verify_physical_tree(&canonical_root, &expected, TraversalLimits::default())
+    {
+        return ValidationOutcome::failure(vec![Diagnostic::error(
+            "registered_fixture_verification_failed",
+            root.to_string_lossy(),
+            format!("could not verify registered fixture bytes: {error}"),
+        )]);
+    }
+
+    ValidationOutcome::success(VerifiedRegisteredFixtureSourceV1 {
+        fixture_id: source.fixture_id,
+        source_descriptor_sha256,
+        canonical_root,
+        physical: source.physical,
+    })
+}
+
+/// Resolve `ID=BUNDLE` mappings, verify each source while copying it through
+/// harness-owned scratch, verify each copy, and remove the workspace.
+///
+/// Success is physical preflight evidence only. It does not claim that a tree
+/// is an executable benchmark fixture or that its observed descriptor digest
+/// matches an independently registered expectation.
+pub fn preflight_copy_fixture_bindings(
+    values: &[String],
+    scratch_root: Option<&Path>,
+) -> ValidationOutcome<Vec<FixtureCopyPreflightReceiptV1>> {
+    let resolved = match resolve_fixture_bundle_bindings(values).into_result() {
+        Ok(resolved) => resolved,
+        Err(diagnostics) => return ValidationOutcome::failure(diagnostics),
+    };
+    let staged = match stage_fixture_bundles(&resolved, scratch_root).into_result() {
+        Ok(staged) => staged,
+        Err(diagnostics) => return ValidationOutcome::failure(diagnostics),
+    };
+    match staged.finish() {
+        Ok(receipts) => ValidationOutcome::success(receipts),
+        Err(diagnostic) => ValidationOutcome::failure(vec![diagnostic]),
+    }
+}
+
+/// Parse one invocation-local `ID=BUNDLE` argument.
+///
+/// Only the first `=` is structural, so bundle paths may themselves contain
+/// `=`. The bundle path is deliberately not canonicalized until resolution.
+fn parse_fixture_bundle_binding(value: &str) -> Result<FixtureBundleBinding, Diagnostic> {
+    let Some((fixture_id, bundle)) = value.split_once('=') else {
+        return Err(Diagnostic::error(
+            "invalid_fixture_binding",
+            "--fixture",
+            "fixture binding must have the form ID=BUNDLE",
+        ));
+    };
+    if !valid_kebab_id(fixture_id) || fixture_id.len() > MAX_FIXTURE_ID_BYTES {
+        return Err(Diagnostic::error(
+            "invalid_fixture_binding",
+            "--fixture",
+            "fixture binding ID must be 1..=128 characters of path-free kebab-case ASCII",
+        ));
+    }
+    if bundle.is_empty() {
+        return Err(Diagnostic::error(
+            "invalid_fixture_binding",
+            "--fixture",
+            "fixture binding BUNDLE path must not be empty",
+        ));
+    }
+    Ok(FixtureBundleBinding {
+        fixture_id: fixture_id.to_string(),
+        bundle: PathBuf::from(bundle),
+    })
+}
+
+/// Parse and resolve a complete set of invocation-local fixture bindings.
+fn resolve_fixture_bundle_bindings(
+    values: &[String],
+) -> ValidationOutcome<Vec<ResolvedFixtureBundleV1>> {
+    if values.is_empty() {
+        return ValidationOutcome::failure(vec![Diagnostic::error(
+            "missing_fixture_binding",
+            "--fixture",
+            "at least one ID=BUNDLE fixture binding is required",
+        )]);
+    }
+    if values.len() > MAX_FIXTURE_BINDINGS {
+        return ValidationOutcome::failure(vec![Diagnostic::error(
+            "fixture_binding_budget_exceeded",
+            "--fixture",
+            format!("at most {MAX_FIXTURE_BINDINGS} fixture bindings are allowed"),
+        )]);
+    }
+
+    let mut diagnostics = Vec::new();
+    let mut bindings = Vec::with_capacity(values.len());
+    for (index, value) in values.iter().enumerate() {
+        match parse_fixture_bundle_binding(value) {
+            Ok(binding) => bindings.push(binding),
+            Err(mut diagnostic) => {
+                diagnostic.path = format!("--fixture[{index}]");
+                diagnostics.push(diagnostic);
+            }
+        }
+    }
+    if !diagnostics.is_empty() {
+        return ValidationOutcome::failure(diagnostics);
+    }
+    resolve_fixture_bundles(&bindings)
+}
+
+/// Resolve bundle layout and source identity without hashing the graph root.
+///
+/// A bundle has two required direct entries: `fixture-source.json` and `root/`.
+/// Unrelated siblings are ignored. This phase is cheap enough to run before
+/// release-build guards, scratch creation, or archive publication.
+fn resolve_fixture_bundles(
+    bindings: &[FixtureBundleBinding],
+) -> ValidationOutcome<Vec<ResolvedFixtureBundleV1>> {
+    if bindings.is_empty() {
+        return ValidationOutcome::failure(vec![Diagnostic::error(
+            "missing_fixture_binding",
+            "--fixture",
+            "at least one ID=BUNDLE fixture binding is required",
+        )]);
+    }
+    if bindings.len() > MAX_FIXTURE_BINDINGS {
+        return ValidationOutcome::failure(vec![Diagnostic::error(
+            "fixture_binding_budget_exceeded",
+            "--fixture",
+            format!("at most {MAX_FIXTURE_BINDINGS} fixture bindings are allowed"),
+        )]);
+    }
+
+    let mut diagnostics = Vec::new();
+    let mut seen = BTreeSet::new();
+    for (index, binding) in bindings.iter().enumerate() {
+        let path = format!("--fixture[{index}]");
+        if !valid_kebab_id(&binding.fixture_id)
+            || binding.fixture_id.len() > MAX_FIXTURE_ID_BYTES
+            || binding.bundle.as_os_str().is_empty()
+        {
+            diagnostics.push(Diagnostic::error(
+                "invalid_fixture_binding",
+                &path,
+                "fixture binding must contain a valid path-free kebab-case ID and a non-empty BUNDLE path",
+            ));
+            continue;
+        }
+        if !seen.insert(binding.fixture_id.clone()) {
+            diagnostics.push(Diagnostic::error(
+                "duplicate_fixture_binding",
+                &path,
+                format!(
+                    "fixture id '{}' is bound more than once",
+                    binding.fixture_id
+                ),
+            ));
+            continue;
+        }
+    }
+    if !diagnostics.is_empty() {
+        return ValidationOutcome::failure(diagnostics);
+    }
+
+    let mut resolved = Vec::with_capacity(bindings.len());
+    for (index, binding) in bindings.iter().enumerate() {
+        let path = format!("--fixture[{index}]");
+        match resolve_fixture_bundle(binding) {
+            Ok(bundle) => resolved.push(bundle),
+            Err(mut bundle_diagnostics) => {
+                for diagnostic in &mut bundle_diagnostics {
+                    diagnostic.path = format!("{path}.{}", diagnostic.path);
+                }
+                diagnostics.extend(bundle_diagnostics);
+            }
+        }
+    }
+    if diagnostics.is_empty() {
+        resolved.sort_by(|left, right| left.fixture_id.cmp(&right.fixture_id));
+        ValidationOutcome::success(resolved)
+    } else {
+        ValidationOutcome::failure(diagnostics)
+    }
+}
+
+/// Copy resolved sources into one harness-owned disposable workspace.
+///
+/// The source is verified against its descriptor before any destination bytes
+/// are written, and the completed destination is re-digested before success.
+/// Neither source nor destination is opened as an OmniGraph database here.
+fn stage_fixture_bundles(
+    bundles: &[ResolvedFixtureBundleV1],
+    scratch_root: Option<&Path>,
+) -> ValidationOutcome<StagedFixtureBundlesV1> {
+    if bundles.is_empty() {
+        return ValidationOutcome::failure(vec![Diagnostic::error(
+            "missing_fixture_binding",
+            "fixtures",
+            "at least one resolved fixture bundle is required for staging",
+        )]);
+    }
+    if bundles.len() > MAX_FIXTURE_BINDINGS {
+        return ValidationOutcome::failure(vec![Diagnostic::error(
+            "fixture_binding_budget_exceeded",
+            "fixtures",
+            format!("at most {MAX_FIXTURE_BINDINGS} fixture bundles may be staged"),
+        )]);
+    }
+    let mut ids = BTreeSet::new();
+    if let Some(duplicate) = bundles
+        .iter()
+        .find(|bundle| !ids.insert(bundle.fixture_id.as_str()))
+    {
+        return ValidationOutcome::failure(vec![Diagnostic::error(
+            "duplicate_fixture_binding",
+            "fixtures",
+            format!(
+                "resolved fixture id '{}' appears more than once",
+                duplicate.fixture_id
+            ),
+        )]);
+    }
+
+    let staging_base = match canonical_staging_base(scratch_root) {
+        Ok(base) => base,
+        Err(diagnostic) => return ValidationOutcome::failure(vec![diagnostic]),
+    };
+    if let Some(bundle) = bundles
+        .iter()
+        .find(|bundle| staging_base.starts_with(&bundle.canonical_bundle))
+    {
+        return ValidationOutcome::failure(vec![Diagnostic::error(
+            "fixture_preflight_scratch_inside_bundle",
+            "--scratch-root",
+            format!(
+                "fixture staging scratch must not equal or lie below bundle for '{}'",
+                bundle.fixture_id
+            ),
+        )]);
+    }
+
+    let workspace = match staging_workspace(&staging_base) {
+        Ok(workspace) => workspace,
+        Err(diagnostic) => return ValidationOutcome::failure(vec![diagnostic]),
+    };
+
+    let limits = TraversalLimits::default();
+    let mut staged = BTreeMap::new();
+    for bundle in bundles {
+        let fixture_directory = workspace.path().join(&bundle.fixture_id);
+        if let Err(error) = fs::create_dir(&fixture_directory) {
+            return stage_failure(
+                workspace,
+                vec![Diagnostic::error(
+                    "fixture_preflight_copy_failed",
+                    &bundle.fixture_id,
+                    format!("could not create private fixture staging directory: {error}"),
+                )],
+            );
+        }
+        let staged_root = fixture_directory.join("root");
+        let expected = physical_digest(&bundle.source.physical);
+        let copied = match copy_verified(&bundle.canonical_root, &staged_root, &expected, limits) {
+            Ok(copied) => copied,
+            Err(error) => {
+                return stage_failure(
+                    workspace,
+                    vec![Diagnostic::error(
+                        "fixture_preflight_copy_failed",
+                        &bundle.fixture_id,
+                        format!(
+                            "could not verify and copy registered fixture into disposable scratch: {error}"
+                        ),
+                    )],
+                );
+            }
+        };
+        if let Err(error) = fs::remove_dir_all(&fixture_directory) {
+            return stage_failure(
+                workspace,
+                vec![Diagnostic::error(
+                    "fixture_preflight_cleanup_failed",
+                    &bundle.fixture_id,
+                    format!(
+                        "could not remove verified fixture copy before processing the next binding: {error}"
+                    ),
+                )],
+            );
+        }
+        staged.insert(
+            bundle.fixture_id.clone(),
+            FixtureCopyPreflightReceiptV1 {
+                fixture_id: bundle.fixture_id.clone(),
+                source_descriptor_sha256: bundle.source_descriptor_sha256.clone(),
+                physical: registered_physical(&copied),
+            },
+        );
+    }
+
+    ValidationOutcome::success(StagedFixtureBundlesV1 {
+        workspace: Some(workspace),
+        fixtures: staged,
+    })
+}
+
+fn resolve_fixture_bundle(
+    binding: &FixtureBundleBinding,
+) -> Result<ResolvedFixtureBundleV1, Vec<Diagnostic>> {
+    let metadata = fs::symlink_metadata(&binding.bundle).map_err(|error| {
+        vec![Diagnostic::error(
+            "invalid_fixture_bundle_layout",
+            "bundle",
+            format!("could not inspect fixture bundle: {error}"),
+        )]
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(vec![Diagnostic::error(
+            "invalid_fixture_bundle_layout",
+            "bundle",
+            "fixture bundle must be a real directory, not a symlink or special file",
+        )]);
+    }
+    let canonical_bundle = fs::canonicalize(&binding.bundle).map_err(|error| {
+        vec![Diagnostic::error(
+            "invalid_fixture_bundle_layout",
+            "bundle",
+            format!("could not canonicalize fixture bundle: {error}"),
+        )]
+    })?;
+    if canonical_bundle.to_str().is_none() {
+        return Err(vec![Diagnostic::error(
+            "invalid_fixture_bundle_layout",
+            "bundle",
+            "fixture bundle must have a canonical UTF-8 path",
+        )]);
+    }
+
+    let source_path = canonical_bundle.join("fixture-source.json");
+    let root_path = canonical_bundle.join("root");
+    let canonical_root = canonical_fixture_root(&root_path).map_err(|diagnostic| {
+        vec![Diagnostic::error(
+            "invalid_fixture_bundle_layout",
+            "bundle.root",
+            diagnostic.message,
+        )]
+    })?;
+    if canonical_root.parent() != Some(canonical_bundle.as_path()) {
+        return Err(vec![Diagnostic::error(
+            "invalid_fixture_bundle_layout",
+            "bundle.root",
+            "bundle root must be a real direct child named 'root'",
+        )]);
+    }
+
+    let (source, source_descriptor_sha256) = load_source_descriptor(&source_path)?;
+    let canonical_source = fs::canonicalize(&source_path).map_err(|error| {
+        vec![Diagnostic::error(
+            "invalid_fixture_bundle_layout",
+            "bundle.fixture-source.json",
+            format!("could not canonicalize fixture source descriptor: {error}"),
+        )]
+    })?;
+    if canonical_source.parent() != Some(canonical_bundle.as_path()) {
+        return Err(vec![Diagnostic::error(
+            "invalid_fixture_bundle_layout",
+            "bundle.fixture-source.json",
+            "fixture source descriptor must be a real direct child named 'fixture-source.json'",
+        )]);
+    }
+    if source.fixture_id != binding.fixture_id {
+        return Err(vec![Diagnostic::error(
+            "fixture_binding_id_mismatch",
+            "fixture_id",
+            format!(
+                "binding id '{}' does not match source fixture_id '{}'",
+                binding.fixture_id, source.fixture_id
+            ),
+        )]);
+    }
+
+    Ok(ResolvedFixtureBundleV1 {
+        fixture_id: binding.fixture_id.clone(),
+        source_descriptor_sha256,
+        canonical_bundle,
+        canonical_root,
+        source,
+    })
+}
+
+fn canonical_staging_base(scratch_root: Option<&Path>) -> Result<PathBuf, Diagnostic> {
+    let root = scratch_root
+        .map(Path::to_path_buf)
+        .unwrap_or_else(std::env::temp_dir);
+    let metadata = fs::symlink_metadata(&root).map_err(|error| {
+        Diagnostic::error(
+            "fixture_preflight_scratch_error",
+            "--scratch-root",
+            format!("could not inspect fixture staging scratch root: {error}"),
+        )
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(Diagnostic::error(
+            "fixture_preflight_scratch_error",
+            "--scratch-root",
+            "fixture staging scratch root must be a real existing directory",
+        ));
+    }
+    fs::canonicalize(&root).map_err(|error| {
+        Diagnostic::error(
+            "fixture_preflight_scratch_error",
+            "--scratch-root",
+            format!("could not canonicalize fixture staging scratch root: {error}"),
+        )
+    })
+}
+
+fn staging_workspace(staging_base: &Path) -> Result<tempfile::TempDir, Diagnostic> {
+    let mut builder = tempfile::Builder::new();
+    builder.prefix("omnigraph-bench-fixture-stage-");
+    builder.tempdir_in(staging_base).map_err(|error| {
+        Diagnostic::error(
+            "fixture_preflight_scratch_error",
+            "--scratch-root",
+            format!("could not create disposable fixture staging workspace: {error}"),
+        )
+    })
+}
+
+fn stage_failure(
+    workspace: tempfile::TempDir,
+    mut diagnostics: Vec<Diagnostic>,
+) -> ValidationOutcome<StagedFixtureBundlesV1> {
+    if let Err(error) = workspace.close() {
+        diagnostics.push(Diagnostic::error(
+            "fixture_preflight_cleanup_failed",
+            "$",
+            format!("could not remove failed fixture staging workspace: {error}"),
+        ));
+    }
+    ValidationOutcome::failure(diagnostics)
+}
+
+fn load_source_descriptor(
+    path: &Path,
+) -> Result<(RegisteredFixtureSourceV1, String), Vec<Diagnostic>> {
+    let source = read_source_descriptor(path).map_err(|diagnostic| vec![diagnostic])?;
+    let header: RegisteredFixtureSourceVersionHeader =
+        serde_json::from_str(&source).map_err(|error| {
+            vec![Diagnostic::error(
+                "invalid_fixture_source_json",
+                path.to_string_lossy(),
+                format!("could not parse fixture source JSON header: {error}"),
+            )]
+        })?;
+    if header.format_version != REGISTERED_FIXTURE_SOURCE_FORMAT_VERSION {
+        return Err(vec![Diagnostic::error(
+            "unsupported_fixture_source_version",
+            "format_version",
+            format!(
+                "unsupported fixture source version {}; this build supports version {REGISTERED_FIXTURE_SOURCE_FORMAT_VERSION}",
+                header.format_version
+            ),
+        )]);
+    }
+    let descriptor: RegisteredFixtureSourceV1 = serde_json::from_str(&source).map_err(|error| {
+        vec![Diagnostic::error(
+            "invalid_fixture_source_json",
+            path.to_string_lossy(),
+            format!("could not parse fixture source JSON: {error}"),
+        )]
+    })?;
+    let digest = seal_source_descriptor(&descriptor)?;
+    Ok((descriptor, digest))
+}
+
+fn seal_source_descriptor(
+    descriptor: &RegisteredFixtureSourceV1,
+) -> Result<String, Vec<Diagnostic>> {
+    let mut diagnostics = Vec::new();
+    if descriptor.format_version != REGISTERED_FIXTURE_SOURCE_FORMAT_VERSION {
+        diagnostics.push(Diagnostic::error(
+            "unsupported_fixture_source_version",
+            "format_version",
+            format!(
+                "unsupported fixture source version {}; this build supports version {REGISTERED_FIXTURE_SOURCE_FORMAT_VERSION}",
+                descriptor.format_version
+            ),
+        ));
+    }
+    if !valid_kebab_id(&descriptor.fixture_id) || descriptor.fixture_id.len() > MAX_FIXTURE_ID_BYTES
+    {
+        diagnostics.push(Diagnostic::error(
+            "invalid_registered_fixture_id",
+            "fixture_id",
+            "fixture_id must be 1..=128 characters of path-free kebab-case ASCII",
+        ));
+    }
+    if descriptor.physical.digest_algorithm != PHYSICAL_TREE_DIGEST_ALGORITHM {
+        diagnostics.push(Diagnostic::error(
+            "unsupported_physical_digest_algorithm",
+            "physical.digest_algorithm",
+            format!("expected '{PHYSICAL_TREE_DIGEST_ALGORITHM}'"),
+        ));
+    }
+    if !is_lowercase_sha256(&descriptor.physical.tree_sha256) {
+        diagnostics.push(Diagnostic::error(
+            "invalid_physical_tree_sha256",
+            "physical.tree_sha256",
+            "tree_sha256 must be exactly 64 lowercase hexadecimal characters",
+        ));
+    }
+    if descriptor.physical.files == 0 || descriptor.physical.bytes == 0 {
+        diagnostics.push(Diagnostic::error(
+            "empty_registered_fixture",
+            "physical",
+            "a registered benchmark fixture must contain at least one non-empty regular file",
+        ));
+    }
+    let limits = TraversalLimits::default();
+    if descriptor.physical.files > limits.max_entries {
+        diagnostics.push(Diagnostic::error(
+            "registered_fixture_entry_budget_exceeded",
+            "physical.files",
+            format!("files must be <= {}", limits.max_entries),
+        ));
+    }
+    if descriptor.physical.bytes > limits.max_bytes {
+        diagnostics.push(Diagnostic::error(
+            "registered_fixture_byte_budget_exceeded",
+            "physical.bytes",
+            format!("bytes must be <= {}", limits.max_bytes),
+        ));
+    }
+    if diagnostics.is_empty() {
+        typed_sha256(descriptor).map_err(|diagnostic| vec![diagnostic])
+    } else {
+        Err(diagnostics)
+    }
+}
+
+fn canonical_fixture_root(root: &Path) -> Result<PathBuf, Diagnostic> {
+    let metadata = fs::symlink_metadata(root).map_err(|error| {
+        Diagnostic::error(
+            "registered_fixture_root_error",
+            root.to_string_lossy(),
+            format!("could not inspect fixture root: {error}"),
+        )
+    })?;
+    if !metadata.file_type().is_dir() {
+        return Err(Diagnostic::error(
+            "registered_fixture_root_error",
+            root.to_string_lossy(),
+            "fixture root must be a real directory, not a symlink or special file",
+        ));
+    }
+    let canonical = fs::canonicalize(root).map_err(|error| {
+        Diagnostic::error(
+            "registered_fixture_root_error",
+            root.to_string_lossy(),
+            format!("could not canonicalize fixture root: {error}"),
+        )
+    })?;
+    if canonical.to_str().is_none() {
+        return Err(Diagnostic::error(
+            "registered_fixture_root_error",
+            root.to_string_lossy(),
+            "fixture root must have a UTF-8 canonical path for machine-readable binding",
+        ));
+    }
+    Ok(canonical)
+}
+
+fn read_source_descriptor(path: &Path) -> Result<String, Diagnostic> {
+    let metadata = fs::symlink_metadata(path).map_err(|error| source_descriptor_io(path, error))?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(Diagnostic::error(
+            "fixture_source_read_error",
+            path.to_string_lossy(),
+            "fixture source descriptor must be a regular file, not a symlink or special file",
+        ));
+    }
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(nix::libc::O_NOFOLLOW | nix::libc::O_NONBLOCK);
+    }
+    let mut file = options
+        .open(path)
+        .map_err(|error| source_descriptor_io(path, error))?;
+    let metadata = file
+        .metadata()
+        .map_err(|error| source_descriptor_io(path, error))?;
+    if !metadata.is_file() || metadata.len() > MAX_SOURCE_DESCRIPTOR_BYTES {
+        return Err(Diagnostic::error(
+            "fixture_source_read_error",
+            path.to_string_lossy(),
+            format!(
+                "fixture source descriptor must be a regular file no larger than {MAX_SOURCE_DESCRIPTOR_BYTES} bytes"
+            ),
+        ));
+    }
+    let mut source = String::new();
+    Read::by_ref(&mut file)
+        .take(MAX_SOURCE_DESCRIPTOR_BYTES + 1)
+        .read_to_string(&mut source)
+        .map_err(|error| source_descriptor_io(path, error))?;
+    if source.len() as u64 > MAX_SOURCE_DESCRIPTOR_BYTES {
+        return Err(Diagnostic::error(
+            "fixture_source_read_error",
+            path.to_string_lossy(),
+            format!(
+                "fixture source descriptor grew beyond {MAX_SOURCE_DESCRIPTOR_BYTES} bytes while being read"
+            ),
+        ));
+    }
+    Ok(source)
+}
+
+fn source_descriptor_io(path: &Path, error: std::io::Error) -> Diagnostic {
+    Diagnostic::error(
+        "fixture_source_read_error",
+        path.to_string_lossy(),
+        format!("could not read fixture source descriptor: {error}"),
+    )
+}
+
+fn registered_physical(observed: &PhysicalDigest) -> RegisteredPhysicalTreeV1 {
+    RegisteredPhysicalTreeV1 {
+        digest_algorithm: PHYSICAL_TREE_DIGEST_ALGORITHM.to_string(),
+        tree_sha256: observed.digest_sha256.clone(),
+        files: observed.files,
+        bytes: observed.bytes,
+    }
+}
+
+fn physical_digest(registered: &RegisteredPhysicalTreeV1) -> PhysicalDigest {
+    PhysicalDigest {
+        files: registered.files,
+        bytes: registered.bytes,
+        digest_sha256: registered.tree_sha256.clone(),
+    }
+}
+
+fn is_lowercase_sha256(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture(root: &Path) {
+        fs::create_dir_all(root.join("tables")).unwrap();
+        fs::write(root.join("manifest"), b"graph-head").unwrap();
+        fs::write(root.join("tables/nodes.lance"), b"node-bytes").unwrap();
+    }
+
+    fn bundle(parent: &Path, id: &str) -> PathBuf {
+        let bundle = parent.join(id);
+        let root = bundle.join("root");
+        fixture(&root);
+        let source = fingerprint_registered_fixture(id.to_string(), &root)
+            .into_result()
+            .unwrap();
+        fs::write(
+            bundle.join("fixture-source.json"),
+            serde_json::to_vec(&source).unwrap(),
+        )
+        .unwrap();
+        bundle
+    }
+
+    #[test]
+    fn source_descriptor_is_strict_and_canonically_hashed() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("root");
+        fixture(&root);
+        let source = fingerprint_registered_fixture("monarch-main-20260829".into(), &root)
+            .into_result()
+            .unwrap();
+        let reordered = format!(
+            "{{\"physical\":{},\"fixture_id\":\"{}\",\"format_version\":1}}",
+            serde_json::to_string(&source.physical).unwrap(),
+            source.fixture_id
+        );
+        let path = directory.path().join("fixture-source.json");
+        fs::write(&path, serde_json::to_vec(&source).unwrap()).unwrap();
+        let (_, first) = load_source_descriptor(&path).unwrap();
+        fs::write(&path, reordered).unwrap();
+        let (_, second) = load_source_descriptor(&path).unwrap();
+        assert_eq!(first, second);
+
+        let unknown = serde_json::json!({
+            "format_version": 1,
+            "fixture_id": "monarch-main-20260829",
+            "physical": source.physical,
+            "unknown": true
+        });
+        fs::write(&path, serde_json::to_vec(&unknown).unwrap()).unwrap();
+        assert_eq!(
+            load_source_descriptor(&path).unwrap_err()[0].code,
+            "invalid_fixture_source_json"
+        );
+
+        fs::write(&path, r#"{"format_version":2,"future_shape":true}"#).unwrap();
+        assert_eq!(
+            load_source_descriptor(&path).unwrap_err()[0].code,
+            "unsupported_fixture_source_version"
+        );
+        fs::write(&path, r#"{"format_version":1,"format_version":1}"#).unwrap();
+        assert_eq!(
+            load_source_descriptor(&path).unwrap_err()[0].code,
+            "invalid_fixture_source_json"
+        );
+    }
+
+    #[test]
+    fn exact_tree_verifies_and_same_length_drift_fails() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("root");
+        fixture(&root);
+        let source = fingerprint_registered_fixture("monarch-main-20260829".into(), &root)
+            .into_result()
+            .unwrap();
+        let path = directory.path().join("fixture-source.json");
+        fs::write(&path, serde_json::to_vec(&source).unwrap()).unwrap();
+        let verified = verify_registered_fixture(&path, &root)
+            .into_result()
+            .unwrap();
+        assert_eq!(verified.physical, source.physical);
+
+        fs::write(root.join("manifest"), b"other-head").unwrap();
+        assert_eq!(
+            verify_registered_fixture(&path, &root).diagnostics[0].code,
+            "registered_fixture_verification_failed"
+        );
+    }
+
+    #[test]
+    fn binding_parser_and_resolver_are_strict_location_only_configuration() {
+        let directory = tempfile::tempdir().unwrap();
+        let bundle = bundle(directory.path(), "monarch-main-20260829");
+        let path_with_equals = directory.path().join("copy=one");
+        fs::rename(&bundle, &path_with_equals).unwrap();
+        let value = format!("monarch-main-20260829={}", path_with_equals.display());
+        let parsed = parse_fixture_bundle_binding(&value).unwrap();
+        assert_eq!(parsed.fixture_id, "monarch-main-20260829");
+        assert_eq!(parsed.bundle, path_with_equals);
+
+        let resolved = resolve_fixture_bundle_bindings(std::slice::from_ref(&value))
+            .into_result()
+            .unwrap();
+        assert_eq!(resolved[0].fixture_id, "monarch-main-20260829");
+        assert_eq!(resolved[0].source_descriptor_sha256.len(), 64);
+
+        for invalid in ["missing-separator", "=bundle", "bad/id=bundle", "id="] {
+            assert_eq!(
+                parse_fixture_bundle_binding(invalid).unwrap_err().code,
+                "invalid_fixture_binding"
+            );
+        }
+        let duplicate = resolve_fixture_bundle_bindings(&[value.clone(), value]);
+        assert!(
+            duplicate
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "duplicate_fixture_binding")
+        );
+        let duplicate_before_io = resolve_fixture_bundle_bindings(&[
+            "same-id=/definitely/missing/first".to_string(),
+            "same-id=/definitely/missing/second".to_string(),
+        ]);
+        assert_eq!(
+            duplicate_before_io.diagnostics[0].code,
+            "duplicate_fixture_binding"
+        );
+    }
+
+    #[test]
+    fn bundle_id_and_required_layout_are_bound_before_tree_hashing() {
+        let directory = tempfile::tempdir().unwrap();
+        let bundle = bundle(directory.path(), "monarch-main-20260829");
+        let mismatch = FixtureBundleBinding {
+            fixture_id: "fin-graph-main-20260829".to_string(),
+            bundle: bundle.clone(),
+        };
+        assert_eq!(
+            resolve_fixture_bundles(&[mismatch]).diagnostics[0].code,
+            "fixture_binding_id_mismatch"
+        );
+
+        fs::remove_file(bundle.join("fixture-source.json")).unwrap();
+        let missing = FixtureBundleBinding {
+            fixture_id: "monarch-main-20260829".to_string(),
+            bundle,
+        };
+        assert!(
+            resolve_fixture_bundles(&[missing])
+                .diagnostics
+                .iter()
+                .any(|diagnostic| { diagnostic.code == "fixture_source_read_error" })
+        );
+    }
+
+    #[test]
+    fn staging_verifies_both_sides_and_removes_owned_scratch() {
+        let directory = tempfile::tempdir().unwrap();
+        let bundle = bundle(directory.path(), "monarch-main-20260829");
+        let scratch = directory.path().join("scratch");
+        fs::create_dir(&scratch).unwrap();
+        let source_before =
+            digest_physical_tree(&bundle.join("root"), TraversalLimits::default()).unwrap();
+        let binding = format!("monarch-main-20260829={}", bundle.display());
+        let resolved = resolve_fixture_bundle_bindings(&[binding])
+            .into_result()
+            .unwrap();
+        let staged = stage_fixture_bundles(&resolved, Some(&scratch))
+            .into_result()
+            .unwrap();
+        assert_eq!(
+            fs::read_dir(staged.workspace.as_ref().unwrap().path())
+                .unwrap()
+                .count(),
+            0
+        );
+        assert_eq!(
+            fs::read(bundle.join("root/manifest")).unwrap(),
+            b"graph-head"
+        );
+        let receipts = staged.finish().unwrap();
+        assert_eq!(receipts.len(), 1);
+        assert_eq!(
+            digest_physical_tree(&bundle.join("root"), TraversalLimits::default()).unwrap(),
+            source_before
+        );
+        assert_eq!(fs::read_dir(&scratch).unwrap().count(), 0);
+    }
+
+    #[test]
+    fn source_drift_after_resolution_fails_and_cleans_partial_scratch() {
+        let directory = tempfile::tempdir().unwrap();
+        let bundle = bundle(directory.path(), "monarch-main-20260829");
+        let scratch = directory.path().join("scratch");
+        fs::create_dir(&scratch).unwrap();
+        let binding = format!("monarch-main-20260829={}", bundle.display());
+        let resolved = resolve_fixture_bundle_bindings(&[binding])
+            .into_result()
+            .unwrap();
+        fs::write(bundle.join("root/manifest"), b"other-head").unwrap();
+
+        let outcome = stage_fixture_bundles(&resolved, Some(&scratch));
+
+        assert_eq!(outcome.diagnostics[0].code, "fixture_preflight_copy_failed");
+        assert_eq!(fs::read_dir(&scratch).unwrap().count(), 0);
+    }
+
+    #[test]
+    fn later_bundle_failure_removes_an_earlier_completed_copy() {
+        let directory = tempfile::tempdir().unwrap();
+        let first = bundle(directory.path(), "a-graph-main-20260829");
+        let second = bundle(directory.path(), "z-graph-main-20260829");
+        let scratch = directory.path().join("scratch");
+        fs::create_dir(&scratch).unwrap();
+        let resolved = resolve_fixture_bundle_bindings(&[
+            format!("a-graph-main-20260829={}", first.display()),
+            format!("z-graph-main-20260829={}", second.display()),
+        ])
+        .into_result()
+        .unwrap();
+        fs::write(second.join("root/manifest"), b"other-head").unwrap();
+
+        let outcome = stage_fixture_bundles(&resolved, Some(&scratch));
+
+        assert_eq!(outcome.diagnostics[0].code, "fixture_preflight_copy_failed");
+        assert_eq!(fs::read_dir(&scratch).unwrap().count(), 0);
+    }
+
+    #[test]
+    fn staging_never_creates_scratch_inside_the_registered_bundle() {
+        let directory = tempfile::tempdir().unwrap();
+        let bundle = bundle(directory.path(), "monarch-main-20260829");
+        let binding = format!("monarch-main-20260829={}", bundle.display());
+        let resolved = resolve_fixture_bundle_bindings(&[binding])
+            .into_result()
+            .unwrap();
+        let descendant = bundle.join("scratch");
+        fs::create_dir(&descendant).unwrap();
+
+        for scratch in [&bundle, &descendant] {
+            let outcome = stage_fixture_bundles(&resolved, Some(scratch));
+            assert_eq!(
+                outcome.diagnostics[0].code,
+                "fixture_preflight_scratch_inside_bundle"
+            );
+        }
+        assert_eq!(fs::read_dir(&descendant).unwrap().count(), 0);
+        assert_eq!(fs::read_dir(bundle.join("root")).unwrap().count(), 2);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn aliases_and_invalid_semantics_fail_closed() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("root");
+        fixture(&root);
+        let source = fingerprint_registered_fixture("monarch-main-20260829".into(), &root)
+            .into_result()
+            .unwrap();
+        let path = directory.path().join("fixture-source.json");
+        fs::write(&path, serde_json::to_vec(&source).unwrap()).unwrap();
+
+        let link = directory.path().join("fixture-link.json");
+        symlink(&path, &link).unwrap();
+        assert_eq!(
+            verify_registered_fixture(&link, &root).diagnostics[0].code,
+            "fixture_source_read_error"
+        );
+        let root_link = directory.path().join("root-link");
+        symlink(&root, &root_link).unwrap();
+        assert_eq!(
+            verify_registered_fixture(&path, &root_link).diagnostics[0].code,
+            "registered_fixture_root_error"
+        );
+        let inside = root.join("fixture-source.json");
+        fs::write(&inside, serde_json::to_vec(&source).unwrap()).unwrap();
+        assert_eq!(
+            verify_registered_fixture(&inside, &root).diagnostics[0].code,
+            "fixture_source_inside_root"
+        );
+
+        let mut invalid = source;
+        invalid.format_version = 2;
+        invalid.fixture_id = "../monarch".into();
+        invalid.physical.digest_algorithm = "sha256".into();
+        invalid.physical.tree_sha256 = "A".repeat(64);
+        invalid.physical.files = 0;
+        assert!(seal_source_descriptor(&invalid).is_err());
+
+        let root_link_bundle = directory.path().join("bundle");
+        fs::create_dir(&root_link_bundle).unwrap();
+        symlink(&root, root_link_bundle.join("root")).unwrap();
+        symlink(&path, root_link_bundle.join("fixture-source.json")).unwrap();
+        let outcome = resolve_fixture_bundles(&[FixtureBundleBinding {
+            fixture_id: "monarch-main-20260829".to_string(),
+            bundle: root_link_bundle,
+        }]);
+        assert_eq!(outcome.diagnostics[0].code, "invalid_fixture_bundle_layout");
+
+        let source_link_bundle = directory.path().join("source-link-bundle");
+        fixture(&source_link_bundle.join("root"));
+        symlink(&path, source_link_bundle.join("fixture-source.json")).unwrap();
+        let outcome = resolve_fixture_bundles(&[FixtureBundleBinding {
+            fixture_id: "monarch-main-20260829".to_string(),
+            bundle: source_link_bundle,
+        }]);
+        assert_eq!(outcome.diagnostics[0].code, "fixture_source_read_error");
+
+        let real_scratch = directory.path().join("real-scratch");
+        fs::create_dir(&real_scratch).unwrap();
+        let scratch_link = directory.path().join("scratch-link");
+        symlink(&real_scratch, &scratch_link).unwrap();
+        let real_bundle = bundle(directory.path(), "fin-graph-main-20260829");
+        let resolved = resolve_fixture_bundle_bindings(&[format!(
+            "fin-graph-main-20260829={}",
+            real_bundle.display()
+        )])
+        .into_result()
+        .unwrap();
+        assert_eq!(
+            stage_fixture_bundles(&resolved, Some(&scratch_link)).diagnostics[0].code,
+            "fixture_preflight_scratch_error"
+        );
+    }
+}

--- a/crates/omnigraph-bench/src/registered_fixture.rs
+++ b/crates/omnigraph-bench/src/registered_fixture.rs
@@ -98,6 +98,61 @@ struct StagedFixtureBundlesV1 {
     fixtures: BTreeMap<String, FixtureCopyPreflightReceiptV1>,
 }
 
+/// One verified registered fixture retained in harness-owned disposable
+/// storage for the lifetime of a validation or diagnostic run.
+///
+/// The source bundle is never opened as an OmniGraph database. Only [`root`](Self::root)
+/// may be handed to graph code, and dropping this guard removes that copy.
+#[derive(Debug)]
+pub struct StagedRegisteredFixtureV1 {
+    workspace: Option<tempfile::TempDir>,
+    root: PathBuf,
+    receipt: FixtureCopyPreflightReceiptV1,
+}
+
+impl StagedRegisteredFixtureV1 {
+    /// Invocation-local root containing the verified copy.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Path-free evidence identifying the registered source and copied bytes.
+    pub fn receipt(&self) -> &FixtureCopyPreflightReceiptV1 {
+        &self.receipt
+    }
+
+    /// Re-read the staged tree and prove graph inspection did not change any
+    /// registered byte before the disposable copy is removed.
+    pub fn verify_unchanged(&self) -> Result<(), Diagnostic> {
+        let expected = physical_digest(&self.receipt.physical);
+        verify_physical_tree(&self.root, &expected, TraversalLimits::default())
+            .map(|_| ())
+            .map_err(|error| {
+                Diagnostic::error(
+                    "staged_fixture_changed",
+                    "$",
+                    format!("disposable registered fixture changed during inspection: {error}"),
+                )
+            })
+    }
+
+    /// Explicitly remove the disposable copy and report cleanup failures.
+    pub fn finish(mut self) -> Result<FixtureCopyPreflightReceiptV1, Diagnostic> {
+        let workspace = self
+            .workspace
+            .take()
+            .expect("staged fixture workspace is present until finish");
+        workspace.close().map_err(|error| {
+            Diagnostic::error(
+                "fixture_preflight_cleanup_failed",
+                "$",
+                format!("could not remove disposable fixture staging workspace: {error}"),
+            )
+        })?;
+        Ok(self.receipt.clone())
+    }
+}
+
 impl StagedFixtureBundlesV1 {
     /// Delete the disposable workspace and return path-free staging evidence.
     fn finish(mut self) -> Result<Vec<FixtureCopyPreflightReceiptV1>, Diagnostic> {
@@ -229,6 +284,78 @@ pub fn preflight_copy_fixture_bindings(
         Ok(receipts) => ValidationOutcome::success(receipts),
         Err(diagnostic) => ValidationOutcome::failure(vec![diagnostic]),
     }
+}
+
+/// Resolve exactly one `ID=BUNDLE` binding, verify its registered source while
+/// copying it into harness-owned scratch, and retain the copy for the caller.
+///
+/// This is the execution twin of [`preflight_copy_fixture_bindings`]. It keeps
+/// the same physical trust boundary but does not delete the copy before graph
+/// validation can inspect it.
+pub fn stage_registered_fixture_binding(
+    value: &str,
+    scratch_root: Option<&Path>,
+) -> ValidationOutcome<StagedRegisteredFixtureV1> {
+    let resolved = match resolve_fixture_bundle_bindings(&[value.to_string()]).into_result() {
+        Ok(mut resolved) => resolved
+            .pop()
+            .expect("one binding resolves to exactly one fixture"),
+        Err(diagnostics) => return ValidationOutcome::failure(diagnostics),
+    };
+    let staging_base = match canonical_staging_base(scratch_root) {
+        Ok(base) => base,
+        Err(diagnostic) => return ValidationOutcome::failure(vec![diagnostic]),
+    };
+    if staging_base.starts_with(&resolved.canonical_bundle) {
+        return ValidationOutcome::failure(vec![Diagnostic::error(
+            "fixture_preflight_scratch_inside_bundle",
+            "--scratch-root",
+            format!(
+                "fixture staging scratch must not equal or lie below bundle for '{}'",
+                resolved.fixture_id
+            ),
+        )]);
+    }
+    let workspace = match staging_workspace(&staging_base) {
+        Ok(workspace) => workspace,
+        Err(diagnostic) => return ValidationOutcome::failure(vec![diagnostic]),
+    };
+    let root = workspace.path().join("root");
+    let expected = physical_digest(&resolved.source.physical);
+    let copied = match copy_verified(
+        &resolved.canonical_root,
+        &root,
+        &expected,
+        TraversalLimits::default(),
+    ) {
+        Ok(copied) => copied,
+        Err(error) => {
+            let mut diagnostics = vec![Diagnostic::error(
+                "fixture_preflight_copy_failed",
+                &resolved.fixture_id,
+                format!(
+                    "could not verify and copy registered fixture into disposable scratch: {error}"
+                ),
+            )];
+            if let Err(cleanup_error) = workspace.close() {
+                diagnostics.push(Diagnostic::error(
+                    "fixture_preflight_cleanup_failed",
+                    "$",
+                    format!("could not remove failed fixture staging workspace: {cleanup_error}"),
+                ));
+            }
+            return ValidationOutcome::failure(diagnostics);
+        }
+    };
+    ValidationOutcome::success(StagedRegisteredFixtureV1 {
+        workspace: Some(workspace),
+        root,
+        receipt: FixtureCopyPreflightReceiptV1 {
+            fixture_id: resolved.fixture_id,
+            source_descriptor_sha256: resolved.source_descriptor_sha256,
+            physical: registered_physical(&copied),
+        },
+    })
 }
 
 /// Parse one invocation-local `ID=BUNDLE` argument.
@@ -1030,6 +1157,59 @@ mod tests {
             source_before
         );
         assert_eq!(fs::read_dir(&scratch).unwrap().count(), 0);
+    }
+
+    #[test]
+    fn retained_staging_exposes_only_the_verified_copy_and_cleans_it() {
+        let directory = tempfile::tempdir().unwrap();
+        let bundle = bundle(directory.path(), "monarch-main-20260829");
+        let scratch = directory.path().join("scratch");
+        fs::create_dir(&scratch).unwrap();
+        let binding = format!("monarch-main-20260829={}", bundle.display());
+
+        let staged = stage_registered_fixture_binding(&binding, Some(&scratch))
+            .into_result()
+            .unwrap();
+
+        assert_ne!(staged.root(), bundle.join("root"));
+        assert_eq!(
+            fs::read(staged.root().join("manifest")).unwrap(),
+            b"graph-head"
+        );
+        assert_eq!(staged.receipt().fixture_id, "monarch-main-20260829");
+        staged.verify_unchanged().unwrap();
+        let receipt = staged.finish().unwrap();
+        assert_eq!(receipt.fixture_id, "monarch-main-20260829");
+        assert_eq!(fs::read_dir(&scratch).unwrap().count(), 0);
+        assert_eq!(
+            fs::read(bundle.join("root/manifest")).unwrap(),
+            b"graph-head"
+        );
+    }
+
+    #[test]
+    fn retained_staging_detects_inspection_writes_before_cleanup() {
+        let directory = tempfile::tempdir().unwrap();
+        let bundle = bundle(directory.path(), "monarch-main-20260829");
+        let scratch = directory.path().join("scratch");
+        fs::create_dir(&scratch).unwrap();
+        let binding = format!("monarch-main-20260829={}", bundle.display());
+        let staged = stage_registered_fixture_binding(&binding, Some(&scratch))
+            .into_result()
+            .unwrap();
+
+        fs::write(staged.root().join("manifest"), b"changed!!!").unwrap();
+
+        assert_eq!(
+            staged.verify_unchanged().unwrap_err().code,
+            "staged_fixture_changed"
+        );
+        staged.finish().unwrap();
+        assert_eq!(fs::read_dir(&scratch).unwrap().count(), 0);
+        assert_eq!(
+            fs::read(bundle.join("root/manifest")).unwrap(),
+            b"graph-head"
+        );
     }
 
     #[test]

--- a/crates/omnigraph-bench/src/reset.rs
+++ b/crates/omnigraph-bench/src/reset.rs
@@ -20,6 +20,8 @@ use std::path::{Component, Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+/// Stable algorithm identifier for [`digest_physical_tree`].
+pub(crate) const PHYSICAL_TREE_DIGEST_ALGORITHM: &str = "omnigraph-bench-physical-tree-v1";
 const DIGEST_DOMAIN: &[u8] = b"omnigraph-bench-physical-tree-v1\0";
 const METADATA_SHAPE_DOMAIN: &[u8] = b"omnigraph-bench-metadata-shape-v1\0";
 const METADATA_STATE_DOMAIN: &[u8] = b"omnigraph-bench-metadata-state-v1\0";
@@ -877,7 +879,6 @@ fn digest_inventory(entries: &[TreeEntry], limits: TraversalLimits) -> io::Resul
                 entry.source.display()
             )));
         }
-
         hasher.update([entry.kind.digest_tag()]);
         hasher.update((entry.portable_path.len() as u64).to_le_bytes());
         hasher.update(entry.portable_path.as_bytes());
@@ -1080,7 +1081,6 @@ fn copy_regular_file(entry: &TreeEntry, target: &Path, buffer: &mut [u8]) -> io:
             entry.source.display()
         )));
     }
-
     let mut source = BufReader::new(File::open(&entry.source).map_err(|error| {
         contextual(
             error,

--- a/crates/omnigraph-bench/src/runner.rs
+++ b/crates/omnigraph-bench/src/runner.rs
@@ -45,9 +45,9 @@ use crate::fixture_worker::supervise_fixture_build;
 use crate::machine::{MachineIdentityV1, capture_machine_identity};
 use crate::preparation::{PreparationWriteGate, guard_preparation_writes};
 use crate::reset::{
-    ClonefileTemplate, MetadataDigest, PhysicalDigest, TraversalLimits,
-    accept_clonefile_template_handoff, copy_verified, digest_metadata_tree, digest_physical_tree,
-    freeze_clonefile_template, verify_metadata_shape, verify_metadata_tree,
+    ClonefileTemplate, MetadataDigest, PHYSICAL_TREE_DIGEST_ALGORITHM, PhysicalDigest,
+    TraversalLimits, accept_clonefile_template_handoff, copy_verified, digest_metadata_tree,
+    digest_physical_tree, freeze_clonefile_template, verify_metadata_shape, verify_metadata_tree,
 };
 use crate::suite::{MAX_REPETITIONS_PER_CASE, MAX_SUITE_RUNS, MAX_TOTAL_REPETITIONS};
 use crate::supervisor::{SupervisionInput, supervise_repetition};
@@ -59,7 +59,6 @@ use crate::{ResolvedRun, ResolvedSuite, validate_case};
 pub const RUNNER_OUTPUT_VERSION: u32 = 2;
 pub const FIXTURE_MANIFEST_FORMAT_VERSION: u32 = 1;
 pub const FIXTURE_VALIDATOR_VERSION: u32 = 1;
-pub(crate) const PHYSICAL_TREE_DIGEST_ALGORITHM: &str = "omnigraph-bench-physical-tree-v1";
 const BUILD_PROFILE: &str = env!("OMNIGRAPH_BENCH_BUILD_PROFILE");
 const BUILD_OPT_LEVEL: &str = env!("OMNIGRAPH_BENCH_BUILD_OPT_LEVEL");
 const SOURCE_COMMIT: &str = env!("OMNIGRAPH_BENCH_SOURCE_GIT_COMMIT");

--- a/crates/omnigraph-bench/tests/cli.rs
+++ b/crates/omnigraph-bench/tests/cli.rs
@@ -160,6 +160,44 @@ fn fixture_reference_validate_refuses_a_missing_expected_content_digest() {
 }
 
 #[test]
+fn real_graph_run_refuses_debug_timing_before_fixture_setup() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let reference = directory.path().join("example.fixture-reference-v1.yaml");
+    fs::write(&reference, fixture_reference_yaml(&"4".repeat(64))).expect("fixture reference");
+    let spec = directory.path().join("example.run-v1.yaml");
+    fs::write(
+        &spec,
+        r#"version: 1
+fixture_id: example-graph-v1
+workload: finbench-disjoint-insert-merge
+repetitions: 1
+operation_deadline_seconds: 1
+"#,
+    )
+    .expect("real graph run spec");
+
+    let output = Command::cargo_bin("omnigraph-bench")
+        .expect("benchmark binary")
+        .args([
+            "fixture",
+            "run-graph",
+            spec.to_str().expect("UTF-8 run spec"),
+            "--reference",
+            reference.to_str().expect("UTF-8 reference"),
+            "--fixture",
+            "example-graph-v1=/not/inspected/in-debug",
+            "--json",
+        ])
+        .output()
+        .expect("refuse debug real graph timing");
+
+    assert!(!output.status.success(), "{output:?}");
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout).expect("failure JSON");
+    assert_eq!(result["ok"], false);
+    assert_eq!(result["diagnostics"][0]["code"], "release_build_required");
+}
+
+#[test]
 fn fixture_verify_binds_a_local_tree_and_fails_closed_on_drift() {
     let directory = tempfile::tempdir().expect("temporary directory");
     let (source, root) = registered_fixture(directory.path());

--- a/crates/omnigraph-bench/tests/cli.rs
+++ b/crates/omnigraph-bench/tests/cli.rs
@@ -47,6 +47,118 @@ fn registered_fixture(directory: &Path) -> (PathBuf, PathBuf) {
     (source_path, root)
 }
 
+fn fixture_reference_yaml(logical_digest: &str) -> String {
+    format!(
+        r#"version: 1
+fixture_id: example-graph-v1
+logical:
+  builder:
+    id: example-import
+    version: 1
+    recipe_sha256: "{}"
+    parameters:
+      - {{ name: scale-factor, value: 1 }}
+    inputs:
+      - role: source
+        sha256: "{}"
+  data:
+    provenance: corpus-derived
+    schema_shape:
+      algorithm: future-schema-shape-v1
+      sha256: "{}"
+    node_tables:
+      - {{ name: Person, rows: 10 }}
+    edge_tables:
+      - {{ name: Knows, rows: 20 }}
+    payload:
+      kind: variable
+      algorithm: future-logical-payload-v1
+      total_bytes: 1920
+    column_shape: scalars
+    topology_skew: source-defined
+  state:
+    aging: bulk-loaded
+    indexes: []
+    deletion_history: none
+    compaction_recency: not-optimized
+    history_depth: 1
+expected:
+  logical_content:
+    algorithm: future-logical-graph-v1
+    sha256: "{logical_digest}"
+"#,
+        "1".repeat(64),
+        "2".repeat(64),
+        "3".repeat(64),
+    )
+}
+
+#[test]
+fn fixture_reference_validate_reports_the_normalized_reference_digest() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let path = directory.path().join("example.fixture-reference-v1.yaml");
+    fs::write(&path, fixture_reference_yaml(&"4".repeat(64))).expect("fixture reference");
+
+    let output = Command::cargo_bin("omnigraph-bench")
+        .expect("benchmark binary")
+        .args([
+            "fixture",
+            "reference",
+            "validate",
+            path.to_str().expect("UTF-8 reference path"),
+            "--json",
+        ])
+        .output()
+        .expect("validate fixture reference");
+
+    assert!(output.status.success(), "{output:?}");
+    let result: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("validation JSON");
+    assert_eq!(result["ok"], true);
+    assert_eq!(
+        result["value"]["definition"]["fixture_id"],
+        "example-graph-v1"
+    );
+    assert_eq!(
+        result["value"]["reference_sha256"]
+            .as_str()
+            .expect("reference digest")
+            .len(),
+        64
+    );
+}
+
+#[test]
+fn fixture_reference_validate_refuses_a_missing_expected_content_digest() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let path = directory
+        .path()
+        .join("incomplete.fixture-reference-v1.yaml");
+    let incomplete = fixture_reference_yaml(&"4".repeat(64))
+        .replace(&format!("    sha256: \"{}\"\n", "4".repeat(64)), "");
+    fs::write(&path, incomplete).expect("incomplete fixture reference");
+
+    let output = Command::cargo_bin("omnigraph-bench")
+        .expect("benchmark binary")
+        .args([
+            "fixture",
+            "reference",
+            "validate",
+            path.to_str().expect("UTF-8 reference path"),
+            "--json",
+        ])
+        .output()
+        .expect("reject incomplete fixture reference");
+
+    assert!(!output.status.success(), "{output:?}");
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout).expect("failure JSON");
+    assert_eq!(result["ok"], false);
+    assert_eq!(
+        result["diagnostics"][0]["code"],
+        "invalid_fixture_reference_yaml"
+    );
+}
+
 #[test]
 fn fixture_verify_binds_a_local_tree_and_fails_closed_on_drift() {
     let directory = tempfile::tempdir().expect("temporary directory");

--- a/crates/omnigraph-bench/tests/cli.rs
+++ b/crates/omnigraph-bench/tests/cli.rs
@@ -13,6 +13,204 @@ fn benchmark_path(relative: &str) -> PathBuf {
     repository_root().join("benchmarks").join(relative)
 }
 
+fn registered_fixture(directory: &Path) -> (PathBuf, PathBuf) {
+    let root = directory.join("root");
+    fs::create_dir_all(root.join("tables")).expect("fixture tree");
+    fs::write(root.join("graph-manifest"), b"head").expect("fixture manifest object");
+    fs::write(root.join("tables/nodes.lance"), b"nodes").expect("fixture table");
+    let output = Command::cargo_bin("omnigraph-bench")
+        .expect("benchmark binary")
+        .args([
+            "fixture",
+            "fingerprint",
+            "--id",
+            "monarch-main-20260829",
+            "--root",
+            root.to_str().expect("UTF-8 root path"),
+        ])
+        .output()
+        .expect("fingerprint fixture");
+    assert!(output.status.success(), "{output:?}");
+    let source: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("registered fixture JSON");
+    assert_eq!(source["format_version"], 1);
+    assert_eq!(source["fixture_id"], "monarch-main-20260829");
+    assert_eq!(
+        source["physical"]["tree_sha256"]
+            .as_str()
+            .expect("tree digest")
+            .len(),
+        64
+    );
+    let source_path = directory.join("fixture-source.json");
+    fs::write(&source_path, output.stdout).expect("registered fixture source descriptor");
+    (source_path, root)
+}
+
+#[test]
+fn fixture_verify_binds_a_local_tree_and_fails_closed_on_drift() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let (source, root) = registered_fixture(directory.path());
+
+    let output = Command::cargo_bin("omnigraph-bench")
+        .expect("benchmark binary")
+        .args([
+            "fixture",
+            "verify",
+            source.to_str().expect("UTF-8 source descriptor path"),
+            "--root",
+            root.to_str().expect("UTF-8 root path"),
+            "--json",
+        ])
+        .output()
+        .expect("verify fixture");
+    assert!(output.status.success(), "{output:?}");
+    let verified: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("verification JSON");
+    assert_eq!(verified["ok"], true);
+    assert_eq!(verified["value"]["fixture_id"], "monarch-main-20260829");
+    assert_eq!(
+        verified["value"]["physical"]["tree_sha256"]
+            .as_str()
+            .expect("tree digest")
+            .len(),
+        64
+    );
+    assert_eq!(
+        verified["value"]["source_descriptor_sha256"]
+            .as_str()
+            .expect("source descriptor digest")
+            .len(),
+        64
+    );
+
+    fs::write(root.join("graph-manifest"), b"tail").expect("mutate fixture");
+    let output = Command::cargo_bin("omnigraph-bench")
+        .expect("benchmark binary")
+        .args([
+            "fixture",
+            "verify",
+            source.to_str().expect("UTF-8 source descriptor path"),
+            "--root",
+            root.to_str().expect("UTF-8 root path"),
+            "--json",
+        ])
+        .output()
+        .expect("verify changed fixture");
+    assert!(!output.status.success(), "{output:?}");
+    let failure: serde_json::Value = serde_json::from_slice(&output.stdout).expect("failure JSON");
+    assert_eq!(failure["ok"], false);
+    assert_eq!(
+        failure["diagnostics"][0]["code"],
+        "registered_fixture_verification_failed"
+    );
+}
+
+#[test]
+fn fixture_preflight_copy_uses_owned_scratch_and_removes_it() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let bundle = directory.path().join("bundle");
+    fs::create_dir(&bundle).expect("bundle");
+    let (_source, root) = registered_fixture(&bundle);
+    let scratch = directory.path().join("scratch");
+    fs::create_dir(&scratch).expect("scratch root");
+    let binding = format!("monarch-main-20260829={}", bundle.display());
+
+    let output = Command::cargo_bin("omnigraph-bench")
+        .expect("benchmark binary")
+        .args([
+            "fixture",
+            "preflight-copy",
+            "--fixture",
+            &binding,
+            "--scratch-root",
+            scratch.to_str().expect("UTF-8 scratch path"),
+            "--json",
+        ])
+        .output()
+        .expect("stage fixture");
+
+    assert!(output.status.success(), "{output:?}");
+    let report: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("preflight result JSON");
+    assert_eq!(report["ok"], true);
+    assert_eq!(report["value"][0]["fixture_id"], "monarch-main-20260829");
+    assert_eq!(
+        report["value"][0]["physical"]["tree_sha256"]
+            .as_str()
+            .expect("tree digest")
+            .len(),
+        64
+    );
+    let output_text = String::from_utf8(output.stdout).expect("UTF-8 stage output");
+    assert!(!output_text.contains(root.to_str().expect("UTF-8 root path")));
+    assert_eq!(fs::read_dir(&scratch).expect("clean scratch").count(), 0);
+}
+
+#[test]
+fn fixture_preflight_copy_rejects_duplicates_before_scratch_copy() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let bundle = directory.path().join("bundle");
+    fs::create_dir(&bundle).expect("bundle");
+    registered_fixture(&bundle);
+    let scratch = directory.path().join("scratch");
+    fs::create_dir(&scratch).expect("scratch root");
+    let binding = format!("monarch-main-20260829={}", bundle.display());
+
+    let output = Command::cargo_bin("omnigraph-bench")
+        .expect("benchmark binary")
+        .args([
+            "fixture",
+            "preflight-copy",
+            "--fixture",
+            &binding,
+            "--fixture",
+            &binding,
+            "--scratch-root",
+            scratch.to_str().expect("UTF-8 scratch path"),
+            "--json",
+        ])
+        .output()
+        .expect("reject duplicate fixture binding");
+
+    assert!(!output.status.success(), "{output:?}");
+    let failure: serde_json::Value = serde_json::from_slice(&output.stdout).expect("failure JSON");
+    assert_eq!(failure["ok"], false);
+    assert!(
+        failure["diagnostics"]
+            .as_array()
+            .expect("diagnostics")
+            .iter()
+            .any(|diagnostic| diagnostic["code"] == "duplicate_fixture_binding")
+    );
+    assert_eq!(
+        fs::read_dir(&scratch).expect("untouched scratch").count(),
+        0
+    );
+}
+
+#[test]
+fn fixture_preflight_copy_rejects_default_scratch_inside_bundle() {
+    let directory = tempfile::tempdir().expect("temporary directory");
+    let (_source, root) = registered_fixture(directory.path());
+    let binding = format!("monarch-main-20260829={}", directory.path().display());
+
+    let output = Command::cargo_bin("omnigraph-bench")
+        .expect("benchmark binary")
+        .env("TMPDIR", &root)
+        .args(["fixture", "preflight-copy", "--fixture", &binding, "--json"])
+        .output()
+        .expect("reject contained default scratch");
+
+    assert!(!output.status.success(), "{output:?}");
+    let failure: serde_json::Value = serde_json::from_slice(&output.stdout).expect("failure JSON");
+    assert_eq!(
+        failure["diagnostics"][0]["code"],
+        "fixture_preflight_scratch_inside_bundle"
+    );
+    assert_eq!(fs::read_dir(&root).expect("untouched root").count(), 2);
+}
+
 #[test]
 fn checked_in_case_and_suite_validate() {
     Command::cargo_bin("omnigraph-bench")

--- a/crates/omnigraph/src/db/manifest.rs
+++ b/crates/omnigraph/src/db/manifest.rs
@@ -152,6 +152,22 @@ pub(crate) async fn refuse_if_internal_schema_unsupported(root_uri: &str) -> Res
     migrations::guard_stamp(&dataset).map(|_| ())
 }
 
+/// Whether the selected graph-manifest dataset depends on files outside its
+/// own dataset root.
+///
+/// A directory copy is self-contained only when both this manifest dataset
+/// and every user dataset have no Lance `base_paths`. Keep the paths private:
+/// callers need a relocation eligibility bit, not access to storage
+/// locations that may contain credentials or deployment details.
+pub(crate) async fn manifest_has_external_base_paths(
+    root_uri: &str,
+    branch: Option<&str>,
+) -> Result<bool> {
+    let control_session = crate::lance_access::control_session();
+    let dataset = open_manifest_dataset_with_session(root_uri, branch, &control_session).await?;
+    Ok(!dataset.manifest().base_paths.is_empty())
+}
+
 /// Immutable point-in-time view of the database.
 ///
 /// Cheap to create (no storage I/O). All reads within a query go through one
@@ -315,6 +331,15 @@ impl SnapshotDataset {
     /// whose compatibility filtering can hide unsupported metadata.
     pub fn has_raw_index_section(&self) -> bool {
         self.dataset.manifest().index_section.is_some()
+    }
+
+    /// Whether this pinned table version depends on files outside its dataset
+    /// root through Lance's `base_paths` relocation mechanism.
+    ///
+    /// The actual paths remain private so this read-only metadata surface
+    /// cannot disclose source locations or expose a writable Lance handle.
+    pub fn has_external_base_paths(&self) -> bool {
+        !self.dataset.manifest().base_paths.is_empty()
     }
 
     /// Whether `column` has complete usable BTREE coverage.

--- a/crates/omnigraph/src/db/omnigraph.rs
+++ b/crates/omnigraph/src/db/omnigraph.rs
@@ -615,6 +615,17 @@ impl Omnigraph {
         Self::open_with_storage_and_mode(uri, storage_for_uri(uri)?, OpenMode::ReadOnly).await
     }
 
+    /// Whether the selected graph-manifest dataset references files outside
+    /// its own root through Lance `base_paths`.
+    ///
+    /// This is relocation audit evidence. A copied graph is self-contained
+    /// only when this returns false and every pinned user dataset reports
+    /// [`SnapshotDataset::has_external_base_paths`](crate::db::SnapshotDataset::has_external_base_paths)
+    /// as false.
+    pub async fn manifest_has_external_base_paths(&self, branch: Option<&str>) -> Result<bool> {
+        crate::db::manifest::manifest_has_external_base_paths(&self.root_uri, branch).await
+    }
+
     /// Open with a caller-supplied [`StorageAdapter`]. Used by init/test paths
     /// and by embedding/test consumers that wrap storage (e.g. a counting
     /// decorator for IO-budget tests). Defaults to `OpenMode::ReadWrite`.
@@ -2706,6 +2717,22 @@ impl Omnigraph {
         writer: &mut W,
     ) -> Result<()> {
         export::export_jsonl_to_writer(self, branch, type_names, writer).await
+    }
+
+    /// Stream export rows without a defined physical row order.
+    ///
+    /// The logical row encoding and coherent branch cut match
+    /// [`Self::export_jsonl_to_writer`]. This variant avoids ordered-scan work
+    /// for commutative consumers; callers must not infer meaning from emission
+    /// order.
+    #[doc(hidden)]
+    pub async fn export_jsonl_unordered_to_writer<W: Write>(
+        &self,
+        branch: &str,
+        type_names: &[String],
+        writer: &mut W,
+    ) -> Result<()> {
+        export::export_jsonl_unordered_to_writer(self, branch, type_names, writer).await
     }
 
     /// The change-feed baseline handshake: stream one exact data-only entity

--- a/crates/omnigraph/src/db/omnigraph/export.rs
+++ b/crates/omnigraph/src/db/omnigraph/export.rs
@@ -38,6 +38,7 @@ impl ExportCut {
             &self.snapshot,
             self.catalog.as_ref(),
             &self.selected_tables,
+            ExportRowOrder::ById,
             emit,
         )
         .await
@@ -201,6 +202,38 @@ pub(super) async fn export_jsonl_to_writer<W: Write>(
         &resolved.snapshot,
         catalog.as_ref(),
         &selected_tables,
+        ExportRowOrder::ById,
+        &mut emit,
+    )
+    .await
+}
+
+/// Stream the same logical row encoding as ordinary export without imposing a
+/// physical row order. This is for commutative consumers such as fixture
+/// multiset hashing; callers must not infer meaning from emission order.
+pub(super) async fn export_jsonl_unordered_to_writer<W: Write>(
+    db: &Omnigraph,
+    branch: &str,
+    type_names: &[String],
+    writer: &mut W,
+) -> Result<()> {
+    let _export_cut = db.write_queue().try_acquire_export_cut().ok_or_else(|| {
+        OmniError::ResourceLimitExceeded {
+            resource: "stream_export_slots".to_string(),
+            limit: 1,
+            actual: 2,
+        }
+    })?;
+    let (resolved, catalog) = db.capture_read_view(ReadTarget::branch(branch)).await?;
+    let selected_tables = export_type_keys(&resolved.snapshot, type_names)?;
+    let mut emit =
+        |chunk: Vec<u8>| std::future::ready(writer.write_all(&chunk).map_err(OmniError::from));
+    export_selected_tables(
+        db,
+        &resolved.snapshot,
+        catalog.as_ref(),
+        &selected_tables,
+        ExportRowOrder::Unspecified,
         &mut emit,
     )
     .await
@@ -313,6 +346,7 @@ pub(super) async fn capture_change_baseline<W: Write>(
         &parts.snapshot,
         parts.catalog.as_ref(),
         &parts.selected_tables,
+        ExportRowOrder::ById,
         &mut emit,
     )
     .await?;
@@ -344,11 +378,18 @@ async fn entity_from_snapshot(
     Ok(Some(record_batch_row_to_json(batch, 0)?))
 }
 
+#[derive(Debug, Clone, Copy)]
+enum ExportRowOrder {
+    ById,
+    Unspecified,
+}
+
 async fn export_selected_tables<Emit, EmitFuture>(
     db: &Omnigraph,
     snapshot: &Snapshot,
     catalog: &Catalog,
     selected_tables: &[String],
+    row_order: ExportRowOrder,
     emit: &mut Emit,
 ) -> Result<()>
 where
@@ -356,7 +397,7 @@ where
     EmitFuture: Future<Output = Result<()>>,
 {
     for table_key in selected_tables {
-        export_table(db, snapshot, catalog, table_key, emit).await?;
+        export_table(db, snapshot, catalog, table_key, row_order, emit).await?;
     }
     Ok(())
 }
@@ -400,6 +441,7 @@ async fn export_table<Emit, EmitFuture>(
     snapshot: &Snapshot,
     catalog: &Catalog,
     table_key: &str,
+    row_order: ExportRowOrder,
     emit: &mut Emit,
 ) -> Result<()>
 where
@@ -410,7 +452,10 @@ where
         .storage()
         .open_snapshot_at_table(snapshot, table_key)
         .await?;
-    let ordering = Some(vec![ColumnOrdering::asc_nulls_last("id".to_string())]);
+    let ordering = match row_order {
+        ExportRowOrder::ById => Some(vec![ColumnOrdering::asc_nulls_last("id".to_string())]),
+        ExportRowOrder::Unspecified => None,
+    };
     let blob_properties = blob_properties_for_table_key(catalog, table_key)?;
 
     if blob_properties.is_empty() {

--- a/crates/omnigraph/tests/export.rs
+++ b/crates/omnigraph/tests/export.rs
@@ -231,6 +231,16 @@ async fn export_jsonl_round_trips_branch_snapshot() {
 
     let main_jsonl = db.export_jsonl("main", &[]).await.unwrap();
     let feature_jsonl = db.export_jsonl("feature", &[]).await.unwrap();
+    let mut feature_unordered = Vec::new();
+    db.export_jsonl_unordered_to_writer("feature", &[], &mut feature_unordered)
+        .await
+        .unwrap();
+    let mut ordered_rows = feature_jsonl.lines().collect::<Vec<_>>();
+    let feature_unordered = String::from_utf8(feature_unordered).unwrap();
+    let mut unordered_rows = feature_unordered.lines().collect::<Vec<_>>();
+    ordered_rows.sort_unstable();
+    unordered_rows.sort_unstable();
+    assert_eq!(unordered_rows, ordered_rows);
 
     let imported_main_dir = tempfile::tempdir().unwrap();
     let imported_feature_dir = tempfile::tempdir().unwrap();

--- a/docs/releases/v0.10.0.md
+++ b/docs/releases/v0.10.0.md
@@ -80,8 +80,14 @@ and GitHub Releases; see the current policy in
   verifies the source while copying it through harness-owned disposable
   scratch, verifies the copy, and completes cleanup without persisting local
   paths. This is physical audit/reset evidence only and does not enter
-  benchmark point identity; registered graphs remain non-executable until they
-  have stamped logical Data/State validation and a real-graph workload adapter.
+  benchmark point identity. `fixture reference validate` now strictly parses a
+  separate versioned imported-graph declaration containing builder provenance,
+  exact node/edge inventories, Data/State, and a required expected logical
+  content digest. It emits a normalized whole-reference audit digest. The
+  command only validates the document: it does not verify the supplied content
+  digest, open, or certify a graph. Registered graphs remain non-executable
+  until canonical graph hashing binds the declaration to copied bytes and a
+  real-graph workload adapter lands.
 - **Typed storage failures (RFC 0038).** The Rust API replaces the exhaustive
   `OmniError::Lance(String)` variant with
   `OmniError::Storage(StorageFailure)`. Embedded callers can inspect the closed

--- a/docs/releases/v0.10.0.md
+++ b/docs/releases/v0.10.0.md
@@ -314,6 +314,10 @@ and GitHub Releases; see the current policy in
   `TableWalk` phase identifies each general three-way ordered staging walk;
   proven-insert routes report none. Production leaves the task-local probe
   unset and performs no timing clock reads.
+- The benchmark CLI can register, byte-verify, logically validate, and run a
+  fixed node-and-edge FinGraph merge diagnostic from declarative fixture and
+  run YAML. This local APFS path is intentionally claim-ineligible and does not
+  publish durable telemetry or dispatch through AWS infrastructure.
 
 ## Compatibility
 

--- a/docs/releases/v0.10.0.md
+++ b/docs/releases/v0.10.0.md
@@ -84,10 +84,10 @@ and GitHub Releases; see the current policy in
   separate versioned imported-graph declaration containing builder provenance,
   exact node/edge inventories, Data/State, and a required expected logical
   content digest. It emits a normalized whole-reference audit digest. The
-  command only validates the document: it does not verify the supplied content
-  digest, open, or certify a graph. Registered graphs remain non-executable
-  until canonical graph hashing binds the declaration to copied bytes and a
-  real-graph workload adapter lands.
+  document-only command does not certify a graph by itself; `fixture
+  validate-graph` binds the declaration to copied bytes through canonical graph
+  hashing, and `fixture run-graph` executes the fixed FinGraph adapter. That
+  adapter remains claim-ineligible and outside the durable archive.
 - **Typed storage failures (RFC 0038).** The Rust API replaces the exhaustive
   `OmniError::Lance(String)` variant with
   `OmniError::Storage(StorageFailure)`. Embedded callers can inspect the closed

--- a/docs/releases/v0.10.0.md
+++ b/docs/releases/v0.10.0.md
@@ -73,6 +73,15 @@ and GitHub Releases; see the current policy in
   only bounded counts/receipts; indeterminate directory-sync outcomes retain a
   typed reconciliation identity. Physical cloud attempts, comparison/noise-floor
   reports, and controlled cloud orchestration remain future slices.
+  A separate `omnigraph-bench fixture fingerprint`/`fixture verify` interface prints a
+  strict, location-free physical copy-source descriptor for a stable local
+  tree, binds later copies by full physical digest, and returns the canonical
+  descriptor digest. `fixture preflight-copy --fixture ID=BUNDLE` additionally
+  verifies the source while copying it through harness-owned disposable
+  scratch, verifies the copy, and completes cleanup without persisting local
+  paths. This is physical audit/reset evidence only and does not enter
+  benchmark point identity; registered graphs remain non-executable until they
+  have stamped logical Data/State validation and a real-graph workload adapter.
 - **Typed storage failures (RFC 0038).** The Rust API replaces the exhaustive
   `OmniError::Lance(String)` variant with
   `OmniError::Storage(StorageFailure)`. Embedded callers can inspect the closed


### PR DESCRIPTION
## What & why

Extends the benchmark harness beyond synthetic fixtures to registered, physically verified real-graph fixtures, with a fixed FinGraph merge diagnostic runnable from declarative YAML.

- `fixture fingerprint` / `fixture verify`: strict, location-free physical copy-source descriptors for a stable local tree; later copies bind by full physical digest and return the canonical descriptor digest.
- `fixture preflight-copy --fixture ID=BUNDLE`: verifies the source while copying through harness-owned disposable scratch, verifies the copy, and cleans up without persisting local paths (physical audit/reset evidence only — never part of benchmark point identity).
- `fixture reference validate`: strictly parses a versioned imported-graph declaration (builder provenance, exact node/edge inventories, Data/State, required expected logical content digest) and emits a normalized whole-reference audit digest. Document-only — it certifies nothing by itself.
- `fixture validate-graph` binds the declaration to copied bytes through canonical graph hashing; `fixture run-graph` executes the fixed FinGraph merge diagnostic from fixture + run YAML.
- The local APFS path stays intentionally claim-ineligible: no durable telemetry, no AWS dispatch.

Engine support: `manifest_has_external_base_paths` (external-blob-base detection for export gating) and `export_jsonl_unordered_to_writer` (streaming unordered export used by canonical graph hashing), with `export.rs` test coverage.

Checked-in artifacts: `benchmarks/README.md`, the `finbench-2026-08-21-sf10-v1` fixture reference and run YAML.

## Checklist

- [x] Focused: registered real-graph fixtures and the FinGraph diagnostic; no changes to the durable archive/claim path
- [x] Tests: `crates/omnigraph-bench/tests/cli.rs` (+348), fixture-reference/registered-fixture unit coverage, engine `export.rs`
- [x] Docs: `benchmarks/README.md`, `crates/omnigraph-bench/README.md`, release note


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds registered real-graph fixture descriptors, physical copy verification, logical graph observation, and a fresh-process APFS FinGraph merge diagnostic. It also adds an unordered streaming engine export used to compute canonical fixture witnesses.

- Introduces strict fixture-reference and real-graph run YAML formats.
- Adds fingerprint, verify, preflight-copy, observe, validate, and run CLI workflows.
- Adds physical staging, canonical graph hashing, APFS clone resets, worker deadlines, and cleanup reporting.
- Extends engine export and manifest metadata surfaces needed by fixture validation.

<h3>Confidence Score: 4/5</h3>

The fixed-width fixture-reference contract should be corrected before merging because the CLI accepts declarations that its graph validation and runner can never execute successfully.

The new reference parser treats fixed payload declarations as valid V1 input, while the only downstream validator rejects that variant unconditionally, breaking an explicitly exposed format path.

**Files Needing Attention:** crates/omnigraph-bench/src/real_graph.rs, crates/omnigraph-bench/src/fixture_reference.rs

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/omnigraph-bench/src/fixture_reference.rs | Defines and normalizes the strict fixture-reference-v1 contract, including a fixed payload variant that downstream validation cannot currently satisfy. |
| crates/omnigraph-bench/src/registered_fixture.rs | Adds bounded physical-tree fingerprinting, bundle validation, verified copying, and scratch ownership/cleanup controls. |
| crates/omnigraph-bench/src/real_graph.rs | Computes graph observations and canonical logical witnesses, but unconditionally rejects the fixed payload form accepted by the reference parser. |
| crates/omnigraph-bench/src/real_graph_run.rs | Implements fixture validation, deterministic branch preparation, APFS clone resets, fresh worker execution, deadlines, and cleanup. |
| crates/omnigraph/src/db/omnigraph/export.rs | Adds an internal unordered writer export while retaining the snapshot and streaming lifecycle used by ordered exports. |
| crates/omnigraph/src/db/manifest.rs | Exposes read-only checks for external Lance base paths to support relocation eligibility. |
| crates/omnigraph-bench/src/bin/omnigraph-bench.rs | Wires the new fixture commands and private real-graph worker into the benchmark CLI. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Registered bundle] --> B[Verify physical digest]
  B --> C[Disposable staged copy]
  C --> D[Observe schema, rows, indexes, and content]
  D --> E{Reference matches?}
  E -->|No| F[Fail and clean workspace]
  E -->|Yes| G[Prepare FinGraph branch delta]
  G --> H[Freeze APFS clone template]
  H --> I[Restore fresh active copy]
  I --> J[Run merge worker with deadline]
  J --> K[Verify and report samples]
  K --> L[Clean workspace]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20modernrelay%2Fomnigraph%20PR%20%23580%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=modernrelay%2Fomnigraph&pr=580&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Acrates%2Fomnigraph-bench%2Fsrc%2Freal_graph.rs%3A125-129%0A**Fixed%20payload%20validation%20is%20broken**%0A%0AWhen%20a%20valid%20fixture%20reference%20declares%20a%20fixed-width%20payload%2C%20reference%20parsing%20accepts%20and%20normalizes%20it%2C%20but%20%60validate_real_graph_reference%60%20rejects%20the%20variant%20unconditionally%2C%20causing%20%60fixture%20validate-graph%60%20and%20%60fixture%20run-graph%60%20to%20fail%20even%20when%20every%20row%20has%20the%20declared%20width.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=modernrelay%2Fomnigraph&pr=580&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(bench): close FinGraph review gaps"](https://github.com/modernrelay/omnigraph/commit/985215d85e23546037f47b3194f68a914001db3b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58426875)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Storage and table lifecycle](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/storage-and-table-lifecycle.md)
- Knowledge Base — [Branching and version history](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/branching-and-version-history.md)
- Knowledge Base — [Data mutation pipeline](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/data-mutation-pipeline.md)
</details>


<!-- /greptile_comment -->