### PR TITLE
release: qualify v0.10 upgrade and finalize compatibility docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -497,6 +497,19 @@ jobs:
           workspaces: |
             . -> target
 
+      - name: Install genuine v0.9 release for upgrade regression
+        run: |
+          set -euo pipefail
+          v09_dir="$RUNNER_TEMP/omnigraph-v09"
+          # The installer downloads the official archive and verifies its
+          # SHA256 before extraction. An exact VERSION never falls back to edge.
+          REPO_SLUG=ModernRelay/omnigraph VERSION=v0.9.0 INSTALL_DIR="$v09_dir" \
+            bash scripts/install.sh
+          test -x "$v09_dir/omnigraph"
+          [[ "$("$v09_dir/omnigraph" --version)" == "omnigraph 0.9.0" ]] \
+            || { echo "::error::upgrade regression requires the genuine v0.9.0 CLI"; exit 1; }
+          echo "OMNIGRAPH_V09_BIN=$v09_dir/omnigraph" >> "$GITHUB_ENV"
+
       - name: Run workspace and failpoint tests once
         run: |
           set -euo pipefail
@@ -508,6 +521,14 @@ jobs:
           cargo test --workspace --locked --no-fail-fast \
             --features omnigraph-engine/failpoints,omnigraph-cluster/failpoints \
             -- --nocapture 2>&1 | tee "$test_log"
+          if grep -Fq "skipping v0.9 upgrade e2e:" "$test_log"; then
+            echo "::error::v0.9 upgrade regression skipped despite a configured release binary"
+            exit 1
+          fi
+          grep -Fq "v0.9 -> v0.10 upgrade e2e completed" "$test_log" \
+            || { echo "::error::v0.9 upgrade regression did not complete"; exit 1; }
+          grep -Eq "test current_v010_upgrades_genuine_v09_graph_end_to_end \\.\\.\\. ok" "$test_log" \
+            || { echo "::error::exact v0.9 upgrade regression did not pass"; exit 1; }
 
 
   v5_v6_format_fence:

--- a/crates/omnigraph-cli/tests/crossversion_upgrade.rs
+++ b/crates/omnigraph-cli/tests/crossversion_upgrade.rs
@@ -14,6 +14,8 @@
 //! `OMNIGRAPH_V5_BIN` (built from the final internal-v5 commit) and proves both
 //! directions of the v5/v6 format fence. Each case skips only when its variable
 //! is unset; a set but invalid path fails loudly.
+//! `OMNIGRAPH_V09_BIN` selects the released v0.9 CLI for the in-place v6
+//! upgrade journey, including full-text rebuilding and current HTTP serving.
 
 mod support;
 
@@ -588,4 +590,476 @@ fn current_v6_refuses_and_rebuilds_genuine_v5_and_v5_refuses_v6() {
             || reverse_stderr.contains("expects v5"),
         "unexpected v5→v6 reverse-refusal message: {reverse_stderr}",
     );
+}
+
+#[test]
+fn current_v010_upgrades_genuine_v09_graph_end_to_end() {
+    use reqwest::blocking::Client;
+    use serde_json::{Value, json};
+    use std::fs;
+    use support::{copy_dir, parse_stdout_json, resolved_snapshot_id, spawn_server_with_cluster};
+
+    let Some(old) = std::env::var_os("OMNIGRAPH_V09_BIN").map(PathBuf::from) else {
+        eprintln!("skipping v0.9 upgrade e2e: OMNIGRAPH_V09_BIN is unset");
+        return;
+    };
+    let version = run_old(&old, &["version"]);
+    assert_ok("version", &version);
+    assert_eq!(
+        String::from_utf8_lossy(&version.stdout).lines().next(),
+        Some("omnigraph 0.9.0"),
+        "the predecessor must be the released v0.9.0 binary"
+    );
+
+    // Extend the existing search fixture, retaining its vector values, with
+    // real edges and a Blob. All persisted state is minted by the old CLI.
+    let temp = tempdir().unwrap();
+    let cluster = temp.path().join("cluster");
+    fs::create_dir(&cluster).unwrap();
+    let schema = cluster.join("graph.pg");
+    fs::write(
+        &schema,
+        format!(
+            "{}\nedge Cites: Doc -> Doc {{ note: String }}\n\
+             node BinaryAsset {{ name: String @key payload: Blob }}\n",
+            fs::read_to_string(fixture("search.pg")).unwrap()
+        ),
+    )
+    .unwrap();
+    let queries = cluster.join("queries.gq");
+    let query_source = r#"
+query docs() {
+    match { $d: Doc }
+    return { $d.slug, $d.title, $d.body, $d.embedding }
+    order { $d.slug }
+}
+query edges() {
+    match { $a: Doc $a $c:cites $b }
+    return { $a.slug, $b.slug, $c.note }
+}
+query terms($term: String) {
+    match { $d: Doc search($d.title, $term) }
+    return { $d.slug }
+    order { $d.slug }
+}
+query ranked($term: String) {
+    match { $d: Doc }
+    return { $d.slug }
+    order { bm25($d.title, $term) }
+    limit 10
+}
+query vectors($q: Vector(4)) {
+    match { $d: Doc }
+    return { $d.slug }
+    order { nearest($d.embedding, $q) }
+    limit 1
+}
+query retitle($title: String) { update Doc set { title: $title } where slug = "ml-intro" }
+query revise($body: String) { update Doc set { body: $body } where slug = "dl-basics" }
+"#;
+    fs::write(&queries, query_source).unwrap();
+    fs::write(
+        cluster.join("cluster.yaml"),
+        "version: 1\nstate: { backend: cluster, lock: true }\ngraphs:\n  knowledge:\n    schema: graph.pg\n    queries: [queries.gq]\n",
+    )
+    .unwrap();
+    let seed = temp.path().join("seed.jsonl");
+    fs::write(
+        &seed,
+        format!(
+            "{}\n{}\n{}\n",
+            fs::read_to_string(fixture("search.jsonl")).unwrap().trim_end(),
+            r#"{"edge":"Cites","from":"ml-intro","to":"dl-basics","data":{"id":"citation-1","note":"organism citation"}}"#,
+            r#"{"type":"BinaryAsset","data":{"name":"blob-sentinel","payload":"base64:AAECA/8="}}"#,
+        ),
+    )
+    .unwrap();
+    let graph = cluster.join("graphs/knowledge.omni");
+    let uri = graph.to_str().unwrap();
+    let query_path = queries.to_str().unwrap();
+    assert_ok(
+        "lint",
+        &run_old(
+            &old,
+            &[
+                "lint",
+                "--schema",
+                schema.to_str().unwrap(),
+                "--query",
+                query_path,
+            ],
+        ),
+    );
+    for operation in ["import", "plan", "apply"] {
+        assert_ok(
+            operation,
+            &run_old(
+                &old,
+                &["cluster", operation, "--config", cluster.to_str().unwrap()],
+            ),
+        );
+    }
+    assert_ok(
+        "load",
+        &run_old(
+            &old,
+            &[
+                "load",
+                "--mode",
+                "overwrite",
+                "--data",
+                seed.to_str().unwrap(),
+                uri,
+            ],
+        ),
+    );
+    assert_ok(
+        "retitle",
+        &run_old(
+            &old,
+            &[
+                "mutate",
+                "retitle",
+                "--query",
+                query_path,
+                "--store",
+                uri,
+                "--params",
+                r#"{"title":"organism baseline"}"#,
+            ],
+        ),
+    );
+    assert_ok("optimize", &run_old(&old, &["optimize", uri]));
+    assert_ok(
+        "branch create",
+        &run_old(&old, &["branch", "create", "review", "--uri", uri]),
+    );
+    assert_ok(
+        "branch retitle",
+        &run_old(
+            &old,
+            &[
+                "mutate",
+                "retitle",
+                "--query",
+                query_path,
+                "--store",
+                uri,
+                "--branch",
+                "review",
+                "--params",
+                r#"{"title":"organism branch"}"#,
+            ],
+        ),
+    );
+
+    let exports: Vec<_> = ["main", "review"]
+        .into_iter()
+        .map(|branch| {
+            let out = run_old(&old, &["export", uri, "--branch", branch]);
+            assert_ok("export", &out);
+            // Five documents, one edge, and one Blob-bearing node.
+            assert_eq!(nonblank_lines(&out.stdout), 7);
+            let search = run_old(
+                &old,
+                &[
+                    "query",
+                    "terms",
+                    "--query",
+                    query_path,
+                    "--store",
+                    uri,
+                    "--branch",
+                    branch,
+                    "--params",
+                    r#"{"term":"organism"}"#,
+                    "--json",
+                ],
+            );
+            assert_ok("old full-text search", &search);
+            assert_eq!(
+                parse_stdout_json(&search)["rows"],
+                json!([{ "d.slug": "ml-intro" }])
+            );
+            out.stdout
+        })
+        .collect();
+    let backup = temp.path().join("backup");
+    copy_dir(&cluster, &backup);
+    let original_heads: Vec<_> = ["main", "review"]
+        .into_iter()
+        .map(|branch| {
+            let commits = run_old(&old, &["commit", "list", uri, "--branch", branch, "--json"]);
+            assert_ok("old commit history", &commits);
+            parse_stdout_json(&commits)["commits"][0]["graph_commit_id"]
+                .as_str()
+                .unwrap()
+                .to_owned()
+        })
+        .collect();
+
+    // The current binary opens v6 directly: no export/import or schema migration.
+    output_success(
+        cli()
+            .args(["lint", "--schema"])
+            .arg(&schema)
+            .arg("--query")
+            .arg(&queries),
+    );
+    for (i, branch) in ["main", "review"].into_iter().enumerate() {
+        assert_eq!(resolved_snapshot_id(&graph, branch), original_heads[i]);
+    }
+    let query_command = |target: &[&str], branch: &str, name: &str, params: &str| {
+        let mut command = cli();
+        command
+            .args([
+                "query", name, "--query", query_path, "--branch", branch, "--params", params,
+                "--json",
+            ])
+            .args(target);
+        command
+    };
+    let direct = ["--store", uri];
+    let vector_params = r#"{"q":[0.1,0.2,0.3,0.4]}"#;
+    let term_params = r#"{"term":"organism"}"#;
+    for (i, branch) in ["main", "review"].into_iter().enumerate() {
+        let exported = output_success(cli().args(["export", uri, "--branch", branch]));
+        assert_eq!(
+            canonical_export_rows(&exported.stdout),
+            canonical_export_rows(&exports[i])
+        );
+        let docs = parse_stdout_json(&output_success(&mut query_command(
+            &direct, branch, "docs", "{}",
+        )));
+        assert_eq!(docs["row_count"], 5);
+        let edges = parse_stdout_json(&output_success(&mut query_command(
+            &direct, branch, "edges", "{}",
+        )));
+        assert_eq!(
+            edges["rows"],
+            json!([{ "a.slug":"ml-intro", "b.slug":"dl-basics", "c.note":"organism citation" }])
+        );
+        let nearest = parse_stdout_json(&output_success(&mut query_command(
+            &direct,
+            branch,
+            "vectors",
+            vector_params,
+        )));
+        assert_eq!(nearest["rows"], json!([{ "d.slug":"ml-intro" }]));
+        for name in ["terms", "ranked"] {
+            let failure = output_failure(&mut query_command(&direct, branch, name, term_params));
+            assert!(String::from_utf8_lossy(&failure.stderr).contains("rebuild-full-text-indexes"));
+        }
+        assert_eq!(resolved_snapshot_id(&graph, branch), original_heads[i]);
+    }
+
+    // Boot the new server on the old cluster catalog. A refusal is a typed
+    // 409, not a plausible empty result, and must leave both heads unchanged.
+    let client = Client::new();
+    let server = spawn_server_with_cluster(&cluster);
+    for branch in ["main", "review"] {
+        let response = client.post(format!("{}/graphs/knowledge/query", server.base_url))
+            .json(&json!({"query":query_source,"name":"terms","params":{"term":"organism"},"branch":branch})).send().unwrap();
+        assert_eq!(response.status(), 409);
+        let error: Value = response.json().unwrap();
+        assert!(
+            error["full_text_index_rebuild_required"].is_object(),
+            "{error}"
+        );
+    }
+    drop(server);
+    for (i, branch) in ["main", "review"].into_iter().enumerate() {
+        assert_eq!(resolved_snapshot_id(&graph, branch), original_heads[i]);
+    }
+
+    // Maintenance runs with serving stopped. Rebuilding main cannot certify
+    // its old snapshot or the independently written branch's old segments.
+    for (i, branch) in ["main", "review"].into_iter().enumerate() {
+        let rebuilt = parse_stdout_json(&output_success(cli().args([
+            "rebuild-full-text-indexes",
+            uri,
+            "--branch",
+            branch,
+            "--json",
+        ])));
+        assert_eq!(
+            rebuilt["rebuilt_indexes"],
+            json!([
+                {"type_key":"node:BinaryAsset", "property":"name"},
+                {"type_key":"node:Doc", "property":"body"},
+                {"type_key":"node:Doc", "property":"slug"},
+                {"type_key":"node:Doc", "property":"title"},
+            ])
+        );
+        assert_eq!(rebuilt["branch"], branch);
+        assert_eq!(
+            rebuilt["graph_commit_id"],
+            resolved_snapshot_id(&graph, branch)
+        );
+        assert_ne!(rebuilt["graph_commit_id"], original_heads[i]);
+        assert_eq!(
+            canonical_export_rows(
+                &output_success(cli().args(["export", uri, "--branch", branch])).stdout
+            ),
+            canonical_export_rows(&exports[i])
+        );
+        if branch == "main" {
+            assert_eq!(resolved_snapshot_id(&graph, "review"), original_heads[1]);
+            output_failure(&mut query_command(&direct, "review", "terms", term_params));
+        }
+        let old_search = output_failure(cli().args([
+            "query",
+            "terms",
+            "--query",
+            query_path,
+            "--store",
+            uri,
+            "--snapshot",
+            &original_heads[i],
+            "--params",
+            term_params,
+        ]));
+        assert!(String::from_utf8_lossy(&old_search.stderr).contains("rebuild-full-text-indexes"));
+    }
+
+    let server = spawn_server_with_cluster(&cluster);
+    let remote = ["--server", server.base_url.as_str(), "--graph", "knowledge"];
+    for branch in ["main", "review"] {
+        for (name, params) in [
+            ("docs", "{}"),
+            ("edges", "{}"),
+            ("terms", term_params),
+            ("ranked", term_params),
+            ("vectors", vector_params),
+        ] {
+            let local = parse_stdout_json(&output_success(&mut query_command(
+                &direct, branch, name, params,
+            )));
+            let served = parse_stdout_json(&output_success(&mut query_command(
+                &remote, branch, name, params,
+            )));
+            assert_eq!(served["rows"], local["rows"], "{branch}/{name}");
+            if matches!(name, "terms" | "ranked" | "vectors") {
+                assert_eq!(served["rows"], json!([{ "d.slug":"ml-intro" }]));
+            }
+        }
+        for target in [&direct[..], &remote[..]] {
+            let blob = output_success(
+                cli()
+                    .args([
+                        "blob",
+                        "get",
+                        "node",
+                        "BinaryAsset",
+                        "blob-sentinel",
+                        "payload",
+                        "--branch",
+                        branch,
+                    ])
+                    .args(target),
+            );
+            assert_eq!(blob.stdout, [0, 1, 2, 3, 255]);
+        }
+    }
+    // Exercise new writes and graph merge through HTTP, then reopen the server.
+    let before = resolved_snapshot_id(&graph, "review");
+    let change = parse_stdout_json(&output_success(
+        cli()
+            .args([
+                "mutate",
+                "revise",
+                "--query",
+                query_path,
+                "--branch",
+                "review",
+                "--params",
+                r#"{"body":"verified after upgrade"}"#,
+                "--json",
+            ])
+            .args(remote),
+    ));
+    assert_eq!(change["affected_nodes"], 1);
+    assert_ne!(resolved_snapshot_id(&graph, "review"), before);
+    output_success(
+        cli()
+            .args(["branch", "merge", "review", "--into", "main", "--json"])
+            .args(remote),
+    );
+    let expected = parse_stdout_json(&output_success(&mut query_command(
+        &remote, "main", "docs", "{}",
+    )))["rows"]
+        .clone();
+    assert!(
+        expected
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|row| row["d.slug"] == "dl-basics" && row["d.body"] == "verified after upgrade")
+    );
+    assert!(
+        expected
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|row| row["d.slug"] == "ml-intro" && row["d.title"] == "organism branch")
+    );
+    drop(server);
+    let reopened = spawn_server_with_cluster(&cluster);
+    let remote = [
+        "--server",
+        reopened.base_url.as_str(),
+        "--graph",
+        "knowledge",
+    ];
+    assert_eq!(
+        parse_stdout_json(&output_success(&mut query_command(
+            &remote, "main", "docs", "{}"
+        )))["rows"],
+        expected
+    );
+    assert_eq!(
+        parse_stdout_json(&output_success(&mut query_command(
+            &remote,
+            "main",
+            "terms",
+            term_params
+        )))["rows"],
+        json!([{ "d.slug":"ml-intro" }])
+    );
+    drop(reopened);
+
+    // Rollback means restoring the quiescent backup at its original path,
+    // never asking the old binary to interpret newly rebuilt postings.
+    fs::rename(&cluster, temp.path().join("upgraded")).unwrap();
+    copy_dir(&backup, &cluster);
+    for (i, branch) in ["main", "review"].into_iter().enumerate() {
+        let restored = run_old(&old, &["export", uri, "--branch", branch]);
+        assert_ok("restored old export", &restored);
+        assert_eq!(
+            canonical_export_rows(&restored.stdout),
+            canonical_export_rows(&exports[i])
+        );
+        let search = run_old(
+            &old,
+            &[
+                "query",
+                "terms",
+                "--query",
+                query_path,
+                "--store",
+                uri,
+                "--branch",
+                branch,
+                "--params",
+                term_params,
+                "--json",
+            ],
+        );
+        assert_ok("restored old search", &search);
+        assert_eq!(
+            parse_stdout_json(&search)["rows"],
+            json!([{ "d.slug":"ml-intro" }])
+        );
+    }
+    eprintln!("v0.9 -> v0.10 upgrade e2e completed");
 }

--- a/crates/omnigraph/src/table_store/fts_compat.rs
+++ b/crates/omnigraph/src/table_store/fts_compat.rs
@@ -381,7 +381,12 @@ mod tests {
     async fn certificate_file_is_bounded_and_follows_shallow_clone_ownership() {
         use arrow_array::{RecordBatch, StringArray};
         use arrow_schema::{DataType, Field, Schema};
-        use lance::index::DatasetIndexExt;
+        use lance::{
+            dataset::{DEFAULT_INDEX_CACHE_SIZE, DEFAULT_METADATA_CACHE_SIZE},
+            index::DatasetIndexExt,
+            io::ObjectStoreRegistry,
+            session::Session,
+        };
         use object_store::ObjectStoreExt;
 
         use crate::{storage_layer::IndexBuildSpec, table_store::TableStore};
@@ -402,10 +407,14 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let uri = directory.path().join("source.lance");
         let uri = uri.to_str().unwrap();
-        let store = TableStore::new(
-            uri,
-            crate::lance_access::LanceAccessContext::new().data_session(),
-        );
+        // Local-file clients (and their counters) are pooled by registry, not
+        // dataset path. Isolate I/O accounting while retaining normal caches.
+        let session = Arc::new(Session::new(
+            DEFAULT_INDEX_CACHE_SIZE,
+            DEFAULT_METADATA_CACHE_SIZE,
+            Arc::new(ObjectStoreRegistry::default()),
+        ));
+        let store = TableStore::new(uri, session);
         let batch = RecordBatch::try_new(
             Arc::new(Schema::new(vec![Field::new("body", DataType::Utf8, false)])),
             vec![Arc::new(StringArray::from(vec!["organism"]))],
@@ -434,10 +443,23 @@ mod tests {
         // wrong mirror must not pass just because our writer and reader agree.
         assert_native_siblings(&dataset, &index).await;
         let object_store = dataset.object_store(None).await.unwrap();
+        let path = certificate_path(&dataset, &index).unwrap();
+        let pooled_reader = TableStore::new(
+            uri,
+            crate::lance_access::LanceAccessContext::new().data_session(),
+        )
+        .open_dataset_head(uri, None)
+        .await
+        .unwrap();
+        let pooled_store = pooled_reader.object_store(None).await.unwrap();
+        assert!(!Arc::ptr_eq(&object_store, &pooled_store));
         object_store.io_stats_incremental();
         verify_index(&dataset, &index).await.unwrap();
         assert!(object_store.io_stats_incremental().read_iops > 0);
         verify_index(&dataset, &index).await.unwrap();
+        // Another graph's pooled client must not contaminate these counters.
+        // Keep this deterministic instead of relying on parallel test timing.
+        pooled_store.read_one_all(&path).await.unwrap();
         let warm = object_store.io_stats_incremental();
         assert_eq!((warm.read_iops, warm.write_iops), (0, 0));
 
@@ -481,7 +503,6 @@ mod tests {
             ));
         }
 
-        let path = certificate_path(&dataset, &index).unwrap();
         let original = object_store.read_one_all(&path).await.unwrap();
 
         let clone_uri = directory.path().join("clone.lance");

--- a/docs/dev/versioning.md
+++ b/docs/dev/versioning.md
@@ -9,7 +9,7 @@ version axes. Never derive one axis from another.
 | Axis | Policy | Guard |
 |---|---|---|
 | Release | Published workspace artifacts move in lockstep. | Workspace manifests, lockfile, generated metadata, release automation. |
-| CLI ↔ server wire | Additive and rolling-safe; no global version handshake. | Shared optional DTO fields and OpenAPI drift tests. |
+| CLI ↔ server wire | Prefer additive changes; documented breaking release boundaries require coordinated upgrades. No global version handshake. | Shared DTOs, OpenAPI drift tests, and release-specific migration guidance. |
 | Graph storage | Strict single version; rebuild across an incompatible change. | Main-manifest stamp with `MIN_SUPPORTED == CURRENT`. |
 | Recovery sidecar | Independently versioned persisted protocol. | Sidecar grammar/version refusal before classification. |
 | Lance dependency and file format | One deliberately pinned Lance family and explicit stable file version. | Lockfile, write parameters, and Lance surface guards. |
@@ -65,8 +65,8 @@ The operator procedure is documented in
 
 ## Wire compatibility
 
-CLI and server deployments may roll independently. Wire changes therefore stay
-additive:
+Prefer additive wire changes so compatible CLI and server releases can roll
+independently:
 
 - new request fields are optional or have a server-side default;
 - new response fields do not change existing field meaning;
@@ -74,7 +74,17 @@ additive:
   closed switches;
 - intentional API changes regenerate and commit `openapi.json`.
 
-Storage strictness is not a reason to add a wire-version gate.
+Do not infer wire compatibility from a shared graph-storage version. The
+v0.9/v0.10 boundary deliberately removes legacy graph-facing field names and
+public aliases; it is **not rolling-safe**. Upgrade CLI, server, and client
+integrations together according to the [v0.10 release notes](../releases/v0.10.0.md).
+The Lance 9/10 to 11 analyzer transition separately requires a quiesced fleet
+and explicit full-text rebuilds; see [the upgrade procedure](../user/operations/upgrade.md#full-text-index-upgrade).
+
+Future incompatible wire changes must identify the affected release boundary,
+document the consumer migration, and test fail-closed behavior where an older
+server could otherwise ignore a new write precondition. There is no global
+wire-version handshake; storage strictness is not a reason to add one.
 
 ## Registry publication status
 

--- a/docs/releases/v0.10.0.md
+++ b/docs/releases/v0.10.0.md
@@ -1,443 +1,192 @@
-# OmniGraph v0.10.0 (unreleased)
+# OmniGraph v0.10.0
 
-The next OmniGraph release moves the storage substrate to **Lance 11.0.0**.
-It keeps OmniGraph's internal manifest schema at v6 and ordinary recovery
-sidecars at v9: this is a dependency/correctness release, not an OmniGraph
-graph-format bump. Existing v0.9.0 graphs remain in the current storage strand.
+OmniGraph 0.10 adds graph-level Blob delivery, commit diffs and change feeds,
+conditional writes, benchmark tooling, and merge/read performance improvements.
+It upgrades the storage substrate from v0.9.0's Lance 9 to **Lance 11.0.0** while
+retaining graph storage format **v6**, recovery sidecars **v9**, and Lance
+**V2_2** data files. Existing v0.9 graphs do not require entity export/import.
 
-**Full-text upgrade required:** stop the old fleet and rebuild full-text indexes
-on each branch that needs search with `rebuild-full-text-indexes`. Unproven old
-indexes now return a rebuild-required error, rather than silently missing
-matches. Ordinary reads and retained history remain available; old snapshots
-may refuse full-text search. Do not run mixed Lance 10/11 readers or writers.
-See [the upgrade procedure](../user/operations/upgrade.md#full-text-index-upgrade).
+**Coordinated upgrade required.** CLI/HTTP JSON and public Rust vocabulary have
+changed; upgrade the CLI, server, and client integrations together. Stop the old
+fleet before opening the store with the new one. Do not mix Lance 9/10 binaries
+with Lance 11 readers or writers.
 
-**Channel note:** crates.io publication remains paused because access to the
-account owning the historical `omnigraph-*` package names is unavailable.
-Those registry packages remain frozen at 0.8.0 and must not be used for this
-release. Binaries continue to ship through the installer, Homebrew, Docker,
-and GitHub Releases; see the current policy in
-[versioning.md](../dev/versioning.md#registry-publication-status).
+**Rebuild full-text indexes on every branch that needs search.** Old indexes
+without compatible analyzer proof now fail explicitly instead of silently
+missing matches. Ordinary reads, traversal, and vector search remain available;
+historical snapshots are retained but may refuse full-text search. Preserve a
+verified whole-root backup for rollback and follow the
+[upgrade procedure](../user/operations/upgrade.md#full-text-index-upgrade).
 
 ## Highlights
 
-- **Explicit full-text rebuilding.** The branch-scoped maintenance command
-  replaces full-text indexes from current rows and publishes them together.
-  Ordinary optimize preserves full-text indexes rather than incrementally
-  folding postings with unproven analyzer compatibility; new rows remain
-  searchable through the uncovered-tail scan. Other index optimization and
-  data compaction continue normally.
-- **Recreated branches never alias their predecessors.** Each branch life now
-  owns an internal Lance ref named `{name}.{ulid}`, so deleting a branch and
-  creating another with the same name yields new storage paths and cache
-  entries by construction (the delete/recreate staleness class of #562:
-  `all columns in a record batch must have the same length`, or stale rows,
-  on a warm handle). `branch delete` acknowledges the manifest publication;
-  the old life's forks are reclaimed by `cleanup`. The branch name stays the
-  only public identity: a path segment ending in `.` plus 26 upper-case
-  letters and digits is now refused on every entry point, and
-  `native_dataset_branch` in snapshot responses carries the suffixed internal
-  name. Existing branches keep their bare refs unchanged. See
-  [RFC 0042](../rfcs/0042-incarnation-suffixed-branch-refs.md).
-- **Canonical graph vocabulary.** Graph operations and their human-facing
-  presentation now use node/edge types, entities, and properties; physical
-  OmniGraph storage units use Lance datasets. This intentionally changes
-  observable wording in help, errors, human output, current documentation,
-  public Rust symbols, and HTTP/CLI JSON. Legacy graph-facing names such as
-  `table_key`, `row_id`, ambiguous `manifest_version`, `rows_loaded`, and
-  `export --table` are removed rather than dual-emitted. Canonical replacements
-  distinguish graph-manifest versions, published dataset versions, Lance HEAD
-  versions, type names/keys, entity IDs/counts, and properties. Persisted Lance
-  and `__manifest` field names do not change; cluster observations now store
-  `graph_manifest_version` instead of the ambiguous `manifest_version` key,
-  and `embed --json` reports `records`, `selected_records`,
-  `embedded_records`, and `cleaned_records` instead of row-named counters,
-  while recovery-sidecar grammar remains unchanged. The renamed schema-layout heading
-  also retains the legacy `#table-layout` deep-link anchor. This is not a
-  rolling-safe v0.9↔v0.10 wire boundary: upgrade CLI and server together.
-- **Lance 11.0.0.** Adds overwrite/restore identity high-water marks and
-  ambiguous-commit verification to the correctness fixes introduced in Lance
-  10. Replacement fragments receive fresh IDs; restoring an older version
-  does not rewind allocation counters. The staged-write adapter accepts the
-  new inline row-ID wrapper without changing its serialized bytes.
-  Unknown commit outcomes remain typed `Unknown`, including when their inner
-  cause is a timeout, missing manifest, or conflict. Native branch tags now
-  block force deletion until explicitly removed. The dependency lock also
-  takes upstream's fix for unbounded empty HTTP/2 DATA frames on the h2 0.4
-  dependency line, now 0.4.16. The AWS SDK's separate legacy h2 0.3 line is
-  unchanged.
-  Scanner row limits and byte targets now compose; strict row coalescing with
-  a byte target is rejected. Benchmark scans retain both bounds without the
-  previous strict-batching workaround.
-  Retains the fix for the stable-row-ID deleted-index alignment defect
-  reachable from OmniGraph's delete + `optimize_indices` path (#7704), and
-  hardens stale CreateIndex coverage (#8011). Lance's flat parallel KNN fix
-  (#7868) remains incomplete when ordinary payload is late-hydrated; OmniGraph
-  temporarily uses one DataFusion output partition for `nearest`, preserving
-  exact rank while Lance keeps concurrent reads/decodes within that partition.
-- **Declarative benchmark telemetry.** The non-gating `omnigraph-bench` tool
-  executes strict YAML-defined branch-merge points from identical frozen
-  fixture state, records per-phase wall time and logical store calls, and can
-  publish complete or explicitly censored canonical run-record-v1 JSON from a
-  clean release build. Censored records contain only a non-empty verified
-  repetition prefix, remain permanently claim-ineligible, and never turn a
-  failed command into success.
-  Records are content-addressed and reached through immutable invocation
-  pointers; `archive verify` streams and rechecks identity and bytes. Fixture
-  construction and every repetition use the configured worker bytes;
-  their attestation records the executable digest,
-  Cargo/compiler observations, checked-in release-profile declarations, and
-  actual engine Cargo features while refusing unmodeled runtime overrides.
-  Fixture and repetition children clear inherited environment, pin locale, and
-  use protocol-owned same-backend scratch as `TMPDIR` and cwd; measured workers
-  also bind merge staging to their per-repetition scratch. The only inherited engine
-  setting is admitted `LANCE_MEM_POOL_SIZE`, which is part of SUT identity;
-  process-runtime thread-count overrides are refused. Every raw sample persists
-  supervisor-observed peak RSS, and local archival revalidates the clean source
-  checkout with raw-byte and bound-Git semantics before preflight and every
-  publication boundary. Engine-feature identity includes Cargo's `default`
-  feature and refuses manifest/registry or implicit-feature drift.
-  Effective LTO/codegen/strip options are explicitly unproved pending a
-  controlled digest-bound build receipt; consequently, even complete local
-  records project `claim_eligible: false` and cannot authorize a performance
-  conclusion. Exact logical/physical fixture stamps are sealed
-  before measurement. A separate OmniGraph projection is rebuilt from the archive
-  into immutable generations, verifies every projected field, and exposes
-  bounded fixed point/run queries. Archive inventory capture is coherent with
-  concurrent immutable-pointer publication; readers durability-close each
-  visible file through its captured archive-root ancestor chain or fail. The
-  JSON archive remains authority, so the projection can be deleted and
-  reconstructed. Archive-mode
-  suite execution releases raw samples after each immutable record and returns
-  only bounded counts/receipts; indeterminate directory-sync outcomes retain a
-  typed reconciliation identity. Physical cloud attempts, comparison/noise-floor
-  reports, and controlled cloud orchestration remain future slices.
-  The local runner also admits the checked-in process-fresh XFS suite on EC2
-  instance-store NVMe. Its verified plain-copy reset runs outside timing and
-  explicitly leaves the OS page cache uncontrolled.
-  A separate `omnigraph-bench fixture fingerprint`/`fixture verify` interface prints a
-  strict, location-free physical copy-source descriptor for a stable local
-  tree, binds later copies by full physical digest, and returns the canonical
-  descriptor digest. `fixture preflight-copy --fixture ID=BUNDLE` additionally
-  verifies the source while copying it through harness-owned disposable
-  scratch, verifies the copy, and completes cleanup without persisting local
-  paths. This is physical audit/reset evidence only and does not enter
-  benchmark point identity. `fixture reference validate` now strictly parses a
-  separate versioned imported-graph declaration containing builder provenance,
-  exact node/edge inventories, Data/State, and a required expected logical
-  content digest. It emits a normalized whole-reference audit digest. The
-  document-only command does not certify a graph by itself; `fixture
-  validate-graph` binds the declaration to copied bytes through canonical graph
-  hashing, and `fixture run-graph` executes the fixed FinGraph adapter. That
-  adapter remains claim-ineligible and outside the durable archive.
-- **Typed storage failures (RFC 0038).** The Rust API replaces the exhaustive
-  `OmniError::Lance(String)` variant with
-  `OmniError::Storage(StorageFailure)`. Embedded callers can inspect the closed
-  `StorageFailureKind` taxonomy (`Transient`, `Configuration`, `NotFound`,
-  `Precondition`, `Permanent`, `Unknown`) without parsing upstream text.
-  Direct `omnigraph-storage` consumers must also migrate the public
-  `StorageError` shapes: handle the new `Backend(StorageFailure)`, update tuple
-  `Io` matches to `Io { failure, source }`, and remove
-  `CreateIfAbsentUnsupported` matches. Automatic `From<std::io::Error>`
-  conversion remains and now produces the structured `Io` variant.
-  `is_transient()` reports only positive transient evidence; it is not a replay
-  decision, and no generic retry API is added. Public `object_store`
-  `HttpErrorKind` transport failures are typed, but exhausted 408, 429, and 5xx
-  status wrappers in `object_store` 0.13.2 remain `Unknown` pending upstream
-  support. Ambiguous public `Request` and `Decode` client errors likewise stay
-  `Unknown`; only positive transport evidence becomes `Transient`. Lance 11 can
-  likewise erase a top-level multiply-owned
-  `DataFusionError::Shared` or an error crossing `ReplayExec` before OmniGraph
-  sees it; those fall back to `Unknown`. `Unknown` never authorizes replay.
-  Genuine adapter and Lance storage diagnostics keep their complete historical
-  display text. Arrow batch/shape failures owned by manifest machinery now map
-  to internal errors, persisted Blob descriptor contradictions remain
-  `BlobIntegrity`, and user query failures remain `DataFusion`. Generic storage
-  errors still map to HTTP 500, with no OpenAPI, graph-format, or
-  manifest-schema migration.
-- **Native Azure Blob storage preview.** Graph and cluster roots now accept strict
-  `az://<container>/<prefix>` URIs through Lance and the shared control-object
-  adapter, with real Blob ETag CAS and fail-closed unknown-scheme handling.
-  Azurite exercises storage, recovery, cluster, server, CLI, and the separate
-  `omnigraph-azure-admission` lease wrapper. The checked-in Container Apps
-  reference keeps the existing single-writer boundary by admitting exactly one
-  server or bootstrap process; the lease is deployment admission, not a
-  distributed engine fence. Code, hermetic Azurite qualification, and a live
-  managed-identity deployment smoke proof are complete; the RFC's disruptive
-  concurrency, forced-termination, and lease-break qualification remains
-  pending. Native Azure is therefore not production-supported in this release.
-  Preview deployments must use the admission wrapper and recovery runbook.
-- **Blob correctness.** Valid empty Blobs remain distinct from null through
-  compaction (#7965/#8070), selection preserves one ordered result per request
-  with explicit nulls (#7903/#8003). Exact raw-Lance and graph-level `optimize`
-  guards pin null, empty, neighbouring payload, stable row-ID, and
-  fragment-reduction behavior. `.gq` now rejects Blob-valued projection,
-  ordering, and aggregation instead of returning plausible null placeholders;
-  newly admitted schemas also reject Blob members in body-level
-  `@unique(...)` instead of failing later during value canonicalization. A v6
-  root already admitted with that historical shape remains openable for
-  inspection and export, but the compatibility reader does not make the
-  constraint functional or permit it in init/schema apply; rebuild with the
-  invalid constraint removed.
-- **Snapshot-aware embedded Blob reads.** The engine now reads one logical node
-  or edge Blob cell through `read_blob_at` at an explicit branch or snapshot.
-  Managed values expose an engine-owned `Send + Sync` reader and a strong
-  dataset-version-granular ETag bound to the exact opened immutable Lance
-  manifest's non-empty `transaction_file` identity; same-version branch
-  deletion/recreation cannot reuse it, and a missing witness is
-  `BlobIntegrity`. External values return their stored descriptor
-  without probing or reading the referenced object. Half-open ranges require
-  `start <= end <= length`, accept empty-at-end, and return at most 4 MiB per
-  call. Malformed persisted descriptors and invalid ranges are matchable
-  `BlobIntegrity` and `BlobRangeNotSatisfiable` errors rather than plausible
-  nulls or Lance strings. The current type alias binds across pure type-rename
-  history by stable identity, subject to the independent property and branch
-  fences; the retired alias is not retained. Crossing a historical property
-  rename to its old physical field is deferred and fails loudly. This is the
-  engine foundation used by the HTTP delivery surface below; no public API
-  exposes Lance placement or `BlobFile`.
-- **Graph-level HTTP Blob delivery.** `GET` and explicit `HEAD` on
-  `/graphs/{graph_id}/blob` select one logical node or edge property by
-  `entity`, `type`, `id`, and `property`, plus a branch or immutable snapshot.
-  Managed GET supports full and single-range reads, strong ETags,
-  strong `If-Match`, weak `If-None-Match`, strong `If-Range`, and exact
-  `200`/`206`/`304`/`412`/`416`
-  headers; every managed response identifies its exact selected graph through
-  `Omnigraph-Snapshot-Id`. HEAD ignores Range/If-Range, honors
-  If-Match/If-None-Match, and performs no payload read. Payload work is
-  backpressured in
-  chunks no larger than 4 MiB with at most two chunks/8 MiB retained per
-  response, and disconnect cancels promptly. External descriptors return an
-  exact `302 Location` with `Cache-Control: no-store` and zero target-object
-  I/O. Only whole-object external descriptors redirect; a persisted ranged
-  external descriptor fails loudly rather than widening the logical value to
-  the complete target object. The selector remains graph-level—physical
-  datasets and per-dataset lanes are not part of the wire contract.
-- **Graph-level CLI Blob reads.** `omnigraph blob get` streams one managed node
-  or edge property as raw bytes to stdout or `--out`; complete,
-  offset-plus-length, offset-to-end, and length-from-zero reads work identically
-  against embedded and served graphs. Requested zero length and overflow fail
-  before resolution; an end beyond EOF is clamped, while an unsatisfiable start
-  fails before payload transfer. A full get of a valid empty Blob succeeds with
-  zero bytes. `omnigraph blob stat` reads metadata only and reports the logical
-  selector, managed size plus ETag or external URI, and the exact resolved
-  graph-view witness. That value is opaque: a live branch normally produces a
-  synthetic graph-manifest witness rather than a commit ULID, and its ETag suffix can
-  differ after copying the graph to another store. The CLI never follows
-  external references: for a whole-object descriptor, `stat` reports the URI
-  without target I/O and `get` refuses with the URI and a stat suggestion.
-  Ranged external descriptors fail loudly on both verbs rather than widening
-  the logical value to the complete target object. Blob commands use `--store`, `--server`
-  plus `--graph`, or store/server profiles and defaults; their positional
-  arguments are the cell selector, so no positional graph URI or `--cluster`
-  is accepted; the read-only verbs also reject `--as`. A failure after
-  streaming begins exits nonzero but may leave already emitted stdout or a
-  partial `--out` prefix, while a pre-transfer failure leaves an existing path
-  untouched. Use a temporary file plus rename when atomic file replacement is
-  required after transfer begins.
-- **Named-branch Blob reads fail closed without an incarnation witness.** An
-  explicit snapshot's reopened graph manifest must still carry the resolved graph
-  commit, including when its backing dataset is inherited from main. V6 entries do not
-  persist Lance's native branch identifier, and a Lance dataset-manifest e-tag is not a
-  sufficient substitute, so a named-native-branch dataset bypasses the held
-  handle cache and is cold-rechecked against the selected graph ref's effective
-  head after opening. A raced live read and an older branch-owned snapshot
-  return `BadRequest` with `no persisted native-branch incarnation witness`
-  instead of risking same-name/same-version branch ABA. Genuine inherited-main
-  history remains eligible after the graph-snapshot proof; property/schema
-  checks still apply.
-- **Blob property-lifetime fencing.** Physical user fields newly initialized,
-  added, or schema-rebuilt by 0.10 persist `omnigraph.stable_property_id`. A
-  schema-preserving Append, Merge, or mutation write after upgrade retains an
-  unmarked pre-0.10 schema; full-type Overwrite carries the 0.10 catalog schema
-  and adopts the marker on its replacement fields. Blob reads compare that graph
-  identity so a soft-dropped property re-added under the same name cannot adopt
-  the retired value; Lance field IDs are never graph identity. Pre-0.10 v6
-  fields have no marker: an exact current physical dataset entry remains readable,
-  while every older snapshot fails `BadRequest` with `no persisted
-  property-lifetime witness`, even when no rename occurred. This adds field
-  metadata without changing manifest schema v6 or rewriting old versions in
-  place.
-- **External Blob ingress is secure by default.** New external URI references
-  are denied unless the graph has exact normalized allow bases. Cluster config
-  carries the policy per graph; server execution drops embedded-only entries
-  and never admits `file://`. Every distinct allowed source is probed before a
-  durable write effect, with at most eight probes in flight. Every Mutation/Load
-  mode—including Overwrite—admits at most 8,192 new external-URI cells across
-  the complete multi-dataset operation; this is a separate source-ingress bound,
-  not Overwrite's keyed-entity ceiling. Overwrite preserves the normalized
-  reference (and canonicalizes embedded local-file targets), while keyed
-  writes materialize it under the existing 32 MiB ceiling. Existing
-  stored references remain readable and exportable under deny. A direct-store
-  CLI open has no allow-policy source in this phase and therefore remains
-  deny-only; use a cluster-served graph with configured bases or install the
-  policy through the embedded builder when new external-reference ingress is
-  required.
-- **Struct reconstruction hardening.** Generic all-null Arrow structs preserve
-  their parent validity during column reconstruction (#8049). Blob-v2 physical
-  cells are structs, so this is relevant defense in depth, but upstream has no
-  Blob-specific reproducer and OmniGraph does not present it as one.
-- **Decoder hardening.** Includes the length-prefix and variable-width offset
-  decoder fixes from #8138/#8144. Those fixes were also backported to Lance
-  9.0.1; OmniGraph takes 11.0.0 for the broader correctness set rather than
-  cutting an intermediate v0.9.1.
-- **Crash-safe manifest initialization.** A fresh `__manifest` now finishes at
-  Lance version 1 instead of version 3. Its entries, genesis lineage, and
-  internal-schema stamp all ride the initial Create commit. The unused
-  `table_version_management` config update and the separate schema-stamp update
-  were removed, closing the crash window in which a manifest could exist with
-  a modern layout but no stamp. This does not change OmniGraph's internal
-  manifest schema version. Initialization cleanup now also stops at the
-  physical-init boundary: failures returned before any Lance dataset Create is
-  invoked may clean their owned schema files, while every error after physical
-  initialization begins is followed by an exact genesis probe. An unavailable or mismatched probe
-  preserves the files and init claim behind a typed
-  indeterminate outcome. An exact committed genesis recovers the lost
-  acknowledgement, while a later read-back or validation failure reports a
-  typed committed outcome without promising that the graph is openable. A
-  durable `__init_claim.json` prevents concurrent force recovery from
-  overwriting or deleting another initializer's schema contract; a stopped
-  initializer may leave a claim that operators must inspect only after
-  quiescing every initializer for that root. Opening a
-  readable manifest without `_schema.pg` now names the missing contract and
-  points to backup or existing-export recovery rather than claiming every data
-  dataset is present.
-- **Graph-head conditional mutations.** Canonical read responses now carry the
-  `graph_commit_id` of the exact snapshot that produced their rows. Pass that
-  raw id back as `Omnigraph-If-Graph-Commit` on the dedicated
-  `/mutate/if-graph-commit` route (or
-  `/queries/{name}/if-graph-commit` for a stored mutation), or as
-  `omnigraph mutate --if-commit <id>`; a stale token fails before effects with
-  HTTP 412 and structured `precondition_failure` details (CLI exit 4). The
-  dedicated route also makes a newer CLI fail closed against an older server:
-  unsupported conditional writes return 404 before executing instead of having
-  their header ignored. Ordinary mutation routes reject the conditional header.
-  The deprecated `/read` response remains byte-stable and omits the new field;
-  current CLI remote reads use canonical `/query`. This compare-and-swap
-  guarantee applies to concurrent requests within OmniGraph's supported
-  single-writer-process topology. The process-local gate is not a distributed
-  lease: an unsupported foreign writer can race after local arbitration, in
-  which case exact publication prevents a silent lost update but the loser may
-  require recovery and return HTTP 503 rather than 412.
-- **Exact write receipts.** Mutation and Load responses now carry the exact
-  `GraphCommit` returned by the same graph-manifest CAS that made the write visible;
-  they do not infer a receipt by rereading the branch head. Effectful ordinary,
-  conditional, and stored mutations return that commit, while a mutation that
-  changes no entities returns `commit: null` and creates no lineage entry. Load and
-  bounded NDJSON ingestion always publish one commit and return it through the
-  embedded, CLI, and HTTP surfaces.
-- **Bounded multi-dataset mutation staging.** Constructive multi-type mutations
-  now overlap independent existing-dataset Lance fragment preparation at
-  `OMNIGRAPH_LOAD_CONCURRENCY` (default 8), matching Load. Deferred first-touch
-  branch effects and deletes remain serial, and all participants still publish
-  through one graph commit.
-- **Entity changes, durable feed, and baselines.** RFC 0030 C0–C3 now ships
-  exact first-parent commit diffs, a stateless at-least-once change feed, and
-  an exact baseline/reset handshake through the embedded, HTTP, and CLI
-  surfaces. Pages are bounded by change and byte ceilings; opaque continuation
-  tokens and terminal feed cursors bind the graph, branch incarnation, filter,
-  and exact captured cut. A reclaimed historical version returns a typed 410
-  gap rather than a partial diff; install a streamed baseline durably before
-  resuming from its terminal cursor.
-- **Compiled query operation descriptors.** Successful `omnigraph lint --json`
-  results now include ordered, structured result fields plus deterministic
-  graph read/write facts from one compiler-owned descriptor. Reads conservatively
-  include dependencies inside nested `not { ... }`, mutation targets, and
-  inserted-edge endpoints; writes exactly include every graph type the mutation may
-  change, including incident edge types affected by a node-delete cascade.
-  Invalid queries emit no partial descriptor. The shared compiler surface is
-  ready for later server and SDK projection without duplicating inference.
-- **Required query parameters fail closed.** Embedded, CLI, and HTTP query
-  execution now rejects an omitted non-nullable parameter before scanning.
-  Node-property matches no longer drop an unresolved parameter filter and
-  silently return every row; nullable parameters remain optional. Inline
-  property matches also reject undeclared variables during typechecking,
-  including inside negation, rather than silently omitting the filter.
+- **Blob reads through the engine, HTTP, and CLI.** Select a node or edge Blob
+  property at a branch or snapshot. `blob get` streams bytes; `blob stat` reads
+  metadata. HTTP GET/HEAD support ranges and conditional delivery. Managed
+  readers are bounded; valid empty values remain distinct from null through
+  compaction. Whole-object external references return their URI without target
+  I/O; HTTP redirects, while the CLI never follows them. See [Blobs](../user/blobs.md).
+- **Secure external-Blob ingress.** New URI references are denied by default and
+  require configured, normalized allow bases. Server execution never admits
+  `file://`; direct-store CLI access remains deny-only. Existing references
+  remain readable/exportable. Writes probe allowed sources before durable
+  effects and bound new external references across the whole operation.
+- **Exact write receipts and conditional mutations.** Mutation and Load return
+  the `GraphCommit` published by that attempt, not a later branch-head lookup.
+  A no-op mutation returns `commit: null`. Canonical reads expose their exact
+  `graph_commit_id`; `mutate --if-commit` and dedicated HTTP conditional routes
+  reject stale tokens before effects with HTTP 412 / CLI exit 4. Older servers
+  reject the dedicated route rather than executing an unguarded write. See
+  [mutations](../user/mutations/index.md).
+- **Commit diffs, change feeds, and baselines.** Embedded, HTTP, and CLI surfaces
+  provide exact first-parent entity diffs, bounded at-least-once feed pages,
+  and streamed baseline/reset handshakes. Cursors bind graph, branch lifetime,
+  filters, and a captured cut; consumers own their checkpoints. Retention gaps
+  return typed HTTP 410, not a partial diff. Install the complete baseline
+  durably before saving its terminal resume cursor. See
+  [changes and change feeds](../user/branching/changes.md).
+- **Less work for merges and reads.** Eligible merges classify candidates from
+  fragment lineage instead of scanning every entity; unsupported cases retain
+  the full-scan fallback. Warm catalog refresh reads newly published commits
+  incrementally. Ordinary node scans omit unneeded properties where safe, and
+  constructive multi-type mutations prepare independent datasets concurrently
+  while still publishing one graph commit.
+- **Safer branch reuse and merge behavior.** Deleting and recreating a branch
+  no longer reuses its predecessor's native paths/cache identity. Deletion
+  acknowledges graph publication; `cleanup` reclaims the retired forks.
+  Branches whose edits net to zero can be merged, and traversal now includes
+  stored self-loop edges. See [branching](../user/branching/index.md).
+- **String predicates and stricter query validation.** String `contains` and
+  `starts_with` provide exact, case-sensitive substring/prefix matching, with
+  index acceleration where available and correct scan fallback. Missing
+  required parameters fail before execution; undeclared variables in inline
+  property matches, including negation, fail during typechecking. Nullable
+  parameters remain optional. Blob projection, ordering, aggregation, and
+  newly declared Blob uniqueness constraints are rejected explicitly.
+- **Initialization and recovery hardening.** Graph creation publishes its
+  initial contents and schema stamp together. An initialization failure no
+  longer deletes a graph that actually committed; typed outcomes distinguish
+  committed, indeterminate, and claimed roots. A live write handle can heal
+  stranded, effect-free recovery intents without reopening, within the existing
+  single-mutation-process boundary.
+- **Lance correctness fixes.** Includes stable-row-ID delete/index alignment,
+  Blob compaction/selection, decoder hardening, and overwrite/restore identity
+  high-water marks. Ambiguous commit outcomes remain `Unknown`, never a reason
+  to replay automatically. OmniGraph retains its final-output-partition fence
+  for exact `nearest` ranking. The h2 0.4 dependency line advances to 0.4.16;
+  the AWS SDK's separate legacy h2 0.3 line is unchanged.
 
 ## Developer-facing
 
-- Branch-merge instrumentation now exposes stable additive phase identifiers,
-  accumulated and maximum microsecond timings, and exact completed-interval
-  counts through `MergeWriteProbes::merge_timing_snapshot`. The new
-  `TableWalk` phase identifies each general three-way ordered staging walk;
-  proven-insert routes report none. Production leaves the task-local probe
-  unset and performs no timing clock reads.
-- The benchmark CLI can register, byte-verify, logically validate, and run a
-  fixed node-and-edge FinGraph merge diagnostic from declarative fixture and
-  run YAML. It uses APFS clonefiles on macOS or verified full-copy reset on
-  direct EC2 instance-store NVMe-backed XFS, waits for reset writeback outside
-  timing, and records measured-worker machine and backend evidence. It remains
-  intentionally claim-ineligible without durable telemetry or AWS dispatch.
+- **Declarative benchmarks.** `omnigraph-bench` runs YAML-defined merge cases
+  from identical frozen fixture state in isolated workers, recording phase
+  timings, logical store calls, peak RSS, fixture identity, and source/binary
+  provenance. Clean release builds can archive complete or explicitly censored
+  canonical JSON; a disposable OmniGraph projection provides bounded queries
+  over that archive. Censored runs remain failures. Local records remain
+  `claim_eligible: false` without a controlled, digest-bound build receipt;
+  logical calls are not physical cloud requests. The separate FinGraph
+  node-and-edge diagnostic supports qualified APFS or EC2 instance-store
+  NVMe/XFS fixtures but does not publish durable telemetry or dispatch AWS jobs.
+  See the [harness guide](../../crates/omnigraph-bench/README.md) and
+  [fixture commands](../../benchmarks/README.md).
+- **Merge timing hooks.** `MergeWriteProbes::merge_timing_snapshot` exposes
+  stable phase identifiers, total/max microseconds, and completed intervals.
+  `TableWalk` identifies general three-way staging walks; proven-insert paths
+  emit none. Normal production execution leaves the task-local probe unset and
+  performs no timing clock reads.
+- **Compiled operation descriptors.** `lint --json` now includes ordered result
+  fields and compiler-owned read/write dependencies, including nested negation,
+  inserted-edge endpoints, and node-delete cascades. Invalid queries emit no
+  partial descriptor. Server/SDK descriptor projection is not included.
+- **Typed storage failures.** Rust callers can inspect `StorageFailureKind`
+  (`Transient`, `Configuration`, `NotFound`, `Precondition`, `Permanent`,
+  `Unknown`) instead of parsing Lance error strings. Positive transient
+  evidence is not replay authorization; erased or ambiguous evidence remains
+  `Unknown`. Generic storage errors still map to HTTP 500.
 
 ## Compatibility
 
-- Internal manifest schema remains **v6**.
-- Ordinary recovery sidecar schema remains **v9**. Sidecar table pins now
-  name a branch's native `{name}.{ulid}` ref; the sidecar `branch` field stays
-  the logical name.
-- The embedded `OmniError` enum adds `InitializationCommitted`,
-  `InitializationIndeterminate`, `InitializationClaimed`,
-  `HistoricalVersionReclaimed`, `ChangeCursorRejected`, `BranchNotFound`,
-  `ChangeFeedGap`, `CommitHasNoParent`, and `ChangeSchemaBoundary`. Exhaustive
-  Rust matches must handle the new variants. The initialization variants
-  preserve the distinction between a confirmed graph-manifest commit, an outcome
-  that cannot be classified, and a root reserved by another attempt; the
-  change variants preserve absence, caller-invalid continuation, retention,
-  and exact-diff refusal without error-text parsing. No HTTP graph-create route
-  is exposed. `__init_claim.json` is a transient control object, not an
-  internal-manifest or recovery-sidecar format change.
-- OmniGraph continues to write explicit Lance **V2_2** data files.
-- Physical user fields newly initialized, added, or schema-rebuilt by 0.10 add
-  `omnigraph.stable_property_id` metadata without changing manifest schema v6.
-  Schema-preserving Append, Merge, and mutation writes retain an upgraded
-  dataset's unmarked schema; full-type Overwrite adopts the 0.10 catalog schema
-  and marker on its replacement fields without rewriting old versions. A
-  pre-0.10 v6 field without that marker is readable only when the selected
-  snapshot points at its exact current physical dataset entry; every older
-  snapshot fails `BadRequest`, even without a rename, rather than inferring
-  property lifetime from Lance field ID or same-name spelling.
-- The pre-1.0 embedded `Omnigraph::read_blob` API, which returned Lance's
-  `BlobFile`, is removed. Use `read_blob_at` and consume managed values through
-  consecutive ranges no larger than `BLOB_READ_RANGE_MAX_BYTES` (4 MiB). No
-  compatibility wrapper continues exposing Lance placement or reader behavior.
-- CLI `blob get/stat` output is an additive 0.10 contract. `get` writes raw
-  bytes, not base64 or a JSON envelope. Structured stat omits inapplicable
-  fields: managed values carry `size` and `etag`; whole-object external values
-  carry `uri`; ranged external descriptors fail loudly. Successful stat output
-  carries `selector` and an exact opaque `target.resolved_snapshot`; an
-  explicitly requested snapshot is echoed separately as `target.snapshot`.
-  `blob put` and `blob clear` remain future RFC 0033 Phase 3 work.
-- A returned Blob reader stays on its captured version across branch advance.
-  It is not a durable or cross-process reclamation pin. Branch deletion/tree
-  reclamation and destructive version GC may make an uncached later range fail
-  loudly, so quiesce readers first when they must finish. A reader never switches
-  to newer or partial bytes.
-- Every explicit Blob snapshot authenticates its reopened graph manifest's
-  exact commit, and every named-native-branch Blob dataset bypasses the held
-  handle cache and is cold-rechecked against the selected graph ref's effective
-  head because v6 persisted no native branch-incarnation witness. A raced live
-  capture and an older branch-owned snapshot are refused. Genuine
-  main/inherited-main dataset history remains eligible after graph-snapshot
-  authentication; property/schema checks still apply. This is a conservative
-  read boundary, not a graph format change.
-- An applied external-Blob allow policy adds an optional field to the cluster
-  state ledger, which a v0.9 control-plane binary rejects. Before rolling a
-  cluster back to v0.9, use the v0.10 binary to remove `external_blobs` from
-  each graph and run `cluster apply` to convergence. That makes the ledger
-  parseable by v0.9 by removing the optional field and restoring the historical
-  graph-resource digest; it does **not** carry default-deny enforcement into
-  v0.9. The v0.9 writer admitted arbitrary supported external URIs, including
-  `file://`. Quiesce writers before the transition and replace the whole serving
-  fleet—never run mixed v0.9/v0.10 writers. If the external-ingress boundary is
-  required, do not roll back to v0.9. Changing only `cluster.yaml`, or
-  hand-editing `state.json`, is not a supported state-shape transition.
+### CLI, HTTP, and embedded API
+
+- Graph-facing names now distinguish nodes/edges, types, entities, properties,
+  graph-manifest versions, and published dataset versions. Legacy aliases such
+  as `table_key`, `row_id`, ambiguous `manifest_version`, `rows_loaded`, and
+  `export --table` are removed rather than dual-emitted. Update consumers to
+  the release's [OpenAPI contract](../../openapi.json) and
+  [CLI reference](../user/cli/reference.md); this is not a rolling-safe
+  v0.9/v0.10 boundary. `embed --json` uses record-named counters, and cluster
+  observations use `graph_manifest_version`.
+- New branch lives use internal native refs named `{name}.{ulid}`;
+  `native_dataset_branch` reports that name. Existing bare refs remain valid.
+  Public branch paths ending a segment in `.` plus 26 upper-case letters/digits
+  are reserved and refused. See [RFC 0042](../rfcs/0042-incarnation-suffixed-branch-refs.md).
+- `OmniError::Lance(String)` becomes `OmniError::Storage(StorageFailure)`.
+  Direct storage consumers must handle `StorageError::Backend`, replace tuple
+  `Io` matches with `Io { failure, source }`, and remove
+  `CreateIfAbsentUnsupported` matches. Exhaustive error matches must also cover
+  new initialization, Blob, precondition, change-feed, and full-text rebuild
+  outcomes; see the [error definitions](../../crates/omnigraph/src/error.rs).
+- The embedded `read_blob` API exposing Lance's `BlobFile` is removed. Use
+  `read_blob_at`; each managed range is at most 4 MiB. CLI/HTTP stream larger
+  values. CLI `get` outputs raw bytes and a failed transfer can leave a partial
+  file; use temporary-file replacement when required. Treat resolved Blob
+  snapshot witnesses and ETags as opaque, not as commit IDs or content hashes.
+
+### Full-text indexes and retained history
+
+`rebuild-full-text-indexes` replaces every planned index on the selected branch
+from current entities and publishes them in one graph commit. It uses the
+default English analyzer, warns that custom tokenizer settings are replaced,
+and refuses unknown physical index kinds before publication. Rebuild each live
+branch that needs search; other branches and historical snapshots are not
+rewritten. Restoring an older snapshot can require another rebuild.
+
+Ordinary `optimize` preserves existing full-text indexes rather than folding
+uncertified postings. Unindexed entities remain searchable through a scan; use
+the explicit rebuild command to refresh coverage. Other index reconciliation
+and compaction continue normally. See [maintenance](../user/operations/maintenance.md).
+
+### Blob identity and rollback
+
+- New or schema-rebuilt fields carry stable property-lifetime metadata.
+  Schema-preserving writes retain an upgraded dataset's old unmarked schema;
+  full-type Overwrite adopts the new metadata. An unmarked pre-0.10 Blob field
+  is readable only at its exact current physical dataset entry; older entries
+  are refused even if no rename occurred. Historical property renames and
+  older branch-owned snapshots can also be refused when identity cannot be
+  proven. Current type aliases can resolve pure type-renamed history; retired
+  aliases do not remain available. Details: [Blob identity](../dev/blob.md).
+- Readers hold their selected version but do not pin it against branch deletion
+  or destructive cleanup. Quiesce readers when they must finish. Persisted
+  ranged external descriptors are refused, never widened to whole objects.
+- A pre-existing v6 schema with a Blob uniqueness constraint remains openable
+  for inspection/export, but that constraint is not made functional. Rebuild
+  with the invalid constraint removed.
+- Configuring `external_blobs` changes cluster state in a way v0.9 rejects.
+  A downgrade also loses default-deny external ingress. Removing the field is
+  not a full-text rollback: restore the whole pre-upgrade graph backup with
+  the old fleet. Follow [cluster rollback](../user/operations/upgrade.md#cluster-state-and-rollback).
+
+## Support boundaries and distribution
+
+- **Azure Blob storage is a preview, not production-supported.** Native
+  `az://` roots, Azurite qualification, and a managed-identity smoke proof are
+  available. The disruptive live-Azure qualification matrix remains pending.
+  Preview writes must use `omnigraph-azure-admission`; its lease admits one
+  writer process and is not a distributed engine fence.
+- **One mutation process per graph remains the supported topology.** Conditional
+  writes and recovery do not introduce distributed writer fencing. Full-text
+  rebuilding is direct-storage maintenance, not an HTTP endpoint; `--as` is
+  attribution, not server-policy authorization.
+- **crates.io publication remains paused.** Historical `omnigraph-*` registry
+  packages are frozen at 0.8.0 and are not this release. Binaries ship through
+  GitHub Releases, the installer, Homebrew, and Docker. See
+  [distribution policy](../dev/versioning.md#registry-publication-status).
 
 ## Development-line note
 
-An earlier, unreleased development line also used the number 0.10.0 while
-exploring RFC 0026 and internal manifest formats v7-v19. No binary or graph from
-that line was released. The experiment was rejected, its formats are abandoned
-and refused, and this release is a fresh continuation from v0.9.0 on manifest
-v6. The retained decision and evidence are in
-[Ingestion](../dev/ingestion.md); the rejected design remains in
+An earlier unreleased experiment also used 0.10.0 while exploring manifest
+formats v7–v19. Those abandoned formats remain refused. This release continues
+from released v0.9.0 on v6; see [ingestion](../dev/ingestion.md) and
 [RFC 0026](../rfcs/0026-memwal-streaming-ingest.md).

--- a/docs/user/operations/upgrade.md
+++ b/docs/user/operations/upgrade.md
@@ -1,4 +1,4 @@
-# Upgrade across a storage-format change
+# Upgrading OmniGraph
 
 OmniGraph intentionally supports one storage format per binary. When a release
 changes that format, the new binary refuses the old graph and tells you which
@@ -12,7 +12,21 @@ release line can export it. Upgrade by rebuilding at a new URI:
 
 Ordinary patch/minor upgrades that keep the same storage format do not require
 this export/import procedure. Derived indexes may still need rebuilding, as
-below. Check the [release notes](../../releases/) before upgrading.
+below, and CLI/API compatibility is independent of graph storage. Check the
+[release notes](../../releases/) before upgrading.
+
+## v0.9 to v0.10
+
+Released v0.9.0 uses Lance 9; v0.10.0 uses Lance 11. Both use graph storage
+format v6, so existing entities, branches, and retained history do not need an
+export/import migration. Development builds using Lance 10 follow the same
+full-text upgrade procedure below.
+
+The CLI/API vocabulary changes are not rolling-compatible. Update the CLI,
+server, and client integrations together, with application traffic stopped.
+Even without full-text indexes, do not run an old and new fleet against the
+same graph. Keep the old executables and a verified whole-root backup until the
+upgrade is proven. See the [v0.10 compatibility notes](../../releases/v0.10.0.md#compatibility).
 
 ## Full-text index upgrade
 
@@ -33,8 +47,10 @@ full-text queries until the selected indexes have been rebuilt.
    a rollback backup. For a cluster-managed graph, the root is
    `<cluster-root>/graphs/<graph-id>.omni`; retain the deployment bundle and
    configuration too. Keep any externally referenced storage available.
-3. Upgrade the CLI and the entire serving fleet together, leaving application
-   traffic stopped. Do not mix Lance 10 and Lance 11 readers or writers.
+3. Stop every old server, embedded writer, and maintenance process. Upgrade the
+   CLI and entire serving fleet together, leaving application traffic stopped.
+   Do not mix Lance 9/10 and Lance 11 readers or writers. Keep the server stopped
+   while the new direct-storage maintenance CLI rebuilds indexes.
 4. Use the new operator CLI to rebuild each branch on the inventory checklist:
 
    ```bash
@@ -51,16 +67,18 @@ full-text queries until the selected indexes have been rebuilt.
    Rebuilding replaces custom tokenizer settings with the default English
    analyzer and reports that warning. See [maintenance](maintenance.md#rebuild-full-text-indexes).
 
-5. Verify representative searches and entity counts before resuming service.
+5. Verify representative searches and entity counts on **every rebuilt branch**.
    Include words affected by stemming, such as `organism` and `university`.
+   Start only the new fleet, keeping application traffic stopped, and verify
+   CLI/API integrations against the new response fields before resuming traffic.
 6. Keep the backup for rollback. Old binaries can silently miss matches in newly
    rebuilt indexes; roll back by restoring the whole pre-upgrade backup with
    the old fleet, not by pointing an old binary at the upgraded store.
 
 Ordinary reads, traversal, and vector search remain available without the
 full-text rebuild. Historical snapshots are unchanged and may refuse full-text
-search. To search old content, create a live branch from the desired snapshot
-and rebuild that branch. Restoring an old snapshot may require another rebuild.
+search; rebuilding a live branch does not upgrade its earlier snapshots.
+Branch creation from a pinned historical snapshot is not supported.
 The operation is explicit and can be expensive on large graphs; `optimize` is
 not a replacement for this migration.
 
@@ -77,6 +95,24 @@ or restore a trusted backup with supported inventory. Export/import preserves
 entities but not shared branch ancestry or history, as described below. Keep the
 source intact until verification and cutover; do not drop unknown indexes or
 edit their metadata to bypass the refusal.
+
+### Cluster state and rollback
+
+Keep the pre-upgrade cluster deployment bundle, configuration, and state backup
+alongside the graph-root backups. A rollback restores that consistent set with
+the old executables; it does not point an old server at upgraded index files.
+
+If v0.10 applied an `external_blobs` policy and the cluster state itself is not
+being restored, v0.9 cannot read that new optional state field. While every
+writer is stopped, remove `external_blobs` from each graph's configuration,
+review `cluster plan`, and use the v0.10 `cluster apply` to converge the removal
+before starting v0.9. Editing only the YAML is insufficient; do not hand-edit
+the state ledger. This state-shape step does **not** replace restoring the
+pre-upgrade graph backup after full-text rebuilding.
+
+A downgrade also removes v0.10's default-deny external-URI enforcement: v0.9
+writers admitted arbitrary supported sources, including `file://`. Do not roll
+back to v0.9 if that ingress boundary is required.
 
 ## What an export/import rebuild preserves
 


### PR DESCRIPTION
## Summary

Prepare the v0.10 release without changing production engine behavior.

- Fix the full-workspace FTS compatibility test failure by isolating its Lance object-store registry. The previous assertion drained counters shared with unrelated tests; a deterministic unrelated-client read now proves isolation while preserving the cold/warm checks.
- Extend the existing cross-version suite with a genuine, checksum-verified released v0.9.0 CLI. Exercise a two-branch graph with nodes, edges, vectors, and Blobs through v0.10 reads, explicit per-branch FTS rebuilds, CLI/HTTP parity, writes, merge, restart, and whole-backup rollback with v0.9.
- Install that predecessor in the existing workspace CI job and fail if the exact upgrade test skips or does not complete.
- Condense the release notes and document coordinated CLI/server cutover, full-text maintenance, historical-snapshot limits, and rollback. No new harness or production code.

## Validation

- Genuine v0.9 → v0.10 upgrade E2E: passed, including original branch heads captured before the first v0.10 open.
- Engine library with failpoints: 378 passed, 1 ignored; four consecutive parallel runs passed after deterministic reproduction of the old counter failure.
- Forbidden-API guard: 22 passed.
- Both workspace/all-target Clippy configurations (default and failpoints), formatting, documentation/link checks, action pins, actionlint, release gates, container contracts, and admission-boundary checks passed.
- Clean full workspace with failpoints passed on commit `217552ef`: `cargo test --workspace --locked --offline --no-fail-fast --features omnigraph-engine/failpoints,omnigraph-cluster/failpoints -- --nocapture`, with `OMNIGRAPH_V09_BIN` pointing at the checksum-verified released v0.9 CLI. The genuine upgrade test completed in 13.34s; recovery/failpoints passed 153 tests with 1 ignored. Older optional predecessor tests and unconfigured cloud tests retain their normal local skips.
- Required PR CI passed. Greptile reviewed all 6 changed files and added 0 comments; independent review found no remaining blockers.

DST oracle work is explicitly outside this release's blocking scope. This PR does not disable DST or alter its semantics. Cloud/backend qualification remains with the configured CI owners; the local E2E is not an ANN-index or live-cloud certification.
