### PR TITLE
docs(skill): align OmniGraph skill with v0.10

### DIFF
--- a/scripts/check-docs.py
+++ b/scripts/check-docs.py
@@ -14,6 +14,8 @@ from urllib.parse import unquote
 
 ROOT = Path(__file__).resolve().parent.parent
 RFC_DIR = ROOT / "docs" / "rfcs"
+SKILL_DIR = ROOT / "skills" / "omnigraph"
+SKILL_PATH = SKILL_DIR / "SKILL.md"
 
 RFC_KEYS = (
     "rfc",
@@ -408,6 +410,44 @@ def check_user_boundary(files: list[Path], errors: list[str]) -> None:
                 errors.append(f"docs/user/{relative}:{line}: {reason}")
 
 
+def check_skill_version(errors: list[str]) -> None:
+    if not SKILL_PATH.exists():
+        errors.append("skills/omnigraph/SKILL.md: missing OmniGraph skill entrypoint")
+        return
+
+    text = SKILL_PATH.read_text(encoding="utf-8")
+    if not text.startswith("---\n") or (end := text.find("\n---\n", 4)) < 0:
+        errors.append("skills/omnigraph/SKILL.md: malformed YAML frontmatter")
+        return
+    metadata = re.search(
+        r"(?ms)^metadata:\s*\n(?P<body>(?:^[ \t]+.*(?:\n|$))+)", text[4:end]
+    )
+    version = (
+        re.search(r'(?m)^\s+version:\s*["\']?([^"\'\s]+)', metadata.group("body"))
+        if metadata
+        else None
+    )
+    if version is None:
+        errors.append("skills/omnigraph/SKILL.md: metadata.version is required")
+        return
+
+    cli_manifest = ROOT / "crates" / "omnigraph-cli" / "Cargo.toml"
+    cli_text = cli_manifest.read_text(encoding="utf-8")
+    package = re.search(r"(?ms)^\[package\]\s*(.*?)(?=^\[|\Z)", cli_text)
+    cli_version = (
+        re.search(r'(?m)^version\s*=\s*["\']([^"\']+)["\']', package.group(1))
+        if package
+        else None
+    )
+    if cli_version is None:
+        errors.append(f"{cli_manifest.relative_to(ROOT)}: package.version is required")
+    elif version.group(1) != cli_version.group(1):
+        errors.append(
+            "skills/omnigraph/SKILL.md: metadata.version "
+            f"{version.group(1)!r} != omnigraph-cli {cli_version.group(1)!r}"
+        )
+
+
 def main() -> int:
     errors: list[str] = []
     files = tracked_markdown()
@@ -416,11 +456,13 @@ def main() -> int:
         path
         for path in files
         if path.is_relative_to(ROOT / "docs")
+        or path.is_relative_to(SKILL_DIR)
         or path in {ROOT / "AGENTS.md", ROOT / "README.md"}
     ]
     check_links(link_files, errors)
     check_rfcs(errors)
     check_user_boundary(files, errors)
+    check_skill_version(errors)
 
     if errors:
         for error in errors:

--- a/skills/omnigraph/SKILL.md
+++ b/skills/omnigraph/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: omnigraph
-description: Store, retrieve, and query knowledge, memory, and relationships in an Omnigraph graph, and operate a local or remote Omnigraph deployment. Use when the user wants to capture or recall facts, notes, or entities, build or query a knowledge graph or agent memory, or run Omnigraph — and whenever you see Omnigraph CLI commands (omnigraph init/query/mutate/load/schema/lint/embed/branch/commit/login/profile/cluster), .pg schema or .gq query files, s3:// graph URIs, bearer-authed graph endpoints, 504 errors, or a cluster.yaml / omnigraph.yaml / ~/.omnigraph/config.yaml. Covers cluster-mode deployments (cluster.yaml plan/apply, omnigraph-server --cluster), the two config surfaces (cluster.yaml + ~/.omnigraph/config.yaml), schema evolution, query linting, data writes (mutate; load needs --mode/--from), branches, embeddings, Cedar policy, and remote ops. Especially important before schema apply (plan first), any load (--mode required), any .gq/.pg edit (lint after), or any remote write (verify via commit list).
+description: Operate OmniGraph graphs and deployments. Use for `.pg` schemas, `.gq` queries, OmniGraph CLI commands, `file://`/`s3://`/`az://` graph URIs, `cluster.yaml`, operator config, bearer-authenticated servers, graph-backed knowledge or memory, Blob values, embeddings, branches, commits, and change feeds. Apply especially before schema changes, bulk loads, and retries after uncertain remote outcomes.
 license: MIT (see LICENSE at repo root)
-compatibility: Requires omnigraph CLI >= 0.7.0 — the unified `load`, the two config surfaces (cluster.yaml + ~/.omnigraph/config.yaml), and cluster apply/serve all require 0.7.0. Version-gated features are marked inline (undirected traversal `<edge>` and enum widening in `schema apply` require >= 0.8.1; edge bindings `$w:EDGE`, strict `--mode append` key conflicts, the keyed per-load bounds, and `branch merge --delete-branch` require >= 0.9.0).
+compatibility: Validated against OmniGraph CLI and server 0.10.x. The CLI, server, and client bindings must be upgraded together.
 metadata:
   author: ModernRelay
   version: "0.10.0"
@@ -18,10 +18,12 @@ This skill captures the operational rules for working with a locally or remotely
 1. **Lint before commit** — `omnigraph lint --schema schema.pg --query queries/foo.gq` validates both sides against each other. No running repo required.
 2. **Plan before apply** — never run `schema apply` without a successful `schema plan` first. Apply is destructive; plan is free. (Cluster mode has the same rule with different verbs: `cluster plan` before `cluster apply` — the plan embeds the engine's real migration steps.)
 3. **Branches are for data; apply is for schema** — review bulk data loads on a feature branch then merge. Schema changes go straight to `main`: in cluster mode edit the `.pg` and run `cluster apply` (a direct `schema apply` **refuses** a cluster-managed graph); `schema plan`/`apply` is for a non-cluster store.
-4. **Pick the right write command** — `mutate` for edits (typechecked, parameterized); `load` for bulk JSONL, local **or** remote, with a **required** `--mode` (`merge` upsert · `append` strict-insert · `overwrite` clean-slate). `load --from <base>` forks a review branch in one shot; bare `load` needs an existing target branch.
+4. **Pick the right write command** — `mutate` for edits (typechecked, parameterized); `load` for bulk JSONL, local **or** remote, with a **required** `--mode` (`merge` upsert · `append` strict-insert · `overwrite` replaces only the node/edge types represented in the batch). `load --from <base>` forks a review branch in one shot; bare `load` needs an existing target branch.
 5. **Parameterize everything** — never string-interpolate values into `.gq` bodies or `--params`. Declare `$var: Type` and pass via `--params`.
-6. **Expose agent operations as aliases** — not raw CLI invocations. Aliases decouple the operation name from the query implementation.
-7. **Verify after every remote write** — compare `commit list --branch main` head before and after. The CLI's exit code is not authoritative on remote graphs; proxies can drop the response while the write commits server-side. See `references/remote-ops.md` for the verification ritual and how to recover from 504s.
+6. **Expose agent reads as aliases** — aliases decouple a read operation name
+   from its stored-query implementation. Aliases are read-only; invoke a served
+   stored mutation with `omnigraph mutate <name> --server ...`.
+7. **Treat a lost remote response as unknown** — a successful JSON write response contains the exact commit published by that attempt, but a proxy can return 504 after publication. On timeout, verify the branch head or intended entity effect before retrying. See `references/remote-ops.md`.
 
 ## Essentials: Queries, Mutations, Loads
 
@@ -44,7 +46,7 @@ query get_signal($slug: String) {
 - **Parameterize, never interpolate.** Declare `$var: Type` in the signature; pass via `--params '{"slug":"sig-foo"}'`. An empty signature still needs parens: `query foo() { ... }`.
 - **Edge traversal is lowerCamelCase** even though the schema declares edges PascalCase (`FormsPattern` → `formsPattern`).
 - **List/sort** by appending `order { $s.stagingTimestamp desc } limit 50` after `return`.
-- **Ranking ops (`nearest`/`bm25`/`rrf`) require a trailing `limit N`** — omitting it is a compile error. They live in `order { }`, not as filters. Scope with `match`/filters first, then rank (`order { nearest($d.embedding, $q) } limit 10`).
+- **`nearest` and `rrf` require a trailing `limit N`** — omitting it is a compile error. `bm25` does not require a limit, but use one to keep ranked output bounded. Ranking operators live in `order { }`, not as filters. Scope with `match`/filters first, then rank (`order { nearest($d.embedding, $q) } limit 10`).
 
 ### Mutation (`.gq`)
 
@@ -60,9 +62,13 @@ query retitle($slug: String, $t: String) { update Signal set { name: $t } where 
 query remove($slug: String)              { delete Signal where slug = $slug }
 ```
 
-- **Every non-nullable property must be supplied** or lint fails (`T12: insert for 'Signal' must provide non-nullable property 'X'`).
+- **Every non-nullable property must be supplied.** Lint normally reports T12
+  when one is missing. In v0.10, a non-null Vector target carrying `@embed`
+  is a known exception: source-only insert can lint successfully even though
+  execution still requires the vector. Supply it explicitly; writes never
+  embed automatically.
 - A single mutation is insert/update-only **or** delete-only — never both (parse-time D₂ rule); split them.
-- Edges have no `@key`: give `from`/`to` slugs; the property block is `{}` when the edge has none.
+- Edges have no `@key`: give logical `from`/`to` endpoint IDs. A propertyless edge needs only `from` and `to`; there is no nested `data` block in GQ.
 
 ### Bulk load (JSONL)
 
@@ -76,16 +82,16 @@ omnigraph load --data seed.jsonl --mode merge $GRAPH                            
 omnigraph load --data delta.jsonl --from main --branch review --mode merge $GRAPH     # fork a review branch in one shot
 ```
 
-- `--mode`: `merge` (upsert by `@key`) · `append` (fails on collision) · `overwrite` (destructive, staged). `--from <base>` forks a missing `--branch`; bare `load` needs an existing branch. Works local **and** remote.
-- **Date footgun**: `mutate --params` takes ISO strings (`Date` `"2026-04-29"`, `DateTime` `"…T00:00:00Z"`); `load` JSONL takes **integer days since epoch** for `Date` (`20572`) but ISO for `DateTime`.
+- `--mode`: `merge` (upsert by logical entity ID; keyed node IDs derive from their `@key` tuple) · `append` (fails on ID collision) · `overwrite` (destructive, staged). `--from <base>` forks a missing `--branch`; bare `load` needs an existing branch. Works local **and** remote.
+- **Date values**: `mutate --params` takes ISO strings. `load` accepts ISO `Date` strings (recommended) or integer epoch days, and ISO `DateTime` strings.
 
 ### Dispatching
 
 ```bash
-omnigraph alias  signal sig-foo                  # operator alias → its bound stored query (read or write)
+omnigraph alias  signal sig-foo                  # operator alias → its bound stored read query
 omnigraph query  get_signal --params '{"slug":"sig-foo"}'   # served stored query by name (verb asserts read vs write)
 omnigraph query  -e 'query q() { match { $s: Signal } return { $s.slug } limit 5 }'   # ad-hoc/inline (or: --query f.gq <name>)
-omnigraph mutate add_signal --query mutations.gq --params '{"slug":"sig-foo", ...}'   # name positional; ad-hoc file source
+omnigraph mutate add_signal --query mutations.gq --params '{"slug":"sig-foo","name":"Foo","brief":"Example","createdAt":"2026-04-14T00:00:00Z"}'   # name positional; ad-hoc file source
 omnigraph lint   --schema schema.pg --query queries/foo.gq    # after EVERY .gq/.pg edit (no server needed)
 ```
 
@@ -97,169 +103,57 @@ The non-obvious facts that bite, then the full grammar:
 - **A read query needs `match` *and* `return`** (`order`/`limit` optional); a mutation has neither — only `insert`/`update`/`delete`.
 - **`limit` takes an integer literal, not a param** — `limit 50`, never `limit $n`.
 - **Variable-hop traversal**: `$p knows{1,3} $f` — bounds are **required to be finite** (`{1,}` is rejected: "unbounded traversal is disabled").
-- **Undirected traversal** (omnigraph >= 0.8.1): `$p <knows> $f` matches the edge in either direction, deduplicated (a pair connected both ways appears once). Same-endpoint-type edges only (e.g. `Related: Issue -> Issue`) — asymmetric edges are rejected (T22). Composes with bounds (`$p <knows>{1,3} $f`) and `not { }`. Replaces the query-both-directions-and-merge workaround for symmetric relations.
-- **Edge bindings** (omnigraph >= 0.9.0): an optional `$var:` prefix on the edge word — `$src $w:knows $dst`, undirected `$a $w:<related> $b` — binds the matched edge row, so edge properties work in filters (`$w.confidence = "asserted"`), projections (`return { $w.role }`), aggregates, and ordering. A bound traversal returns one row per edge (parallel edges stay distinct); binding a `{min,max}` multi-hop, rebinding a taken name, or projecting bare `$w` is rejected (T23).
+- **Undirected traversal**: `$p <knows> $f` matches the edge in either direction, deduplicated (a pair connected both ways appears once). Same-endpoint-type edges only (e.g. `Related: Issue -> Issue`) — asymmetric edges are rejected (T22). Composes with bounds (`$p <knows>{1,3} $f`) and `not { }`.
+- **Edge bindings**: an optional `$var:` prefix on the edge word — `$src $w:knows $dst`, undirected `$a $w:<related> $b` — binds the matched edge row, so edge properties work in filters (`$w.confidence = "asserted"`), projections (`return { $w.role }`), aggregates, and ordering. A bound traversal returns one row per edge (parallel edges stay distinct); binding a `{min,max}` multi-hop, rebinding a taken name, or projecting bare `$w` is rejected (T23).
 - **Literals & calls**: `now()`, `date("2026-04-29")`, `datetime("…T00:00:00Z")`, list `[…]`.
-- **Filters** `= != > < >= <= contains`; **aggregates** `count/sum/avg/min/max` (`count($f) as n`).
+`starts_with`, `contains`, `>=`, `<=`, `!=`, `>`, `<`, `=`
+
+Those are the complete **filter operators**; String predicates are exact and
+case-sensitive. **Aggregates** are `count/sum/avg/min/max` (`count($f) as n`).
 - **Stored-query metadata**: `@description("…")` / `@instruction("…")` may follow the param list.
 - **Casing**: type names uppercase-initial (`Signal`); idents/edges lowercase-initial (`formsPattern`); variables `$`-prefixed. `//` and `/* */` comments only.
 
-Authoritative PEG grammar (pest) for `.gq` files:
-
-```pest
-//  Query Grammar (.gq files)
-
-WHITESPACE = _{ " " | "\t" | "\r" | "\n" }
-COMMENT = _{ LINE_COMMENT | BLOCK_COMMENT }
-LINE_COMMENT = _{ "//" ~ (!"\n" ~ ANY)* }
-BLOCK_COMMENT = _{ "/*" ~ (!"*/" ~ ANY)* ~ "*/" }
-
-query_file = { SOI ~ query_decl* ~ EOI }
-
-query_decl = {
-    "query" ~ ident ~ "(" ~ param_list? ~ ")" ~ query_annotation* ~ "{"
-        ~ query_body
-    ~ "}"
-}
-query_annotation = { description_annotation | instruction_annotation }
-description_annotation = { "@description" ~ "(" ~ string_lit ~ ")" }
-instruction_annotation = { "@instruction" ~ "(" ~ string_lit ~ ")" }
-
-query_body = { read_query_body | mutation_body }
-mutation_body = { mutation_stmt+ }
-read_query_body = {
-    match_clause
-    ~ return_clause
-    ~ order_clause?
-    ~ limit_clause?
-}
-
-mutation_stmt = { insert_stmt | update_stmt | delete_stmt }
-insert_stmt = { "insert" ~ type_name ~ "{" ~ mutation_assignment+ ~ "}" }
-update_stmt = { "update" ~ type_name ~ "set" ~ "{" ~ mutation_assignment+ ~ "}" ~ "where" ~ mutation_predicate }
-delete_stmt = { "delete" ~ type_name ~ "where" ~ mutation_predicate }
-mutation_assignment = { ident ~ ":" ~ match_value ~ ","? }
-mutation_predicate = { ident ~ comp_op ~ match_value }
-
-param_list = { param ~ ("," ~ param)* }
-param = { variable ~ ":" ~ type_ref }
-
-type_ref = { (list_type | base_type | vector_type) ~ "?"? }
-list_type = { "[" ~ base_type ~ "]" }
-vector_type = { "Vector" ~ "(" ~ integer ~ ")" }
-base_type = { "String" | "Blob" | "Bool" | "I32" | "I64" | "U32" | "U64" | "F32" | "F64" | "DateTime" | "Date" }
-
-match_clause = { "match" ~ "{" ~ clause+ ~ "}" }
-
-clause = { negation | binding | traversal | filter | text_search_clause }
-text_search_clause = { search_call | fuzzy_call | match_text_call }
-
-// Binding: $p: Person { name: "Alice" }
-binding = { variable ~ ":" ~ type_name ~ ("{" ~ prop_match_list ~ "}")? }
-
-prop_match_list = { prop_match ~ ("," ~ prop_match)* ~ ","? }
-prop_match = { ident ~ ":" ~ match_value }
-match_value = { literal | variable | now_call }
-
-// Traversal: $p knows $f (directional) or $p <knows> $f (undirected, >= 0.8.1)
-// Edge binding: $p $w:knows $f then $w.prop in filter/return (>= 0.9.0)
-traversal = { variable ~ edge_binding? ~ (undirected_edge | edge_ident) ~ traversal_bounds? ~ variable }
-edge_binding = { variable ~ ":" }
-undirected_edge = { "<" ~ edge_ident ~ ">" }
-traversal_bounds = { "{" ~ integer ~ "," ~ integer? ~ "}" }
-
-// Filter: $f.age > 25
-filter = { expr ~ filter_op ~ expr }
-
-// Negation: not { ... }
-negation = { "not" ~ "{" ~ clause+ ~ "}" }
-
-// Return clause — projections separated by commas or newlines
-return_clause = { "return" ~ "{" ~ projection+ ~ "}" }
-projection = { expr ~ ("as" ~ ident)? ~ ","? }
-
-// Order clause
-order_clause = { "order" ~ "{" ~ ordering ~ ("," ~ ordering)* ~ "}" }
-ordering = { nearest_ordering | (expr ~ order_dir?) }
-nearest_ordering = { "nearest" ~ "(" ~ prop_access ~ "," ~ expr ~ ")" }
-order_dir = { "asc" | "desc" }
-
-// Limit clause
-limit_clause = { "limit" ~ integer }
-
-// Expressions
-expr = { now_call | nearest_ordering | search_call | fuzzy_call | match_text_call | bm25_call | rrf_call | agg_call | prop_access | variable | literal | ident }
-now_call = { "now" ~ "(" ~ ")" }
-search_call = { "search" ~ "(" ~ expr ~ "," ~ expr ~ ")" }
-fuzzy_call = { "fuzzy" ~ "(" ~ expr ~ "," ~ expr ~ ("," ~ expr)? ~ ")" }
-match_text_call = { "match_text" ~ "(" ~ expr ~ "," ~ expr ~ ")" }
-bm25_call = { "bm25" ~ "(" ~ expr ~ "," ~ expr ~ ")" }
-rank_expr = { nearest_ordering | bm25_call }
-rrf_call = { "rrf" ~ "(" ~ rank_expr ~ "," ~ rank_expr ~ ("," ~ expr)? ~ ")" }
-
-prop_access = { variable ~ "." ~ ident }
-
-agg_call = { agg_func ~ "(" ~ expr ~ ")" }
-agg_func = { "count" | "sum" | "avg" | "min" | "max" }
-
-comp_op = { ">=" | "<=" | "!=" | ">" | "<" | "=" }
-filter_op = { "contains" | comp_op }
-
-// Terminals
-variable = @{ "$" ~ (ident_chars | "_") }
-ident_chars = @{ (ASCII_ALPHA_LOWER | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
-
-// Edge identifier — lowercase start, same as ident but used in traversal context
-// Must not match keywords
-edge_ident = @{ !("not" ~ !ASCII_ALPHANUMERIC) ~ (ASCII_ALPHA_LOWER | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
-
-type_name = @{ ASCII_ALPHA_UPPER ~ (ASCII_ALPHANUMERIC | "_")* }
-ident = @{ (ASCII_ALPHA_LOWER | "_") ~ (ASCII_ALPHANUMERIC | "_")* }
-
-literal = { list_lit | datetime_lit | date_lit | string_lit | float_lit | integer | bool_lit }
-date_lit = { "date" ~ "(" ~ string_lit ~ ")" }
-datetime_lit = { "datetime" ~ "(" ~ string_lit ~ ")" }
-list_lit = { "[" ~ (literal ~ ("," ~ literal)*)? ~ "]" }
-string_lit = @{ "\"" ~ string_char* ~ "\"" }
-string_char = @{ !("\"" | "\\") ~ ANY | "\\" ~ ANY }
-float_lit = @{ ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ }
-integer = @{ ASCII_DIGIT+ }
-bool_lit = { "true" | "false" }
-```
+The compiler grammar in `crates/omnigraph-compiler/src/query/query.pest` is the
+single source of truth.
 
 ## CLI Reference (condensed)
 
 Notation: `<x>` required · `[x]` optional · `<a|b>` choice · `…` repeatable.
 
-**Global addressing flags**: `--as <actor>` (direct/`--store` writes only — a server resolves the actor from its token), `--server <name|url>`, `--cluster <dir|uri>` (cluster-managed storage, for maintenance), `--graph <id>` (selects the graph within a `--server` or `--cluster` scope), `--profile <name>` (`$OMNIGRAPH_PROFILE`), `--store <uri>`. Data commands also take a positional `file://`/`s3://` URI (`--config <dir>` is for `cluster` commands only). Output: `--json`, or reads take `--format <json|jsonl|csv|kv|table>`. **Write guards:** `--yes` skips the confirm prompt for a destructive write (`cleanup`, overwrite `load`, `branch delete`) against a non-local scope (it *refuses* without it when non-TTY or `--json`); `--quiet` suppresses the resolved-target echo.
+**Global addressing flags**: `--as <actor>` (direct-engine writes and actor-bound cluster operations; remote writes derive the actor from the bearer token), `--server <name|url>`, `--cluster <dir|uri>` (cluster-managed storage, primarily for maintenance), `--graph <id>` (selects within a `--server` or `--cluster` scope), `--profile <name>` (`$OMNIGRAPH_PROFILE`), `--store <uri>`. Commands with an open positional slot also accept `file://`, `s3://`, or preview `az://` directly. `--config <dir>` belongs only to `cluster` subcommands. Output: `--json`, or read queries take `--format <json|jsonl|csv|kv|table>`. **Write guards:** `--yes` skips non-local confirmation for destructive writes; `--quiet` suppresses the resolved-target echo.
 
 **Data plane** — `any` (served via `--server`/`--profile`, or direct via `--store`/URI):
 - `query` (alias `read`) `<name>` — a **served stored query** by name (via `--server`/`--profile`); or ad-hoc `[<name>] (--query <f.gq> | -e '<GQ>')` where `<name>` picks which query in the source. `[--params <json> | --params-file <p>] [--branch <b> | --snapshot <id>] [--format <fmt> | --json]`. No positional URI — address via `--server`/`--store`/`--profile`.
-- `mutate` (alias `change`) — same shape (served stored mutation by `<name>`, or ad-hoc `--query`/`-e`); `[--params …] [--branch <b>] [--json]`. The verb asserts kind: `query`→read, `mutate`→write (400 on mismatch).
-- `alias <name> [args…]` — invoke an operator alias's bound stored query (read or write); `[--params … | --params-file <p>] [--format <fmt> | --json]` (server/graph/query come from the binding)
-- `load --data <f.jsonl> --mode <overwrite|append|merge> [--branch <b>] [--from <base>] [--json]` — `--mode` required; `--from` forks a missing `--branch`
+- `mutate` (alias `change`) — same shape (served stored mutation by `<name>`, or ad-hoc `--query`/`-e`); `[--params …] [--branch <b>] [--if-commit <graph_commit_id>] [--json]`. The verb asserts kind; a failed precondition has no effect and exits 4.
+- `load --data <f.jsonl> --mode <overwrite|append|merge> [--branch <b>] [--from <base>] [--json]` — `--mode` required; `--from` forks a missing `--branch`; overwrite replaces only represented types
+- `blob <get|stat> <node|edge> <TYPE> <ID> <PROPERTY>` — dedicated Blob-cell reads; `get` supports ranges/`--out`, `stat` returns metadata
 - `snapshot [--branch <b>] [--json]`
-- `export [--branch <b>] [--type <T>…] [--table <K>…]` (streams JSONL)
-- `branch <create <name> [--from <base>] | list | delete <name> | merge <source> --into <target>> [--json]`
-- `commit <list [--branch <b>] | show <commit_id>> [--json]`
-- `schema <plan | apply> --schema <f.pg> [--allow-data-loss] [--json]` · `schema show` (alias `get`) — `apply` **refuses a cluster-managed graph** (evolve those via `cluster apply`)
+- `export [--branch <b>] [--type <T>…]` (streams JSONL)
+- `branch <create <name> [--from <base>] | list | delete <name> | merge <source> --into <target> [--delete-branch]> [--json]`
+- `commit <list [--branch <b>] | show <commit_id> | changes <commit_id> [filters…]> [--json]`
+- `changes <poll [--start now|beginning|after:<id> | --cursor <c>] | baseline --out <snapshot.jsonl>> [filters…] [--json]`
+- `schema apply --schema <f.pg> [--allow-data-loss] [--json]` · `schema show` (alias `get`) — `apply` **refuses a cluster-managed graph** (evolve those via `cluster apply`)
 
 **Served only** (needs `--server`/`--profile`): `graphs list [--json]`
 
-**Direct / storage** — reject `--server`; address by positional URI or `--cluster <dir|s3> --graph <id>`:
+**Direct / storage** — reject `--server`. `init` requires its positional URI;
+`schema plan` uses a positional URI or `--store`; lint and maintenance also
+accept `--cluster <dir|file://|s3://|az://> --graph <id>`:
 - `init --schema <f.pg> <uri> [--force]`
+- `schema plan --schema <f.pg> [--allow-data-loss] [--json]`
 - `lint --query <f.gq> [--schema <f.pg>] [<uri>] [--json]` — offline with `--schema`, graph-backed with a URI
-- `optimize [--json]` · `repair [--confirm] [--force] [--json]` · `cleanup (--keep <N> | --older-than <7d>) --confirm [--json]`
-- `rebuild-full-text-indexes [--branch <b>] [--json]` (>= 0.10.0) — replace full-text indexes on one branch with default English analysis; custom tokenizer settings are replaced. Stop overlapping writers and retain a whole-store backup for upgrades. `--as` records attribution; direct access does not load server policy. See [maintenance commands](references/commands.md#rebuild-full-text-indexes--explicit-analyzer-upgrade-v0100).
-- `queries <validate [<uri>] | list> [--json]`
+- `optimize [--json]` · `repair [--confirm] [--force] [--json]` · `cleanup [--keep <N>] [--older-than <7d>] --confirm [--json]` (at least one retention option; both may be combined)
+- `rebuild-full-text-indexes [--branch <b>] [--json]` — replace full-text indexes on one branch with default English analysis; custom tokenizer settings are replaced. Stop overlapping writers and retain a whole-store backup for upgrades. `--as` records attribution; direct access does not load server policy. See [maintenance commands](references/commands.md#rebuild-full-text-indexes--explicit-analyzer-upgrade).
 
-**Control plane** — cluster (`--config <dir>`, default `.`):
+**Control plane**:
 - `cluster <validate | plan | apply | status | refresh | import> [--config <dir>] [--json]`
 - `cluster approve <resource> --as <actor> [--config <dir>] [--json]` · `cluster force-unlock <lock_id> [--config <dir>] [--json]`
+- `policy <validate | test --tests <f> | explain --actor <a> --action <act> [--branch <b> | --target-branch <b>]> --cluster <dir|uri> [--graph <id>]`
+- `queries <validate | list> --cluster <dir|uri> [--graph <id>] [--json]`
 
 **Local** (no graph):
-- `policy <validate | test --tests <f> | explain --actor <a> --action <act> [--branch <b> | --target-branch <b>]> --cluster <dir> [--graph <id>]`
-- `embed --seed <embed.yaml> [--reembed_all | --clean | --select "<Type>:<field>=<value>"]`
+- `alias <name> [args…]` — invoke an operator alias's bound stored read query; `[--params … | --params-file <p>] [--format <fmt> | --json]` (server/graph/query come from the binding)
+- `embed (--seed <embed.yaml> | --input <raw.jsonl> --output <out.jsonl> --spec <spec.json>) [--reembed-all | --clean] [--type <T>…] [--select "<Type>:<field>=<value>"]`
 - `login <server> [--token <t>]` (prefer piping the token on stdin) · `logout <server>` · `profile <list | show [<name>]>` · `version`
 
 Pre-0.7.0 spellings (`read`/`change`/`ingest`, `--target`, positional `http://`) → [`references/migrations.md`](references/migrations.md).
@@ -288,35 +182,43 @@ When Omnigraph serves as canonical truth across multiple agents, every assertion
 
 Without structural provenance, agents cannot reconcile contradictory assertions, retract facts when a source is discredited, replay graph state at a past timestamp, or distinguish high-evidence facts from speculation.
 
-**In Omnigraph:** model provenance as a `Claim`-style interface (or a separate `Claim` node linked to each sourced fact) with required fields — `asserted_by: Actor`, `asserted_at: DateTime`, `evidence_source: Source`, optionally `confidence: F64`. Don't stash provenance into a free-text `source: String` or a `metadata: JSON` dump — structured provenance is queryable, indexable, and migratable; free-form is none of these.
+**In Omnigraph:** model provenance as a `Claim` node linked by typed edges to
+the asserted fact, an `Actor`, and a `Source`. Keep scalar facts such as
+`asserted_at: DateTime` and optional `confidence: F64` on `Claim`; properties
+cannot be node-typed. Don't stash provenance into a free-text `source: String`
+or a metadata dump—structural provenance is queryable and migratable;
+free-form provenance is neither.
 
 ## Storage & Credentials
 
-A graph's bytes live in one of two backends:
+A graph's bytes live in one of three supported URI families:
 
 - **Local filesystem** — a path or `file://` URI. In cluster mode `storage:` defaults to the config directory, so local dev needs no object store.
-- **S3-compatible object storage** — AWS, Railway, Tigris, etc. (`s3://bucket/prefix`). Authenticate with the standard `AWS_*` environment contract; keep dev creds in a git-ignored `.env.omni` and source it before CLI calls:
+- **S3-compatible object storage** — AWS, Railway, Tigris, etc. (`s3://bucket/prefix`). Authenticate with the standard `AWS_*` environment contract.
+- **Azure Blob storage preview** — `az://container/prefix`. Reads and Azurite qualification are available, but Azure is not production-supported; every write or maintenance process must be launched through the root-scoped `omnigraph-azure-admission` wrapper.
+
+Keep development credentials in a git-ignored `.env.omni` and source it before CLI calls:
 
 ```bash
 set -a && source .env.omni && set +a
 ```
 
-`init`, `load`, and **`cluster apply`** write storage directly (bypassing the server). `cluster apply` is a storage-direct control-plane command — it reaches the object store directly (the `__cluster/` ledger *and* each graph's Lance datasets, to create/migrate/delete them), never through a running server, so the host that runs it needs storage access (the `AWS_*` contract for an `s3://` cluster). That is by design: the control plane is declarative (config → cluster), not a runtime mutation API on the serving process. The server reads **cluster** state read-only at boot, but it is not read-only against storage overall — data-plane HTTP writes (`mutate`/`load`/`branch`) still go through the server to the graph datasets, so it needs read-write storage access. Validate with `curl http://127.0.0.1:8080/healthz`, then `omnigraph snapshot <graph-uri> --json`.
+Direct `init`/`load` and **`cluster apply`** write storage without an HTTP server. A served `load` is different: the CLI sends it to `omnigraph-server`, which performs the graph write. `cluster apply` reaches the cluster ledger and graph datasets directly, so its host needs storage credentials. A serving process also needs read-write access for served data-plane writes. Validate with `curl http://127.0.0.1:8080/healthz`, then `omnigraph snapshot --server <name> --graph <id> --json`.
 
 ## Project Layout
 
-### Deployment & access (omnigraph >= 0.7.0)
+### Deployment & access
 
 - **Cluster deployment — the only way to serve.** A `cluster.yaml` declares the
-  whole deployment (graphs, schemas, stored queries, policies, optional S3
+  whole deployment (graphs, schemas, stored queries, policies, optional S3/Azure
   `storage:` root); `omnigraph cluster apply` converges it and
   `omnigraph-server --cluster .` (or `--cluster s3://bucket/prefix`,
   config-free) serves it. See `references/cluster.md`.
 - **Direct / embedded access — no server.** Address a graph's storage directly
-  with `--store <file://|s3:// uri>` or a positional URI for one-off CLI ops.
+  with `--store <file://|s3://|az:// uri>` or a positional URI for one-off CLI ops.
   There is **no single-graph server mode** — the server is cluster-only.
 
-### The two config surfaces (omnigraph >= 0.7.0)
+### The two config surfaces
 
 Configuration has two single-owner homes (RFC-007/008), plus an
 everything-explicit flag/env tier:
@@ -344,13 +246,13 @@ aliases:                     # personal bindings to TEAM stored queries (see ref
   triage: { server: intel-dev, graph: spike, query: weekly_triage, args: [since] }
 ```
 
-The operator config and credentials are **auto-discovered — no flag points at them**: the CLI reads `$OMNIGRAPH_HOME/config.yaml` (default `~/.omnigraph/config.yaml`), and an absent file is just an empty layer (zero-config). `$OMNIGRAPH_HOME` relocates the *directory* only, not a specific file. (`--config`/`$OMNIGRAPH_CONFIG` is a separate flag for the cluster / server config — not this.)
+The operator config and credentials are **auto-discovered — no flag points at them**: the CLI reads `$OMNIGRAPH_HOME/config.yaml` (default `~/.omnigraph/config.yaml`), and an absent file is just an empty layer (zero-config). `$OMNIGRAPH_HOME` relocates the *directory* only, not a specific file. Only `cluster` subcommands take `--config`.
 
 Credentials live outside config: `echo $TOKEN | omnigraph login intel-dev`
 writes `~/.omnigraph/credentials` (`0600`); the matching token resolves via
 `OMNIGRAPH_TOKEN_INTEL_DEV` or that file.
 
-**Addressing a graph**: `--store <file://|s3:// uri>` or a positional URI for
+**Addressing a graph**: `--store <file://|s3://|az:// uri>` or a positional URI for
 direct storage; `--server <name|url>` (+ `--graph <id>`) for a served remote;
 `--profile <name>` for a named bundle; else the operator `defaults`. A remote is
 addressed with `--server` (a bare `http(s)://` URL is not a graph address). Run
@@ -376,33 +278,31 @@ These are the traps most likely to bite. Scan this table before debugging any pa
 | `#` comments in `.pg` | `parse error: expected schema_file` | Use `//` |
 | Standalone `enum Foo { ... }` block | `parse error: expected EOI or schema_decl` | Inline: `kind: enum(a, b)` |
 | `[Category]` (list of enum) | compile error | Use `[String]`; lists must contain scalars |
-| `@embed(text)` without quotes | `unexpected constraint_name` | `@embed("text")` |
+| Assuming `@embed` must quote its source | unnecessary schema churn | `@embed(text)` and `@embed("text")` are both valid; quoted form is canonical |
 | `@unique(src)` on edge without body block | parse error | `@card(1..1) { @unique(src) }` |
-| `load --mode merge` after `@embed` source change | stale embeddings | `omnigraph embed --reembed_all` or `load --mode overwrite` |
+| Expecting `@embed` to populate vectors during load | missing/stale vectors | `@embed` is metadata; run the offline `omnigraph embed ... --reembed-all` file pipeline, then load its output |
 | `schema apply` with feature branches open | rejected | Merge or delete branches first |
-| `nearest(...)` / `bm25(...)` / `rrf(...)` without `limit` | compile error | Add `limit N` |
+| `nearest(...)` / `rrf(...)` without `limit` | compile error | Add `limit N`; a BM25-only query may omit it, though bounded output is recommended |
 | Adding non-nullable property without backfill | unsupported migration | Make optional → backfill; keep it optional (tightening `T?` → `T` is refused, OG-MF-106) |
 | `omnigraph init --json` | `unexpected argument --json` | `init` doesn't support `--json`; drop the flag |
-| `omnigraph init` on an already-initialized URI | `AlreadyInitialized` error (v0.6.0+) | `--force` to re-init (skips the schema preflight; does **not** purge data) |
-| `schema apply` dropping a property/type | soft-dropped or rejected (no data loss) | add `--allow-data-loss` to actually drop the column |
+| `omnigraph init` on an already-initialized URI | `AlreadyInitialized` error | Never overwrite it. `--force` only replaces orphan schema artifacts after proving there is no graph manifest |
+| `schema apply` dropping a property/type | soft-dropped by default (no physical data loss) | use `--allow-data-loss` on both plan and apply to preview and execute a hard drop |
 | Committing `.env.omni` | credential leak | Add `.env*` to `.gitignore` |
 | Non-parameterized query values | typecheck surprise, injection risk | Declare `$param: Type` and pass via `--params` |
 | Missing required field in `insert` | `T12: insert for 'X' must provide non-nullable property 'Y'` | Accept the param in the mutation signature |
 | Long-lived feature branches | merge conflicts, schema apply blocked | Merge promptly; delete when done |
 | `mutation { ... }` wrapper in `.gq` | `parse error: expected query_file` at line 1 | Use `query <name>(...) { insert T { ... } }`; there is no top-level `mutation` keyword |
-| `--config` placed before subcommand | `unexpected argument --config` | Put `--config` **after** the subcommand (e.g. `omnigraph schema show --config X`) |
-| Reading a large schema via stdout-capped tool | Truncated, garbled, or duplicated output | `omnigraph schema show > /tmp/schema.pg` first; then read the file with offset/limit |
-| `omnigraph load` without `--mode` | error: `--mode` is required | Pass `--mode merge\|append\|overwrite` — there is no default (overwrite is destructive, so it is never implicit). `load` works against local and remote URIs |
-| Blind retry after 504 | Duplicate Signal/Decision/Claim (append-only types lack `@key` dedup) | `commit list --branch main --json` first; head advanced means it landed; only retry if unchanged |
-| `sync_branch()` mentioned in version-drift error | Searching for nonexistent CLI command | Server-internal directive in error text; just retry — the next call re-pins to the new head |
+| `--config` on a data/schema command | `unexpected argument --config` | Only `cluster` subcommands accept it; use `--server`/`--graph`, `--store`, or `--profile` elsewhere |
+| Reading a large schema via stdout-capped tool | Truncated, garbled, or duplicated output | `omnigraph schema show --server <name> --graph <id> > /tmp/schema.pg`, then read the file in chunks |
+| `omnigraph load` without `--mode` | error: `--mode` is required | Pass `--mode merge\|append\|overwrite` — there is no default (overwrite is destructive, so it is never implicit). Address direct storage or a served graph |
+| Blind retry after 504 | duplicate unkeyed nodes/edges or a repeated effect | compare the intended branch/entity state first; retry only after proving the attempt did not land |
 | Stale empty branches at `main`'s head | 504-orphaned forks from a timed-out `load --from`; eventually block writes | List branches, find ones at `main`'s `graph_commit_id`, `omnigraph branch delete <name> --store <graph-uri>` |
 | `omnigraph schema apply` / `init` on a cluster-managed graph | refused — bypasses the cluster ledger | Evolve cluster graphs via `omnigraph cluster apply --config .`; `schema apply`/`init` are for a non-cluster store |
-| `omnigraph optimize` against a table with a `Blob` property | table is **skipped**, not failed (Lance blob-v2 compaction bug) | Expected — `--json` reports it under `skipped`; non-blob tables still compact |
-| `@unique` on a `[List]`/`Blob` column | `load` now errors loudly (was silently un-enforced before #160) | Use `@unique` only on scalar columns (and composite `@unique(a, b)`, now keyed as a true tuple) — uniqueness needs a type that reduces to a scalar key |
+| Assuming Blob-bearing data cannot compact | unnecessary skipped maintenance | Lance 11 Blob compaction is supported; `optimize` preserves null/empty/non-empty values |
+| `@unique`/`@index` on a Blob column | schema parse/validation rejection | Blob properties cannot be keys, unique, or indexed |
+| Full-text search after upgrading an old store to 0.10 | explicit rebuild-required error | stop mixed-version access and run `rebuild-full-text-indexes` on every live branch that needs text search |
 
 ## Deep Dives
-
-- `references/cluster.md` — cluster-mode declarative deployments: cluster.yaml, the validate/import/plan/apply loop, approval-gated deletes, `--cluster` serving, the two-file contract, recovery
 
 For anything beyond the basics, load the relevant reference file. Each is self-contained — load only what you need.
 
@@ -410,11 +310,13 @@ For anything beyond the basics, load the relevant reference file. Each is self-c
 |-----------|--------------|
 | [`references/schema.md`](references/schema.md) | Editing `.pg` files, running `schema plan`/`apply`, renaming types, backfilling required fields |
 | [`references/queries.md`](references/queries.md) | Writing or linting `.gq` files, search functions, aggregations, multi-hop patterns |
-| [`references/data.md`](references/data.md) | Choosing between `mutate` and `load` (required `--mode`, `--from` to fork a review branch); branch review workflow; destructive ops |
-| [`references/remote-ops.md`](references/remote-ops.md) | Operating against a remote/CloudFront-fronted graph: 504 verification ritual, version drift, fork-branch 504 fingerprints, append-only retry safety, operator `--server`/`login` targeting |
+| [`references/data.md`](references/data.md) | Choosing between `mutate` and `load` (required `--mode`, `--from` to fork a review branch); branch review workflow; exact overwrite scope |
+| [`references/blobs.md`](references/blobs.md) | Writing and reading managed/external Blob values, selectors/ranges, security and lifecycle boundaries |
+| [`references/changes.md`](references/changes.md) | Exact read/write positions, conditional mutations, commit diffs, feed cursors, baselines, and retention gaps |
+| [`references/remote-ops.md`](references/remote-ops.md) | Operating through `--server`: exact receipts, unknown 504 outcomes, conflict handling, and safe retry decisions |
 | [`references/search.md`](references/search.md) | Embeddings, `@embed`, vector/text ranking, scope-then-rank pattern |
 | [`references/aliases.md`](references/aliases.md) | Defining aliases for agents, structured output, JSON args |
-| [`references/stored-queries.md`](references/stored-queries.md) | Server-side stored-query registry: declared in `cluster.yaml`, `omnigraph queries validate/list`, `GET /graphs/{id}/queries` + `POST /graphs/{id}/queries/{name}`, `invoke_query` Cedar gating |
+| [`references/stored-queries.md`](references/stored-queries.md) | Cluster stored-query registry: declaration, `queries validate/list --cluster`, served invocation, and `invoke_query` Cedar gating |
 | [`references/server-policy.md`](references/server-policy.md) | Starting the HTTP server, routes, bearer auth, Cedar policy gating, multi-graph mode |
-| [`references/commands.md`](references/commands.md) | `snapshot`, `export`, `commit list/show`, addressing & resolution |
-| [`references/migrations.md`](references/migrations.md) | Migrating a pre-0.7.0 setup, or you hit an old config/command/flag/route/error and need its current form |
+| [`references/commands.md`](references/commands.md) | Current command shapes, addressing, output, and maintenance |
+| [`references/migrations.md`](references/migrations.md) | Pre-0.7 vocabulary and the coordinated v0.9→v0.10 upgrade boundary |

--- a/skills/omnigraph/references/aliases.md
+++ b/skills/omnigraph/references/aliases.md
@@ -47,7 +47,10 @@ aliases:
     format: table|kv|csv|jsonl|json   # optional: output format
 ```
 
-Dispatch with `omnigraph alias <name> [args]` — one subcommand for read **and** write stored queries (a mutation alias is double-gated by `invoke_query` + `change`). Aliases live in their own namespace, so one can never shadow or be shadowed by a built-in verb.
+Dispatch with `omnigraph alias <name> [args]`. Operator aliases are read-only;
+the CLI rejects a bound stored mutation. Invoke stored mutations with
+`omnigraph mutate <name> --server <server> --graph <id>`. Aliases live in their
+own namespace, so one can never shadow or be shadowed by a built-in verb.
 
 ### `args` bind to query parameters
 
@@ -83,8 +86,8 @@ Or per-alias (`format: jsonl`), or per-call (`--format jsonl`).
 
 ### When to use which
 
-- **`jsonl`** — one JSON object per line, first line is metadata; streams; ideal for agents
-- **`json`** — pretty-printed JSON array; smaller results; human-readable
+- **`jsonl`** — line-oriented NDJSON, with metadata first; ideal for agents
+- **`json`** — pretty-printed `ReadOutput` envelope (metadata, columns, and rows)
 - **`kv`** — `key: value` per line; good for single-row lookups
 - **`csv`** — for spreadsheets or line-count-heavy analysis
 - **`table`** — default human view; don't use in automation
@@ -96,7 +99,6 @@ Short, hyphenated, matches the conceptual operation:
 - `signal`, `pattern`, `element` — single lookup (typical pair with `format: kv`)
 - `signals`, `patterns`, `elements` — list
 - `signal-patterns`, `pattern-signals` — traversals
-- `add-signal`, `link-forms-pattern` — mutations
 
 ## Secrets Don't Belong in Aliases
 
@@ -116,9 +118,6 @@ aliases:
   signals:  { server: intel-dev, graph: spike, query: recent_signals }
   # Traversals
   pattern-signals: { server: intel-dev, graph: spike, query: pattern_signals, args: [slug] }
-  # Mutations (stored mutation; invoke_query + change)
-  add-signal:         { server: intel-dev, graph: spike, query: add_signal, args: [slug, name, brief, stagingTimestamp, createdAt, updatedAt] }
-  link-forms-pattern: { server: intel-dev, graph: spike, query: link_signal_forms_pattern, args: [signal, pattern] }
 ```
 
 Each `query:` names a stored query the cluster serves — declare them in `cluster.yaml` and `cluster apply` first (see [`stored-queries.md`](stored-queries.md)).
@@ -126,10 +125,12 @@ Each `query:` names a stored query the cluster serves — declare them in `clust
 ## Invocation Patterns
 
 ```bash
-# Invoke an alias (read or write — the bound stored query decides)
+# Invoke a read alias
 omnigraph alias signal sig-kimi-k25
-omnigraph alias add-signal sig-new "Name" "Brief" \
-  2026-04-14T00:00:00Z 2026-04-14T00:00:00Z 2026-04-14T00:00:00Z
+
+# Invoke a served stored mutation directly (aliases are read-only)
+omnigraph mutate add_signal --server intel-dev --graph spike \
+  --params '{"slug":"sig-new","name":"Name","brief":"Brief","stagingTimestamp":"2026-04-14T00:00:00Z","createdAt":"2026-04-14T00:00:00Z","updatedAt":"2026-04-14T00:00:00Z"}'
 
 # Override output format
 omnigraph alias signals --format jsonl
@@ -138,4 +139,7 @@ omnigraph alias signals --format jsonl
 omnigraph alias signal --params '{"slug":"sig-override"}'
 ```
 
-The `alias` subcommand carries `--params`/`--params-file`, `--format`/`--json`, and `--config`; the server, graph, and stored-query name come from the binding. For a different server/graph or a branch read, call `query`/`mutate` directly.
+The `alias` subcommand carries `--params`/`--params-file` and
+`--format`/`--json`; the server, graph, and stored-query name come from the
+binding. For a different server/graph or a branch read, call `query`/`mutate`
+directly.

--- a/skills/omnigraph/references/blobs.md
+++ b/skills/omnigraph/references/blobs.md
@@ -1,0 +1,88 @@
+# Blob Values
+
+Read this when a schema or workflow uses `Blob`. Blob values are intentionally
+outside ordinary `.gq` projection: write them through normal mutations or
+loads, then read one cell through the dedicated CLI or HTTP surface.
+
+## Schema and values
+
+```pg
+node Document {
+    slug: String @key
+    content: Blob?
+}
+```
+
+`Blob` cannot be a key, unique member, index, embed source, or list member.
+Schema parsing rejects those combinations. Blob properties also cannot be
+projected, filtered, ordered, or aggregated in `.gq`.
+
+Write input uses one String representation:
+
+- `base64:<payload>` stores graph-managed bytes;
+- another String requests an external object URI;
+- `null` stores null when the property is optional.
+
+There is no `blob put` or `blob clear`; use the normal atomic graph write path.
+Blob payloads count toward write limits.
+
+## External-reference policy and ownership
+
+New external references are denied by default. A cluster graph may declare
+normalized allowed bases under `external_blobs`; direct CLI access remains
+deny-only. Never put credentials in a stored URI.
+
+Ownership depends on the write:
+
+- `load --mode overwrite` preserves an allowed external reference;
+- insert, update, append/merge load, and branch merge copy allowed source bytes
+  into graph-managed storage;
+- a previously stored external reference remains readable/exportable if new
+  external ingress is later disabled.
+
+OmniGraph never deletes the external source object.
+
+## CLI reads
+
+Select one cell as `<node|edge> <TYPE> <ID> <PROPERTY>` and address the graph
+with `--store`, `--server`, or a profile:
+
+```bash
+omnigraph blob stat node Document manual content --store graph.omni --json
+omnigraph blob get node Document manual content \
+  --store graph.omni --out manual.bin
+```
+
+Use `--branch` or the mutually exclusive `--snapshot`. `get` supports
+`--offset` and `--length`; one embedded managed range is limited to 4 MiB, so
+read larger values in consecutive ranges. The CLI and HTTP server stream bytes.
+
+A failed transfer can leave a prefix in stdout or `--out`. For atomic file
+installation, write a temporary file, check the exit status, then rename it.
+
+`stat` reports the exact resolved snapshot and value kind. Managed values also
+have size and ETag; an external whole-object value reports its stored URI. The
+CLI never follows an external URI: `get` refuses it and directs the caller to
+`stat`.
+
+## HTTP reads
+
+`GET` and `HEAD /graphs/{id}/blob` take `entity`, `type`, `id`, `property`, and
+either `branch` or `snapshot`. Managed values support one standard `Range`,
+`ETag`, `If-Match`, and `If-None-Match`. Treat an ETag as an opaque validator of
+that graph representation, not a content hash.
+
+For a whole-object external value, the server returns `302` with the stored URI
+in `Location`; it does not fetch, sign, authorize, or proxy the object.
+
+## Lifecycle
+
+A reader stays pinned to the snapshot selected when it opens. Branch deletion
+or destructive cleanup can reclaim bytes needed by a long read, so quiesce such
+readers first. Blob-aware compaction is supported.
+
+Historical identity fails closed: if a rename, drop/re-add, or branch lifetime
+does not prove that a historical property is the same logical Blob property,
+OmniGraph returns an error rather than guessing.
+
+Canonical user contract: [Blob values](../../../docs/user/blobs.md).

--- a/skills/omnigraph/references/changes.md
+++ b/skills/omnigraph/references/changes.md
@@ -1,0 +1,73 @@
+# Commits, Change Feeds, and Baselines
+
+Use exact positions rather than time-based polling when a consumer must process
+graph changes durably.
+
+## Read and write positions
+
+Read query JSON includes the `graph_commit_id` pinned with the returned rows
+when the read snapshot has an effective graph head; a fresh pre-commit graph can
+omit it. A conditional mutation requires an ID returned by the read.
+An effectful `mutate --json` or `load --json` returns `commit` with the exact
+commit published by that attempt; a no-op mutation returns `"commit": null`.
+
+Protect a mutation derived from a read with `--if-commit <graph_commit_id>`.
+Any intervening branch commit fails without effects (CLI exit `4`, HTTP `412`).
+Re-read and decide again rather than retrying the stale mutation.
+
+## Inspect one commit
+
+```bash
+omnigraph commit changes <commit-id> --store graph.omni --json
+```
+
+The commit is compared with its first parent. Inserts contain `after`, updates
+contain `before` and `after`, and deletes contain `before`; edge images also
+carry endpoints. Filter with repeatable `--kind`, `--type`, and `--op`.
+
+Large results use `next_page_token`. The CLI normally follows every page;
+`--page-token` fetches exactly one. A page token continues one commit result and
+is not a feed cursor. Parentless commits and schema-boundary diffs return `409`;
+capture a baseline instead of treating them as empty changes.
+
+## Follow a branch
+
+```bash
+omnigraph changes poll --start now --store graph.omni --json
+omnigraph changes poll --start beginning --store graph.omni --json
+omnigraph changes poll --start after:<commit-id> --store graph.omni --json
+omnigraph changes poll --cursor <cursor> --store graph.omni --json
+```
+
+Each poll captures a fixed branch head and walks complete commits in first-parent
+order. `now` is the default. A durable cursor appears only on the terminal page;
+an intermediate page has only `next_page_token`. `caught_up` says whether the
+terminal page reached the captured head.
+
+Delivery is at least once. Apply each block idempotently by `graph_commit_id`,
+then atomically persist the terminal cursor with the applied blocks. Cursors are
+opaque and bound to graph, branch lifetime, and filter scope; the server stores
+no consumer position.
+
+## Recover from retention gaps
+
+Cleanup can reclaim history needed by a cursor. A `410 change_feed_gap` cannot
+be repaired by retrying the same cursor. Capture and install a new baseline:
+
+```bash
+omnigraph changes baseline --out snapshot.jsonl --store graph.omni --json
+```
+
+The HTTP equivalent streams snapshot entity records followed by one terminal
+record containing `snapshot_commit_id` and `resume_cursor`. An interrupted
+stream has no usable cursor. Install the complete snapshot durably before
+saving that cursor; resumed delivery begins after the captured snapshot.
+Kind/type filters scope the snapshot; an operation filter applies only to the
+resumed feed.
+
+On POSIX, CLI `--out` syncs and atomically replaces the snapshot file before it
+prints the handshake to JSON stdout. Baselines require Cedar `export`; commit
+changes and feed polling require `read`.
+
+Canonical contracts: [change feeds](../../../docs/user/branching/changes.md)
+and [conditional mutations](../../../docs/user/mutations/index.md#conditional-mutations).

--- a/skills/omnigraph/references/cluster.md
+++ b/skills/omnigraph/references/cluster.md
@@ -7,7 +7,7 @@
 - Serving (`--cluster`, config-free bucket boot)
 - Recovery cheat-sheet
 
-The cluster control plane (omnigraph >= 0.7.0) manages a whole deployment —
+The cluster control plane manages a whole deployment —
 graphs, schemas, stored queries, Cedar policies — as **declared files in one
 directory**, converged Terraform-style. It is the **only way to serve** a
 graph (the server is cluster-only); the data-plane operations in the other
@@ -28,15 +28,16 @@ company-brain/
 ```yaml
 # cluster.yaml
 version: 1
-# storage: s3://my-bucket/clusters/company-brain   # optional — put ledger,
-#   catalog, and graph roots on S3 object storage (default: this folder)
+# storage: s3://my-bucket/clusters/company-brain   # optional object-store root;
+# preview Azure roots use az://container/prefix (default: this folder)
 state: { backend: cluster, lock: true }
 graphs:
   knowledge:
     schema: schema.pg
     queries: queries/    # the .gq files ARE the declaration — every `query <name>` registers
-policies:
-  base: { file: base.policy.yaml, applies_to: [knowledge] }  # or [cluster] for server-level
+    external_blobs:      # omitted means deny new external references
+      allow:
+        - { base: s3://company-assets/knowledge/, scope: server_safe }
 ```
 
 `queries` also accepts a file list (`[a.gq, b.gq]`) or a fine-grained
@@ -67,8 +68,22 @@ omnigraph-server --cluster . --bind 127.0.0.1:8080 --unauthenticated  # serve (l
   the lock becomes genuinely cross-machine. Absent, everything defaults to the
   config directory (byte-compatible with pre-existing clusters). Credentials
   come from the standard `AWS_*` env contract, never `cluster.yaml`.
-- **`--as <actor>` attributes every run** (sidecars, audit, engine commits).
-  Defaults from your operator config's `operator.actor`; required for `approve`.
+- **`storage: az://container/prefix` is preview-only.** Every writer, server,
+  apply job, and maintenance process for an Azure root must run through
+  `omnigraph-azure-admission`; the preview lease is external admission, not an
+  engine-level distributed-writer fence.
+- **One mutation-capable process per graph remains the supported topology.** A
+  cluster ledger lock serializes control-plane runs; it does not fence arbitrary
+  data-plane writers. Provide external admission before running another writer.
+- **External Blob ingress is default-deny.** `graphs.<id>.external_blobs.allow`
+  lists normalized URI bases. `scope: server_safe` can be installed by the
+  server; `embedded_only` is never installed by the server or direct-store CLI.
+  Cedar chooses who may write; this list chooses which source objects a writer
+  may cause the process to inspect.
+- **`--as <actor>` attributes `cluster apply` and `cluster approve`** (sidecars,
+  audit, and engine commits where applicable). It defaults from operator config's
+  `operator.actor` and is required for `approve`; the other cluster subcommands
+  reject this flag.
 - **Destructive changes are gated**: removing a graph from `cluster.yaml`
   blocks with `approval_required` until
   `omnigraph cluster approve graph.<id> --config . --as <you>` records a
@@ -95,16 +110,20 @@ coupling.
 
 ## Serving
 
-`omnigraph-server --cluster <dir>` is exclusive (cannot combine with a URI,
-`--target`, or `--config`), always multi-graph (`/graphs/{id}/...`), and
-fail-fast: missing/pending/tampered state refuses boot with a remedy. Every
-declared query is exposed (`GET /graphs/<id>/queries`, `POST
+`omnigraph-server --cluster <dir-or-uri>` is the exclusive boot source (there
+is no separate `--config` merge) and is always multi-graph
+(`/graphs/{id}/...`). By default, graph-attributed recovery, query-registry, or
+provider failures quarantine only the affected graph and healthy graphs still
+serve. Cluster-global or unattributable failures are fatal, as are any graph
+failures with `--require-all-graphs`. Every healthy graph's applied query is
+exposed (`GET /graphs/<id>/queries`, `POST
 /graphs/<id>/queries/<name>`); Cedar bundles attach via `applies_to`
-(`cluster` → server-level gate incl. `graph_list`; `graph.<id>` → that
+(`cluster` → server-level gate incl. `graph_list`; a graph id → that
 graph's gate incl. `invoke_query`). Bearer tokens and bind stay process-level
 (env/flags).
 
-**Config-free serving.** `--cluster` also accepts the storage-root URI
+**Config-free serving.** `--cluster` also accepts a `file://`, `s3://`, or
+preview `az://` storage-root URI
 directly — `omnigraph-server --cluster s3://bucket/prefix` boots from the
 applied revision on the bucket with **no checkout of the config repo**. The
 ledger and catalog on the bucket are the whole deployment artifact; policy
@@ -119,10 +138,11 @@ in-container `cluster apply`.
 | Symptom | Fix |
 |---|---|
 | Apply crashed mid-run | run `cluster apply` again — sidecars + sweep reconcile |
-| Held lock | `cluster status` (shows lock id) → `cluster force-unlock <LOCK_ID> --config .` |
-| Lost/corrupt `state.json` | `cluster import` rebuilds from config + live graphs, then `apply` |
+| Held lock | First prove no `plan`/`apply`/`refresh`/`import` is still live; then use `cluster status` and clear that exact id with `cluster force-unlock <LOCK_ID> --config .` |
+| Missing `state.json` | `cluster import` bootstraps state from config + live graphs, then `apply` |
+| Corrupt `state.json` | restore a trusted cluster-state backup or follow the diagnostic; `cluster import` never overwrites existing state |
 | Server refuses to boot | the error names its remedy (usually `cluster refresh` + `apply`, restart) |
-| `approval_stale` warning | re-run `cluster approve` — the plan changed since you approved |
+| `approval_stale` warning | re-run and review `cluster plan`, then approve the current digest — the planned change changed |
 
 Full reference: the omnigraph repo's `docs/user/clusters/index.md` (operator guide)
 and `docs/user/clusters/config.md` (every key, flag, and diagnostic).

--- a/skills/omnigraph/references/commands.md
+++ b/skills/omnigraph/references/commands.md
@@ -2,7 +2,8 @@
 
 ## Contents
 - Inspect state (snapshot, export)
-- Branches · commits · graphs
+- Branches · commits · changes · graphs
+- Blob reads
 - Schema · lint · embed · init
 - Load (bulk JSONL)
 - Query / mutate
@@ -17,13 +18,14 @@ Commands you'll reach for but don't need best-practice rules around. Quick synta
 
 ## Inspect State
 
-### `snapshot` — tables + row counts
+### `snapshot` — node/edge types and entity counts
 
 ```bash
 omnigraph snapshot $REPO --branch main --json
 ```
 
-Returns the manifest: all node/edge tables with row counts and versions. Use this to verify a load succeeded or to see what types exist.
+Returns every node/edge type with entity counts and published dataset versions.
+Use it to verify a load or inspect the graph shape.
 
 ### `export` — full JSONL dump
 
@@ -39,33 +41,53 @@ Filter by type:
 omnigraph export $REPO --branch main --type Signal > signals.jsonl
 ```
 
+Use repeatable `--type` to filter node or edge types.
+
+## Blob Reads
+
+```bash
+omnigraph blob stat node Document manual content --store "$REPO" --json
+omnigraph blob get node Document manual content --store "$REPO" --out manual.bin
+omnigraph blob get node Document manual content --store "$REPO" --offset 0 --length 4096
+```
+
+The selector is `<node|edge> <TYPE> <ID> <PROPERTY>`. Choose a branch or
+snapshot; `get` streams managed bytes and `stat` inspects metadata. See
+[`blobs.md`](blobs.md) before handling external references or ranged reads.
+
 ## Branches
 
 ```bash
 omnigraph branch create --from main <branch-name> --store $REPO
 omnigraph branch list --store $REPO
-omnigraph branch merge <branch-name> --into main --store $REPO
+omnigraph branch merge <branch-name> --into main --delete-branch --store $REPO
 omnigraph branch delete <branch-name> --store $REPO
 ```
 
-All support `--json`.
+All support `--json`. `--delete-branch` removes the source only after a
+successful merge publication.
 
 ## Commits (History)
 
 ```bash
-omnigraph commit list $REPO --branch main
-omnigraph commit show $REPO <commit-id>
+omnigraph commit list --store "$REPO" --branch main
+omnigraph commit show <commit-id> --store "$REPO"
+omnigraph commit changes <commit-id> --store "$REPO" --json
 ```
 
-Inspect graph history. Useful for "what changed between these two points" investigation.
+`commit changes` compares one commit with its first parent and can filter with
+repeatable `--kind`, `--type`, and `--op`. For a durable branch feed and
+baseline recovery, see [`changes.md`](changes.md).
 
 ## Graphs (multi-graph servers)
 
 ```bash
-omnigraph graphs list --config X --json
+omnigraph graphs list --server <name-or-url> --json
 ```
 
-Lists the graphs a multi-graph server serves. Remote servers only (rejects local URIs); the server must expose `GET /graphs` via `server.policy.file`. See `references/server-policy.md`.
+Lists the graphs a multi-graph server serves. Remote servers only (rejects local
+URIs); a cluster-scoped policy bundle must grant `graph_list`. See
+[`server-policy.md`](server-policy.md).
 
 ## Schema
 
@@ -89,9 +111,9 @@ omnigraph lint --query queries/foo.gq $REPO --json
 ## Embed
 
 ```bash
-omnigraph embed --seed embed-config.yaml                  # fill missing
-omnigraph embed --seed embed-config.yaml --reembed_all    # regenerate all
-omnigraph embed --seed embed-config.yaml --clean          # delete
+omnigraph embed --input raw.jsonl --output embedded.jsonl --spec embeddings.json
+omnigraph embed --input raw.jsonl --output embedded.jsonl --spec embeddings.json --reembed-all
+omnigraph embed --seed embed-config.yaml --clean
 omnigraph embed --seed embed-config.yaml --select "Type:field=value"
 ```
 
@@ -105,7 +127,9 @@ omnigraph init --schema schema.pg $REPO
 
 Creates a new graph at `$REPO` with the given schema. Declare the deployment in a `cluster.yaml` (see `references/cluster.md`).
 
-**Strict by default (v0.6.0+):** `init` against a URI that already holds schema files errors with `AlreadyInitialized` instead of silently overwriting. Use `omnigraph init --force` to re-init deliberately. `--force` only skips the schema-file preflight — it does **not** purge existing Lance datasets.
+**Strict by default:** `init` refuses any initialized graph. `--force` only
+replaces orphan schema artifacts after proving there is no `__manifest`; it
+never overwrites an initialized graph or purges Lance datasets.
 
 **Note:** `init` does not accept `--json`. Drop the flag if you see `unexpected argument --json`.
 
@@ -119,36 +143,44 @@ omnigraph load --data seed.jsonl --mode merge $REPO
 omnigraph load --data delta.jsonl --branch feature-x --from main --mode merge $REPO
 ```
 
-`--mode` is **required** (no default): `merge`, `append`, or `overwrite`. `load` works against local **and** remote URIs. See `references/data.md`.
+`--mode` is **required** (no default): `merge`, `append`, or `overwrite`.
+Address either direct storage or a served graph. See `references/data.md`.
 
 ## Query / Mutate
 
 ```bash
 omnigraph query  get_signal --query queries/signals.gq --params '{"slug":"sig-foo"}'    # ad-hoc file; <name> is positional
 omnigraph query  get_signal --server intel-dev --params '{"slug":"sig-foo"}'            # served stored query by name
-omnigraph mutate add_signal --query queries/mutations.gq --params '{"slug":"sig-foo",...}'
+omnigraph mutate add_signal --query queries/mutations.gq --params '{"slug":"sig-foo","name":"Foo","brief":"Example","createdAt":"2026-04-14T00:00:00Z"}'
 ```
 
-With aliases:
+With a read alias:
 
 ```bash
 omnigraph alias signal sig-foo
-omnigraph alias add-signal sig-foo "Name" "Brief" 2026-04-14T00:00:00Z 2026-04-14T00:00:00Z 2026-04-14T00:00:00Z
 ```
+
+Aliases are read-only. Invoke a served stored mutation with `omnigraph mutate
+<name> --server ...`.
 
 > `query` and `mutate` also accept inline source via `-e/--query-string '<gq>'` instead of `--query <file>`.
 
 ## Maintenance
 
-### `optimize` — non-destructive Lance compaction
+### `optimize` — compaction and index reconciliation
 
 ```bash
 omnigraph optimize $REPO --json
 ```
 
-Compacts fragments and reclaims deleted-row space. Non-destructive — safe to run any time. **Skips tables with a `Blob` property** (Lance blob-v2 compaction decode bug); skipped tables are reported in the `skipped` field of `--json` output and in logs. Non-blob tables compact normally. Blob-table fragment count won't shrink until the upstream Lance fix lands — reads/writes are unaffected.
+Compacts fragments and reconciles declared scalar/vector index coverage without
+deleting retained versions. Lance 11 supports compaction of Blob-bearing data;
+null,
+valid-empty, and non-empty Blob values remain distinct. Existing full-text
+indexes are preserved and any uncovered tail is scanned; use the explicit
+rebuild command when full-text coverage or analyzer compatibility must change.
 
-### `rebuild-full-text-indexes` — explicit analyzer upgrade (v0.10.0)
+### `rebuild-full-text-indexes` — explicit analyzer upgrade
 
 ```bash
 omnigraph rebuild-full-text-indexes "$REPO" --branch main --json
@@ -169,16 +201,22 @@ actor attribution and does not install server policy on direct access.
 omnigraph cleanup $REPO --keep 5 --older-than 7d --confirm
 ```
 
-Garbage-collects old table versions, dropping time-travel reachability for anything pruned. **Destructive** — requires `--confirm`. Duration units for `--older-than`: `s`, `m`, `h`, `d`, `w`. Also reconciles orphaned per-table forks left by an interrupted `branch delete`.
+Garbage-collects old dataset versions, dropping time-travel reachability for
+anything pruned. **Destructive** — requires `--confirm`. At least one of
+`--keep` and `--older-than` is required; with both, a version must be outside
+both windows. Duration units: `s`, `m`, `h`, `d`, `w`.
 
-## Stored Queries (v0.6.1)
+## Stored Queries
 
 ```bash
-omnigraph queries validate              # type-check the stored-query registry vs the live schema (offline; exits non-zero on drift)
-omnigraph queries list                  # list registry query names, MCP exposure, and typed params
+omnigraph queries validate --cluster .              # type-check every applied registry
+omnigraph queries list --cluster . --graph knowledge # list names and typed params
 ```
 
-`validate` opens the addressed graph and type-checks every applied stored query against the live schema — catches drift without restarting the server. `list` prints that graph's registry. Address the graph with `--store <uri>` or a positional URI. Distinct from `lint` (which validates a single `.gq` file). See `references/stored-queries.md`.
+`queries` operates on applied cluster state, not a graph URI. `validate`
+checks every registry against its applied schema; `list` may select one graph.
+Distinct from `lint`, which validates authoring source. See
+[`stored-queries.md`](stored-queries.md).
 
 ## Operator Config & Credentials
 
@@ -187,7 +225,7 @@ echo "$TOKEN" | omnigraph login <server>   # store a bearer token in ~/.omnigrap
 omnigraph logout <server>                  # remove it (idempotent)
 ```
 
-The operator config and `~/.omnigraph/credentials` are **auto-discovered — there is no flag to point at them.** `$OMNIGRAPH_HOME` relocates the `~/.omnigraph` *directory* (mainly for test isolation), and an absent file is just an empty layer (zero-config). Separately, `$OMNIGRAPH_CONFIG` stands in for the `--config` flag — which targets the **cluster directory / server config**, never the operator config. See SKILL.md → *The two config surfaces*.
+The operator config and `~/.omnigraph/credentials` are **auto-discovered — there is no flag to point at them.** `$OMNIGRAPH_HOME` relocates the `~/.omnigraph` directory, and an absent file is an empty layer. Only `cluster` subcommands accept `--config`.
 
 ## Addressing a Graph
 
@@ -195,34 +233,45 @@ How the CLI resolves which graph a data command (`query`, `mutate`, `load`, `bra
 
 Precedence (highest first):
 
-1. **`--store <uri>`** or a **positional `file://`/`s3://` URI** — direct storage access (bypasses any server; no catalog, so stored-query *names* don't resolve). `--store` is exclusive with a positional URI and with `--server`.
+1. **`--store <uri>`** or a **positional `file://`/`s3://`/`az://` URI** — direct storage access (bypasses any server; no catalog, so stored-query *names* don't resolve). `--store` is exclusive with a positional URI and with `--server`. Azure is a qualification preview and writes require `omnigraph-azure-admission`.
 2. **`--server <name|url>`** (+ `--graph <id>` for a multi-graph server) — served/remote. A name resolves from `servers:` in `~/.omnigraph/config.yaml`; a literal `http(s)://` URL also works.
 3. **`--profile <name>`** (or `$OMNIGRAPH_PROFILE`) — a named scope bundle from `profiles:` in the operator config (binds one of server/cluster/store + a default graph).
 4. **Operator defaults** — `defaults.server` + `defaults.default_graph`, or `defaults.store` for a zero-flag local scope (mutually exclusive with `defaults.server`).
 
-Control-plane commands use `--config <dir>` (cluster); maintenance against a cluster-managed graph uses `--cluster <dir|s3://> --graph <id>`. Each command declares a **capability** — `any` / `served` / `direct` / `control` / `local` — shown in `omnigraph --help`; mis-addressing (e.g. `--server` on a `direct` verb, or a remote URI to `optimize`) fails loudly.
+Cluster subcommands use `--config <dir>`; policy and stored-query control-plane
+commands use `--cluster <dir|uri>`. Maintenance against a
+cluster-managed graph uses `--cluster <dir|file://|s3://|az://> --graph <id>`.
+Each command declares a **capability** — `any` / `served` / `direct` /
+`control` / `local` — shown in `omnigraph --help`; mis-addressing fails loudly.
 
 For query source (`query`/`mutate`):
 
 1. **`--query <file>`** or **`-e/--query-string '<gq>'`** — exactly one (operator aliases are invoked via the separate `alias` subcommand)
-2. Relative `--query` paths resolve through **`query.roots`** in config
+2. Relative `--query` paths resolve from the current working directory
 
 For params:
 
 1. **Explicit `--params '{...}'`** wins on key conflict
 2. **Positional alias args** map to alias `args` list
 
-## Output Formats
+## Output Formats and Positions
 
-`--format <fmt>` on query/mutate:
+`--format <fmt>` on read queries and aliases:
 
 - `table` (default) — human-readable
 - `kv` — `key: value` per line; good for single rows
 - `csv` — comma-separated
 - `jsonl` — NDJSON, one per line, with metadata line first
-- `json` — pretty JSON array
+- `json` — pretty `ReadOutput` envelope (metadata, columns, and rows)
 
-For admin commands (branch, commit, schema, policy): use `--json` for structured output, otherwise human text.
+Mutations do not take `--format`; use `--json`. Successful `mutate --json` and
+`load --json` include the exact published `commit` (`null` for a no-op
+mutation). `query --json` includes `graph_commit_id` when the read snapshot has
+an effective graph head (a fresh pre-commit graph can omit it). When returned,
+use that position with `mutate --if-commit`; see [`changes.md`](changes.md).
+
+For admin commands that advertise it (branch, commit, schema): use `--json` for
+structured output, otherwise human text. Policy subcommands do not offer JSON.
 
 ## Health Check
 
@@ -232,7 +281,7 @@ curl http://127.0.0.1:8080/healthz
 
 Returns `200 OK` if the server is up.
 
-## Cluster Control Plane (omnigraph >= 0.7.0)
+## Cluster Control Plane
 
 ```bash
 omnigraph cluster validate     --config <dir>          # parse + typecheck the declaration

--- a/skills/omnigraph/references/data.md
+++ b/skills/omnigraph/references/data.md
@@ -20,16 +20,16 @@ edits.
 | Task | Command | Why |
 |------|---------|-----|
 | Add/update a single entity | `mutate` with a named mutation | typechecked, parameterized, auditable |
-| Bulk upsert by `@key` | `load --mode merge` | preserves rows not in the file |
+| Bulk upsert by logical entity ID | `load --mode merge` | preserves rows not in the file; keyed node IDs derive from `@key` |
 | Additive-only bulk | `load --mode append` | fails on key collision |
-| Clean-slate reseed | `load --mode overwrite` | **destructive** — wipes the branch |
+| Replace complete batches by type | `load --mode overwrite` | **destructive for represented types**; absent types remain |
 | Bulk load onto a fresh review branch | `load --from main --mode merge --branch <name>` | forks `<name>` from `main`, loads onto it, leaves it for review |
 
 > **`--mode` is required** — there is no default. Overwrite is destructive, so
 > the CLI never picks a mode for you.
 
-> **Per-load bounds (omnigraph >= 0.9.0).** One keyed load (`append`/`merge`)
-> stages at most **8,192 rows and 32 MiB of Arrow memory per table**; a larger
+> **Per-load bounds.** One keyed load (`append`/`merge`)
+> stages at most **8,192 entities and 32 MiB of Arrow memory per touched type**; a larger
 > batch is refused up front (HTTP 413, typed `resource_limit`) with no durable
 > effect — split it into chunks, each an atomic graph commit. `overwrite`
 > escapes the row ceiling but not the 32 MiB strict-input Arrow preflight
@@ -38,15 +38,15 @@ edits.
 > target, `--mode overwrite` (like `cleanup` and `branch delete`) requires
 > explicit `--yes` consent in non-interactive runs.
 >
-> **Local and remote are one command.** `load` works against a local repo URI
-> (writing storage directly) *and* a remote `omnigraph-server` endpoint (the
+> **Direct and served are one command.** `load` works against a graph store
+> (writing storage directly) *and* an `omnigraph-server` endpoint (the
 > server orchestrates the write and publishes one atomic commit). See
 > [`references/remote-ops.md`](remote-ops.md) for remote-specific concerns
 > (504 handling, write-verification ritual).
 
 ## `mutate` — Single Edits
 
-Goes through the running server (the configured default graph, or an alias):
+Runs either directly (`--store`) or through a server (`--server`/profile):
 
 ```bash
 omnigraph mutate add_signal \
@@ -54,10 +54,11 @@ omnigraph mutate add_signal \
   --params '{"slug":"sig-foo","name":"Foo","brief":"...","stagingTimestamp":"2026-04-14T00:00:00Z","createdAt":"2026-04-14T00:00:00Z","updatedAt":"2026-04-14T00:00:00Z"}'
 ```
 
-Or via an alias:
+Or invoke a served stored mutation by name:
 
 ```bash
-omnigraph alias add-signal sig-foo "Foo" "..." 2026-04-14T00:00:00Z 2026-04-14T00:00:00Z 2026-04-14T00:00:00Z
+omnigraph mutate add_signal --server intel-dev --graph spike \
+  --params '{"slug":"sig-foo","name":"Foo","brief":"...","stagingTimestamp":"2026-04-14T00:00:00Z","createdAt":"2026-04-14T00:00:00Z","updatedAt":"2026-04-14T00:00:00Z"}'
 ```
 
 Prefer `mutate` for interactive edits, mutations called from agents, and anything you want typechecked at call time.
@@ -67,12 +68,15 @@ Prefer `mutate` for interactive edits, mutations called from agents, and anythin
 JSONL format:
 
 ```jsonl
-{"type":"Signal","data":{"id":"sig-foo","slug":"sig-foo","name":"Foo","brief":"...","stagingTimestamp":"2026-04-14T00:00:00Z","createdAt":"2026-04-14T00:00:00Z","updatedAt":"2026-04-14T00:00:00Z"}}
+{"type":"Signal","data":{"slug":"sig-foo","name":"Foo","brief":"...","stagingTimestamp":"2026-04-14T00:00:00Z","createdAt":"2026-04-14T00:00:00Z","updatedAt":"2026-04-14T00:00:00Z"}}
 {"edge":"FormsPattern","from":"sig-foo","to":"pat-bar","data":{}}
 ```
 
-- Nodes: `{"type":"<NodeType>","data":{...props...}}` — `id` equals `slug`
-- Edges: `{"edge":"<EdgeType>","from":"<src_slug>","to":"<dst_slug>","data":{...edge_props...}}`
+- Nodes: `{"type":"<NodeType>","data":{...props...}}`. A keyed node derives
+  `id` from its complete typed key tuple; omit `id` in hand-authored keyed
+  input. An unkeyed node gets a generated id unless one is supplied.
+- Edges: `{"edge":"<EdgeType>","from":"<src_id>","to":"<dst_id>","data":{...edge_props...}}`.
+  Edges also use generated or supplied ids.
 
 Load command:
 
@@ -86,24 +90,31 @@ one-shot review-branch flow below). Without `--from`, the target `--branch`
 
 ### `--mode` semantics
 
-- **`overwrite`** (destructive) — replaces every node/edge table on the branch with the file's contents. **Staged**: the loader validates node/edge constraints, referential integrity, and edge cardinality *before* any data moves, so a bad file fails before touching the branch. Safe on a **first** load; risky afterward. Don't run it against `main` in production without a branch backup path.
-- **`merge`** (upsert) — for each row, insert if `@key` is new, update if it exists. Rows not in the file are preserved. The safe default for incremental bulk updates.
-- **`append`** (strict insert) — fails on key collision. Use when you're certain every row is new.
+- **`overwrite`** (destructive by represented type) — replaces each node or
+  edge type present in the batch; types absent from the batch stay unchanged.
+  The loader validates constraints and referential integrity before publication.
+  Use a review branch for an established graph.
+- **`merge`** (upsert) — inserts or updates each row by logical entity `id`
+  (derived from the typed `@key` tuple for keyed nodes). Rows not in the file
+  are preserved. The safe default for incremental bulk updates.
+- **`append`** (strict insert) — fails on entity-ID collision. Use when you're
+  certain every row is new.
 
-### `merge` does NOT recompute embeddings
+With `--json`, an effectful `mutate` or `load` returns the exact published
+`commit`; a no-op mutation returns `commit: null`. For compare-and-swap writes,
+feeds, and diff inspection, see [`changes.md`](changes.md).
 
-If you change seed rows that feed into `@embed("source")` via `load --mode merge`, the source field updates but the embedding stays stale.
+### Embeddings are explicit input
 
-**Fix:** run `omnigraph embed --reembed_all` after, or use `load --mode overwrite` once (which re-triggers embedding on load).
+`@embed` does not populate vectors during `merge` or `overwrite`. Supply
+vectors in the JSONL, or run the offline `omnigraph embed` file transformation
+and load its output. See [`search.md`](search.md).
 
-### `overwrite` is destructive
+### `overwrite` is scoped but destructive
 
-Wipes the entire branch's data for every node and edge type. Use only for:
-- First-time seed
-- Intentional full reseed on a feature branch
-- Recovery scenarios
-
-Never on `main` without a branch backup.
+It removes existing entities of every type represented in the batch. Use it
+for a complete type replacement, preferably on a review branch. Do not assume
+that it clears unrelated types or the whole branch.
 
 ## Branches: Review Before Merge
 
@@ -123,11 +134,8 @@ omnigraph load --data delta.jsonl --branch staging-2026-04-14 --mode merge $REPO
 # 3. Verify on the branch (reads can target --branch or --snapshot)
 omnigraph query recent_signals --query queries/signals.gq --branch staging-2026-04-14 --store $REPO
 
-# 4. Merge to main when happy
-omnigraph branch merge staging-2026-04-14 --into main --store $REPO
-
-# 5. Optionally delete the branch
-omnigraph branch delete staging-2026-04-14 --store $REPO
+# 4. Merge to main and delete the source only after publication
+omnigraph branch merge staging-2026-04-14 --into main --delete-branch --store $REPO
 ```
 
 ### Fork a branch in one shot with `--from`
@@ -139,7 +147,9 @@ Use `--from` for anything you want reviewed before it touches `main`.
 
 ### Keep branches short-lived
 
-Long-lived branches compound merge risk. The usual flow is: create → load → verify → merge → delete, all in the same session. A week-old feature branch is a yellow flag.
+Long-lived branches compound merge risk. The usual flow is: create → load →
+verify → `merge --delete-branch`, all in the same session. Source deletion only
+happens after a successful merge publication.
 
 ### Schema apply blocks non-main branches
 
@@ -147,13 +157,15 @@ Long-lived branches compound merge risk. The usual flow is: create → load → 
 
 ## Destructive Ops Go Through a Branch
 
-For any bulk load that could disrupt downstream queries (overwriting a heavily-referenced node type, removing edges en masse, reseeding a core table), use a feature branch:
+For any bulk load that could disrupt downstream queries (overwriting a
+heavily-referenced node type, removing edges en masse, or reseeding a core
+type), use a feature branch:
 
 ```bash
 omnigraph load --data risky.jsonl --branch recovery-2026-04-14 \
   --from main --mode overwrite $REPO
 # inspect, diff, verify reads
-omnigraph branch merge recovery-2026-04-14 --into main --store $REPO
+omnigraph branch merge recovery-2026-04-14 --into main --delete-branch --store $REPO
 ```
 
 ## Branch Commands (quick reference)
@@ -161,17 +173,18 @@ omnigraph branch merge recovery-2026-04-14 --into main --store $REPO
 ```bash
 omnigraph branch create --from main <branch-name> --store $REPO
 omnigraph branch list --store $REPO
-omnigraph branch merge <branch-name> --into main --store $REPO
+omnigraph branch merge <branch-name> --into main --delete-branch --store $REPO
 omnigraph branch delete <branch-name> --store $REPO
 ```
 
 All support `--json` for automation-friendly output. Address the graph with a
-positional `file://`/`s3://` URI (shown), `--store <uri>`, or `--server <name>`.
+positional `file://`/`s3://`/preview `az://` URI (shown), `--store <uri>`, or
+`--server <name>`.
 
 ## Inspecting State After Changes
 
 ```bash
-omnigraph snapshot $REPO --branch main --json           # tables + row counts
+omnigraph snapshot $REPO --branch main --json           # node/edge entity counts
 omnigraph export $REPO --branch main > graph.jsonl      # full JSONL dump
 omnigraph commit list $REPO --branch main --json        # history
 ```

--- a/skills/omnigraph/references/migrations.md
+++ b/skills/omnigraph/references/migrations.md
@@ -1,65 +1,89 @@
-# Migration & Deprecations (pre-0.7.0 → 0.7.0)
+# Migration and Retired Vocabulary
 
-The rest of this skill teaches the **current 0.7.0 surface only**. Consult this page solely when you meet an old config file, command, flag, route, or error and need its current form. Pre-0.7.0 spellings keep working as deprecated aliases (they print a warning) unless marked **removed**.
+The rest of this skill describes OmniGraph 0.10.x. Use this page only to
+recognize an older command, config, route, or upgrade boundary.
 
-## Config files
+## Upgrade v0.9 to v0.10
 
-| Before (pre-0.7.0) | Now (0.7.0) |
+v0.10 moves from Lance 9 to Lance 11 but retains graph storage format v6, so
+existing entities, branches, and retained history do not need entity
+export/import. The interface boundary is not rolling-compatible: stop traffic
+and upgrade CLI, server, and client bindings together. Do not mix Lance 9/10 and
+Lance 11 readers or writers on one graph root.
+
+Preserve a verified backup of the whole graph root and the cluster deployment
+state. Then rebuild every full-text index on every live branch that needs
+full-text search:
+
+```bash
+omnigraph branch list --store graph.omni --json
+omnigraph rebuild-full-text-indexes --store graph.omni \
+  --branch main --as operator --json
+```
+
+The rebuild uses the default English analyzer and replaces custom tokenizer
+settings. It does not rewrite historical snapshots. Ordinary traversal and
+vector search remain available without it; full-text search refuses indexes
+whose analyzer compatibility cannot be proved. An unknown physical index kind
+is a fail-closed migration case—use compatible old tooling for a controlled
+export/import rather than editing index metadata.
+
+Before reopening traffic, verify representative full-text searches and entity
+counts on every rebuilt branch, then check the upgraded CLI/API integrations
+against the new response fields. Resume only with the new fleet.
+
+Rollback means restoring the whole pre-upgrade graph and cluster-state backup
+with the old fleet. v0.9 cannot read applied `external_blobs` state and also
+lacks v0.10's default-deny external ingress, so do not downgrade when that
+boundary is required.
+
+v0.10 also removes ambiguous client vocabulary such as `table_key`, `row_id`,
+`manifest_version`, `rows_loaded`, and `export --table`. Use node/edge, type,
+entity, property, graph-manifest, and published-dataset terms plus
+`export --type`. See the canonical [upgrade procedure](../../../docs/user/operations/upgrade.md).
+
+## Pre-0.7 configuration
+
+| Before | v0.10 |
 |---|---|
-| `omnigraph.yaml` (one combined file) | **`cluster.yaml`** (team deployment) + **`~/.omnigraph/config.yaml`** (operator) |
+| `omnigraph.yaml` | `cluster.yaml` for team deployment plus `~/.omnigraph/config.yaml` for operator settings |
 | `cli.actor` | `operator.actor` |
-| `cli.graph` / `server.graph` | `defaults.default_graph` (+ `defaults.server`) |
+| `cli.graph` / `server.graph` | `defaults.default_graph` plus optional `defaults.server` |
 | `targets:` / `target:` | `graphs:` / `graph:` |
-| `omnigraph init` scaffolds `omnigraph.yaml` | `init` scaffolds nothing — start a `cluster.yaml` from [`cluster.md`](cluster.md) |
 
-- **`omnigraph.yaml` is fully removed in 0.7.0** — no CLI command or server reads it, and there is **no `config migrate`**. Move team settings to `cluster.yaml` and personal settings (identity, `servers:`, `defaults:`, `aliases:`) to `~/.omnigraph/config.yaml` by hand.
+`omnigraph.yaml` is removed and there is no automatic config migration. Move
+schema/query/policy declarations into `cluster.yaml`; move identity, named
+servers, output defaults, profiles, and aliases into the operator file.
 
-## CLI addressing (RFC-011)
+## Retired addressing and verbs
 
-| Before | Now |
+| Before | v0.10 |
 |---|---|
-| `--target <name>` | **removed** — use `--server <name\|url>`, `--store <uri>`, or `--profile <name>` (SKILL.md → *Addressing a graph*) |
-| positional `http(s)://` URL → a server | **removed** — address a remote with `--server <url>` |
-| `--as` on a served (remote) write | no-op — the server resolves the actor from the bearer token (`--as` applies to direct `--store` writes) |
-| `--cluster-graph <id>` | **removed** — `--cluster <dir\|uri>` is a global scope; pick the graph with `--graph <id>`. `--graph` now selects within a `--server` *or* `--cluster` scope |
-| `query`/`mutate` `--name <q>` + positional graph URI / `--uri` | **removed** — the query name is the **positional** (`omnigraph query <name>`): a bare `<name>` invokes a served stored query (kind-asserted), `--query`/`-e` is the ad-hoc lane. Address the graph via `--server`/`--store`/`--profile` (not a positional URI on query/mutate) |
+| `--target <name>` | `--server`, `--store`, `--cluster`, or `--profile`, as the command permits |
+| positional HTTP URL | `--server <name|url>` |
+| `--cluster-graph <id>` | `--cluster <dir|uri> --graph <id>` |
+| query `--name <q>` | positional query name plus `--query`/`-e` for ad-hoc source |
+| `ingest` | `load --mode <append|merge|overwrite>` |
+| `read` / `change` | `query` / `mutate` |
+| `query lint` / `query check` | `lint` |
+| query/mutate `--alias` | dedicated `alias <name>` command |
 
-## Server boot & schema (RFC-011)
+The server is cluster-only: start it with `omnigraph-server --cluster
+<dir|file://|s3://|az://>`. Data-plane commands do not take the cluster
+control-plane `--config` flag. `policy` and the stored-query registry use
+`--cluster` plus optional `--graph`.
 
-| Before | Now |
-|---|---|
-| `omnigraph-server <URI>` / `--config omnigraph.yaml` / `--target` / single-graph flat routes | **removed** — the server is **cluster-only**: `omnigraph-server --cluster <dir\|s3://>`; all HTTP is nested under `/graphs/<id>/...` (flat routes → 404) |
-| `omnigraph schema apply` on a cluster-managed graph | **refused** — evolve cluster graphs via `cluster apply` (the ledger). `schema apply` still works on a non-cluster store or via `--server` |
-| `policy …` / `queries validate` via `--config omnigraph.yaml` | `policy validate\|test\|explain` reads `--cluster <dir>` (+ `--graph`); `queries validate` takes the store URI |
+Direct `schema apply` remains available for a non-cluster store. A cluster-only
+server rejects the legacy schema-apply route with `409`; edit the declared `.pg`
+and use `cluster plan`/`cluster apply`.
 
-## CLI verbs
+## HTTP compatibility aliases
 
-| Before | Now |
-|---|---|
-| `omnigraph ingest …` | `omnigraph load --from main --mode merge …` |
-| `omnigraph read` | `omnigraph query` |
-| `omnigraph change` | `omnigraph mutate` |
-| `omnigraph query lint` / `query check` | `omnigraph lint` |
-| `omnigraph query --alias <n>` / `mutate --alias <n>` | `omnigraph alias <n>` (dedicated subcommand; the `--alias` flag was removed) |
+Canonical routes are `/query`, `/mutate`, and `/load`. `/read`, `/change`, and
+`/ingest` remain deprecated compatibility aliases and identify their successor
+in response headers. Per-graph routes are nested below `/graphs/{id}`; old flat
+single-graph routes are gone.
 
-## HTTP routes
-
-| Before | Now |
-|---|---|
-| `POST /ingest` | `POST /load` |
-| `POST /read` | `POST /query` |
-| `POST /change` | `POST /mutate` |
-
-The old routes remain as **deprecated aliases** (retained indefinitely), carrying `Deprecation: true` + `Link: <successor>` response headers.
-
-## Server token resolution
-
-| Before | Now |
-|---|---|
-| `graphs.<name>.bearer_token_env` in `omnigraph.yaml` | `omnigraph login <server>` → `~/.omnigraph/credentials`, or `OMNIGRAPH_TOKEN_<NAME>` |
-
-The client bearer token now comes only from `OMNIGRAPH_TOKEN_<NAME>` or the credentials file — the `omnigraph.yaml` `bearer_token_env` chain is gone with the file.
-
-## Older removals (still worth knowing)
-
-- The transactional **Run** state machine, its `/runs` routes, and the `run_publish` / `run_abort` Cedar actions were **removed in v0.4.0**. Writes publish directly — use `GET /commits` for history and the `change` action for write gating; `/runs` returns 404.
+The pre-v0.4 transactional Run state machine, `/runs`, and the `run_publish` /
+`run_abort` policy actions are removed. Writes publish directly; use exact write
+receipts, commit history, and the `change` action.

--- a/skills/omnigraph/references/queries.md
+++ b/skills/omnigraph/references/queries.md
@@ -18,7 +18,8 @@ Writing `.gq` query files in Omnigraph.
 
 - One `.gq` file per primary node type (`signals.gq`, `patterns.gq`, `elements.gq`)
 - One `mutations.gq` file for all insert/update/delete queries
-- Put query files in `queries/` — cluster mode discovers `queries/*.gq` automatically
+- Put query files in `queries/`, then declare `graphs.<id>.queries: queries/` in
+  `cluster.yaml`; cluster mode does not scan an undeclared directory.
 
 ## Linting
 
@@ -58,7 +59,7 @@ omnigraph query get_signal --query signals.gq --params '{"slug":"sig-foo"}'
 
 The compiler typechecks parameter values against declared types.
 
-> For one-off/ad-hoc execution, pass the query inline instead of a file with `-e/--query-string` (v0.6.0+): `omnigraph query -e 'query q($slug: String){ match { $s: Signal { slug: $slug } } return { $s.name } }' --params '{"slug":"sig-foo"}'` (and `omnigraph mutate -e '...'`). `-e` is mutually exclusive with `--query <file>` — exactly one of the two is required. (Operator aliases are invoked via the separate `omnigraph alias <name>` subcommand.)
+> For one-off/ad-hoc execution, pass the query inline instead of a file with `-e/--query-string`: `omnigraph query -e 'query q($slug: String){ match { $s: Signal { slug: $slug } } return { $s.name } }' --params '{"slug":"sig-foo"}'` (and `omnigraph mutate -e '...'`). `-e` is mutually exclusive with `--query <file>` — exactly one of the two is required. (Operator aliases are invoked via the separate `omnigraph alias <name>` subcommand.)
 
 ## Query Structure
 
@@ -115,7 +116,7 @@ query employees_of($company: String) {
 }
 ```
 
-### Undirected traversal (omnigraph >= 0.8.1)
+### Undirected traversal
 
 For symmetric relations (same-endpoint-type edges like `IssueRelated: Issue -> Issue`),
 angle brackets match the edge in **either direction**, deduplicated — one
@@ -131,7 +132,7 @@ query related_to($slug: String) {
 }
 ```
 
-### Edge bindings — filtering and projecting edge properties (omnigraph >= 0.9.0)
+### Edge bindings — filtering and projecting edge properties
 
 An optional `$var:` prefix on the edge word binds the matched edge *row*, so
 declared edge properties (confidence, role, provenance, …) become usable
@@ -192,11 +193,11 @@ match {
 ```gq
 match {
     $d: Doc
-    match_text($d.body, $q)    // phrase match
+    match_text($d.body, $q)    // regular full-text match (not phrase search)
 }
 ```
 
-### Vector/ranking (require `limit`)
+### Vector/ranking
 
 ```gq
 query vector_search($q: Vector(3072)) {
@@ -207,7 +208,9 @@ query vector_search($q: Vector(3072)) {
 }
 ```
 
-`nearest`, `bm25`, and `rrf` are ranking operators, not filters. Every query using them **must** end with `limit N` — omitting it is a compile error.
+`nearest`, `bm25`, and `rrf` are ranking operators, not filters. `nearest` and
+`rrf` require `limit N`; BM25 alone does not, though a limit is recommended for
+bounded output.
 
 ### Hybrid (reciprocal rank fusion)
 
@@ -241,13 +244,18 @@ Supported: `count`, `sum`, `avg`, `min`, `max`. Grouping is implicit on non-aggr
 
 ## Filter Operators
 
-`=`, `!=`, `>`, `<`, `>=`, `<=`, `contains`
+`starts_with`, `contains`, `>=`, `<=`, `!=`, `>`, `<`, `=`
+
+Both String predicates are exact and case-sensitive: `contains` matches a
+substring and `starts_with` matches a prefix. Either can use an index when one
+is available and must retain correct scan fallback.
 
 ```gq
 match {
     $p: Person
     $p.age > 30
     $p.name contains "Al"
+    $p.name starts_with "A"
 }
 ```
 
@@ -271,11 +279,17 @@ query add_signal($slug: String, $name: String, $brief: String,
 }
 ```
 
-**Every non-nullable property must be provided.** Lint catches missing ones as:
+**Every non-nullable property must be provided.** Lint normally catches missing
+ones as:
 
 ```
 error: T12: insert for 'Signal' must provide non-nullable property 'brief'
 ```
+
+One v0.10 exception matters: lint permits omission of a non-null Vector target
+annotated with `@embed(source)`, but mutation execution does not auto-embed and
+still rejects the missing vector. Supply that target explicitly; use the
+offline embedding pipeline for generated values.
 
 ### Insert edge
 
@@ -285,7 +299,8 @@ query link_signal_forms_pattern($signal: String, $pattern: String) {
 }
 ```
 
-Edge `data` block is `{}` if the edge has no properties — just specify `from` and `to` slugs.
+A propertyless edge needs only `from` and `to`, which are logical endpoint IDs.
+GQ has no nested `data {}` block.
 
 ### Update
 
@@ -315,24 +330,19 @@ query add_and_link($slug: String, $pattern: String, $createdAt: DateTime, $updat
 
 There's no `upsert` keyword at the query level — use `load --mode merge` for bulk upsert.
 
-> **Insert/update-only OR delete-only (the D₂ rule).** A single mutation query may contain inserts and updates, **or** deletes — never both. Mixing a `delete` with an `insert`/`update` in the same query is rejected at parse time. (Deletes stage through the same two-phase publish as inserts/updates since 0.8.0; the D₂ split is a deliberate semantic boundary — one mutation query is constructive XOR destructive, keeping read-your-writes unambiguous — not an implementation gap.) Split a delete-then-insert into two separate mutations.
+> **Insert/update-only OR delete-only (the D₂ rule).** A single mutation query may contain inserts and updates, **or** deletes — never both. Mixing a `delete` with an `insert`/`update` in the same query is rejected at parse time. The split is deliberate: one mutation query is constructive XOR destructive. Split a delete-then-insert into two separate mutations.
 
 ### Date and DateTime values
 
-Date format is asymmetric between `mutate` (parameter values) and `load` (JSONL):
+Prefer ISO strings on both paths:
 
 | Path | Date | DateTime |
 |---|---|---|
 | `mutate --params` | ISO string `"2026-04-29"` | ISO string `"2026-04-29T10:00:00Z"` |
-| `load` JSONL | Integer days since epoch `20572` | ISO string `"2026-04-29T10:00:00Z"` |
+| `load` JSONL | ISO string `"2026-04-29"` (integer epoch days also accepted) | ISO string `"2026-04-29T10:00:00Z"` |
 
-Compute integer days form for a given date `d`:
-
-```python
-(d - datetime.date(1970, 1, 1)).days   # d is the date you're loading, not today()
-```
-
-This asymmetry is one of the most common silent type errors when bulk-loading data prepared for one path through the other.
+Integer epoch days remain useful for generated Arrow-oriented input, but are
+not required for hand-authored JSONL.
 
 ## Naming Convention
 

--- a/skills/omnigraph/references/remote-ops.md
+++ b/skills/omnigraph/references/remote-ops.md
@@ -1,142 +1,98 @@
 # Remote Graph Operations
 
-## Contents
-- What's different about remote
-- Verify after every write
-- 504 Gateway Timeout
-- Fork-branch 504 fingerprint
-- Targeting a remote graph (`--server`, `login`)
-- Version drift / `sync_branch()`
-- `manifest_conflict` 409
-- 429 Too Many Requests
-- Duplicate risk on blind retry
-- Reading large schemas safely
-- Prevention checklist
+Remote commands address an `omnigraph-server`; the server executes the graph
+operation and the CLI only receives its HTTP response. Network failure can hide
+a successful publication, so retry decisions must use graph evidence rather
+than the transport status alone.
 
-When the graph URI is a remote endpoint (`omnigraph-server` behind ALB / CloudFront, bearer-authenticated) instead of a local S3 path, several CLI behaviors change in ways the local-storage workflow never exposes. This reference covers the failures and operational rituals specific to remote graphs.
+## Address the graph
 
-## What's different about remote
-
-A remote graph runs server-side. Every write executes on the server — staged per touched table, then published atomically as a **single manifest commit** guarded by a compare-and-swap on expected table versions — and is gated by a connection-level idle timeout (CloudFront defaults to ~30s). There is no separate "run" object to poll — write status is implied by the HTTP response (and verifiable via `commit list`). The local CLI is a thin client; it never sees the commit happen, only the HTTP response. That asymmetry is the root of every gotcha below.
-
-| Local repo | Remote repo |
-|---|---|
-| CLI writes S3 directly | Server executes the write, publishes one atomic manifest commit |
-| No connection timeout | ~30s idle timeout (CloudFront) |
-| No admission control | Per-actor `429` + `Retry-After` on writes |
-| `load` writes S3-backed storage directly | `load` is server-orchestrated — same command, one atomic commit |
-| CLI exit code is authoritative | CLI exit code can lie — verify via `commit list` |
-
-## Verify after every write
-
-The CLI's exit code is **not authoritative on remote graphs**. The proxy can drop a response after the server has already committed. Always verify by comparing `main`'s head:
+Register a named server and keep the token outside project configuration:
 
 ```bash
-HEAD_BEFORE=$(omnigraph commit list --config X --branch main --json | jq -r '.commits[0].graph_commit_id')
-
-# … run your load / mutate …
-
-HEAD_AFTER=$(omnigraph commit list --config X --branch main --json | jq -r '.commits[0].graph_commit_id')
-
-if [[ "$HEAD_BEFORE" != "$HEAD_AFTER" ]]; then
-  echo "landed"
-else
-  echo "did NOT land — safe to retry"
-fi
+echo "$TOKEN" | omnigraph login production
+omnigraph query get_person --server production --graph knowledge \
+  --params '{"email":"ada@example.com"}' --json
 ```
 
-For a `load --from` that forks a review branch, also compare the new branch head's `graph_commit_id` against `main`'s. **Identical means the load didn't land — empty fork left behind.**
+`--server <name>` resolves the URL from `~/.omnigraph/config.yaml`; `--graph`
+selects a graph served by that cluster. Do not use the cluster control-plane
+`--config` flag on data-plane commands.
 
-For pointed verification of a single record:
+## Successful write receipts
+
+With `--json`, a successful effectful `mutate` or `load` returns `commit` with
+the exact `graph_commit_id` and metadata published by that attempt. A successful
+mutation that matches nothing returns `"commit": null`.
+
+Persist the receipt with downstream state when a workflow needs an audit or
+resume position. Do not infer the published commit by listing history after the
+write; another actor may commit in between.
+
+## A 504 means the outcome is unknown
+
+A gateway can time out after the server has published. A `504` therefore does
+not prove success or failure:
+
+1. Do not immediately repeat the write.
+2. Inspect the target branch and the intended entity effect.
+3. Retry only when that evidence proves the original attempt did not land.
+
+Use server addressing for the checks too:
 
 ```bash
-omnigraph export --config X --type <NodeType> | grep <slug>
-omnigraph export --config X --type <EdgeType> | grep <slug>
+omnigraph commit list --server production --graph knowledge \
+  --branch main --json
+omnigraph export --server production --graph knowledge \
+  --branch main --type Person > /tmp/people.jsonl
 ```
 
-## 504 Gateway Timeout: response lost, write status unknown
+For `load --from <base> --branch <review>`, inspect the review branch rather
+than assuming branch creation means the load landed. Strict inserts of unkeyed
+nodes and edges can duplicate on a blind retry. Mutation `insert` and
+`load --mode merge` upsert keyed nodes by their derived logical IDs;
+`load --mode append` remains strict and reports an ID collision. Verification
+is still safer when the requested value matters.
 
-A 504 from the proxy means the server didn't respond within the idle timeout. Two server-side outcomes are possible — **the 504 alone cannot distinguish them**:
+## Conditional mutations
 
-1. **Write completed and published** — landed, `main`'s head advanced. Common for small mutations finishing just past the 30s edge.
-2. **Write still in progress** — will publish or fail soon. Re-check after a minute.
-
-Always verify via `commit list` before retrying. Blind retry on append-only types creates duplicates.
-
-## Fork-branch 504 fingerprint
-
-`load --from <base>` creates the branch **before** loading data. A timed-out fork-load where the data didn't land leaves an empty branch at `<base>`'s head. Stale numbered branches (`feature-v2`, `-v3`, `-v4` …) all sitting at the same `graph_commit_id` as `main` are the fingerprint of prior 504-blocked attempts.
-
-Find them by comparing each branch's head against `main`'s in `omnigraph branch list --config X --json`, then delete the empty ones.
-
-## Targeting a remote graph: `--server` and `login`
-
-`load`, `query`, and `mutate` all run against a remote `omnigraph-server` endpoint — there is no local-only restriction as of 0.7.0. Address an operator-defined server by name instead of pasting URLs and juggling tokens:
+When a mutation is derived from returned rows, protect it with the commit pinned
+to those rows:
 
 ```bash
-echo "$TOKEN" | omnigraph login intel-dev          # stores it in ~/.omnigraph/credentials (0600)
-omnigraph load --server intel-dev --graph spike \
-  --data delta.jsonl --from main --mode merge --branch staging
+omnigraph query find_person --server production --graph knowledge --json
+omnigraph mutate update_person --server production --graph knowledge \
+  --params '{"name":"Ada"}' --if-commit <graph_commit_id> --json
 ```
 
-`--server <name>` resolves the URL from `~/.omnigraph/config.yaml` and the token via `OMNIGRAPH_TOKEN_<NAME>` or the credentials file. A token is only ever sent to the server it is keyed to. `--graph <id>` selects the graph on a multi-graph server.
+Any intervening branch commit makes the condition fail without effects. The CLI
+exits `4`; HTTP returns `412` with the expected and actual positions. Re-read
+and decide again. Fetching a head id after the read does not close the race.
 
-## Version drift / `sync_branch()`
+## Other safe refusals
 
-```
-version drift on node:<Type>: snapshot pinned vN but dataset is at vM — call sync_branch() and retry
-```
+- `429 Too Many Requests`: the write did not start. Honor `Retry-After`, then
+  retry.
+- `read_set_conflict`: a strict update, delete, or overwrite was computed from
+  stale data and did not publish. Refresh the branch and retry deliberately.
+- `key_conflict`: an append or strict insert found an existing id. Decide
+  whether that entity is the intended one; do not silently turn the operation
+  into an upsert.
+- `recovery_required`: reopen the graph read-write or restart the server before
+  retrying from a fresh branch head.
 
-- `sync_branch()` is **not a CLI command** — it's a server-internal directive that leaked into the error text. Don't go looking for it.
-- Cause: another actor committed to `main` between your CLI's snapshot pin and your `mutate` attempt.
-- Usually self-resolves on retry — the next call re-pins.
-- Calling `omnigraph snapshot` does **not** reliably re-pin for subsequent `mutate`s in the same session.
-- If persistent, fall back to `load --from main` onto a fresh branch — a forked branch doesn't suffer from concurrent-commit drift on `main`.
-- The cleaner, modern form of this conflict is a structured `manifest_conflict` **409** — see below.
+These explicit refusals are different from a lost response: they establish that
+the rejected attempt did not commit.
 
-## `manifest_conflict` 409 — stale snapshot, retry
+## Read large output safely
 
-When another actor commits to the same branch between your query's snapshot pin and your write, the server returns a structured **`manifest_conflict` 409** carrying `table_key` / `expected` / `actual`, rather than silently overwriting. Since v0.4.2 this is the form most concurrent update/delete/merge races take.
-
-- **Retry it.** A 409 means your write was computed against a stale view and was rejected *before* committing — there is no partial state and no duplicate risk. Re-issue the same call; it re-pins to the new head.
-- Concurrent `mutate` × branch-merge on the same target branch resolves to either success or a clean 409 depending on who wins the server's per-table queue — both outcomes are safe.
-
-## 429 Too Many Requests — back off, then retry
-
-The server applies **per-actor admission control** to every mutating endpoint (`mutate` / `load` / `schema apply` / branch create·delete·merge). An actor that exceeds its in-flight-request or estimated-byte budget gets a structured **HTTP 429** (`code: too_many_requests`) with a `Retry-After` header — instead of blocking unrelated actors behind a global lock.
-
-- This is **not** a failed write — the write never started. Honor `Retry-After` and retry; it is always safe (no partial write, no duplicate risk).
-- It's per-actor, so one noisy automation can't starve others. If you hit it constantly, batch less aggressively or space your calls out.
-- Read-only endpoints are not admission-gated.
-
-## Duplicate risk on blind retry
-
-After a 504, never retry without verifying first. Different node kinds have different retry semantics:
-
-| Kind | Retry safety |
-|---|---|
-| Pointer nodes (`Org`, `Person`, `Opportunity`, `Channel`, `Actor`, `ActionItem`, `Artifact`, `Meeting`, `Technology`, `Campaign`, `UseCase`) | ✓ Idempotent — `@key` upserts dedupe |
-| Append-only nodes (`Signal`, `Claim`, `Decision`, `Event`, `Interaction`, `MarketingElement`, `Policy`, `Outcome`) | ✗ Duplicates on retry — verify before retrying |
-| Edges | ⚠ No `@key`. Verify via `export --type <EdgeName>` + grep. Some simple edges dedupe server-side; don't rely on it. |
-
-## Reading large schemas safely
-
-Remote schemas can be large (tens of KB). Tools that cap stdout (~50KB is common) will truncate or duplicate the output silently — leading to memory-based answers from agents that look correct but reference nonexistent fields.
-
-Always redirect to a file before reading:
+Redirect large schemas and exports to a file before inspecting them so an agent
+or terminal output cap cannot silently truncate the result:
 
 ```bash
-omnigraph schema show --config X > /tmp/schema.pg
+omnigraph schema show --server production --graph knowledge > /tmp/schema.pg
 wc -l /tmp/schema.pg
 ```
 
-Then read the file with offset/limit, not via piped stdout.
-
-## Prevention checklist
-
-- Keep mutations small. Single-node inserts finish well under the timeout.
-- Prefer `mutate` over `load` for ≤ a handful of records.
-- Always run `commit list` after a 504 before deciding to retry.
-- For destructive or large-batch work, use `load --from main` onto a feature branch and verify the branch head before merging.
-- Read large schemas via file redirect, not piped stdout.
-- A `429` (throttle) or a `manifest_conflict` `409` (stale snapshot) is always safe to retry — the write never committed. Honor `Retry-After` on a 429.
+For ordered downstream consumption and durable cursors, use
+[commit changes and change feeds](changes.md) instead of polling commit lists.

--- a/skills/omnigraph/references/schema.md
+++ b/skills/omnigraph/references/schema.md
@@ -35,13 +35,14 @@ If the same enum appears on multiple nodes, duplicate it inline — there's no s
 
 `[String]` and `[I32]` are fine. `[Category]` (a list of enum values) is **not** supported. Use `[String]` with query-side filtering, or use a single-valued enum property if one value is enough.
 
-### `@embed` takes a quoted string
+### `@embed` takes a source and optional model
 
 ```pg
-embedding: Vector(3072) @embed("text") @index
+embedding: Vector(1536) @embed("text", model="openai/text-embedding-3-large") @index
 ```
 
-Not `@embed(text)`. The source property name is a string literal.
+The identifier form `@embed(text)` is also valid. The quoted form is canonical;
+omit `model=...` when the embedding provider supplies the model.
 
 ### Edge constraints go inside a body block
 
@@ -73,15 +74,22 @@ omnigraph schema apply --schema next.pg s3://bucket/repo
 
 If `supported: false`, fix the source before applying. Plan is free; run it as often as needed.
 
-Plan/apply diagnostics carry stable codes of the form **`OG-XXX-NNN`** (since v0.5.0) — match on the code, not the free-form message text.
+Plan/apply diagnostics may carry stable codes of the form **`OG-XXX-NNN`**. When
+a code is present, match it rather than the free-form message text.
 
-**Destructive drops are gated (since v0.5.0).** Dropping a property or type is a soft drop by default (or rejected); to actually lose data you must opt in:
+**Destructive drops are gated.** Dropping a property or type is a soft drop by
+default. To preview and execute a hard destructive drop, opt in on both steps:
 
 ```bash
+omnigraph schema plan --schema next.pg s3://bucket/repo --allow-data-loss --json
+# inspect the hard-drop plan
 omnigraph schema apply --schema next.pg s3://bucket/repo --allow-data-loss
 ```
 
-Over HTTP the equivalent is `{"allow_data_loss": true}` in the schema-apply body. Without the flag, a destructive drop returns a structured diagnostic instead of silently deleting columns.
+Without the flag, supported drops preserve prior physical data through soft
+drop semantics. A cluster-only server rejects
+`POST /graphs/{id}/schema/apply` with `409`; evolve a served graph through
+`cluster plan` and `cluster apply`.
 
 ### Apply is main-only
 
@@ -101,7 +109,8 @@ Works on node types, edge types, and properties.
 
 ### Required properties need a backfill plan
 
-Adding a non-nullable property to an existing node is rejected as unsupported. Pattern:
+Adding a non-nullable property to an existing node or edge type is rejected as
+unsupported. Pattern:
 
 1. Add as optional: `new_prop: String?`
 2. Apply
@@ -110,7 +119,7 @@ Adding a non-nullable property to an existing node is rejected as unsupported. P
    (a property-type change, OG-MF-106). Enforce presence at write time by
    convention until required-tightening ships as a migration step.
 
-### Enum widening is a supported apply (omnigraph >= 0.8.1)
+### Enum widening is a supported apply
 
 Adding variants to an `enum(...)` property is a metadata-only migration step:
 `schema plan` shows `extend enum ...`, `apply` touches no table data, and new
@@ -135,25 +144,28 @@ No concurrent mutations during an apply. Plan for a short read-only window.
 
 ## Decorators (quick reference)
 
-**Property-level:**
-- `@key` — primary key (implies index; usually one per node)
-- `@unique` — uniqueness constraint
-- `@index` — query optimization
-- `@range(min, max)` — numeric bounds (open ranges allowed)
-- `@check(prop, "regex")` — regex pattern validation on a String property
-- `@embed("source_prop")` — embed from a String source into a Vector property
+**Property-level shorthand:**
+- `@key` — single-property node key
+- `@unique` — single-property uniqueness constraint
+- `@index` — single-property index intent (currently materialized automatically only for node properties)
+- `@embed("source_prop")` — on a node Vector property, embed from a String source
 - `@description("...")` — metadata (no migration impact)
-- `@instruction("...")` — semantic hint for LLMs/operators
 
 **Edge-level:**
 - `@card(min..max)` — edge cardinality (default: `0..*`)
 
-**Type-level (nodes/edges/properties):**
+**Type-level (nodes/edges):**
+- `@instruction("...")` — semantic hint for LLMs/operators
+
+**Rename (nodes/edges/properties):**
 - `@rename_from("OldName")` — migration-aware rename
 
 **Group-level (inside body block):**
-- `@unique(prop1, prop2)` — composite uniqueness, enforced as a true tuple key at both intake and merge (works on edges too: `@unique(src, dst)`). Columns must reduce to a scalar key: `@unique` on a `[List]`/`Blob` column is rejected loudly at `load` (it used to be silently un-enforced — fixed in #160).
-- `@index(prop1, prop2)` — composite index
+- `@key(prop1, prop2)` — ordered node identity tuple
+- `@unique(prop1, prop2)` — composite uniqueness, enforced as a true tuple key at intake and merge (works on edges too: `@unique(src, dst)`). Members must reduce to scalar keys. Blob is rejected at schema admission; list/vector declarations may parse but writes fail scalar-key validation.
+- `@index(prop1, prop2)` — composite index intent. Composite and edge intents are accepted but are not currently materialized as property indexes.
+- `@range(prop, min..max)` — node-only numeric bounds; either bound may be omitted
+- `@check(prop, "regex")` — node-only String regular-expression constraint
 
 ## Interfaces
 

--- a/skills/omnigraph/references/search.md
+++ b/skills/omnigraph/references/search.md
@@ -2,8 +2,7 @@
 
 ## Contents
 - Embeddings are schema-declared
-- Generating embeddings
-- Embeddings + `load --mode merge` interaction
+- Offline embedding pipeline
 - Search functions in queries
 - The key pattern: scope first, rank second
 - Model / config
@@ -16,70 +15,53 @@ Vector embeddings and text search in Omnigraph.
 node Chunk {
     text: String
     chunk_index: I32
-    embedding: Vector(3072) @embed("text") @index
+    embedding: Vector(1536) @embed("text", model="openai/text-embedding-3-large") @index
     createdAt: DateTime
 }
 ```
 
 - `Vector(N)` — fixed-size float vector
-- `@embed("source_prop")` — what text field to embed from (quoted string)
-- `@index` — enables vector search on this field
+- `@embed("source_prop", model="model-id")` — associates the vector with its
+  String source and, optionally, the exact model space
+- `@index` — declares derived index intent and can accelerate vector search;
+  correctness falls back to an exact scan when coverage is missing
 
-The schema says **where** embeddings live and **what** they come from. Queries don't recompute; they read.
+The schema says **where** embeddings live and **what** they come from. It does
+not populate vectors during a load. Supply vectors in input or prepare JSONL
+with the offline command.
 
-## Generating Embeddings
+## Offline Embedding Pipeline
 
-### First time / refresh missing
+`omnigraph embed` transforms JSONL files; it does **not** mutate a graph:
 
 ```bash
-omnigraph embed --seed embed-config.yaml
+omnigraph embed --input raw.jsonl --output embedded.jsonl --spec embeddings.json
 ```
 
-Default mode is `fill_missing` — only generates embeddings for rows without one.
+By default it fills missing vectors. Load the output explicitly afterward.
 
-### Re-embed everything
-
-```bash
-omnigraph embed --seed embed-config.yaml --reembed_all
-```
-
-Use when:
-- You changed the source field: `@embed("body")` → `@embed("title")`
-- You mutated text at scale and need fresh embeddings
-- You switched embedding models (rare)
-
-### Selective refresh
+Use the same file/spec form with `--reembed-all` to replace selected vectors,
+or `--clean` to remove them. `--type` and `--select` narrow the records. A seed
+manifest is an alternative:
 
 ```bash
+omnigraph embed --seed embed-config.yaml --reembed-all
+omnigraph embed --seed embed-config.yaml --clean
 omnigraph embed --seed embed-config.yaml --select "Chunk:chunk_index=42"
 ```
 
-Regenerate only rows matching the selector.
-
-### Clean (delete) embeddings
-
-```bash
-omnigraph embed --seed embed-config.yaml --clean
-```
-
-## Embeddings + `load --mode merge` Interaction
-
-**`load --mode merge` does NOT recompute embeddings.**
-
-If you update rows whose source fields feed into `@embed(...)`, the source updates but the embedding stays stale.
-
-Two fixes:
-1. Run `omnigraph embed --reembed_all` after the merge
-2. Use `load --mode overwrite` instead, which re-triggers embedding on load
+Changing source text, source-property metadata, or model requires generating
+replacement vectors; neither `merge` nor `overwrite` does that automatically.
 
 ## Search Functions in Queries
 
-All ranking functions require `limit N` — they're order operators, not filters.
+Ranking functions are order operators, not filters. `nearest` and `rrf` require
+`limit N`; BM25 alone does not, though a limit keeps output bounded.
 
 ### Vector similarity
 
 ```gq
-query nearest_chunks($q: Vector(3072)) {
+query nearest_chunks($q: Vector(1536)) {
     match { $c: Chunk }
     return { $c.text }
     order { nearest($c.embedding, $q) }
@@ -101,7 +83,7 @@ query top_titles($q: String) {
 ### Hybrid (Reciprocal Rank Fusion)
 
 ```gq
-query hybrid($vq: Vector(3072), $tq: String) {
+query hybrid($vq: Vector(1536), $tq: String) {
     match { $d: Doc }
     return { $d.slug, $d.title }
     order { rrf(nearest($d.embedding, $vq), bm25($d.title, $tq)) }
@@ -116,7 +98,7 @@ match {
     $d: Doc
     search($d.title, $q)          // full-text filter
     fuzzy($d.title, $q, 2)        // fuzzy filter, max 2 edits
-    match_text($d.body, $q)       // phrase filter
+    match_text($d.body, $q)       // regular full-text filter (not phrase search)
 }
 ```
 
@@ -125,7 +107,7 @@ match {
 Filter with graph traversal before invoking vector or text ranking. Ranking over a narrow set is both cheaper and more relevant.
 
 ```gq
-query related_chunks($artifact_slug: String, $q: Vector(3072)) {
+query related_chunks($artifact_slug: String, $q: Vector(1536)) {
     match {
         $a: InformationArtifact { slug: $artifact_slug }
         $c partOfArtifact $a                      // scope: only this artifact's chunks
@@ -140,11 +122,29 @@ Don't rank over the entire chunk set if you know a traversal can narrow it first
 
 ## Model / Config
 
-Omnigraph uses **two distinct embedding clients** — don't conflate them:
+The offline command and a served graph have separate configuration surfaces,
+but must resolve to the same provider/model space. Stored and query vectors
+must match the schema's `Vector(N)` dimension; recording `model=` on `@embed`
+makes that contract explicit.
 
-| Client | When it runs | Default model | Configured via |
-|--------|--------------|---------------|----------------|
-| **Engine / load-time** | At load, when an `@embed("source")` field is populated (and `omnigraph embed`) | `gemini-embedding-2-preview` (3072-dim) | `GEMINI_API_KEY`, `OMNIGRAPH_GEMINI_BASE_URL`, `OMNIGRAPH_EMBED_*`, `OMNIGRAPH_EMBEDDINGS_MOCK` |
-| **Compiler / query-time** | When a query passes a *string* to a ranking op (e.g. `nearest($c.embedding, "some text")`) and the server auto-embeds it | `text-embedding-3-small` (OpenAI-style) | `NANOGRAPH_EMBED_MODEL`, `OPENAI_API_KEY`, `OPENAI_BASE_URL`, `NANOGRAPH_EMBEDDINGS_MOCK` |
+| Provider | Default model | Credential |
+|---|---|---|
+| `openai-compatible` (default, OpenRouter endpoint) | `openai/text-embedding-3-large` | `OPENROUTER_API_KEY` |
+| `openai` | `text-embedding-3-large` | `OPENAI_API_KEY` |
+| `gemini` | `gemini-embedding-2` | `GEMINI_API_KEY` |
+| `mock` | deterministic test vectors | none |
 
-The vector stored in the schema is produced by the **load-time (engine)** client, so `Vector(N)` must match that model's output dimension — `Vector(3072)` for `gemini-embedding-2-preview`. If you point the query-time client at a model with a different dimension than your stored vectors, similarity search returns garbage or errors — keep both sides on the same dimension. Vectors are stored L2-normalized.
+Configure direct/offline use with `OMNIGRAPH_EMBED_PROVIDER`,
+`OMNIGRAPH_EMBED_BASE_URL`, and `OMNIGRAPH_EMBED_MODEL`. Deadline/retry controls
+are `OMNIGRAPH_EMBED_DEADLINE_MS`, `OMNIGRAPH_EMBED_TIMEOUT_MS`,
+`OMNIGRAPH_EMBED_RETRY_ATTEMPTS`, and `OMNIGRAPH_EMBED_RETRY_BACKOFF_MS`;
+`OMNIGRAPH_EMBEDDINGS_MOCK` forces the mock provider.
+
+For a served graph, declare a named provider under `providers.embedding` in
+`cluster.yaml` and bind it with `graphs.<id>.embedding_provider`. API keys must
+be `${ENV_VAR}` references and are resolved by the server at startup. Generated
+vectors are finite, nonzero, and L2-normalized.
+
+After upgrading a Lance 9/10 store, full-text queries can require
+`rebuild-full-text-indexes` on each live branch. Ordinary reads and vector
+search do not depend on that rebuild; see [`commands.md`](commands.md#rebuild-full-text-indexes--explicit-analyzer-upgrade).

--- a/skills/omnigraph/references/server-policy.md
+++ b/skills/omnigraph/references/server-policy.md
@@ -1,226 +1,141 @@
-# HTTP Server & Cedar Policy
+# HTTP Server and Cedar Policy
 
-## Contents
-- Starting the server (boot sources)
-- HTTP routes
-- Auth
-- Setup operations bypass the server
-- Cedar policy
-- Multi-graph mode
-- Server + policy together
-- Cluster-booted servers
+Use this reference for a cluster-served graph. The server is cluster-only; CLI
+commands can instead open graph storage directly when their help permits it.
 
-How to run `omnigraph-server` and gate operations with Cedar policies.
-
-## Starting the Server
-
-The server is the canonical runtime entry point — all CLI queries, mutations, and admin ops go through it. **Boot is cluster-only** (RFC-011): the server boots from a cluster and serves N graphs (N ≥ 1) under nested routes. There is **no** single-graph / bare-URI / `omnigraph.yaml` boot.
+## Start a server
 
 ```bash
-omnigraph-server --cluster ./company-brain --bind 127.0.0.1:8080   # a config directory …
-omnigraph-server --cluster s3://bucket/prefix --bind 0.0.0.0:8080  # … or a storage-root URI (config-free)
+export OMNIGRAPH_SERVER_BEARER_TOKENS_JSON='{"act-alice":"replace-with-a-secret"}'
+omnigraph-server --cluster ./company-brain --bind 127.0.0.1:8080
+omnigraph-server --cluster s3://bucket/prefix --bind 0.0.0.0:8080
 ```
 
-`--cluster` boots from the cluster's applied revision (see *Cluster-Booted Servers* below). Run it in a separate terminal or background process.
+The server loads the cluster's applied revision and serves each graph under
+`/graphs/{id}`. Apply changes, then restart; there is no hot reload or
+single-graph server mode.
 
-## HTTP Routes
+## Route families
 
-All per-graph routes are nested under `/graphs/{id}/...` (`{id}` = a graph id from the applied cluster); bare flat paths (`/query`, `/snapshot`, …) return **404**. `/healthz` and `/graphs` stay flat.
+| Route family | Purpose |
+|---|---|
+| `GET /healthz`, `/openapi.json` | Process metadata |
+| `GET /graphs` | List served graphs (`graph_list`) |
+| `/graphs/{id}/query`, `/mutate` | Inline GQ reads and writes |
+| `/graphs/{id}/mutate/if-graph-commit` | Conditional inline mutation |
+| `/graphs/{id}/queries` | List/invoke stored queries, including conditional writes |
+| `/graphs/{id}/load`, `/load/ndjson` | Bounded atomic loads |
+| `/graphs/{id}/blob` | GET/HEAD one Blob cell |
+| `/graphs/{id}/branches` | Branch operations and merge |
+| `/graphs/{id}/snapshot`, `/commits` | Snapshot and history |
+| `/graphs/{id}/commits/{commit}/changes` | One first-parent commit diff |
+| `/graphs/{id}/changes` | Poll a feed or capture a baseline |
+| `/graphs/{id}/schema` | Read the accepted schema |
+| `/graphs/{id}/export` | Stream a branch snapshot |
 
-| Route | Purpose |
-|-------|---------|
-| `GET /healthz` | liveness probe (flat) |
-| `GET /graphs` | enumerate served graphs (flat; `graph_list`-gated) |
-| `GET /graphs/{id}/snapshot?branch=` | table state + row counts |
-| `POST /graphs/{id}/query` | read query (canonical; `/read` = deprecated alias) |
-| `POST /graphs/{id}/mutate` | mutation (`/change` = deprecated alias) |
-| `POST /graphs/{id}/load` | bulk JSONL load, 32 MB; branch creation opt-in via `from` (`/ingest` = deprecated alias) |
-| `POST /graphs/{id}/export` | NDJSON stream of a branch |
-| `GET /graphs/{id}/queries` · `POST /graphs/{id}/queries/{name}` | stored-query catalog (`read`) + invocation (`invoke_query`, +`change` for a stored mutation; deny == 404) |
-| `GET /graphs/{id}/schema` · `POST /graphs/{id}/schema/apply` | read `.pg` · migrate (`schema_apply`) |
-| `GET/POST /graphs/{id}/branches` · `DELETE …/branches/{b}` · `POST …/branches/merge` | branch ops |
-| `GET /graphs/{id}/commits?branch=` · `…/commits/{commit_id}` | history |
+`/read`, `/change`, and `/ingest` are deprecated compatibility routes. A
+cluster-only server retains `POST /graphs/{id}/schema/apply` for wire
+compatibility but rejects it with `409`; use `cluster plan`/`cluster apply`.
 
-Read routes take `?branch=main` or `?snapshot=<id>`. Writes publish directly and commit atomically via `__manifest`; use the commits route for write/audit history.
+Canonical `/query` JSON includes the graph commit pinned with its rows when the
+read snapshot has an effective graph head; a fresh pre-commit graph can omit it. Exact
+write receipts and conditional semantics are summarized in
+[commit changes and feeds](changes.md). Blob delivery is in [Blob values](blobs.md).
+The deprecated `/read` response does not carry that commit position; consumers
+that need conditional writes must use `/query`.
 
-## Auth
+## Authentication and actor identity
 
-Set bearer tokens on the server process. Three sources, in precedence: `OMNIGRAPH_SERVER_BEARER_TOKENS_AWS_SECRET` (AWS Secrets Manager) → `OMNIGRAPH_SERVER_BEARER_TOKENS_JSON`/`_FILE` (JSON `{actor_id: token}`) → `OMNIGRAPH_SERVER_BEARER_TOKEN` (single token, actor `default`):
+Bearer tokens map actors at the server boundary. Request headers and bodies
+cannot choose another actor. Configure token sources on the server process;
+clients can store a named server token with:
 
 ```bash
-OMNIGRAPH_SERVER_BEARER_TOKENS_JSON='{"act-reader":"s3cret"}' \
-  omnigraph-server --cluster ./company-brain --bind 0.0.0.0:8080
+echo "$TOKEN" | omnigraph login production
+omnigraph query get_person --server production --graph knowledge
 ```
 
-On the client side (0.7.0), register the server once and store its token out of band:
+A server with neither tokens nor policy refuses to start unless explicitly
+given `--unauthenticated` (or `OMNIGRAPH_UNAUTHENTICATED=1`). Use that only on a
+trusted development network. Tokens without a policy allow only `read`; other
+actions remain denied.
 
-```bash
-echo "s3cret" | omnigraph login remote          # → ~/.omnigraph/credentials (0600)
-omnigraph query get_signal --server remote --graph spike --params '{"slug":"sig-foo"}'
-```
+## Cedar actions
 
-`--server remote` resolves the URL from `~/.omnigraph/config.yaml`'s `servers:` and the token via `OMNIGRAPH_TOKEN_REMOTE` or the credentials file. A token is only ever sent to the server it is keyed to.
+Graph-scoped actions are:
 
-### Running without auth requires an explicit opt-in
+| Action | Covers |
+|---|---|
+| `read` | Queries, snapshots, branches, commits, Blob reads, and change polling |
+| `export` | Export and change-feed baseline capture |
+| `change` | Mutations and loads |
+| `schema_apply` | Schema changes in an engine host that exposes them |
+| `branch_create`, `branch_delete`, `branch_merge` | Corresponding branch operation |
+| `invoke_query` | Entry to a stored query |
+| `admin` | Reserved; no current public operation |
 
-You can no longer just "leave auth off." Since v0.6.0 the server **refuses to start** when it has neither bearer tokens nor a policy file, unless you explicitly opt in:
+`graph_list` is cluster-scoped and controls `GET /graphs`. A stored read needs
+`invoke_query` plus `read`; a stored mutation needs `invoke_query` plus
+`change`. A denied and unknown stored-query name both appear as `404` to a
+caller lacking `invoke_query`.
 
-```bash
-omnigraph-server --cluster . --unauthenticated
-# or: OMNIGRAPH_UNAUTHENTICATED=1 omnigraph-server --cluster .
-```
+## Declare and test policy
 
-This is a guardrail against accidentally shipping an open server. For pure local dev, pass `--unauthenticated` deliberately.
-
-## Setup Operations Bypass the Server
-
-`init` and **local** `load` write storage directly — they don't go through the server (a **remote** `load` is server-orchestrated, POSTing `/load`). Pass the repo URI:
-
-```bash
-omnigraph init --schema schema.pg s3://my-bucket/repos/<name>
-omnigraph load --data seed.jsonl --mode overwrite s3://my-bucket/repos/<name>
-```
-
-Everything else — `query`, `mutate`, `snapshot`, `schema plan/apply`, `branch`, `commit` — goes through the running server.
-
-## Cedar Policy
-
-Omnigraph can gate sensitive actions with [Cedar](https://www.cedarpolicy.com/) policies.
-
-### Default-deny posture
-
-Policy is enforced engine-wide (every authoring path calls the same gate), and the default is **closed**, not open:
-
-| Server state | Bearer tokens | Policy file | Behavior |
-|---|---|---|---|
-| **Open** | no | no | Every request permitted — but the server refuses to start without `--unauthenticated` / `OMNIGRAPH_UNAUTHENTICATED=1`. |
-| **DefaultDeny** | yes | no | Every authenticated request for an action other than `read` is rejected (HTTP 403). "Tokens but forgot the policy file" no longer ships the illusion of protection. |
-| **PolicyEnabled** | yes | yes | Requests are evaluated against your Cedar rules. |
-
-So configuring a policy file is what *enables* writes — there is no "permit everything by default" mode once tokens are set.
-
-### Gated actions
-
-Per-graph actions (evaluated against the graph being addressed):
-
-| Action | Protects |
-|--------|----------|
-| `read` | query execution |
-| `export` | data export |
-| `change` | mutations |
-| `invoke_query` | stored-query invocation via `POST /graphs/{id}/queries/{name}` (graph-scoped, not branch-scoped). A stored **mutation** is double-gated — it also passes `change`. For a caller without the grant, a denial and an unknown query name both return the same **404** so the catalog can't be probed. |
-| `schema_apply` | schema migrations |
-| `branch_create` | branch creation |
-| `branch_delete` | branch deletion |
-| `branch_merge` | merges (especially into protected branches) |
-
-`admin` exists but is reserved (no call site yet — don't write rules for it).
-A server-scoped `graph_list` action gates `GET /graphs`; declare it in a
-`[cluster]`-scoped bundle.
-
-For any shared repo, gate at least `schema_apply` and `branch_merge`.
-
-### Where policy is declared
-
-Cedar bundles are declared in `cluster.yaml` and attach via `applies_to`: `[cluster]` is the server-level engine (gates `graph_list` / `GET /graphs`); `[<graph-id>]` is that graph's engine (gates `invoke_query`, `read`, `change`, `branch_*`, and `schema_apply`). `cluster apply` publishes them and the `--cluster` server enforces the applied revision. The `policy.yaml` rule format (below) is the bundle content.
-
-### `policy.yaml` shape
-
-The policy model is **allow-only**: every rule is a `permit`. You grant capabilities to groups; anything ungranted is denied by default. There is **no `deny` / `effect` key** — to forbid something, simply don't grant it.
+Bind one bundle to graph ids and another, if needed, to the cluster scope:
 
 ```yaml
-version: 1                          # required; must be 1
+# cluster.yaml
+policies:
+  graph-access:
+    file: graph.policy.yaml
+    applies_to: [knowledge]
+  server-access:
+    file: server.policy.yaml
+    applies_to: [cluster]
+```
 
+Policies are allow-only; omit a grant to deny it:
+
+```yaml
+version: 1
 groups:
-  admins: [act-alice, act-bob]
-  team:   [act-carol, act-dan]
-
-protected_branches:
-  - main
-
+  readers: [act-alice, act-bob]
 rules:
-  - id: admins-can-apply-schema     # rules use `id`, not `name`
-    allow:                          # required `allow:` block
-      actors: { group: admins }     # references a group by name
-      actions: [schema_apply]
-      target_branch_scope: protected
-
-  - id: team-can-merge-to-protected
+  - id: readers-can-read
     allow:
-      actors: { group: team }
-      actions: [branch_merge]
-      target_branch_scope: protected
-
-  - id: team-can-read-write-unprotected
+      actors: { group: readers }
+      actions: [read]
+      branch_scope: any
+  - id: readers-can-invoke
     allow:
-      actors: { group: team }
-      actions: [read, change]
-      branch_scope: unprotected
+      actors: { group: readers }
+      actions: [invoke_query]
 ```
 
-To "block unreviewed schema applies," you don't write a deny rule — you just don't grant `schema_apply` to that group. Default-deny does the rest.
-
-Scope rules (a rule's `allow` block may use **at most one**):
-
-- `branch_scope: any | protected | unprotected` — for `read`, `export`, `change` (matches the source branch).
-- `target_branch_scope: any | protected | unprotected` — for `schema_apply`, `branch_create`, `branch_delete`, `branch_merge` (matches the destination branch).
-
-### Validate, test, explain
+`branch_scope` protects source branches; `target_branch_scope` protects
+destinations. Values are `any`, `protected`, or `unprotected`; one rule cannot
+set both scopes. `invoke_query` and server actions take no branch scope.
 
 ```bash
-# Compile Cedar + check the cluster's applied policies
-omnigraph policy validate --cluster .
-
-# Run declarative test cases
-omnigraph policy test --cluster . --tests policy.tests.yaml
-
-# Debug a single decision
-omnigraph policy explain \
-  --actor act-alice \
-  --action schema_apply \
-  --target-branch main \
-  --cluster .
+omnigraph policy validate --cluster . --graph knowledge
+omnigraph policy test --cluster . --graph knowledge --tests policy.tests.yaml
+omnigraph policy explain --cluster . --graph knowledge \
+  --actor act-alice --action read --branch main
 ```
 
-### Test cases (`policy.tests.yaml`)
+Run `cluster apply` and restart servers after policy changes.
 
-```yaml
-version: 1                          # required; must be 1
-cases:
-  - id: alice-can-apply-schema      # cases use `id`, not `name`
-    actor: act-alice
-    action: schema_apply
-    target_branch: main             # schema_apply is target-branch scoped
-    expect: allow                   # `allow` / `deny` (not `permit`)
+## Direct access is a separate trust boundary
 
-  - id: random-user-cannot-merge-to-main
-    actor: act-random
-    action: branch_merge
-    target_branch: main
-    expect: deny
-```
+Served requests always use the server's policy engine. Embedded engine hosts
+can also install a policy engine, and every mutating engine entry point then
+enforces it.
 
-Run `policy test` after every policy edit. Tests are cheap.
+The standalone CLI opening `--store` or a positional URI does **not** load the
+cluster server's Cedar bundle. Its `--as` value records actor attribution but
+does not recreate server authorization. Protect raw graph storage with object
+store IAM/ACLs and restrict who can run direct maintenance. Served writes reject
+client-supplied actor identity because only the token may select it.
 
-## Multi-graph serving
-
-A `--cluster` server serves every graph in the applied cluster, each under `/graphs/{id}/...`. `GET /graphs` enumerates them (sorted by id), gated by the cluster-level `graph_list` action — even under `--unauthenticated`, topology stays closed until a `[cluster]` policy grants it. `omnigraph graphs list` mirrors it (remote servers only).
-
-Policy attaches at two levels via `cluster.yaml` `applies_to`:
-- `[<graph-id>]` — per-graph rules (`read`, `change`, `branch_*`, `schema_apply`, `invoke_query`).
-- `[cluster]` — server-level rules (`graph_list`).
-
-There is no runtime add/remove of graphs — edit `cluster.yaml`, `cluster apply`, restart.
-
-## Server + Policy Together
-
-When the server is running with a policy file:
-1. Every request resolves the actor from the bearer token (the client cannot set actor identity) and checks it against Cedar rules.
-2. Unauthorized requests return `403 Forbidden`.
-3. The CLI doesn't bypass policy when it connects over HTTP — it's enforced at the server. Enforcement is also engine-wide, so CLI direct-engine writes and embedded SDK consumers hit the same gate.
-
-Setup ops (`init`, `load`) write storage directly. With a policy configured they still flow through the engine-layer enforce gate for the actor you pass via `--as` (or `operator.actor` in `~/.omnigraph/config.yaml`); gate the raw storage layer too (S3 bucket ACLs, object locks) if the bucket is shared.
-
-## Cluster-Booted Servers
-
-`omnigraph-server --cluster <dir|s3://>` is the only boot source (covered above). It serves the cluster's **applied revision**: `cluster apply` changes take effect on the next restart (no hot reload), and boot is fail-fast with named remedies for missing/pending/tampered state. Bearer tokens and bind stay process-level (env/flags). See `references/cluster.md`.
+Canonical contracts: [server operations](../../../docs/user/operations/server.md)
+and [authorization](../../../docs/user/operations/policy.md).

--- a/skills/omnigraph/references/stored-queries.md
+++ b/skills/omnigraph/references/stored-queries.md
@@ -2,7 +2,9 @@
 
 A **stored query** is a `.gq` query that the *server* loads, type-checks at startup, and exposes by name — without ever accepting ad-hoc query source from the client. It's how you publish a vetted, typed query surface to remote callers and MCP tools.
 
-This is a server-side feature introduced in **v0.6.1**. It is distinct from CLI `aliases:` (see [`aliases.md`](aliases.md)): an alias is local client ergonomics; a stored query is a server-published, policy-gated endpoint.
+It is distinct from CLI `aliases:` (see [`aliases.md`](aliases.md)): an alias
+is local client ergonomics; a stored query is a server-published,
+policy-gated endpoint.
 
 ## Declaring stored queries (`cluster.yaml`)
 
@@ -20,12 +22,19 @@ graphs:
 ## CLI
 
 ```bash
-omnigraph queries validate     # type-check every stored query against the live schema (offline; opens the graph; exits non-zero on drift)
-omnigraph queries list         # print the addressed graph's registry: query names and typed params
+omnigraph queries validate --cluster .             # all applied graphs
+omnigraph queries validate --cluster . --graph dev # one graph
+omnigraph queries list --cluster . --graph dev     # names and typed params
 ```
 
-- `validate` catches schema drift **without restarting the server** — run it after a `schema apply` or before deploying a config change. The server also runs this check at startup and **refuses to boot** on drift or on a duplicate MCP tool name.
-- `validate` opens the graph (address with `--store <uri>` or a positional URI); `list` reads the addressed graph's catalog.
+- `cluster validate --config .` checks desired `.gq` sources before apply.
+  `queries validate` instead audits the **applied** registry against each
+  applied schema without restarting the server; it cannot see unapplied source
+  edits. Registry drift or duplicate names quarantine the affected graph by
+  default while healthy graphs serve; startup is fatal when no healthy graph
+  remains or `--require-all-graphs` is set.
+- Both commands take `--cluster <dir|uri>`; `--graph` narrows the operation to
+  one declared graph.
 - `queries` is distinct from `lint` — `lint` validates a single `.gq` file you point it at; `queries validate` validates the registry the server will actually serve.
 
 ## HTTP surface
@@ -42,7 +51,9 @@ omnigraph queries list         # print the addressed graph's registry: query nam
 - **`invoke_query`** is a per-graph Cedar action gating the whole stored-query invocation surface. Grant it like any other action (see [`server-policy.md`](server-policy.md)).
 - **Stored mutations are double-gated:** the caller needs `invoke_query` to reach the query **and** `change` for the write. An actor with `invoke_query` but not `change` gets `403` on a stored mutation.
 - **Deny == unknown:** for a caller *lacking* `invoke_query`, a denial and an unknown query name return the **same 404** (identical body) — the catalog can't be probed. A caller who *holds* `invoke_query` may still get a `403` from the inner gate for a query it can't `read`/`change`, so existence is visible to grant-holders by design.
-- **Default-deny mode** (bearer tokens, no `policy.file`) permits only `read`, so *every* `/graphs/{id}/queries/{name}` call returns `404` until an `invoke_query` rule is configured.
+- **Default-deny mode** (bearer tokens, no policy bundle) permits only `read`,
+  so every `/graphs/{id}/queries/{name}` call returns `404` until an
+  `invoke_query` rule is configured.
 
 ## MCP exposure
 
@@ -51,4 +62,3 @@ Every applied query is listed in `GET /graphs/{id}/queries` as a typed MCP tool.
 ## Note on per-query authorization
 
 The catalog is **not** Cedar-filtered per query yet: a caller with `read` but not `invoke_query` can *list* a query it cannot *invoke* (invocation would 404). Per-query authorization is future work; for now the catalog is a discovery surface and `invoke_query` is the invocation gate.
-


### PR DESCRIPTION
## Summary

- align the bundled OmniGraph skill with the released v0.10 CLI, server, schema, query, storage, and cluster contracts
- add focused Blob and commit/change-feed references, plus the coordinated Lance 11 / full-text-index upgrade boundary
- correct agent-facing traps around aliases, load identity, query commit positions, embedding/index behavior, auth, quarantine, and destructive schema plans
- include skill Markdown in existing link validation and keep skill metadata pinned to the CLI package version

## Validation

- `python3 scripts/check-docs.py`
- `bash scripts/check-agents-md.sh`
- `python3 scripts/check-workflow-action-pins.py`
- parsed every skill Markdown page with Pandoc
- cross-checked command shapes and behavioral claims against the exact v0.10.0 binary, canonical user docs, and implementation source
- independent final review: no remaining actionable issues


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates the bundled OmniGraph skill for the v0.10 CLI, server, schema, query, storage, and cluster contracts.
- Adds focused Blob and commit/change-feed operational references.
- Corrects guidance for aliases, load identity and overwrite scope, conditional writes, embeddings, authorization, quarantine, and destructive schema operations.
- Extends documentation link validation to the skill tree and checks that skill metadata matches the CLI package version.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no concrete changed-code defect or independently actionable non-blocking issue was identified.

The new validation correctly recognizes the current skill and CLI versions, all changed skill links resolve, and the checked v0.10 command, authorization, addressing, and query-language claims agree with their implementations.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/check-docs.py | Extends local-link checks to bundled skill Markdown and validates that skill metadata is pinned to the CLI package version. |
| skills/omnigraph/SKILL.md | Reworks the primary agent-facing operational guide around the released v0.10 command and behavior contracts. |
| skills/omnigraph/references/changes.md | Adds commit-diff, conditional-write, polling, cursor, and baseline guidance for change-feed workflows. |
| skills/omnigraph/references/server-policy.md | Updates authentication and Cedar authorization guidance consistently with the checked server policy and handlers. |
| skills/omnigraph/references/data.md | Clarifies logical entity identity, load modes, overwrite scope, branch workflows, and input limits. |
| skills/omnigraph/references/migrations.md | Documents the coordinated v0.10 storage and full-text-index upgrade boundary. |
| skills/omnigraph/references/queries.md | Aligns query syntax, ranking, mutation, traversal, and filtering guidance with the v0.10 language surface. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Skill[Bundled OmniGraph skill] --> CLI[CLI workflows]
  Skill --> Server[Server and authorization]
  Skill --> Schema[Schema and query contracts]
  Skill --> Storage[Blob, load, and migration guidance]
  Validator[Documentation checker] --> Links[Skill link validation]
  Validator --> Version[Skill and CLI version alignment]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs(skill): align with OmniGraph 0.10"](https://github.com/modernrelay/omnigraph/commit/21b763594ff06ad799ffabf4444296b1a78f9012) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58849273)</sub>

<!-- /greptile_comment -->