### PR TITLE
feat(engine): add edge keys with derived identity

### DIFF
--- a/crates/omnigraph-compiler/src/catalog/mod.rs
+++ b/crates/omnigraph-compiler/src/catalog/mod.rs
@@ -122,6 +122,13 @@ pub struct EdgeType {
     pub to_type: String,
     pub cardinality: Cardinality,
     pub properties: HashMap<String, PropType>,
+    /// Key column names (from `@key(src, dst, ...)`), always including both
+    /// endpoints. IR-bound catalogs order endpoints first (src, dst), then
+    /// composite members in stable property-ID order so renames cannot
+    /// change physical tuple identity. The parse-path catalog
+    /// (`build_catalog`) keeps declared order and never feeds id
+    /// derivation; only IR-bound catalogs do.
+    pub key: Option<Vec<String>>,
     /// Uniqueness constraints on edge fields, including endpoint fields
     /// (e.g. `@unique(src, dst)`).
     pub unique_constraints: Vec<Vec<String>>,
@@ -466,13 +473,20 @@ pub fn build_catalog(schema: &SchemaFile) -> Result<Catalog> {
             }
 
             // Extract edge constraints
+            let mut key: Option<Vec<String>> = None;
             let mut unique_constraints = Vec::new();
             let mut edge_indices = Vec::new();
             for constraint in &edge.constraints {
                 match constraint {
+                    Constraint::Key(cols) => {
+                        // No implied index: edge keys are always composite and
+                        // index maintenance builds single-column indices only;
+                        // the fixed id/src/dst BTREEs already cover endpoints.
+                        key = Some(cols.clone());
+                    }
                     Constraint::Unique(cols) => unique_constraints.push(cols.clone()),
                     Constraint::Index(cols) => edge_indices.push(cols.clone()),
-                    _ => {} // Key/Range/Check validated at parse time to not appear on edges
+                    _ => {} // Range/Check validated at parse time to not appear on edges
                 }
             }
 
@@ -495,6 +509,7 @@ pub fn build_catalog(schema: &SchemaFile) -> Result<Catalog> {
                     to_type: edge.to_type.clone(),
                     cardinality: edge.cardinality.clone(),
                     properties,
+                    key,
                     unique_constraints,
                     indices: edge_indices,
                     blob_properties,
@@ -665,10 +680,75 @@ pub fn build_catalog_from_ir(ir: &schema_ir::SchemaIR) -> Result<Catalog> {
             .filter(|property| matches!(property.prop_type.scalar, ScalarType::Blob))
             .map(|property| property.name.clone())
             .collect();
+        let mut key = None;
         let mut unique_constraints = Vec::new();
         let mut indices = Vec::new();
         for constraint in &edge.constraints {
+            if let schema_ir::ConstraintIR::Key { fields } = constraint {
+                let mut has_src = false;
+                let mut has_dst = false;
+                let mut stable_fields = Vec::new();
+                for field in fields {
+                    match field {
+                        schema_ir::FieldRefIR::System(reference) => match reference.role {
+                            schema_ir::SystemFieldRole::Src => {
+                                if has_src {
+                                    return Err(CompilerError::Catalog(format!(
+                                        "edge '{}' @key repeats an endpoint",
+                                        edge.name
+                                    )));
+                                }
+                                has_src = true;
+                            }
+                            schema_ir::SystemFieldRole::Dst => {
+                                if has_dst {
+                                    return Err(CompilerError::Catalog(format!(
+                                        "edge '{}' @key repeats an endpoint",
+                                        edge.name
+                                    )));
+                                }
+                                has_dst = true;
+                            }
+                            schema_ir::SystemFieldRole::Id => {
+                                return Err(CompilerError::Catalog(format!(
+                                    "edge '{}' @key cannot reference the id",
+                                    edge.name
+                                )));
+                            }
+                        },
+                        schema_ir::FieldRefIR::Property(reference) => {
+                            stable_fields
+                                .push((reference.property_id, reference.property_name.clone()));
+                        }
+                    }
+                }
+                if !has_src || !has_dst {
+                    return Err(CompilerError::Catalog(format!(
+                        "edge '{}' @key must include both endpoints",
+                        edge.name
+                    )));
+                }
+                stable_fields.sort_by_key(|(property_id, _)| *property_id);
+                if stable_fields.windows(2).any(|pair| pair[0].0 == pair[1].0) {
+                    return Err(CompilerError::Catalog(format!(
+                        "edge '{}' @key repeats a property identity",
+                        edge.name
+                    )));
+                }
+                let mut columns = vec!["src".to_string(), "dst".to_string()];
+                columns.extend(
+                    stable_fields
+                        .into_iter()
+                        .map(|(_, property_name)| property_name),
+                );
+                // No implied index: edge keys are always composite and index
+                // maintenance builds single-column indices only; the fixed
+                // id/src/dst BTREEs already cover endpoints.
+                key = Some(columns);
+                continue;
+            }
             match schema_ir::constraint_from_ir(constraint) {
+                Constraint::Key(_) => unreachable!("@key handled in stable property-id order"),
                 Constraint::Unique(columns) => unique_constraints.push(columns),
                 Constraint::Index(columns) => indices.push(columns),
                 _ => {}
@@ -704,6 +784,7 @@ pub fn build_catalog_from_ir(ir: &schema_ir::SchemaIR) -> Result<Catalog> {
                 to_type: edge.to_type.type_name.clone(),
                 cardinality: edge.cardinality.clone(),
                 properties,
+                key,
                 unique_constraints,
                 indices,
                 blob_properties,

--- a/crates/omnigraph-compiler/src/catalog/schema_ir.rs
+++ b/crates/omnigraph-compiler/src/catalog/schema_ir.rs
@@ -27,6 +27,25 @@ use super::schema_shape::{
 
 pub const SCHEMA_IR_VERSION: u32 = 2;
 
+/// Minted only when a schema declares an edge `@key` (RFC 0044); unkeyed
+/// schemas keep stamping [`SCHEMA_IR_VERSION`].
+pub const SCHEMA_IR_VERSION_EDGE_KEYS: u32 = 3;
+
+/// The `ir_version` an accepted schema is stamped with: the highest version
+/// its declared features require.
+pub fn required_ir_version(ir: &SchemaIR) -> u32 {
+    let has_edge_key = ir.edges.iter().any(|edge| {
+        edge.constraints
+            .iter()
+            .any(|constraint| matches!(constraint, ConstraintIR::Key { .. }))
+    });
+    if has_edge_key {
+        SCHEMA_IR_VERSION_EDGE_KEYS
+    } else {
+        SCHEMA_IR_VERSION
+    }
+}
+
 /// Opaque namespace for every numeric identity in one graph root.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 #[serde(transparent)]
@@ -654,7 +673,7 @@ fn resolve(
         })
         .collect::<Result<Vec<_>>>()?;
 
-    let schema_ir = SchemaIR {
+    let mut schema_ir = SchemaIR {
         ir_version: SCHEMA_IR_VERSION,
         schema_identity_domain: domain,
         next_identity_id: allocator.next,
@@ -662,6 +681,7 @@ fn resolve(
         nodes,
         edges,
     };
+    schema_ir.ir_version = required_ir_version(&schema_ir);
     validate_schema_ir(&schema_ir)?;
     Ok(SchemaResolution {
         schema_ir,
@@ -1070,9 +1090,16 @@ pub(crate) fn constraint_from_ir(constraint: &ConstraintIR) -> Constraint {
 
 /// Fail closed on malformed or hand-authored identity authority.
 pub fn validate_schema_ir(ir: &SchemaIR) -> Result<()> {
-    if ir.ir_version != SCHEMA_IR_VERSION {
+    if ir.ir_version != SCHEMA_IR_VERSION && ir.ir_version != SCHEMA_IR_VERSION_EDGE_KEYS {
         return invalid_ir(format!(
-            "unsupported ir_version {} (expected {SCHEMA_IR_VERSION})",
+            "unsupported ir_version {} (supported {SCHEMA_IR_VERSION} and {SCHEMA_IR_VERSION_EDGE_KEYS})",
+            ir.ir_version
+        ));
+    }
+    let required = required_ir_version(ir);
+    if ir.ir_version != required {
+        return invalid_ir(format!(
+            "ir_version {} does not match the declared features (expected {required})",
             ir.ir_version
         ));
     }
@@ -1423,6 +1450,66 @@ fn validate_constraints(
     properties: &HashMap<StablePropertyId, (AcceptedType<'_>, &PropertyIR)>,
 ) -> Result<()> {
     for constraint in constraints {
+        // Edge keys are identity authority: refuse malformed shapes here, not
+        // only at catalog build, so a hand-authored IR fails closed before
+        // acceptance can commit it.
+        if kind == TypeKind::Edge
+            && let ConstraintIR::Key { fields } = constraint
+        {
+            let owner_name = &types[&owner_id].name;
+            let mut src_seen = false;
+            let mut dst_seen = false;
+            let mut property_ids = HashSet::new();
+            for field in fields {
+                match field {
+                    FieldRefIR::System(reference) => {
+                        let seen = match reference.role {
+                            SystemFieldRole::Src => &mut src_seen,
+                            SystemFieldRole::Dst => &mut dst_seen,
+                            SystemFieldRole::Id => {
+                                return invalid_ir(format!(
+                                    "edge '{owner_name}' @key cannot reference the id"
+                                ));
+                            }
+                        };
+                        if *seen {
+                            return invalid_ir(format!(
+                                "edge '{owner_name}' @key repeats an endpoint"
+                            ));
+                        }
+                        *seen = true;
+                    }
+                    FieldRefIR::Property(reference) => {
+                        if !property_ids.insert(reference.property_id) {
+                            return invalid_ir(format!(
+                                "edge '{owner_name}' @key repeats a property identity"
+                            ));
+                        }
+                        if let Some((_, property)) = properties.get(&reference.property_id) {
+                            let prop_type = &property.prop_type;
+                            if prop_type.nullable
+                                || prop_type.list
+                                || matches!(
+                                    prop_type.scalar,
+                                    crate::types::ScalarType::Vector(_)
+                                        | crate::types::ScalarType::Blob
+                                )
+                            {
+                                return invalid_ir(format!(
+                                    "edge '{owner_name}' @key member '{}' must be a non-null scalar",
+                                    reference.property_name
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+            if !src_seen || !dst_seen {
+                return invalid_ir(format!(
+                    "edge '{owner_name}' @key must include both endpoints"
+                ));
+            }
+        }
         let fields: Vec<&FieldRefIR> = match constraint {
             ConstraintIR::Key { fields }
             | ConstraintIR::Unique { fields }
@@ -1750,6 +1837,58 @@ edge Relates: Human -> Human @rename_from("Knows") { @unique(src, dst) }
         let mut v1 = ir;
         v1.ir_version = 1;
         assert!(validate_schema_ir(&v1).is_err());
+    }
+
+    #[test]
+    fn ir_version_stamps_the_highest_declared_feature() {
+        let unkeyed = initialize("node P { n: String } edge E: P -> P { s: String }");
+        assert_eq!(unkeyed.ir_version, SCHEMA_IR_VERSION);
+        let keyed =
+            initialize("node P { n: String } edge E: P -> P { s: String @key(src, dst, s) }");
+        assert_eq!(keyed.ir_version, SCHEMA_IR_VERSION_EDGE_KEYS);
+    }
+
+    #[test]
+    fn ir_version_restamps_the_base_number_when_the_last_edge_key_drops() {
+        let keyed = initialize("node P { n: String } edge E: P -> P { @key(src, dst) }");
+        assert_eq!(keyed.ir_version, SCHEMA_IR_VERSION_EDGE_KEYS);
+        let unkeyed_shape =
+            compile_schema_shape(&parse_schema("node P { n: String }").unwrap()).unwrap();
+        let resolved = resolve_schema_ir(&keyed, &unkeyed_shape).unwrap().schema_ir;
+        assert_eq!(resolved.ir_version, SCHEMA_IR_VERSION);
+    }
+
+    #[test]
+    fn validation_rejects_ir_version_feature_mismatch() {
+        let keyed = initialize("node P { n: String } edge E: P -> P { @key(src, dst) }");
+        let mut spoofed_low = keyed;
+        spoofed_low.ir_version = SCHEMA_IR_VERSION;
+        assert!(validate_schema_ir(&spoofed_low).is_err());
+
+        let unkeyed = initialize("node P { n: String }");
+        let mut spoofed_high = unkeyed;
+        spoofed_high.ir_version = SCHEMA_IR_VERSION_EDGE_KEYS;
+        assert!(validate_schema_ir(&spoofed_high).is_err());
+    }
+
+    #[test]
+    fn edge_key_catalog_orders_endpoints_first_then_stable_property_ids() {
+        let ir = initialize(
+            "node P { n: String } edge E: P -> P { a: String b: String @key(b, dst, src, a) }",
+        );
+        let catalog = build_catalog_from_ir(&ir).unwrap();
+        assert_eq!(
+            catalog.edge_types["E"].key.as_deref(),
+            Some(
+                &[
+                    "src".to_string(),
+                    "dst".to_string(),
+                    "a".to_string(),
+                    "b".to_string()
+                ][..]
+            ),
+            "endpoints lead, composite members follow preserved property identity"
+        );
     }
 
     #[test]

--- a/crates/omnigraph-compiler/src/catalog/schema_ir.rs
+++ b/crates/omnigraph-compiler/src/catalog/schema_ir.rs
@@ -31,6 +31,12 @@ pub const SCHEMA_IR_VERSION: u32 = 2;
 /// schemas keep stamping [`SCHEMA_IR_VERSION`].
 pub const SCHEMA_IR_VERSION_EDGE_KEYS: u32 = 3;
 
+/// The one owner of "which stamped `ir_version`s this build opens": the
+/// contract validator and the engine's pre-recovery envelope gate both ask here.
+pub fn is_supported_ir_version(version: u32) -> bool {
+    version == SCHEMA_IR_VERSION || version == SCHEMA_IR_VERSION_EDGE_KEYS
+}
+
 /// The `ir_version` an accepted schema is stamped with: the highest version
 /// its declared features require.
 pub fn required_ir_version(ir: &SchemaIR) -> u32 {
@@ -1090,7 +1096,7 @@ pub(crate) fn constraint_from_ir(constraint: &ConstraintIR) -> Constraint {
 
 /// Fail closed on malformed or hand-authored identity authority.
 pub fn validate_schema_ir(ir: &SchemaIR) -> Result<()> {
-    if ir.ir_version != SCHEMA_IR_VERSION && ir.ir_version != SCHEMA_IR_VERSION_EDGE_KEYS {
+    if !is_supported_ir_version(ir.ir_version) {
         return invalid_ir(format!(
             "unsupported ir_version {} (supported {SCHEMA_IR_VERSION} and {SCHEMA_IR_VERSION_EDGE_KEYS})",
             ir.ir_version

--- a/crates/omnigraph-compiler/src/catalog/schema_ir.rs
+++ b/crates/omnigraph-compiler/src/catalog/schema_ir.rs
@@ -28,8 +28,9 @@ use super::schema_shape::{
 pub const SCHEMA_IR_VERSION: u32 = 2;
 
 /// Minted only when a schema declares an edge `@key` (RFC 0044); unkeyed
-/// schemas keep stamping [`SCHEMA_IR_VERSION`].
-pub const SCHEMA_IR_VERSION_EDGE_KEYS: u32 = 3;
+/// schemas keep stamping [`SCHEMA_IR_VERSION`]. 3 is burned: the withdrawn
+/// actor-provenance build stamped it and RFC 0054 refuses it before recovery.
+pub const SCHEMA_IR_VERSION_EDGE_KEYS: u32 = 4;
 
 /// The one owner of "which stamped `ir_version`s this build opens": the
 /// contract validator and the engine's pre-recovery envelope gate both ask here.

--- a/crates/omnigraph-compiler/src/catalog/schema_plan.rs
+++ b/crates/omnigraph-compiler/src/catalog/schema_plan.rs
@@ -1177,6 +1177,34 @@ node Ticket {
     }
 
     #[test]
+    fn plan_refuses_adding_edge_key_to_existing_type() {
+        // The `is_key` committed-lookup skip is sound only because a key
+        // exists from type creation on; this pin makes a future Key
+        // special-case in plan_constraints a deliberate decision.
+        let accepted = ir(r#"
+node Person { name: String @key }
+edge Knows: Person -> Person {
+    since: String?
+}
+"#);
+        let desired = evolve(
+            &accepted,
+            r#"
+node Person { name: String @key }
+edge Knows: Person -> Person {
+    since: String?
+    @key(src, dst)
+}
+"#,
+        );
+        let plan = plan_schema_migration(&accepted, &desired).unwrap();
+        assert!(
+            !plan.supported,
+            "adding @key to an existing edge type must be unsupported: {plan:?}"
+        );
+    }
+
+    #[test]
     fn plan_orders_rename_before_widening_and_names_the_new_property() {
         // A property renamed AND widened in one migration emits both steps:
         // RenameProperty first, then ExtendEnum carrying the post-rename name

--- a/crates/omnigraph-compiler/src/lib.rs
+++ b/crates/omnigraph-compiler/src/lib.rs
@@ -11,11 +11,12 @@ pub mod types;
 
 pub use catalog::schema_ir::{
     ConstraintIR, EdgeIR, EmbedSourceIR, FieldRefIR, InterfaceIR, NodeIR, PropertyIR,
-    PropertyRefIR, SCHEMA_IR_VERSION, SchemaIR, SchemaIdentityDiagnostic,
-    SchemaIdentityDiagnosticKind, SchemaIdentityDomain, SchemaResolution, StablePropertyId,
-    StableTypeId, SystemFieldRefIR, SystemFieldRole, TableIncarnationId, TypeRefIR,
-    initialize_schema_ir, resolve_schema_ir, schema_ir_hash, schema_ir_json, schema_ir_pretty_json,
-    schema_shape_from_ir, schema_shape_hash_from_ir, validate_schema_ir,
+    PropertyRefIR, SCHEMA_IR_VERSION, SCHEMA_IR_VERSION_EDGE_KEYS, SchemaIR,
+    SchemaIdentityDiagnostic, SchemaIdentityDiagnosticKind, SchemaIdentityDomain, SchemaResolution,
+    StablePropertyId, StableTypeId, SystemFieldRefIR, SystemFieldRole, TableIncarnationId,
+    TypeRefIR, initialize_schema_ir, is_supported_ir_version, resolve_schema_ir, schema_ir_hash,
+    schema_ir_json, schema_ir_pretty_json, schema_shape_from_ir, schema_shape_hash_from_ir,
+    validate_schema_ir,
 };
 pub use catalog::schema_plan::{
     DropMode, SchemaMigrationPlan, SchemaMigrationStep, SchemaTypeKind, plan_schema_migration,

--- a/crates/omnigraph-compiler/src/schema/parser.rs
+++ b/crates/omnigraph-compiler/src/schema/parser.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use pest::Parser;
 use pest::error::InputLocation;
@@ -774,6 +774,17 @@ fn validate_property_annotations(
     all_properties: &[PropDecl],
     is_edge: bool,
 ) -> Result<()> {
+    // Logical system-column and endpoint-parameter names on edges: a property
+    // with one of these names would shadow the physical column (the Arrow
+    // schema gains a duplicate field) or collide with the insert's from/to
+    // parameter namespace, splitting identity between write doors.
+    if is_edge && matches!(prop.name.as_str(), "id" | "src" | "dst" | "from" | "to") {
+        return Err(CompilerError::Parse(format!(
+            "property name '{}' is reserved on edge types ({}.{})",
+            prop.name, type_name, prop.name
+        )));
+    }
+
     let is_vector = matches!(prop.prop_type.scalar, ScalarType::Vector(_));
     let is_blob = matches!(prop.prop_type.scalar, ScalarType::Blob);
 
@@ -991,20 +1002,37 @@ fn validate_type_constraints(
     for constraint in constraints {
         match constraint {
             Constraint::Key(cols) => {
-                if is_edge {
-                    return Err(CompilerError::Parse(format!(
-                        "@key constraint is not supported on edges (edge {})",
-                        type_name
-                    )));
-                }
                 key_count += 1;
                 if key_count > 1 {
                     return Err(CompilerError::Parse(format!(
-                        "node type {} has multiple @key constraints; only one is supported",
+                        "{} type {} has multiple @key constraints; only one is supported",
+                        if is_edge { "edge" } else { "node" },
                         type_name
                     )));
                 }
+                let mut seen_columns = HashSet::new();
                 for col in cols {
+                    if !seen_columns.insert(col.as_str()) {
+                        return Err(CompilerError::Parse(format!(
+                            "@key on {} repeats member '{}'",
+                            type_name, col
+                        )));
+                    }
+                }
+                if is_edge {
+                    for endpoint in ["src", "dst"] {
+                        if !cols.iter().any(|col| col == endpoint) {
+                            return Err(CompilerError::Parse(format!(
+                                "@key on edge {} must include both endpoints (missing '{}')",
+                                type_name, endpoint
+                            )));
+                        }
+                    }
+                }
+                for col in cols {
+                    if is_edge && (col == "src" || col == "dst") {
+                        continue;
+                    }
                     let prop = prop_names.get(col.as_str()).ok_or_else(|| {
                         CompilerError::Parse(format!(
                             "@key on {} references unknown property '{}'",

--- a/crates/omnigraph-compiler/src/schema/parser_tests.rs
+++ b/crates/omnigraph-compiler/src/schema/parser_tests.rs
@@ -1255,3 +1255,231 @@ fn test_reject_search_output_column_property_names_at_parse_only() {
         );
     }
 }
+
+#[test]
+fn test_parse_edge_body_constraint_key() {
+    let input = r#"
+node Person { name: String }
+edge Knows: Person -> Person {
+since: Date
+@key(src, dst, since)
+}
+"#;
+    let schema = parse_schema(input).unwrap();
+    match &schema.declarations[1] {
+        SchemaDecl::Edge(e) => {
+            assert!(
+                e.constraints
+                    .iter()
+                    .any(|c| matches!(c, Constraint::Key(v) if v == &["src", "dst", "since"]))
+            );
+        }
+        _ => panic!("expected Edge"),
+    }
+}
+
+#[test]
+fn test_parse_edge_key_endpoints_only() {
+    let input = r#"
+node Person { name: String }
+edge Knows: Person -> Person {
+@key(src, dst)
+}
+"#;
+    let schema = parse_schema(input).unwrap();
+    match &schema.declarations[1] {
+        SchemaDecl::Edge(e) => {
+            assert!(
+                e.constraints
+                    .iter()
+                    .any(|c| matches!(c, Constraint::Key(v) if v == &["src", "dst"]))
+            );
+        }
+        _ => panic!("expected Edge"),
+    }
+}
+
+#[test]
+fn test_reject_edge_key_missing_endpoint() {
+    let cases = [
+        (
+            "missing dst",
+            "@key(src)",
+            "@key on edge Knows must include both endpoints (missing 'dst')",
+        ),
+        (
+            "missing src",
+            "@key(dst)",
+            "@key on edge Knows must include both endpoints (missing 'src')",
+        ),
+        (
+            "missing both",
+            "@key(since)",
+            "@key on edge Knows must include both endpoints (missing 'src')",
+        ),
+    ];
+    for (case, constraint, expected) in cases {
+        let input = format!(
+            "node Person {{ name: String }}\nedge Knows: Person -> Person {{\nsince: Date\n{constraint}\n}}\n"
+        );
+        let error = parse_schema_diagnostic(&input).expect_err(case);
+        assert_eq!(
+            error.to_string(),
+            format!("parse error: {expected}"),
+            "{case}"
+        );
+    }
+}
+
+#[test]
+fn test_reject_multiple_edge_keys() {
+    let input = r#"
+node Person { name: String }
+edge Knows: Person -> Person {
+since: Date
+@key(src, dst)
+@key(src, dst, since)
+}
+"#;
+    let error = parse_schema_diagnostic(input).expect_err("two @key groups");
+    assert_eq!(
+        error.to_string(),
+        "parse error: edge type Knows has multiple @key constraints; only one is supported"
+    );
+}
+
+#[test]
+fn test_edge_key_body_group_is_the_only_accepted_spelling() {
+    // The parenthesized form in type-annotation position is a grammar error.
+    let type_level_group = r#"
+node Person { name: String }
+edge Knows: Person -> Person @key(src, dst) {
+since: Date
+}
+"#;
+    let error = parse_schema_diagnostic(type_level_group).expect_err("type-level @key(...)");
+    assert!(
+        error.to_string().contains("unexpected constraint_name"),
+        "got: {error}"
+    );
+
+    // A bare type-level @key annotation stays refused, matching nodes.
+    let type_level_bare = r#"
+node Person { name: String }
+edge Knows: Person -> Person @key {
+since: Date
+}
+"#;
+    let error = parse_schema_diagnostic(type_level_bare).expect_err("type-level bare @key");
+    assert_eq!(
+        error.to_string(),
+        "parse error: @key is not supported on edges (edge Knows)"
+    );
+
+    // Property-level @key stays refused: a single-property key can never
+    // include both endpoints.
+    let property_level = r#"
+node Person { name: String }
+edge Knows: Person -> Person {
+since: Date @key
+}
+"#;
+    let error = parse_schema_diagnostic(property_level).expect_err("property-level @key");
+    assert_eq!(
+        error.to_string(),
+        "parse error: @key is not supported on edge properties (edge Knows.since)"
+    );
+}
+
+#[test]
+fn test_reject_reserved_logical_property_names() {
+    for name in ["id", "src", "dst", "from", "to"] {
+        let input = format!(
+            "node Person {{ name: String }}\nedge Knows: Person -> Person {{\n{name}: String\n}}\n"
+        );
+        let error = parse_schema_diagnostic(&input).expect_err(name);
+        assert_eq!(
+            error.to_string(),
+            format!("parse error: property name '{name}' is reserved on edge types (Knows.{name})"),
+            "{name}"
+        );
+    }
+    // Node types keep today's latitude (test_parse_annotation pins a node
+    // property named `id`); the reservation is edge-scoped.
+    parse_schema("node Person { from: String to: String src: String dst: String }")
+        .expect("nothing is reserved on node types");
+}
+
+#[test]
+fn test_reject_repeated_key_column() {
+    let edge = r#"
+node Person { name: String }
+edge Knows: Person -> Person {
+since: Date
+@key(src, dst, since, since)
+}
+"#;
+    let error = parse_schema_diagnostic(edge).expect_err("repeated edge member");
+    assert_eq!(
+        error.to_string(),
+        "parse error: @key on Knows repeats member 'since'"
+    );
+    let node = r#"
+node Person {
+name: String
+@key(name, name)
+}
+"#;
+    let error = parse_schema_diagnostic(node).expect_err("repeated node member");
+    assert_eq!(
+        error.to_string(),
+        "parse error: @key on Person repeats member 'name'"
+    );
+}
+
+#[test]
+fn test_reject_edge_key_column_rules() {
+    let cases = [
+        (
+            "nullable member",
+            "since: Date?",
+            "@key(src, dst, since)",
+            "@key property Knows.since cannot be nullable",
+        ),
+        (
+            "list member",
+            "tags: [String]",
+            "@key(src, dst, tags)",
+            "@key is not supported on list property Knows.tags",
+        ),
+        (
+            "vector member",
+            "embedding: Vector(3)",
+            "@key(src, dst, embedding)",
+            "@key is not supported on vector property Knows.embedding",
+        ),
+        (
+            "blob member",
+            "payload: Blob",
+            "@key(src, dst, payload)",
+            "@key is not supported on blob property Knows.payload",
+        ),
+        (
+            "unknown member",
+            "since: Date",
+            "@key(src, dst, weight)",
+            "@key on Knows references unknown property 'weight'",
+        ),
+    ];
+    for (case, property, constraint, expected) in cases {
+        let input = format!(
+            "node Person {{ name: String }}\nedge Knows: Person -> Person {{\n{property}\n{constraint}\n}}\n"
+        );
+        let error = parse_schema_diagnostic(&input).expect_err(case);
+        assert_eq!(
+            error.to_string(),
+            format!("parse error: {expected}"),
+            "{case}"
+        );
+    }
+}

--- a/crates/omnigraph-dst/src/harness.rs
+++ b/crates/omnigraph-dst/src/harness.rs
@@ -1328,21 +1328,28 @@ impl WorldModel {
 /// equal passes; both-changed-differently is a `MergeConflict` and the WHOLE
 /// merge is rejected (state untouched). `None` = rejection predicted.
 ///
-/// Two hypotheses layered on top (dual-hypothesis method, as with
+/// One hypothesis layered on top (dual-hypothesis method, as with
 /// recorded engine discoveries — if the engine disagrees, an assert fails loudly and
 /// the real semantics get recorded with evidence):
-///   H-A (EDGES ONLY since the 2026-08-14 predict-triage): an edge BORN on
-///        both sides since the fork — the engine merges edges keyed on
-///        ULID row id, never sees the two rows as one logical edge, and
-///        ACCEPTS a duplicate (the born-on-both signature); the model keeps
-///        predicting reject so the illegal state stays flagged. PERSON
-///        rows are `@key`-keyed and the engine's measured semantics are
-///        content-based: equal-content born-on-both CONVERGES to one row,
-///        divergent inserts are typed `MergeConflict{DivergentInsert}` —
-///        exactly the plain three-way arms, so persons skip H-A (probed
-///        both cells, `dst_predict_born_on_both_person_probe`).
 ///   H-B: the merged state is RI-validated — an edge surviving the cursor
 ///        walk whose endpoint the other side deleted rejects the merge.
+///
+/// H-A (reject edges born on both sides) is RETIRED: unkeyed born-on-both
+/// is the DOCUMENTED multiset default (the merge keeps both physical rows;
+/// `@key(src, dst)` opts a type into convergence instead). The model's
+/// edge reads are visited-gated membership, and the set model predicts the
+/// merged MEMBERSHIP for the multiset default in every sampled shape so
+/// far. Known gap: hidden multiplicity can split a delete-vs-readd fork —
+/// one side removes every row of a pair the other side has also re-added
+/// as a fresh second row; the set model sees an unchanged side and
+/// predicts absence while the engine keeps the fresh row. A pair-count
+/// edge model is the fix if the fleet ever trips it. Physical row counts
+/// are pinned by the targeted scenario
+/// `dst_merge_duplicates_born_on_both_edge` and its keyed twin. PERSON
+/// rows are `@key`-keyed: equal-content born-on-both CONVERGES to one row
+/// and divergent inserts are typed `MergeConflict{DivergentInsert}` —
+/// exactly the plain three-way arms (probed both cells,
+/// `dst_predict_born_on_both_person_probe`).
 fn predict_merge(base: &Model, source: &Model, target: &Model) -> Option<Model> {
     // Predict-triage aid (env-gated): DST_PREDICT_LOG=1
     // prints WHICH rule rejected and on what evidence, so a
@@ -1359,8 +1366,6 @@ fn predict_merge(base: &Model, source: &Model, target: &Model) -> Option<Model> 
         base: &BTreeMap<K, V>,
         source: &BTreeMap<K, V>,
         target: &BTreeMap<K, V>,
-        // H-A applies to EDGES only — rationale in the fn doc's H-A entry.
-        reject_born_on_both: bool,
     ) -> Option<BTreeMap<K, V>> {
         let mut keys: BTreeSet<&K> = BTreeSet::new();
         keys.extend(base.keys());
@@ -1371,10 +1376,6 @@ fn predict_merge(base: &Model, source: &Model, target: &Model) -> Option<Model> 
             let b = base.get(key);
             let s = source.get(key);
             let t = target.get(key);
-            if reject_born_on_both && b.is_none() && s.is_some() && t.is_some() {
-                reject_log("H-A born-on-both", format!("key={key:?} s={s:?} t={t:?}"));
-                return None; // H-A: two distinct fresh rows under one key
-            }
             let pick = if s == b {
                 t
             } else if t == b || s == t {
@@ -1393,12 +1394,12 @@ fn predict_merge(base: &Model, source: &Model, target: &Model) -> Option<Model> 
         Some(merged)
     }
 
-    let persons = three_way(&base.persons, &source.persons, &target.persons, false)?;
+    let persons = three_way(&base.persons, &source.persons, &target.persons)?;
     let to_map = |m: &Model| -> BTreeMap<(String, String), ()> {
         m.edges.iter().cloned().map(|p| (p, ())).collect()
     };
     let edges: BTreeSet<(String, String)> =
-        three_way(&to_map(base), &to_map(source), &to_map(target), true)?
+        three_way(&to_map(base), &to_map(source), &to_map(target))?
             .into_keys()
             .collect();
     for (from, to) in &edges {
@@ -5448,7 +5449,7 @@ pub fn run_universe_caught(
                 match exec_result {
                     Ok(()) => {
                         // A merge the model predicted as conflicting MUST NOT
-                        // succeed — dual-hypothesis assert (H-A/H-B live
+                        // succeed — dual-hypothesis assert (H-B lives
                         // here). Scope-out with a watch active: the flag was
                         // captured from a model the deferred op's roll-forward
                         // may have outrun, and the true prediction epoch is

--- a/crates/omnigraph-dst/tests/scenarios.rs
+++ b/crates/omnigraph-dst/tests/scenarios.rs
@@ -2113,9 +2113,9 @@ fn census_setup(window: &'static str) -> Option<(&'static str, usize)> {
 /// milestone-constructed merges made `predict_merge` say REJECT while the
 /// engine ACCEPTED. Rerun exactly those census cells with the prediction
 /// reason log on (`DST_PREDICT_LOG`), so every disagreement names its
-/// rejecting rule (H-A born-on-both / both-changed-differently / H-B
-/// referential) and its evidence — engine bug XOR wrong model
-/// belief, and the reason decides which.
+/// rejecting rule (both-changed-differently / H-B referential; the H-A
+/// born-on-both rule is retired, RFC 0044) and its evidence — engine bug
+/// XOR wrong model belief, and the reason decides which.
 #[test]
 #[serial]
 #[ignore = "instrument: law-8 predict_merge disagreement triage — run explicitly"]
@@ -2865,8 +2865,8 @@ fn dst_reborn_branch_cache_poison_minimal_shape_probe() {
 /// PHYSICAL rows through the raw snapshot scan. Two rows = the born-on-both duplication
 /// (edge duplication) widened to node rows under a declared `@key` —
 /// engine wrong-accept. One row = the engine resolves equal-content
-/// born-on-both and the model's H-A is too strict for the equal case —
-/// model fix.
+/// born-on-both exactly as the plain three-way arms predict (the H-A edge
+/// rule, since retired entirely by RFC 0044, never applied to persons).
 #[test]
 #[serial]
 #[ignore = "instrument: law-8 deciding probe — run explicitly"]
@@ -3712,16 +3712,15 @@ fn dst_merge_version_collision_diverged_edge_table() {
     })
 }
 
-/// BORN-ON-BOTH FINDING pin (localized 2026-08-12 from seed 10228's op
-/// transcript): the SAME logical edge added independently on BOTH sides
-/// of a fork, then merged. `predict_merge`'s H-A treats a key born on both
-/// sides as a uniqueness conflict; the engine ACCEPTS — and the three-way
-/// merge keys rows on ULID `id`, so the rows never collide and the merge
-/// SILENTLY DUPLICATES the edge (bound raw = 2, gated traversal = 1 — the
-/// visited gate hides the duplicate; Knows row_count 3 → 5 for one logical
-/// add). The pin asserts the bug AS IT STANDS; when the engine fix lands
-/// it goes red with instructions (the version-collision pattern). The
-/// fleet's accept-assert trips are this shape.
+/// MULTISET-DEFAULT CONTRACT pin (localized 2026-08-12 from seed 10228's
+/// op transcript; reclassified from bug pin to contract pin by RFC 0044):
+/// the SAME logical unkeyed edge added independently on BOTH sides of a
+/// fork, then merged. The three-way merge keys rows on the generated `id`,
+/// so the rows never collide and the merge keeps both (bound raw = 2,
+/// gated traversal = 1 — the visited gate dedupes membership). This is the
+/// documented multiset default for edge types without `@key`; declaring
+/// `@key(src, dst)` opts into convergence instead, pinned by the keyed
+/// twin `dst_keyed_born_on_both_edge_converges` below.
 #[test]
 #[serial]
 fn dst_merge_duplicates_born_on_both_edge() {
@@ -3827,17 +3826,148 @@ fn dst_merge_duplicates_born_on_both_edge() {
                 );
                 assert_eq!(
                     bound_dup, 2,
-                    "BORN-ON-BOTH pinned as-is: the merge duplicates the \
-                     born-on-both edge (bound raw = 2 rows). If this is now 1, \
-                     the engine fix landed — flip this pin to assert 1, drop \
-                     the model's H-A-edge carve-out plan, and \
-                     un-classify the fleet's born-on-both class."
+                    "multiset default: an unkeyed born-on-both edge merges \
+                     into two physical rows. If this is 1, unkeyed edges \
+                     started converging — a contract change beyond RFC 0044 \
+                     (which scopes convergence to @key(src, dst) types)."
                 );
                 println!(
                     "BORN-ON-BOTH pinned: the edge merged into {bound_dup} \
                      physical rows (logical 1)"
                 );
             }
+        }
+
+        omnigraph::dst_clock::uninstall_logical_clock();
+        omnigraph::dst_ids::uninstall_seeded_ulids();
+    })
+}
+
+/// Keyed twin of the multiset-default pin: the same born-on-both shape with
+/// `@key(src, dst)` declared on `Knows`. Both sides derive the same id, so
+/// the merge converges the edge to ONE physical row with no conflict
+/// (RFC 0044 opt-in). Bound raw and gated traversal agree at 1.
+#[test]
+#[serial]
+fn dst_keyed_born_on_both_edge_converges() {
+    // Mirrors fixtures/test.pg plus the one `@key(src, dst)` line; a
+    // TEST_SCHEMA edit must be carried here by hand.
+    const KEYED_TEST_SCHEMA: &str = r#"
+node Person {
+    name: String @key
+    age: I32?
+    ver: I64?
+}
+
+node Company {
+    name: String @key
+}
+
+edge Knows: Person -> Person {
+    since: Date?
+    @key(src, dst)
+}
+
+edge WorksAt: Person -> Company
+"#;
+    let mut seeds = SplitMix64(9203);
+    let runtime_seed = seeds.next_u64();
+    let ulid_seed = seeds.next_u64();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .start_paused(true)
+        .rng_seed(tokio::runtime::RngSeed::from_bytes(
+            &runtime_seed.to_le_bytes(),
+        ))
+        .build_local(Default::default())
+        .expect("seeded runtime");
+    runtime.block_on(async move {
+        omnigraph::dst_ids::install_seeded_ulids(ulid_seed);
+        omnigraph::dst_clock::install_logical_clock();
+        let storage: Arc<dyn StorageAdapter> = Arc::new(ObjectStorageAdapter::in_memory());
+        let db = Omnigraph::init_with_storage(
+            "shared-memory://dst-keyed-born-on-both",
+            KEYED_TEST_SCHEMA,
+            storage.clone(),
+            InitOptions::default(),
+        )
+        .await
+        .expect("init");
+        load_jsonl(&db, TEST_DATA, LoadMode::Overwrite)
+            .await
+            .expect("load");
+
+        db.branch_create("b0").await.expect("branch create");
+        db.mutate(
+            "b0",
+            MUTATION_QUERIES,
+            "add_friend",
+            &mixed_params(&[("$from", "Diana"), ("$to", "Alice")], &[]),
+        )
+        .await
+        .expect("b0 add edge");
+        db.mutate(
+            "main",
+            MUTATION_QUERIES,
+            "add_friend",
+            &mixed_params(&[("$from", "Diana"), ("$to", "Alice")], &[]),
+        )
+        .await
+        .expect("main add edge");
+
+        Box::pin(db.branch_merge("b0", "main"))
+            .await
+            .expect("identical born-on-both keyed edges converge without conflict");
+
+        let gated = knows_pairs_on(&db, "main").await;
+        let gated_dup = gated
+            .iter()
+            .filter(|(f, t)| f == "Diana" && t == "Alice")
+            .count();
+        use arrow_array::{Array, StringArray};
+        let qr = query_target(
+            &db,
+            omnigraph::db::ReadTarget::branch("main"),
+            MUTATION_QUERIES,
+            "all_knows_bound",
+            &omnigraph_compiler::ir::ParamMap::new(),
+        )
+        .await
+        .expect("bound read");
+        let mut bound_dup = 0usize;
+        for batch in qr.batches() {
+            let froms = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("bound col 0");
+            let tos = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("bound col 1");
+            for i in 0..froms.len() {
+                if froms.is_valid(i)
+                    && tos.is_valid(i)
+                    && froms.value(i) == "Diana"
+                    && tos.value(i) == "Alice"
+                {
+                    bound_dup += 1;
+                }
+            }
+        }
+        assert_eq!(gated_dup, 1, "gated traversal sees one (Diana, Alice) pair");
+        assert_eq!(
+            bound_dup, 1,
+            "keyed born-on-both must converge to one physical row"
+        );
+        // Convergence must not cost unrelated rows: every fixture edge
+        // survives the merge.
+        for (from, to) in omnigraph_dst::fixtures::fixture_knows() {
+            assert!(
+                gated.contains(&(from.clone(), to.clone())),
+                "fixture edge {from}->{to} lost through the keyed merge: {gated:?}"
+            );
         }
 
         omnigraph::dst_clock::uninstall_logical_clock();

--- a/crates/omnigraph-gqt/cases/issue_583_keyed_edge_born_on_both_sides_merges_once.gqt
+++ b/crates/omnigraph-gqt/cases/issue_583_keyed_edge_born_on_both_sides_merges_once.gqt
@@ -1,0 +1,76 @@
+# issue: 583
+# red_on: 2026-09-07, main @ ad425c68 (no edge keys yet): the schema is refused at parse, "@key constraint is not supported on edges (edge Knows)"; with that line removed the same fork returned the a->c edge TWICE from the bound traversal and count($w.since) was 2, one physical row per side of the fork (the #583 shape).
+# notes: a keyed edge (@key(src, dst)) inserted on both sides of a fork with the
+# notes: same key derives the same id on both sides, so the three-way merge sees
+# notes: one logical edge changed identically and main holds it once: the bound
+# notes: traversal returns one row and counts 1. Unkeyed edge types keep both rows (multiset default, RFC 0044).
+
+--- schema
+node Person {
+    name: String @key
+}
+
+edge Knows: Person -> Person {
+    since: I32
+    @key(src, dst)
+}
+
+--- seed
+{"type":"Person","data":{"name":"a"}}
+{"type":"Person","data":{"name":"c"}}
+
+--- mutate
+branch create s
+
+--- expect ok
+
+--- mutate branch: s
+query link_on_s() {
+    insert Knows { from: "a", to: "c", since: 1 }
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- mutate
+query link_on_main() {
+    insert Knows { from: "a", to: "c", since: 1 }
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- mutate
+branch merge s
+
+--- expect outcome: merged
+
+--- query
+query bound_edges() {
+    match {
+        $p: Person
+        $p $w:knows $f
+    }
+    return { $p.name, $f.name, $w.since }
+}
+
+--- expect unordered
+{"p.name": "a", "f.name": "c", "w.since": 1}
+
+--- expect shape
+p.name: String
+f.name: String
+w.since: I32
+
+--- query
+query edge_count() {
+    match {
+        $p: Person
+        $p $w:knows $f
+    }
+    return { count($w.since) as n }
+}
+
+--- expect unordered
+{"n": 1}
+
+--- expect shape
+n: I64

--- a/crates/omnigraph/src/db/schema_state.rs
+++ b/crates/omnigraph/src/db/schema_state.rs
@@ -48,12 +48,13 @@ pub(crate) async fn refuse_unsupported_schema_versions(
             continue;
         };
         if let Ok(envelope) = serde_json::from_str::<VersionEnvelope>(&text)
-            && envelope.ir_version != omnigraph_compiler::SCHEMA_IR_VERSION
+            && !omnigraph_compiler::is_supported_ir_version(envelope.ir_version)
         {
             return Err(schema_lock_conflict(format!(
-                "unsupported ir_version {} in {filename} (expected {}); open will not recover or migrate this schema",
+                "unsupported ir_version {} in {filename} (supported {} and {}); open will not recover or migrate this schema",
                 envelope.ir_version,
                 omnigraph_compiler::SCHEMA_IR_VERSION,
+                omnigraph_compiler::SCHEMA_IR_VERSION_EDGE_KEYS,
             )));
         }
     }

--- a/crates/omnigraph/src/exec/mutation.rs
+++ b/crates/omnigraph/src/exec/mutation.rs
@@ -1187,7 +1187,7 @@ impl Omnigraph {
                         1,
                     )?);
                 }
-                crate::loader::canonical_node_id(&typed_keys, 0)?.ok_or_else(|| {
+                crate::loader::canonical_key_id(&typed_keys, 0)?.ok_or_else(|| {
                     let key_description = match key_properties.as_slice() {
                         [key] => format!("@key property '{key}'"),
                         _ => format!("@key properties ({})", key_properties.join(", ")),
@@ -1233,30 +1233,80 @@ impl Omnigraph {
             let edge_type = &catalog.edge_types[type_name];
             let schema = edge_type.arrow_schema.clone();
             let blob_props = edge_type.blob_properties.clone();
-            let id = crate::dst_ids::new_ulid().to_string();
+            let id = if let Some(key_columns) = edge_type.key.as_ref() {
+                let mut typed_keys = Vec::with_capacity(key_columns.len());
+                for key_col in key_columns {
+                    // Endpoint key columns arrive under the insert's from/to
+                    // parameters, aliased to src/dst by build_insert_batch.
+                    let assignment = match key_col.as_str() {
+                        "src" => "from",
+                        "dst" => "to",
+                        other => other,
+                    };
+                    let key_literal = resolved.get(assignment).ok_or_else(|| {
+                        if key_col == "src" || key_col == "dst" {
+                            OmniError::manifest(format!(
+                                "missing required edge endpoint '{}'",
+                                assignment
+                            ))
+                        } else {
+                            OmniError::manifest(format!(
+                                "insert missing @key property '{}'",
+                                assignment
+                            ))
+                        }
+                    })?;
+                    let key_field = schema.field_with_name(key_col).map_err(|_| {
+                        OmniError::manifest_internal(format!(
+                            "@key property '{}' is missing from edge {} Arrow schema",
+                            key_col, edge_type.name
+                        ))
+                    })?;
+                    typed_keys.push(literal_to_typed_array(
+                        key_literal,
+                        key_field.data_type(),
+                        1,
+                    )?);
+                }
+                crate::loader::canonical_key_id(&typed_keys, 0)?.ok_or_else(|| {
+                    OmniError::manifest(format!(
+                        "insert @key properties ({}) cannot contain null",
+                        key_columns.join(", ")
+                    ))
+                })?
+            } else {
+                crate::dst_ids::new_ulid().to_string()
+            };
 
             let batch = build_insert_batch(&schema, &id, &resolved, &blob_props)?;
             // Validation (edge-RI, enum, unique, @card against the live
             // manifest-visible branch snapshot) runs
             // end-of-query via the evaluator.
+            let has_key = edge_type.key.is_some();
             let table_key = format!("edge:{}", type_name);
+            let insert_kind = if has_key {
+                crate::db::MutationOpKind::Merge
+            } else {
+                crate::db::MutationOpKind::Insert
+            };
             // Capture pre-write metadata on first touch (ensure_path). Edge
             // inserts are non-strict, so with a `WriteTxn` this opens NOTHING
             // (collapse #1) and the handle is discarded — validation, including
             // `@card` against the live committed branch snapshot, runs
             // end-of-query via the evaluator.
-            let (_handle, _full_path, _table_branch) = open_table_for_mutation(
-                self,
-                staging,
-                branch,
-                &table_key,
-                crate::db::MutationOpKind::Insert,
-                Some(txn),
-            )
-            .await?;
-            // Accumulate the new edge row. Edge IDs are ULID-generated so
-            // Append mode is correct (no key-based dedup needed).
-            staging.append_batch(&table_key, schema, PendingMode::StrictInsert, batch)?;
+            let (_handle, _full_path, _table_branch) =
+                open_table_for_mutation(self, staging, branch, &table_key, insert_kind, Some(txn))
+                    .await?;
+            // Accumulate. @key inserts go into the Merge stream (so a
+            // later update on the same derived id coalesces correctly);
+            // no-key inserts keep ULID-generated ids, where Append mode is
+            // correct (no key-based dedup needed).
+            let mode = if has_key {
+                PendingMode::Upsert
+            } else {
+                PendingMode::StrictInsert
+            };
+            staging.append_batch(&table_key, schema, mode, batch)?;
 
             self.invalidate_graph_index().await;
 

--- a/crates/omnigraph/src/loader/mod.rs
+++ b/crates/omnigraph/src/loader/mod.rs
@@ -12,7 +12,7 @@ use arrow_array::{
         UInt32Builder, UInt64Builder,
     },
 };
-use arrow_schema::DataType;
+use arrow_schema::{DataType, SchemaRef};
 use base64::Engine;
 use lance::blob::BlobArrayBuilder;
 use omnigraph_compiler::catalog::{Catalog, EdgeType, NodeType};
@@ -1469,7 +1469,7 @@ fn build_node_batch(
                     [key] => format!("@key property '{key}'"),
                     _ => format!("@key properties ({})", key_properties.join(", ")),
                 };
-                let key_value = canonical_node_id(key_columns, row_index)?.ok_or_else(|| {
+                let key_value = canonical_key_id(key_columns, row_index)?.ok_or_else(|| {
                     OmniError::manifest(format!(
                         "node {} missing {key_description}",
                         node_type.name
@@ -1518,15 +1518,6 @@ fn build_edge_batch(
         &row_refs,
     )?;
 
-    let ids: Vec<String> = rows
-        .iter()
-        .map(|(_, _, data)| {
-            data.get("id")
-                .and_then(|v| v.as_str())
-                .map(str::to_string)
-                .unwrap_or_else(generate_id)
-        })
-        .collect();
     let srcs: Vec<String> = rows
         .iter()
         .map(|(from, _, _)| {
@@ -1545,18 +1536,17 @@ fn build_edge_batch(
                 .to_string()
         })
         .collect();
-
-    let mut columns: Vec<ArrayRef> = Vec::with_capacity(schema.fields().len());
-    columns.push(Arc::new(StringArray::from(ids)));
-    columns.push(Arc::new(StringArray::from(srcs)));
-    columns.push(Arc::new(StringArray::from(dsts)));
+    let src_column: ArrayRef = Arc::new(StringArray::from(srcs));
+    let dst_column: ArrayRef = Arc::new(StringArray::from(dsts));
 
     // Build edge property columns (skip id, src, dst at indices 0-2)
     let data_values: Vec<JsonValue> = rows.iter().map(|(_, _, data)| data.clone()).collect();
+    let mut property_columns: Vec<ArrayRef> =
+        Vec::with_capacity(schema.fields().len().saturating_sub(3));
     for field in schema.fields().iter().skip(3) {
         if edge_type.blob_properties.contains(field.name()) {
             let col = build_blob_column(field.name(), field.is_nullable(), &data_values)?;
-            columns.push(col);
+            property_columns.push(col);
         } else {
             let col = build_column_from_json(
                 field.name(),
@@ -1565,11 +1555,108 @@ fn build_edge_batch(
                 &data_values,
                 JsonConversionMode::LoaderCompat,
             )?;
-            columns.push(col);
+            property_columns.push(col);
         }
     }
 
+    // Keyed edge types derive the id from the (remapped) key columns; an
+    // explicit id must equal the derivation exactly. Unkeyed types keep the
+    // explicit-or-generated behavior.
+    let key_columns = edge_key_columns(
+        edge_type,
+        &schema,
+        &src_column,
+        &dst_column,
+        &property_columns,
+    )?;
+    let ids = rows
+        .iter()
+        .enumerate()
+        .map(|(row_index, (_, _, data))| {
+            if let Some(key_columns) = &key_columns {
+                let canonical = canonical_key_id(key_columns, row_index)?.ok_or_else(|| {
+                    OmniError::manifest(format!(
+                        "edge {} is missing a non-null @key value",
+                        edge_type.name
+                    ))
+                })?;
+                match data.get("id") {
+                    None => {}
+                    Some(JsonValue::String(explicit_id)) => {
+                        if *explicit_id != canonical {
+                            return Err(OmniError::manifest(format!(
+                                "edge {} explicit id '{}' does not match its canonical @key id '{}'",
+                                edge_type.name, explicit_id, canonical
+                            )));
+                        }
+                    }
+                    Some(value) => {
+                        return Err(OmniError::manifest(format!(
+                            "edge {} explicit id must be a string, got {}",
+                            edge_type.name, value
+                        )));
+                    }
+                }
+                Ok(canonical)
+            } else {
+                Ok(data
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+                    .unwrap_or_else(generate_id))
+            }
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut columns: Vec<ArrayRef> = Vec::with_capacity(schema.fields().len());
+    columns.push(Arc::new(StringArray::from(ids)));
+    columns.push(src_column);
+    columns.push(dst_column);
+    columns.extend(property_columns);
+
     RecordBatch::try_new(schema, columns).map_err(OmniError::arrow_internal)
+}
+
+/// Resolve a keyed edge type's key columns to their built arrays: endpoints
+/// from the src/dst columns, composite members from the property columns
+/// (schema positions 3+). `Ok(None)` for unkeyed edge types.
+fn edge_key_columns(
+    edge_type: &omnigraph_compiler::catalog::EdgeType,
+    schema: &SchemaRef,
+    src_column: &ArrayRef,
+    dst_column: &ArrayRef,
+    property_columns: &[ArrayRef],
+) -> Result<Option<Vec<ArrayRef>>> {
+    edge_type
+        .key
+        .as_ref()
+        .map(|columns| {
+            columns
+                .iter()
+                .map(|column| match column.as_str() {
+                    "src" => Ok(src_column.clone()),
+                    "dst" => Ok(dst_column.clone()),
+                    property => {
+                        let schema_index = schema.index_of(property).map_err(|_| {
+                            OmniError::manifest_internal(format!(
+                                "@key property '{property}' is missing from edge {} Arrow schema",
+                                edge_type.name
+                            ))
+                        })?;
+                        schema_index
+                            .checked_sub(3)
+                            .and_then(|property_index| property_columns.get(property_index))
+                            .cloned()
+                            .ok_or_else(|| {
+                                OmniError::manifest_internal(format!(
+                                    "@key property '{property}' has an invalid schema position"
+                                ))
+                            })
+                    }
+                })
+                .collect::<Result<Vec<_>>>()
+        })
+        .transpose()
 }
 
 /// Normalize a bounded group of caller-shaped rows into one dense logical
@@ -1673,7 +1760,7 @@ fn normalize_strict_node_rows(node_type: &NodeType, rows: &[JsonValue]) -> Resul
         .map(|(row_index, object)| {
             let explicit_id = optional_row_id(&node_type.name, object)?;
             if let Some(key_columns) = &key_columns {
-                let canonical = canonical_node_id(key_columns, row_index)?.ok_or_else(|| {
+                let canonical = canonical_key_id(key_columns, row_index)?.ok_or_else(|| {
                     OmniError::manifest(format!(
                         "node {} is missing a non-null @key value",
                         node_type.name
@@ -1723,13 +1810,6 @@ fn normalize_strict_edge_rows(edge_type: &EdgeType, rows: &[JsonValue]) -> Resul
         &rows.iter().collect::<Vec<_>>(),
     )?;
 
-    let ids = objects
-        .iter()
-        .map(|object| {
-            optional_row_id(&edge_type.name, object)
-                .map(|id| id.map(str::to_string).unwrap_or_else(generate_id))
-        })
-        .collect::<Result<Vec<_>>>()?;
     let srcs = objects
         .iter()
         .map(|object| validate_required_row_string(&edge_type.name, "src", object))
@@ -1738,11 +1818,10 @@ fn normalize_strict_edge_rows(edge_type: &EdgeType, rows: &[JsonValue]) -> Resul
         .iter()
         .map(|object| validate_required_row_string(&edge_type.name, "dst", object))
         .collect::<Result<Vec<_>>>()?;
+    let src_column: ArrayRef = Arc::new(StringArray::from(srcs));
+    let dst_column: ArrayRef = Arc::new(StringArray::from(dsts));
 
-    let mut columns = Vec::with_capacity(schema.fields().len());
-    columns.push(Arc::new(StringArray::from(ids)) as ArrayRef);
-    columns.push(Arc::new(StringArray::from(srcs)) as ArrayRef);
-    columns.push(Arc::new(StringArray::from(dsts)) as ArrayRef);
+    let mut property_columns = Vec::with_capacity(schema.fields().len().saturating_sub(3));
     for field in schema.fields().iter().skip(3) {
         let column = if edge_type.blob_properties.contains(field.name()) {
             build_blob_column(field.name(), field.is_nullable(), rows)?
@@ -1755,8 +1834,51 @@ fn normalize_strict_edge_rows(edge_type: &EdgeType, rows: &[JsonValue]) -> Resul
                 JsonConversionMode::Strict,
             )?
         };
-        columns.push(column);
+        property_columns.push(column);
     }
+
+    // Keyed edge types derive the id from the key columns; an explicit id
+    // must equal the derivation exactly. Unkeyed types keep the
+    // explicit-or-generated behavior.
+    let key_columns = edge_key_columns(
+        edge_type,
+        &schema,
+        &src_column,
+        &dst_column,
+        &property_columns,
+    )?;
+    let ids = objects
+        .iter()
+        .enumerate()
+        .map(|(row_index, object)| {
+            let explicit_id = optional_row_id(&edge_type.name, object)?;
+            if let Some(key_columns) = &key_columns {
+                let canonical = canonical_key_id(key_columns, row_index)?.ok_or_else(|| {
+                    OmniError::manifest(format!(
+                        "edge {} is missing a non-null @key value",
+                        edge_type.name
+                    ))
+                })?;
+                if let Some(explicit_id) = explicit_id
+                    && explicit_id != canonical
+                {
+                    return Err(OmniError::manifest(format!(
+                        "edge {} explicit id '{}' does not match its canonical @key id '{}'",
+                        edge_type.name, explicit_id, canonical
+                    )));
+                }
+                Ok(canonical)
+            } else {
+                Ok(explicit_id.map(str::to_string).unwrap_or_else(generate_id))
+            }
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut columns = Vec::with_capacity(schema.fields().len());
+    columns.push(Arc::new(StringArray::from(ids)) as ArrayRef);
+    columns.push(src_column);
+    columns.push(dst_column);
+    columns.extend(property_columns);
     RecordBatch::try_new(schema, columns).map_err(OmniError::arrow_internal)
 }
 
@@ -2912,19 +3034,19 @@ pub(crate) fn composite_unique_key(
     Ok(Some(parts))
 }
 
-/// Derive the exact physical node id for a typed `@key` tuple.
+/// Derive the exact physical row id for a typed `@key` tuple (node or edge).
 ///
 /// A one-column key retains the historical scalar spelling. Composite keys use
 /// a JSON array of the per-column canonical strings: JSON escaping makes the
 /// encoding deterministic and unambiguous without inventing a delimiter that
 /// user data could forge.
-pub(crate) fn canonical_node_id(key_columns: &[ArrayRef], row: usize) -> Result<Option<String>> {
+pub(crate) fn canonical_key_id(key_columns: &[ArrayRef], row: usize) -> Result<Option<String>> {
     let Some(parts) = composite_unique_key(key_columns, row)? else {
         return Ok(None);
     };
     match parts.as_slice() {
         [] => Err(OmniError::manifest_internal(
-            "cannot derive a physical node id from an empty @key tuple",
+            "cannot derive an id from an empty @key tuple",
         )),
         [scalar] => Ok(Some(scalar.clone())),
         _ => serde_json::to_string(&parts)
@@ -4290,7 +4412,7 @@ node Doc {
     fn composite_node_id_is_deterministic_and_unambiguous() {
         let scalar: Vec<ArrayRef> = vec![Arc::new(StringArray::from(vec!["a,b"]))];
         assert_eq!(
-            canonical_node_id(&scalar, 0).unwrap().as_deref(),
+            canonical_key_id(&scalar, 0).unwrap().as_deref(),
             Some("a,b"),
             "one-column keys retain their historical scalar id"
         );
@@ -4301,7 +4423,7 @@ node Doc {
             Arc::new(StringArray::from(vec!["quote\"and\\slash"])),
         ];
         assert_eq!(
-            canonical_node_id(&composite, 0).unwrap().as_deref(),
+            canonical_key_id(&composite, 0).unwrap().as_deref(),
             Some(r#"["a,b","7","quote\"and\\slash"]"#)
         );
     }

--- a/crates/omnigraph/src/validate.rs
+++ b/crates/omnigraph/src/validate.rs
@@ -219,8 +219,34 @@ pub(crate) fn constraints_for(catalog: &Catalog) -> Vec<Constraint> {
     __dst_ve.sort_by(|a, b| a.0.cmp(b.0));
     for (name, edge_type) in __dst_ve {
         let table_key = format!("edge:{name}");
-        // Edges have no `@key`; every `@unique` group needs the committed lookup.
+        // `@key` is id-backed: cross-version duplication is impossible (the key
+        // IS the identity), so it needs only intra-delta dedup — `is_key: true`
+        // tells the evaluator to skip the committed lookup. Sound only because
+        // a key exists from type creation on: schema_plan refuses adding or
+        // removing constraints on an existing type, so committed rows always
+        // carry derived ids.
+        if let Some(key) = &edge_type.key {
+            out.push(Constraint::Unique {
+                table_key: table_key.clone(),
+                columns: key.clone(),
+                is_key: true,
+            });
+        }
+        // `@unique` (non-key) groups CAN collide cross-version → committed lookup.
+        // Subsumption compares column SETS: uniqueness is order-free, and the
+        // catalog stores the key endpoint-first while shape normalization
+        // stores `@unique` groups lexically, so tuple equality can never hold.
+        let sorted_key = edge_type.key.as_ref().map(|key| {
+            let mut key = key.clone();
+            key.sort();
+            key
+        });
         for columns in &edge_type.unique_constraints {
+            let mut sorted_columns = columns.clone();
+            sorted_columns.sort();
+            if Some(&sorted_columns) == sorted_key.as_ref() {
+                continue; // same column set as @key — already covered above.
+            }
             out.push(Constraint::Unique {
                 table_key: table_key.clone(),
                 columns: columns.clone(),

--- a/crates/omnigraph/tests/branching.rs
+++ b/crates/omnigraph/tests/branching.rs
@@ -3638,3 +3638,255 @@ async fn merge_delta_only_bumps_changed_rows() {
         unique_versions
     );
 }
+
+// ─── Edge @key: born-on-both convergence and divergence (issue #583) ─────────
+
+const EDGE_KEY_MERGE_SCHEMA: &str = r#"
+node Person {
+    name: String @key
+}
+
+edge Knows: Person -> Person {
+    since: String?
+    @key(src, dst)
+}
+"#;
+
+// The unkeyed control: identical fixture without the key declaration.
+const EDGE_UNKEYED_MERGE_SCHEMA: &str = r#"
+node Person {
+    name: String @key
+}
+
+edge Knows: Person -> Person {
+    since: String?
+}
+"#;
+
+const EDGE_KEY_MERGE_DATA: &str = r#"{"type":"Person","data":{"name":"Alice"}}
+{"type":"Person","data":{"name":"Bob"}}
+{"type":"Person","data":{"name":"Carol"}}
+{"type":"Person","data":{"name":"Dave"}}
+{"type":"Person","data":{"name":"Eve"}}
+{"edge":"Knows","from":"Alice","to":"Carol"}
+{"edge":"Knows","from":"Alice","to":"Dave"}
+{"edge":"Knows","from":"Alice","to":"Eve"}"#;
+
+const EDGE_KEY_MERGE_MUTATIONS: &str = r#"
+query add_knows($from: String, $to: String) {
+    insert Knows { from: $from, to: $to }
+}
+
+query add_knows_since($from: String, $to: String, $since: String) {
+    insert Knows { from: $from, to: $to, since: $since }
+}
+"#;
+
+const EDGE_KEY_MERGE_QUERIES: &str = r#"
+query friends() {
+    match {
+        $p: Person { name: "Alice" }
+        $p knows $f
+    }
+    return { $f.name }
+}
+
+query friend_edges() {
+    match {
+        $p: Person { name: "Alice" }
+        $p $w:knows $f
+    }
+    return { $f.name }
+}
+"#;
+
+/// Issue #583's repro with `@key(src, dst)` declared: the same keyed edge
+/// inserted on both sides of a fork derives the same id, so the merge
+/// converges with no conflict and both the plain and the bound-edge
+/// traversal return 4 rows.
+#[tokio::test]
+async fn branch_merge_converges_born_on_both_keyed_edge() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = dir.path().to_str().unwrap();
+    let mut main =
+        init_db_from_schema_and_data(&dir, EDGE_KEY_MERGE_SCHEMA, EDGE_KEY_MERGE_DATA).await;
+    main.branch_create("feature").await.unwrap();
+
+    let mut feature = Omnigraph::open(uri).await.unwrap();
+
+    mutate_main(
+        &mut main,
+        EDGE_KEY_MERGE_MUTATIONS,
+        "add_knows",
+        &params(&[("$from", "Alice"), ("$to", "Bob")]),
+    )
+    .await
+    .unwrap();
+
+    mutate_branch(
+        &mut feature,
+        "feature",
+        EDGE_KEY_MERGE_MUTATIONS,
+        "add_knows",
+        &params(&[("$from", "Alice"), ("$to", "Bob")]),
+    )
+    .await
+    .unwrap();
+
+    main.branch_merge("feature", "main")
+        .await
+        .expect("identical born-on-both keyed edges converge without conflict");
+
+    assert_eq!(count_rows(&main, "edge:Knows").await, 4);
+    let plain = query_main(&mut main, EDGE_KEY_MERGE_QUERIES, "friends", &params(&[]))
+        .await
+        .unwrap();
+    assert_eq!(first_column_sorted(&plain).len(), 4);
+    let bound = query_main(
+        &mut main,
+        EDGE_KEY_MERGE_QUERIES,
+        "friend_edges",
+        &params(&[]),
+    )
+    .await
+    .unwrap();
+    assert_eq!(first_column_sorted(&bound).len(), 4);
+}
+
+/// The unkeyed control pins the documented multiset outcome the RFC's
+/// acceptance threshold names: the merge keeps both rows (5 edges), the
+/// plain traversal's visited gate suppresses the duplicate (4), and the
+/// bound-edge traversal reports every row (5).
+#[tokio::test]
+async fn branch_merge_keeps_both_born_on_both_unkeyed_edges() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = dir.path().to_str().unwrap();
+    let mut main =
+        init_db_from_schema_and_data(&dir, EDGE_UNKEYED_MERGE_SCHEMA, EDGE_KEY_MERGE_DATA).await;
+    main.branch_create("feature").await.unwrap();
+
+    let mut feature = Omnigraph::open(uri).await.unwrap();
+
+    mutate_main(
+        &mut main,
+        EDGE_KEY_MERGE_MUTATIONS,
+        "add_knows",
+        &params(&[("$from", "Alice"), ("$to", "Bob")]),
+    )
+    .await
+    .unwrap();
+
+    mutate_branch(
+        &mut feature,
+        "feature",
+        EDGE_KEY_MERGE_MUTATIONS,
+        "add_knows",
+        &params(&[("$from", "Alice"), ("$to", "Bob")]),
+    )
+    .await
+    .unwrap();
+
+    main.branch_merge("feature", "main")
+        .await
+        .expect("unkeyed born-on-both edges keep the documented multiset outcome");
+
+    assert_eq!(count_rows(&main, "edge:Knows").await, 5);
+    let plain = query_main(&mut main, EDGE_KEY_MERGE_QUERIES, "friends", &params(&[]))
+        .await
+        .unwrap();
+    assert_eq!(first_column_sorted(&plain).len(), 4);
+    let bound = query_main(
+        &mut main,
+        EDGE_KEY_MERGE_QUERIES,
+        "friend_edges",
+        &params(&[]),
+    )
+    .await
+    .unwrap();
+    assert_eq!(first_column_sorted(&bound).len(), 5);
+}
+
+/// Distinct keyed pairs inserted one per side derive distinct ids and merge
+/// cleanly: no conflict, both rows land.
+#[tokio::test]
+async fn branch_merge_keeps_distinct_keyed_pairs() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = dir.path().to_str().unwrap();
+    let mut main =
+        init_db_from_schema_and_data(&dir, EDGE_KEY_MERGE_SCHEMA, EDGE_KEY_MERGE_DATA).await;
+    main.branch_create("feature").await.unwrap();
+
+    let mut feature = Omnigraph::open(uri).await.unwrap();
+
+    mutate_main(
+        &mut main,
+        EDGE_KEY_MERGE_MUTATIONS,
+        "add_knows",
+        &params(&[("$from", "Alice"), ("$to", "Bob")]),
+    )
+    .await
+    .unwrap();
+
+    mutate_branch(
+        &mut feature,
+        "feature",
+        EDGE_KEY_MERGE_MUTATIONS,
+        "add_knows",
+        &params(&[("$from", "Bob"), ("$to", "Alice")]),
+    )
+    .await
+    .unwrap();
+
+    main.branch_merge("feature", "main")
+        .await
+        .expect("distinct keyed pairs must merge cleanly");
+    // Three fixture edges plus the two distinct new pairs.
+    assert_eq!(count_rows(&main, "edge:Knows").await, 5);
+}
+
+/// Two branches inserting the same key with DIFFERENT non-key properties
+/// surface `DivergentInsert`, with the derived id as the conflict entity id.
+#[tokio::test]
+async fn branch_merge_reports_divergent_insert_for_keyed_edge() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = dir.path().to_str().unwrap();
+    let mut main =
+        init_db_from_schema_and_data(&dir, EDGE_KEY_MERGE_SCHEMA, EDGE_KEY_MERGE_DATA).await;
+    main.branch_create("feature").await.unwrap();
+
+    let mut feature = Omnigraph::open(uri).await.unwrap();
+
+    mutate_main(
+        &mut main,
+        EDGE_KEY_MERGE_MUTATIONS,
+        "add_knows_since",
+        &params(&[("$from", "Alice"), ("$to", "Bob"), ("$since", "2020")]),
+    )
+    .await
+    .unwrap();
+
+    mutate_branch(
+        &mut feature,
+        "feature",
+        EDGE_KEY_MERGE_MUTATIONS,
+        "add_knows_since",
+        &params(&[("$from", "Alice"), ("$to", "Bob"), ("$since", "2021")]),
+    )
+    .await
+    .unwrap();
+
+    let err = main.branch_merge("feature", "main").await.unwrap_err();
+    match err {
+        OmniError::MergeConflicts(conflicts) => {
+            assert!(
+                conflicts.iter().any(|conflict| {
+                    conflict.type_key == "edge:Knows"
+                        && conflict.kind == MergeConflictKind::DivergentInsert
+                        && conflict.entity_id.as_deref() == Some(r#"["Alice","Bob"]"#)
+                }),
+                "expected DivergentInsert on the derived edge id, got {conflicts:?}"
+            );
+        }
+        other => panic!("expected merge conflicts, got {other:?}"),
+    }
+}

--- a/crates/omnigraph/tests/merge_truth_table.rs
+++ b/crates/omnigraph/tests/merge_truth_table.rs
@@ -46,7 +46,7 @@ mod helpers;
 
 use std::time::Instant;
 
-use helpers::{count_rows, mixed_params, mutate_branch, params, query_main};
+use helpers::{count_rows, first_column_sorted, mixed_params, mutate_branch, params, query_main};
 use omnigraph::db::{MergeOutcome, Omnigraph};
 use omnigraph::error::{MergeConflictKind, OmniError};
 use omnigraph::loader::{LoadMode, load_jsonl};
@@ -100,6 +100,22 @@ query get_person($name: String) {
         $p: Person { name: $name }
     }
     return { $p.name, $p.age }
+}
+
+query all_knows() {
+    match {
+        $a: Person
+        $a $w:knows $b
+    }
+    return { $a.name, $b.name }
+}
+
+query knows_of($name: String) {
+    match {
+        $p: Person { name: $name }
+        $p knows $f
+    }
+    return { $f.name }
 }
 "#;
 
@@ -602,10 +618,11 @@ fn build_case(left: OpVariant, right: OpVariant) -> MergeCase {
             InsertAliceCarol,
             // Both sides insert the same logical edge but each generates a
             // fresh ULID id, so the merge sees two distinct rows with the
-            // same (src, dst) pair and keeps both. This is the current
-            // behavior; whether duplicate Knows edges should be deduplicated
-            // by endpoints is tracked separately — the cell pins the
-            // current contract.
+            // same (src, dst) pair and keeps both: the documented multiset
+            // default for unkeyed edge types. Declaring `@key(src, dst)`
+            // opts into convergence instead (RFC 0044); the keyed twin
+            // `add_edge_add_edge_keyed_twin_converges` asserts it. This
+            // cell pins the unkeyed contract.
             Expected::Merged(GraphAssert {
                 persons: 4,
                 knows_edges: 3,
@@ -1070,4 +1087,78 @@ async fn merge_pair_truth_table() {
     // a fixed time budget in a correctness test flakes under parallel test load
     // (it tripped at ~31s in the full `--test-threads=4` gate while passing at
     // ~20s in isolation). Merge-perf regressions belong in a bench, not here.
+}
+
+// ─── Keyed twin of (AddEdge, AddEdge) ───────────────────────────────────────
+
+const KEYED_TRUTH_SCHEMA: &str = r#"
+node Person {
+    name: String @key
+    age: I32?
+}
+
+edge Knows: Person -> Person {
+    @key(src, dst)
+}
+"#;
+
+/// The keyed twin of the `(AddEdge, AddEdge)` cell: with `@key(src, dst)`
+/// declared, both sides insert Alice→Carol, the ids derive equal, and the
+/// merge converges to one row instead of keeping both. The matrix cell
+/// pins the unkeyed multiset default; this twin pins the opt-in.
+#[tokio::test]
+async fn add_edge_add_edge_keyed_twin_converges() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = dir.path().to_str().unwrap();
+    let mut main_db = Omnigraph::init(uri, KEYED_TRUTH_SCHEMA).await.unwrap();
+    load_jsonl(&main_db, TRUTH_DATA, LoadMode::Overwrite)
+        .await
+        .unwrap();
+    main_db.branch_create("feature").await.unwrap();
+    let mut feature = Omnigraph::open(uri).await.unwrap();
+
+    let insert = params(&[("$from", "Alice"), ("$to", "Carol")]);
+    mutate_branch(
+        &mut main_db,
+        "main",
+        TRUTH_MUTATIONS,
+        "insert_knows",
+        &insert,
+    )
+    .await
+    .unwrap();
+    mutate_branch(
+        &mut feature,
+        "feature",
+        TRUTH_MUTATIONS,
+        "insert_knows",
+        &insert,
+    )
+    .await
+    .unwrap();
+
+    main_db
+        .branch_merge("feature", "main")
+        .await
+        .expect("identical born-on-both keyed edges converge without conflict");
+    // Base holds Bob→Carol; the converged Alice→Carol makes two rows, not
+    // three — and the PAIRS must be exactly these two (a merge that dropped
+    // Bob→Carol while duplicating Alice→Carol would also count 2, as would
+    // one with the right sources and wrong targets).
+    assert_eq!(count_rows(&main_db, "edge:Knows").await, 2);
+    for (from, to) in [("Alice", "Carol"), ("Bob", "Carol")] {
+        let knows = query_main(
+            &mut main_db,
+            TRUTH_MUTATIONS,
+            "knows_of",
+            &params(&[("$name", from)]),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            first_column_sorted(&knows),
+            vec![to.to_string()],
+            "{from} must know exactly {to} after the merge"
+        );
+    }
 }

--- a/crates/omnigraph/tests/validators.rs
+++ b/crates/omnigraph/tests/validators.rs
@@ -711,3 +711,226 @@ async fn cardinality_rejected_on_jsonl_load() {
         err
     );
 }
+
+// ─── Edge @key: derivation, upsert convergence, subsumption, load refusal ────
+
+const EDGE_KEY_SCHEMA: &str = r#"
+node Person { name: String @key }
+edge Knows: Person -> Person {
+    since: String?
+    @key(src, dst)
+}
+"#;
+
+const EDGE_KEY_SEED: &str = r#"{"type":"Person","data":{"name":"Alice"}}
+{"type":"Person","data":{"name":"Bob"}}"#;
+
+const EDGE_KEY_MUTATIONS: &str = r#"
+query add_knows($from: String, $to: String) {
+    insert Knows { from: $from, to: $to }
+}
+
+query add_knows_since($from: String, $to: String, $since: String) {
+    insert Knows { from: $from, to: $to, since: $since }
+}
+"#;
+
+/// Two separate mutations inserting the same keyed (src, dst) pair converge to
+/// one row: the derived id makes the second insert an upsert of the first.
+#[tokio::test]
+async fn keyed_edge_reinsert_converges_to_one_row() {
+    let (_dir, mut db) = init_with(EDGE_KEY_SCHEMA, EDGE_KEY_SEED).await;
+    for _ in 0..2 {
+        mutate_main(
+            &mut db,
+            EDGE_KEY_MUTATIONS,
+            "add_knows",
+            &params(&[("$from", "Alice"), ("$to", "Bob")]),
+        )
+        .await
+        .expect("re-inserting an existing keyed edge upserts");
+    }
+    assert_eq!(count_rows(&db, "edge:Knows").await, 1);
+}
+
+/// Distinct endpoint pairs derive distinct ids and stay distinct rows.
+#[tokio::test]
+async fn keyed_edge_distinct_pairs_stay_distinct() {
+    let (_dir, mut db) = init_with(EDGE_KEY_SCHEMA, EDGE_KEY_SEED).await;
+    for (from, to) in [("Alice", "Bob"), ("Bob", "Alice")] {
+        mutate_main(
+            &mut db,
+            EDGE_KEY_MUTATIONS,
+            "add_knows",
+            &params(&[("$from", from), ("$to", to)]),
+        )
+        .await
+        .unwrap();
+    }
+    assert_eq!(count_rows(&db, "edge:Knows").await, 2);
+}
+
+/// A re-insert with a different non-key property updates the row in place
+/// (last write wins on the derived id), matching the keyed-node contract.
+#[tokio::test]
+async fn keyed_edge_reinsert_updates_non_key_properties() {
+    let (_dir, mut db) = init_with(EDGE_KEY_SCHEMA, EDGE_KEY_SEED).await;
+    for since in ["2020", "2021"] {
+        mutate_main(
+            &mut db,
+            EDGE_KEY_MUTATIONS,
+            "add_knows_since",
+            &params(&[("$from", "Alice"), ("$to", "Bob"), ("$since", since)]),
+        )
+        .await
+        .unwrap();
+    }
+    assert_eq!(count_rows(&db, "edge:Knows").await, 1);
+}
+
+const EDGE_KEY_UNIQUE_SCHEMA: &str = r#"
+node Person { name: String @key }
+edge Knows: Person -> Person {
+    @key(src, dst)
+    @unique(src, dst)
+}
+"#;
+
+/// A `@unique` group over the key's column set must not turn a keyed
+/// re-insert into a unique violation. (This pins the outcome, not the
+/// subsumption skip itself: the evaluator's same-id exclusion alone would
+/// also pass it — the skip's observable effect is only the saved probe.)
+#[tokio::test]
+async fn keyed_edge_unique_group_equal_to_key_is_subsumed() {
+    let (_dir, mut db) = init_with(EDGE_KEY_UNIQUE_SCHEMA, EDGE_KEY_SEED).await;
+    for _ in 0..2 {
+        mutate_main(
+            &mut db,
+            EDGE_KEY_MUTATIONS,
+            "add_knows",
+            &params(&[("$from", "Alice"), ("$to", "Bob")]),
+        )
+        .await
+        .expect("@unique equal to the key tuple is subsumed by identity");
+    }
+    assert_eq!(count_rows(&db, "edge:Knows").await, 1);
+}
+
+/// A loaded keyed edge derives its id; a supplied id is refused unless it
+/// exactly equals the derivation (the append surface has its own pin below).
+#[tokio::test]
+async fn keyed_edge_load_refuses_mismatched_explicit_id() {
+    let (_dir, db) = init_with(EDGE_KEY_SCHEMA, EDGE_KEY_SEED).await;
+    let err = load_jsonl(
+        &db,
+        r#"{"edge":"Knows","from":"Alice","to":"Bob","data":{"id":"wrong"}}"#,
+        LoadMode::Merge,
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("does not match its canonical @key id"),
+        "got: {}",
+        err
+    );
+}
+
+/// A supplied id exactly equal to the derivation is accepted (round-tripping
+/// an export), and a repeated merge-load of the same pair converges.
+#[tokio::test]
+async fn keyed_edge_load_derives_and_converges_on_merge() {
+    let (_dir, db) = init_with(EDGE_KEY_SCHEMA, EDGE_KEY_SEED).await;
+    let row = r#"{"edge":"Knows","from":"Alice","to":"Bob"}"#;
+    load_jsonl(&db, row, LoadMode::Merge).await.unwrap();
+    load_jsonl(&db, row, LoadMode::Merge)
+        .await
+        .expect("merge-load re-upserting an existing keyed edge converges");
+    assert_eq!(count_rows(&db, "edge:Knows").await, 1);
+
+    // The derived id for @key(src, dst) is the composite JSON array; supplying
+    // it verbatim round-trips.
+    let explicit =
+        r#"{"edge":"Knows","from":"Alice","to":"Bob","data":{"id":"[\"Alice\",\"Bob\"]"}}"#;
+    load_jsonl(&db, explicit, LoadMode::Merge)
+        .await
+        .expect("an explicit id equal to the derivation is accepted");
+    assert_eq!(count_rows(&db, "edge:Knows").await, 1);
+}
+
+/// The explicit-id refusal holds on the append surface too.
+#[tokio::test]
+async fn keyed_edge_append_load_refuses_mismatched_explicit_id() {
+    let (_dir, db) = init_with(EDGE_KEY_SCHEMA, EDGE_KEY_SEED).await;
+    let err = load_jsonl(
+        &db,
+        r#"{"edge":"Knows","from":"Alice","to":"Bob","data":{"id":"wrong"}}"#,
+        LoadMode::Append,
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("does not match its canonical @key id"),
+        "got: {}",
+        err
+    );
+}
+
+/// Append (strict insert) of an already-committed key reports a conflict
+/// instead of a silent duplicate.
+#[tokio::test]
+async fn keyed_edge_append_load_conflicts_on_committed_key() {
+    let (_dir, db) = init_with(EDGE_KEY_SCHEMA, EDGE_KEY_SEED).await;
+    let row = r#"{"edge":"Knows","from":"Alice","to":"Bob"}"#;
+    load_jsonl(&db, row, LoadMode::Append).await.unwrap();
+    let err = load_jsonl(&db, row, LoadMode::Append).await.unwrap_err();
+    assert!(
+        err.to_string().contains("already has this id"),
+        "got: {}",
+        err
+    );
+    assert_eq!(count_rows(&db, "edge:Knows").await, 1);
+}
+
+const EDGE_COMPOSITE_KEY_SCHEMA: &str = r#"
+node Person { name: String @key }
+edge Knows: Person -> Person {
+    since: String
+    @key(src, dst, since)
+}
+"#;
+
+/// A scalar key member rides the derivation end to end: identical triples
+/// converge, a distinct `since` is a distinct identity.
+#[tokio::test]
+async fn keyed_edge_scalar_member_derives_end_to_end() {
+    let (_dir, mut db) = init_with(EDGE_COMPOSITE_KEY_SCHEMA, EDGE_KEY_SEED).await;
+    for since in ["2020", "2020", "2021"] {
+        mutate_main(
+            &mut db,
+            EDGE_KEY_MUTATIONS,
+            "add_knows_since",
+            &params(&[("$from", "Alice"), ("$to", "Bob"), ("$since", since)]),
+        )
+        .await
+        .unwrap();
+    }
+    assert_eq!(count_rows(&db, "edge:Knows").await, 2);
+}
+
+/// A null value in a key column is refused on the load surface. The column
+/// is declared non-nullable, so the column builder refuses before the
+/// derivation's own null arm (which stays as defense-in-depth behind it).
+#[tokio::test]
+async fn keyed_edge_null_key_member_rejected_on_load() {
+    let (_dir, db) = init_with(EDGE_COMPOSITE_KEY_SCHEMA, EDGE_KEY_SEED).await;
+    let err = load_jsonl(
+        &db,
+        r#"{"edge":"Knows","from":"Alice","to":"Bob","data":{"since":null}}"#,
+        LoadMode::Merge,
+    )
+    .await
+    .unwrap_err();
+    assert!(err.to_string().contains("since"), "got: {}", err);
+}

--- a/crates/omnigraph/tests/writes.rs
+++ b/crates/omnigraph/tests/writes.rs
@@ -2777,3 +2777,97 @@ async fn multi_table_staging_matches_serial_staging() {
         "staging concurrency must not change any observable effect"
     );
 }
+
+// ─── Edge @key write-path pins ───────────────────────────────────────────────
+
+const EDGE_KEY_WRITE_SCHEMA: &str = r#"
+node Person { name: String @key }
+edge Knows: Person -> Person {
+    since: String?
+    @key(src, dst)
+}
+"#;
+
+const EDGE_KEY_WRITE_SEED: &str = r#"{"type":"Person","data":{"name":"Alice"}}
+{"type":"Person","data":{"name":"Bob"}}"#;
+
+/// A query is constructive or destructive, never both: a mutation mixing a
+/// delete and an insert of the same derived edge id is refused with the
+/// split guidance. Across two mutations the later commit wins: a delete
+/// then a re-insert of the same key re-creates the row under the same
+/// derived id.
+#[tokio::test]
+async fn keyed_edge_delete_then_reinsert_spans_two_mutations() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = dir.path().to_str().unwrap();
+    let mut db = Omnigraph::init(uri, EDGE_KEY_WRITE_SCHEMA).await.unwrap();
+    load_jsonl(&db, EDGE_KEY_WRITE_SEED, LoadMode::Overwrite)
+        .await
+        .unwrap();
+
+    const MUTATIONS: &str = r#"
+query seed_knows() {
+    insert Knows { from: "Alice", to: "Bob", since: "2020" }
+}
+
+query replace_knows() {
+    delete Knows where from = "Alice"
+    insert Knows { from: "Alice", to: "Bob", since: "2021" }
+}
+
+query drop_knows() {
+    delete Knows where from = "Alice"
+}
+"#;
+    mutate_main(&mut db, MUTATIONS, "seed_knows", &params(&[]))
+        .await
+        .unwrap();
+
+    let err = mutate_main(&mut db, MUTATIONS, "replace_knows", &params(&[]))
+        .await
+        .expect_err("a mutation mixing a delete and an insert must be refused");
+    assert!(
+        err.to_string().contains("constructive or destructive"),
+        "got: {}",
+        err
+    );
+
+    mutate_main(&mut db, MUTATIONS, "drop_knows", &params(&[]))
+        .await
+        .unwrap();
+    assert_eq!(count_rows(&db, "edge:Knows").await, 0);
+
+    mutate_main(&mut db, MUTATIONS, "seed_knows", &params(&[]))
+        .await
+        .expect("re-inserting a deleted key re-creates the row");
+    assert_eq!(count_rows(&db, "edge:Knows").await, 1);
+}
+
+/// Edge key immutability is enforced structurally: the typechecker refuses
+/// every edge update (T16; the mutation executor carries a second refusal
+/// behind it). A future edge-update feature must revisit the key-column
+/// rule when this pin goes red.
+#[tokio::test]
+async fn update_refuses_edge_types_pinning_key_immutability() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = dir.path().to_str().unwrap();
+    let mut db = Omnigraph::init(uri, EDGE_KEY_WRITE_SCHEMA).await.unwrap();
+    load_jsonl(&db, EDGE_KEY_WRITE_SEED, LoadMode::Overwrite)
+        .await
+        .unwrap();
+
+    const MUTATIONS: &str = r#"
+query set_since() {
+    update Knows set { since: "2021" } where from = "Alice"
+}
+"#;
+    let err = mutate_main(&mut db, MUTATIONS, "set_since", &params(&[]))
+        .await
+        .expect_err("update on an edge type must be refused");
+    assert!(
+        err.to_string()
+            .contains("update mutation for edge type `Knows` is not supported"),
+        "got: {}",
+        err
+    );
+}

--- a/docs/releases/v0.11.0.md
+++ b/docs/releases/v0.11.0.md
@@ -220,6 +220,15 @@ Notes accumulate here until the release is cut.
   bounded top-k sort. `_distance` and `_score` become reserved property names
   for NEW schema declarations (existing graphs that already declared them
   keep opening).
+- **Edge keys: derived edge identity (RFC 0044).** An edge type may declare
+  `@key(src, dst, ...)`; keyed edge inserts derive their row id from the key,
+  so the same relationship inserted on two branches converges on merge (or
+  surfaces `divergent_insert` when non-key properties differ) instead of
+  silently duplicating. A schema that declares an edge key is stamped with a
+  new `ir_version`; unkeyed schemas keep the current number and existing
+  graphs are unaffected. Property names `id`, `src`, `dst`, `from`, and `to`
+  are now refused on new edge declarations — they shadow physical columns
+  or endpoint parameters.
 - **Bounded ranked full-text scans.** A `bm25()` ordering with a `limit` now
   reads only the top-scoring matches (a small multiple of the limit) instead
   of hydrating every matching entity. This fixes ranked reads with traversals

--- a/docs/rfcs/0044-edge-keys.md
+++ b/docs/rfcs/0044-edge-keys.md
@@ -242,13 +242,14 @@ Six localized changes:
    is a pure function of the key) holds only because every id source
    derives, from canonical inputs.
 6. **Version acceptance.** `validate_schema_ir` moves from exact equality
-   (`schema_ir.rs:1067`) to accepting the supported version set {2, 3};
-   3 is the edge-key number, assigned here at acceptance. The
+   (`schema_ir.rs:1067`) to accepting the supported version set {2, 4};
+   4 is the edge-key number, assigned here at acceptance (3 is burned by
+   the withdrawn actor-provenance build, RFC 0054, and stays refused). The
    deliberate v1 rejection is unchanged (pinned by the v1-rejection test
    beside `validate_schema_ir`, `schema_ir.rs:1735`). One stamping rule
    owns every case: an accepted schema is stamped with the highest
    `ir_version` its declared features require. Everything else derives
-   from it: 3 is minted only when a schema declares an edge key; an
+   from it: 4 is minted only when a schema declares an edge key; an
    unkeyed schema accepted by the new binary stamps the base number, as
    does a fresh init without edge keys; and a schema apply that removes
    the last keyed edge type (by drop-and-re-add) re-stamps the base
@@ -294,16 +295,18 @@ introduced.
 
 - **Schema vintage.** Design change 6 carries the guarantees. To the
   operator of an existing graph: the new binary accepts both supported
-  numbers (2 and 3, with the deliberate v1 rejection
-  unchanged), so existing graphs open unchanged, and a schema that
+  numbers (2 and 4; the deliberate v1 rejection and RFC 0054's v3
+  refusal stay unchanged), so existing graphs open unchanged, and a schema that
   declares no edge key stamps the base number even when applied by
   the new binary (change 6's single stamping rule), so an unkeyed
   deployment stays downgrade-safe. Only a
-  schema that declares an edge key mints version 3; from that point an
+  schema that declares an edge key mints version 4; from that point an
   old binary refuses the graph with the existing hard error
   (`schema_ir.rs:1067`), so downgrade after keying fails closed instead of
   misreading identity. The edge-key number is fixed here at acceptance,
-  not at implementation time: 3. How the version composes with PR #546's
+  not at implementation time: 4 (renumbered from 3 on 2026-09-07, see the
+  decision log: 3 was stamped by the withdrawn actor-provenance build and
+  RFC 0054 refuses it). How the version composes with PR #546's
   system columns and later schema features is deferred to a dedicated
   versioning RFC, per change 6; RFC 0040's unresolved question 1 tracks
   it.
@@ -438,7 +441,8 @@ asserts gated 1 vs bound 2).
 
 None. The one settle-before-acceptance candidate (whether every edge key
 must include both endpoints) is settled in Design change 1: it must. The
-edge-key `ir_version` is fixed at acceptance: 3 (change 6, Compatibility).
+edge-key `ir_version` is fixed at acceptance: 4 (change 6, Compatibility;
+renumbered from 3 on 2026-09-07, decision log).
 The cross-feature versioning scheme is out of this RFC's scope and
 deferred to a dedicated versioning RFC, per change 6; RFC 0040's
 unresolved question 1 tracks it.
@@ -452,3 +456,10 @@ unresolved question 1 tracks it.
   express independent features, such as RFC 0040's spellings beside edge
   keys) is deliberately not solved in this RFC and is deferred to a
   dedicated versioning RFC.
+- 2026-09-07: edge-key number renumbered 3 to 4 at the implementation
+  PR's rebase (#593). Between acceptance and the rebase, the interim
+  actor-provenance implementation stamped version 3 and its withdrawal
+  (RFC 0054, Compatibility boundary) requires every version-3 graph to be
+  refused before recovery and never reinterpreted; `lifecycle.rs` pins
+  that refusal. A shared number would reinterpret those graphs as keyed
+  schemas. The number is still fixed here, not at implementation time.

--- a/docs/user/branching/merge.md
+++ b/docs/user/branching/merge.md
@@ -76,6 +76,26 @@ HTTP server returns conflicts with status `409`, the same answer for
 `POST /branches/merge` and for a `branch merge` statement on `POST /mutate`.
 Reconcile the data on one or both branches, then run the merge again.
 
+### Edges inserted on both sides
+
+Whether the same edge added on both branches converges depends on the edge
+type's declared identity:
+
+- No declaration: edge ids are generated, so each side's insert is its own
+  row and the merge keeps both. This is the documented multiset default;
+  parallel edges are legitimate data.
+- `@unique(src, dst)`: each branch's write succeeds on its own, and the
+  merge reports `unique_violation`. This is the available guard on
+  releases that predate edge keys.
+- `@key(src, dst)`: both sides derive the same id, so identical inserts
+  converge to one row with no conflict. If the sides disagree on a non-key
+  property, the merge reports `divergent_insert` on the edge type with the
+  derived id as the entity id (for `@key(src, dst)` a JSON array such as
+  `["Alice","Bob"]`; the elements are the endpoint node ids, so they are
+  generated ids when the endpoint type declares no key). Reconcile it like any divergent insert: align the
+  property on one branch (insert the same key again with the agreed
+  values; the insert upserts), then merge again.
+
 ## Merge classification mode
 
 `OMNIGRAPH_MERGE_LINEAGE` selects how a branch merge finds what changed. `on`

--- a/docs/user/mutations/index.md
+++ b/docs/user/mutations/index.md
@@ -49,11 +49,15 @@ visible on the target in one atomic step. See
 
 ## Insert and update identity
 
-- Inserting a node with `@key` is an upsert by its derived id.
+- Inserting a node or edge with `@key` is an upsert by its derived id.
+  Inserting the same key again updates the existing row.
 - Inserting a node without a key is a strict insert with a generated or supplied
   id.
-- Edge inserts are strict inserts with a generated or supplied id.
-- Key properties cannot be changed by an update.
+- Inserting an edge without a key is a strict insert with a generated or
+  supplied id; the same pair inserted twice is two edges.
+- Key properties cannot be changed by an update. Edge types do not support
+  update at all: change a keyed edge by inserting its key again with the new
+  values (an upsert), and an unkeyed edge by delete and re-insert.
 
 All declared value, uniqueness, endpoint, and cardinality constraints are
 checked before publication.
@@ -89,6 +93,10 @@ Choose the mode explicitly:
 | `append` | Fails with `key_conflict` | Add entities without replacing anything. |
 | `merge` | Updates the existing entity | Upsert a batch. |
 | `overwrite` | Replaces every node or edge type represented in the batch; types absent from the batch remain unchanged | Rebuild from a complete export or seed. |
+
+For a keyed edge the existing-id column applies to its derived id: `append`
+reports `key_conflict` on an already-committed pair, `merge` upserts it, and
+a supplied `data.id` must equal the derivation exactly.
 
 ```bash
 omnigraph load --data batch.jsonl --mode merge graph.omni

--- a/docs/user/schema/index.md
+++ b/docs/user/schema/index.md
@@ -63,6 +63,10 @@ queries rank results by those columns. A graph whose schema already declared
 either name before this reservation keeps opening; only new schemas are
 refused.
 
+On edge types the names `id`, `src`, `dst`, `from`, and `to` are also
+reserved: they name the physical id, the endpoint columns, and the insert
+parameters.
+
 ## Constraints
 
 Constraints can be written in the type body. `@key`, `@unique`, and `@index`
@@ -70,7 +74,7 @@ also have a single-property shorthand.
 
 | Constraint | Applies to | Meaning |
 |---|---|---|
-| `@key(p, ...)` | node | The ordered property tuple identifies the node. Key properties must be non-null scalar values. |
+| `@key(p, ...)` | node or edge | The property tuple identifies the entity; its id is derived from it. Key properties must be non-null scalar values. An edge key must include both `src` and `dst`, and a key may be declared only when the type is created. |
 | `@unique(p, ...)` | node or edge | No two entities may share the property tuple. Edge constraints may include `src` and `dst`. |
 | `@index(p, ...)` | node or edge | Declares index intent. Indexes affect performance, not correctness. |
 | `@range(p, min..max)` | node | Restricts a numeric property; either bound may be omitted. |
@@ -94,11 +98,15 @@ Every node and edge has a String `id` in load and export data.
 - A node with `@key` derives its id from the complete typed key tuple. Renaming a
   key property with `@rename_from` does not change existing ids.
 - A node without a key receives a generated id unless input supplies one.
-- Edges use generated or supplied ids and store their endpoints as `src` and
-  `dst`.
+- An edge with `@key` derives its id the same way, in the catalog's key
+  order: `src`, then `dst`, then any scalar members. A composite id encodes
+  as a JSON array of the member values, for example `["Alice","Bob"]`.
+- An edge without a key uses generated or supplied ids. Edges store their
+  endpoints as `src` and `dst`.
 
-For hand-authored load data, omit a keyed node's `data.id` and let OmniGraph
-derive it. Export includes ids so a graph can be rebuilt without losing edge
+For hand-authored load data, omit a keyed node's or keyed edge's `data.id`
+and let OmniGraph derive it; a supplied id on a keyed edge must equal the
+derived id exactly. Export includes ids so a graph can be rebuilt without losing edge
 references.
 
 ## Annotations


### PR DESCRIPTION
## What & why

Implements RFC 0044, "Edge keys: derived edge identity", in full. Closes #583.

`@key(src, dst, ...)` becomes legal on edge types. A keyed edge derives its id from the key with the canonical encoding keyed nodes already use, so the same relationship inserted on both sides of a branch fork derives the same id and the merge converges to one row; the same key with different non-key properties surfaces a typed `divergent_insert` conflict instead of a silent duplicate. Unkeyed edge types are bit-for-bit untouched: generated ids, parallel edges, and the keep-both merge outcome stay.

The change set, per the RFC's six design changes plus contract closure:

- Grammar and IR: the parser accepts one body-level `@key` group on an edge (both endpoints required, scalar members optional, repeats refused); property names `id`, `src`, `dst`, `from`, and `to` are now reserved on edge declarations.
- Id derivation: keyed inserts and both loader doors derive the id (endpoints first, then members by stable property identity); a supplied id must equal the derivation exactly.
- Write mode: keyed edge inserts are upserts by derived id, matching keyed nodes.
- Validation: the edge key is emitted as an identity-backed uniqueness constraint; a `@unique` group over the key's column set is subsumed.
- Version acceptance: a schema declaring an edge key stamps a new `ir_version` (3); the supported set is {2, 3}, the v1 rejection is unchanged, and `validate_schema_ir` refuses a stamp that does not match the declared features.
- Contract closure: merge truth-table keyed twin, DST updates (the born-on-both carve-out retires; the multiset default and the keyed convergence are each pinned by a targeted scenario), user docs (schema page, mutations guide, branching merge guide), release-note entry.

## Backing issue / RFC

- [x] Implements RFC 0044, docs/rfcs/0044-edge-keys.md (RFC PR #584). Closes #583.

## Checklist

- [x] Change is focused (one RFC implemented end to end)
- [x] Tests added/updated for behavior changes: parser, schema-IR, catalog, and schema-plan units; writes, validators, and branching integration including the #583 acceptance shape (keyed born-on-both converges to 4 rows on both traversals; the unkeyed control pins 5 stored rows, 4 plain, 5 bound); merge truth-table keyed twin; DST contract pin and keyed twin
- [x] Public docs updated: schema page (constraint table, reserved names, edge id derivation), mutations guide (insert identity, load modes), branching merge guide (edges inserted on both sides), release notes
- [x] Reviewed against docs/dev/invariants.md: edge identity is owned by the accepted SchemaIR (invariant 6), the silent keep-both for keyed types becomes declared convergence or a typed conflict (invariant 8), no new durable step or deny-list surface

## Local verification

- `cargo test -p omnigraph-compiler`: 330 passed
- `cargo test -p omnigraph-engine --test writes --test validators --test branching --test merge_truth_table --test traversal`: green; engine lib 373 passed, 1 failure is a pre-existing sandbox limitation (UnixListener bind denied in the dev harness), 1 ignored
- `omnigraph-dst`: full suite green (78 passed), including the reclassified multiset-contract pin and its keyed twin
- `cargo clippy -p omnigraph-compiler -p omnigraph-engine --all-targets -- -D warnings -W clippy::dbg_macro`: clean; `cargo fmt --all` clean
- `python3 scripts/check-docs.py`: OK (115 files)

## Notes for reviewers

- `ir_version` mints 3 for edge-key schemas. #546 also advances `ir_version` and is open; renumbering follows if #546's implementation lands first (the coordination gate is stated in the RFC's Compatibility section).
- `validate_schema_ir` now refuses a stamp that does not match the declared features, one step beyond the RFC's letter: it closes the hand-authored low-stamp route that would let an old binary open a graph holding derived ids.
- Reserving `id`/`src`/`dst`/`from`/`to` on edge declarations is a behavior change for new schemas only; accepted graphs are untouched. Node declarations keep today's latitude.
- The DST model change is scoped deliberately: the model predicts merged membership (its reads are visited-gated), and physical row counts are pinned by the two targeted scenarios; count-level fleet modeling of unkeyed edges is out of scope.
- The fleet's born-on-both failure family retires with the carve-out: that outcome is documented contract now.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements derived identity for keyed edges across schema parsing, accepted IR, runtime catalogs, mutations, loaders, validation, and branch merging.

- Permits `@key(src, dst, ...)` on edge declarations and validates endpoint and scalar-member requirements.
- Derives keyed-edge IDs consistently from accepted schema identity and uses upsert semantics for repeated keys.
- Adds IR version 3 for schemas using edge keys while retaining version 2 for schemas without them.
- Adds merge, loading, validation, deterministic-simulation, and documentation coverage while preserving unkeyed multiset behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no concrete blocking or independently actionable non-blocking issue remains.

The schema, mutation, loader, validation, and merge paths consistently derive keyed-edge identity from the accepted catalog, while tests preserve the existing behavior of unkeyed edges.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| crates/omnigraph-compiler/src/catalog/schema_ir.rs | Adds feature-dependent IR versioning and fail-closed edge-key validation while preserving version-2 acceptance for unkeyed schemas. |
| crates/omnigraph-compiler/src/catalog/mod.rs | Carries edge keys into catalogs and orders runtime key members by stable property identity so renames do not change derived IDs. |
| crates/omnigraph-compiler/src/schema/parser.rs | Admits body-level edge keys, enforces both endpoints and valid scalar members, and reserves colliding edge property names. |
| crates/omnigraph/src/exec/mutation.rs | Derives keyed-edge IDs from the same resolved values used to build rows and stages keyed inserts with intentional upsert semantics. |
| crates/omnigraph/src/loader/mod.rs | Applies the shared canonical key encoding to keyed edges through both loader normalization paths and validates explicit IDs. |
| crates/omnigraph/src/validate.rs | Emits identity-backed edge-key uniqueness validation and subsumes equivalent explicit uniqueness groups. |
| crates/omnigraph-dst/src/harness.rs | Updates the reference model to distinguish documented unkeyed multiset behavior from keyed-edge convergence. |
| crates/omnigraph/tests/branching.rs | Covers keyed convergence, divergent inserts, distinct keys, and preservation of the unkeyed merge contract. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    S[Edge schema with @key] --> IR[Validated SchemaIR v3]
    IR --> C[Identity-bound catalog]
    C --> M[Mutation insert]
    C --> L[Loader input]
    M --> K[Canonical typed key tuple]
    L --> K
    K --> ID[Derived edge id]
    ID --> U[Upsert by identity]
    U --> V[Shared integrity validation]
    V --> B[Branch merge]
    B -->|equal keyed rows| O[One converged row]
    B -->|different non-key values| D[DivergentInsert conflict]
    C -->|no edge key| G[Generated ULID and multiset behavior]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(engine): add edge keys with derived..."](https://github.com/modernrelay/omnigraph/commit/6fe4aeae19597e1e0327eb38227442c4a64fb182) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58989236)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Data mutation pipeline](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/data-mutation-pipeline.md)
- Knowledge Base — [Schema and query compilation](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/schema-and-query-compilation.md)
- Knowledge Base — [Schema validation and linting](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/schema-validation-and-linting.md)
- Knowledge Base — [Deterministic simulation and fault testing](https://app.greptile.com/modernrelay/-/custom-context/knowledge-base/modernrelay/omnigraph/-/docs/deterministic-simulation-and-fault-testing.md)
</details>


<!-- /greptile_comment -->