### PR TITLE
test(bench): remove synthetic worker timing race

### DIFF
--- a/crates/omnigraph-bench/src/supervisor.rs
+++ b/crates/omnigraph-bench/src/supervisor.rs
@@ -1379,7 +1379,9 @@ mod tests {
     use super::*;
 
     const TEST_REPETITION: u32 = 7;
-    const TEST_ELAPSED_US: u64 = 1_000;
+    // Protocol stubs perform no timed merge. Zero is a valid lower bound;
+    // even a complete process round trip need not consume a fixed duration.
+    const TEST_ELAPSED_US: u64 = 0;
     const QUICK_DEADLINE: Duration = Duration::from_millis(250);
     const BOUNDED_AUXILIARY_DEADLINE: Duration = Duration::from_secs(2);
     const GENEROUS_DEADLINE: Duration = Duration::from_secs(10);
@@ -1614,7 +1616,7 @@ mod tests {
             .child_process
             .as_ref()
             .expect("spawned worker failures must carry containment evidence");
-        assert_eq!(evidence.stage, expected_stage, "{evidence:?}");
+        assert_eq!(evidence.stage, expected_stage, "{error:?}");
         assert!(evidence.direct_child_reaped, "{evidence:?}");
         assert!(evidence.peak_rss_bytes.is_some(), "{evidence:?}");
         assert!(evidence.process_group_gone, "{evidence:?}");


### PR DESCRIPTION
## What and why

Final v0.10 qualification exposed a timing-dependent failure in `forged_complete_sample_is_rejected_by_parent_admission` ([hosted workspace run](https://github.com/ModernRelay/omnigraph/actions/runs/33431518704)). Its shell worker claimed 1,000 microseconds of measured work without performing any timed work. A sufficiently fast Begin/Settled exchange therefore correctly failed the parent's elapsed-time guard before reaching the forged Complete assertion.

Use zero as the synthetic protocol fixture's clock-independent lower bound, and include the complete error in stage-mismatch diagnostics. This is a test-only change: production timing validation, watchdogs, and admission rules are unchanged. The existing impossible-duration rejection test still proves the guard is enforced.

## Validation

- Entire benchmark crate: 294 passed, one pre-existing ignored test.
- 50 repetitions of valid protocol, forged Complete, and impossible elapsed-time tests: 150 passed.
- `cargo fmt --all --check` and `git diff --check` passed.
- The original hosted failure is the regression evidence; 501 baseline invocations did not reproduce its scheduling window on macOS.

This does not alter engine code, benchmark measurements, release compatibility, or DST scope.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This test-only change removes a scheduling-dependent benchmark supervisor fixture value and improves failure diagnostics.
- Uses zero as the synthetic worker’s clock-independent elapsed-time lower bound.
- Prints the complete runner error when a child-process stage assertion fails.
- Leaves production timing validation, watchdogs, and admission logic unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the changed fixture remains internally consistent and the independent impossible-duration test still covers rejection by the parent timing guard.

Both protocol frames continue to report the same elapsed value, zero cannot exceed the parent’s observed nonnegative duration, and the diagnostic change only broadens assertion output.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/omnigraph-bench/src/supervisor.rs | Replaces an artificial positive elapsed-time fixture with zero and expands assertion diagnostics without introducing a concrete correctness issue. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(bench): remove synthetic worker tim..."](https://github.com/modernrelay/omnigraph/commit/d19e9102d66aa4c9ffdb95b9fc14da2e90e0e7fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58773615)</sub>

<!-- /greptile_comment -->