### PR TITLE
docs(release): foreground v0.10 vocabulary break

### DIFF
--- a/docs/releases/v0.10.0.md
+++ b/docs/releases/v0.10.0.md
@@ -6,10 +6,12 @@ It upgrades the storage substrate from v0.9.0's Lance 9 to **Lance 11.0.0** whil
 retaining graph storage format **v6**, recovery sidecars **v9**, and Lance
 **V2_2** data files. Existing v0.9 graphs do not require entity export/import.
 
-**Coordinated upgrade required.** CLI/HTTP JSON and public Rust vocabulary have
-changed; upgrade the CLI, server, and client integrations together. Stop the old
-fleet before opening the store with the new one. Do not mix Lance 9/10 binaries
-with Lance 11 readers or writers.
+**Coordinated upgrade required.** Public graph-facing APIs now describe nodes,
+edges, types, entities, and properties; ambiguous table/row names are removed.
+CLI/HTTP JSON and public Rust vocabulary have changed, so upgrade the CLI,
+server, and client integrations together. Stop the old fleet before opening the
+store with the new one. Do not mix Lance 9/10 binaries with Lance 11 readers or
+writers.
 
 **Rebuild full-text indexes on every branch that needs search.** Old indexes
 without compatible analyzer proof now fail explicitly instead of silently
@@ -109,7 +111,8 @@ verified whole-root backup for rollback and follow the
 
 ### CLI, HTTP, and embedded API
 
-- Graph-facing names now distinguish nodes/edges, types, entities, properties,
+- **Breaking graph vocabulary.** Graph-facing names now distinguish nodes/edges,
+  types, entities, properties,
   graph-manifest versions, and published dataset versions. Legacy aliases such
   as `table_key`, `row_id`, ambiguous `manifest_version`, `rows_loaded`, and
   `export --table` are removed rather than dual-emitted. Update consumers to
@@ -183,10 +186,3 @@ and compaction continue normally. See [maintenance](../user/operations/maintenan
   packages are frozen at 0.8.0 and are not this release. Binaries ship through
   GitHub Releases, the installer, Homebrew, and Docker. See
   [distribution policy](../dev/versioning.md#registry-publication-status).
-
-## Development-line note
-
-An earlier unreleased experiment also used 0.10.0 while exploring manifest
-formats v7–v19. Those abandoned formats remain refused. This release continues
-from released v0.9.0 on v6; see [ingestion](../dev/ingestion.md) and
-[RFC 0026](../rfcs/0026-memwal-streaming-ingest.md).


### PR DESCRIPTION
## Summary

- state the public node/edge/type/entity/property vocabulary break in the coordinated-upgrade warning
- label the detailed compatibility entry as a breaking graph-vocabulary change
- remove the redundant internal development-line history from the public release note

The published GitHub v0.10.0 release body has already received the same correction. The immutable v0.10.0 tag is unchanged.

## Validation

- `python3 scripts/check-docs.py`
- `git diff --check`


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR clarifies that v0.10 introduces a breaking public graph-vocabulary change and strengthens the coordinated-upgrade warning.
- Foregrounds the node, edge, type, entity, and property terminology migration.
- Labels the detailed compatibility entry as breaking.
- Removes redundant history about unreleased experimental manifest formats.

<h3>Confidence Score: 5/5</h3>

The documentation-only PR appears safe to merge.

The revised compatibility warning is consistent with the public vocabulary contract, and the retained release text continues to identify storage format v6 and the supported v0.9 upgrade path.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/releases/v0.10.0.md | Clarifies the documented v0.10 vocabulary break and removes internal development-line history without introducing an actionable documentation defect. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(release): foreground v0.10 vocabula..."](https://github.com/modernrelay/omnigraph/commit/11c33b6f98f523fae98a78e6bd2c630e4c21201b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58875288)</sub>

<!-- /greptile_comment -->