### PR TITLE
test(gq): add the GQ logic test harness, corpus, and fix-regression gate

### DIFF
--- a/.github/branch-protection.json
+++ b/.github/branch-protection.json
@@ -10,7 +10,8 @@
       "Test omnigraph-server --features aws",
       "Format (rustfmt)",
       "Lint (clippy)",
-      "GQ Logic Tests"
+      "GQ Logic Tests",
+      "Fix Regression Gate"
     ]
   },
   "enforce_admins": false,

--- a/.github/branch-protection.json
+++ b/.github/branch-protection.json
@@ -9,7 +9,8 @@
       "Graph Vocabulary Guard",
       "Test omnigraph-server --features aws",
       "Format (rustfmt)",
-      "Lint (clippy)"
+      "Lint (clippy)",
+      "GQ Logic Tests"
     ]
   },
   "enforce_admins": false,

--- a/.github/workflows/fix-regression-gate.yml
+++ b/.github/workflows/fix-regression-gate.yml
@@ -1,0 +1,58 @@
+name: Fix Regression Gate
+
+# This is a policy check on the pull request, so it must run code the pull
+# request cannot edit. `pull_request_target` takes this workflow file and
+# the scripts it runs from the base branch; the head is fetched only as
+# data for the diff range and is never checked out or executed. Under a
+# plain `pull_request` trigger a PR could replace the check with `true`
+# while keeping the required context name. The metadata events re-run the
+# gate when a body edit or the `no-repro` label changes its answer; this
+# workflow builds nothing, so those re-runs cost seconds.
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+      - labeled
+      - unlabeled
+
+concurrency:
+  group: fix-regression-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  fix_regression_gate:
+    name: Fix Regression Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      # Base branch, full history: the checker and this diff's merge base.
+      - name: Checkout base
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
+
+      # The head as data only. `refs/pull/N/head` resolves for fork PRs too.
+      - name: Fetch the pull request head
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: git fetch --no-tags origin "refs/pull/${PR_NUMBER}/head"
+
+      - name: Check closed issues carry regressions
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          python3 scripts/check-fix-regression.py --self-test
+          printf '%s' "$PR_BODY" > "$RUNNER_TEMP/pr-body.txt"
+          python3 scripts/check-fix-regression.py \
+            --body-file "$RUNNER_TEMP/pr-body.txt" \
+            --labels "$PR_LABELS" \
+            --range "$BASE_SHA...$HEAD_SHA"

--- a/.github/workflows/gq-logic-tests.yml
+++ b/.github/workflows/gq-logic-tests.yml
@@ -1,0 +1,51 @@
+name: GQ Logic Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: gq-logic-tests-${{ github.ref }}
+  # Superseded PR runs are safe to cancel; post-merge main runs stay alive.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  gq_logic_tests:
+    name: GQ Logic Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    env:
+      CARGO_TERM_COLOR: always
+      # Same floor as the Test Workspace job: unoptimized builds keep every
+      # nested async engine frame, deeper than a default 2 MiB thread stack.
+      RUST_MIN_STACK: 16777216
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler libprotobuf-dev
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+
+      - name: Cache Rust build data
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: |
+            . -> target
+          # PR runs only restore; saving per-PR caches would evict the
+          # main-branch entries every warm run depends on.
+          save-if: ${{ github.event_name == 'push' }}
+
+      - name: Run GQ logic tests
+        run: cargo test -p omnigraph-engine --test gq_logic_tests --locked -- --nocapture

--- a/.github/workflows/gq-logic-tests.yml
+++ b/.github/workflows/gq-logic-tests.yml
@@ -2,6 +2,16 @@ name: GQ Logic Tests
 
 on:
   pull_request:
+    # `edited`, `labeled`, and `unlabeled` re-run the gate job when a body
+    # edit or the `no-repro` label changes its answer; the types list is
+    # workflow-level, so the test job re-runs on them too (accepted cost).
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+      - labeled
+      - unlabeled
   push:
     branches:
       - main
@@ -49,3 +59,33 @@ jobs:
 
       - name: Run GQ logic tests
         run: cargo test -p omnigraph-engine --test gq_logic_tests --locked -- --nocapture
+
+  fix_regression_gate:
+    name: Fix Regression Gate
+    # A push or dispatch run has no PR body to read; a skipped context does
+    # not block.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Check closed issues carry regressions
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          python3 scripts/check-fix-regression.py --self-test
+          printf '%s' "$PR_BODY" > "$RUNNER_TEMP/pr-body.txt"
+          python3 scripts/check-fix-regression.py \
+            --body-file "$RUNNER_TEMP/pr-body.txt" \
+            --labels "$PR_LABELS" \
+            --range "$BASE_SHA...$HEAD_SHA"

--- a/.github/workflows/gq-logic-tests.yml
+++ b/.github/workflows/gq-logic-tests.yml
@@ -1,17 +1,14 @@
 name: GQ Logic Tests
 
 on:
+  # Code-bearing events only. The body and label events belong to
+  # `fix-regression-gate.yml`, which builds nothing; listing them here
+  # would re-run this Rust build on every label change.
   pull_request:
-    # `edited`, `labeled`, and `unlabeled` re-run the gate job when a body
-    # edit or the `no-repro` label changes its answer; the types list is
-    # workflow-level, so the test job re-runs on them too (accepted cost).
     types:
       - opened
       - synchronize
       - reopened
-      - edited
-      - labeled
-      - unlabeled
   push:
     branches:
       - main
@@ -25,7 +22,8 @@ concurrency:
 jobs:
   # A job cannot depend on another workflow's job, so this is a verbatim
   # copy of `ci.yml`'s `classify_changes`; `ci.yml` is the source of truth,
-  # and the gate job below asserts the two stay identical.
+  # and an unconditional step at the top of the test job, right after
+  # checkout, asserts the two stay identical.
   classify_changes:
     name: Classify Changes (GQ Logic Tests)
     runs-on: ubuntu-latest
@@ -108,15 +106,19 @@ jobs:
       # nested async engine frame, deeper than a default 2 MiB thread stack.
       RUST_MIN_STACK: 16777216
     steps:
+      # Unconditional: the copy assertion below must run on every PR, the
+      # documentation-only ones included, inside this required context.
+      - name: Checkout source
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Assert the classification copy matches ci.yml
+        run: python3 scripts/check-classify-copy.py
+
       # Documentation-only change: report success without building, so the
       # required context is never left pending.
       - name: Skip for documentation-only changes
         if: needs.classify_changes.outputs.run_full_ci != 'true'
         run: echo "Documentation-only change detected; skipping the GQ logic tests."
-
-      - name: Checkout source
-        if: needs.classify_changes.outputs.run_full_ci == 'true'
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install system dependencies
         if: needs.classify_changes.outputs.run_full_ci == 'true'
@@ -143,36 +145,3 @@ jobs:
       - name: Run GQ logic tests
         if: needs.classify_changes.outputs.run_full_ci == 'true'
         run: cargo test -p omnigraph-engine --test gq_logic_tests --locked -- --nocapture
-
-  fix_regression_gate:
-    name: Fix Regression Gate
-    # A push or dispatch run has no PR body to read; a skipped context does
-    # not block. Runs on every PR event, with no documentation-only skip.
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-        with:
-          fetch-depth: 0
-
-      - name: Assert the classification copy matches ci.yml
-        run: python3 scripts/check-classify-copy.py
-
-      - name: Check closed issues carry regressions
-        env:
-          PR_BODY: ${{ github.event.pull_request.body }}
-          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          set -euo pipefail
-          python3 scripts/check-fix-regression.py --self-test
-          printf '%s' "$PR_BODY" > "$RUNNER_TEMP/pr-body.txt"
-          python3 scripts/check-fix-regression.py \
-            --body-file "$RUNNER_TEMP/pr-body.txt" \
-            --labels "$PR_LABELS" \
-            --range "$BASE_SHA...$HEAD_SHA"

--- a/.github/workflows/gq-logic-tests.yml
+++ b/.github/workflows/gq-logic-tests.yml
@@ -23,8 +23,81 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # A job cannot depend on another workflow's job, so this is a verbatim
+  # copy of `ci.yml`'s `classify_changes`; `ci.yml` is the source of truth,
+  # and the gate job below asserts the two stay identical.
+  classify_changes:
+    name: Classify Changes (GQ Logic Tests)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      run_full_ci: ${{ steps.filter.outputs.run_full_ci }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Detect documentation-only changes
+        id: filter
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REF_TYPE: ${{ github.ref_type }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" || "$REF_TYPE" == "tag" ]]; then
+            echo "run_full_ci=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            base="$PR_BASE_SHA"
+            head="$PR_HEAD_SHA"
+          else
+            base="$BEFORE_SHA"
+            head="$GITHUB_SHA"
+            if [[ "$base" == "0000000000000000000000000000000000000000" ]]; then
+              base="$(git rev-parse "${head}^" 2>/dev/null || true)"
+            fi
+          fi
+
+          if [[ -z "${base:-}" ]]; then
+            echo "run_full_ci=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Disable rename collapsing so moving source into docs still reports
+          # the source-side deletion and cannot become a docs-only false skip.
+          mapfile -t changed < <(git diff --name-only --no-renames "$base" "$head")
+          if [[ "${#changed[@]}" -eq 0 ]]; then
+            echo "run_full_ci=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          run_full_ci=false
+          for path in "${changed[@]}"; do
+            case "$path" in
+              docs/*.md|docs/*.mdx|docs/*.rst|docs/*.adoc) ;;
+              README.md|AGENTS.md|CLAUDE.md|CHANGELOG.md|CONTRIBUTING.md|CODE_OF_CONDUCT.md) ;;
+              LICENSE|LICENSE.md) ;;
+              *)
+                run_full_ci=true
+                ;;
+            esac
+          done
+
+          printf 'Changed files:\n'
+          printf '  %s\n' "${changed[@]}"
+          echo "run_full_ci=$run_full_ci" >> "$GITHUB_OUTPUT"
+
   gq_logic_tests:
     name: GQ Logic Tests
+    needs: classify_changes
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -35,20 +108,30 @@ jobs:
       # nested async engine frame, deeper than a default 2 MiB thread stack.
       RUST_MIN_STACK: 16777216
     steps:
+      # Documentation-only change: report success without building, so the
+      # required context is never left pending.
+      - name: Skip for documentation-only changes
+        if: needs.classify_changes.outputs.run_full_ci != 'true'
+        run: echo "Documentation-only change detected; skipping the GQ logic tests."
+
       - name: Checkout source
+        if: needs.classify_changes.outputs.run_full_ci == 'true'
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install system dependencies
+        if: needs.classify_changes.outputs.run_full_ci == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler libprotobuf-dev
 
       - name: Install Rust stable
+        if: needs.classify_changes.outputs.run_full_ci == 'true'
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           toolchain: stable
 
       - name: Cache Rust build data
+        if: needs.classify_changes.outputs.run_full_ci == 'true'
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: |
@@ -58,12 +141,13 @@ jobs:
           save-if: ${{ github.event_name == 'push' }}
 
       - name: Run GQ logic tests
+        if: needs.classify_changes.outputs.run_full_ci == 'true'
         run: cargo test -p omnigraph-engine --test gq_logic_tests --locked -- --nocapture
 
   fix_regression_gate:
     name: Fix Regression Gate
     # A push or dispatch run has no PR body to read; a skipped context does
-    # not block.
+    # not block. Runs on every PR event, with no documentation-only skip.
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -74,6 +158,9 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
+
+      - name: Assert the classification copy matches ci.yml
+        run: python3 scripts/check-classify-copy.py
 
       - name: Check closed issues carry regressions
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,8 +149,22 @@ Set `OMNIGRAPH_UPDATE_OPENAPI=1` only when the drift is intentional.
 
 - Preserve unrelated work in a dirty tree. Never discard user changes.
 - Make the smallest coherent change that closes the behavior and test surface.
-- For a bug, reproduce the predicted failure in the existing owning suite,
-  then fix the root cause and prove the regression turns green.
+- For a bug, reproduce the predicted failure at the tier the regression rule
+  below names, then fix the root cause and prove the regression turns green.
+- Query-behavior tests default to `.gqt` logic tests under
+  `crates/omnigraph/tests/gq_logic_tests/`; a Rust test needs a reason the
+  logic test format cannot express (mechanism assertions, scale symptoms,
+  process environment, concurrency).
+- Every issue fix lands a regression test at the cheapest tier that catches
+  the defect: a `.gqt` logic test when the defect is visible in rows, counts,
+  or errors, a `_issue_NNN` Rust test when it needs mechanism or scale
+  assertions; when the reported symptom additionally needs scale to
+  manifest, a second `#[ignore]`d test in a `tests/repro_issue_*.rs` target
+  guards it, and the two cross-reference each other in comments.
+- Every `#[ignore]`d test opens its ignore message with its species
+  (`instrument:`, `hunt:`, `heavy-repro:`, or the environment it needs);
+  expensive regression repros use `heavy-repro:` and thereby enroll in the
+  nightly job.
 - Update user-visible docs in the same change as a flag, endpoint, format,
   schema construct, behavior, or limit.
 - Update current developer guides when architecture or support boundaries

--- a/crates/omnigraph/src/exec/query.rs
+++ b/crates/omnigraph/src/exec/query.rs
@@ -2498,6 +2498,7 @@ async fn execute_expand_dispatch(
             mode = "csr",
             "expand mode chosen",
         );
+        crate::instrumentation::record_expand_path(false);
         return execute_expand_bfs(
             wide,
             graph_index,
@@ -2558,6 +2559,7 @@ async fn execute_expand_dispatch(
                     reason = "index coverage degraded",
                     "expand mode chosen",
                 );
+                crate::instrumentation::record_expand_path(false);
                 return execute_expand_bfs(
                     wide,
                     graph_index,
@@ -2589,6 +2591,7 @@ async fn execute_expand_dispatch(
         mode = "indexed",
         "expand mode chosen",
     );
+    crate::instrumentation::record_expand_path(true);
     // Surface the C6 silent scalar-index fallback once, now that coverage is known.
     warn_on_degraded_coverage(&coverage, key_col, edge_type);
     // Per-hop re-decision policy (issue #533): a forced mode is a contract and
@@ -3077,6 +3080,7 @@ async fn execute_expand_bfs(
             };
             if switch {
                 crate::instrumentation::record_traversal_mid_switch();
+                crate::instrumentation::record_expand_path(false);
                 let gi = graph_index.get().await?.ok_or_else(|| {
                     OmniError::manifest("graph index required for CSR traversal".to_string())
                 })?;

--- a/crates/omnigraph/src/instrumentation.rs
+++ b/crates/omnigraph/src/instrumentation.rs
@@ -113,6 +113,15 @@ pub struct QueryIoProbes {
     /// Lets the switch tests assert the mechanism actually ran — mode
     /// equivalence alone stays green with the switch disabled.
     pub traversal_mid_switches: Arc<AtomicU64>,
+    /// Path commitments per Expand: the indexed scan, the CSR walk chosen up
+    /// front, or the CSR walk switched to mid-traversal (an Expand that
+    /// switches counts once on each). A logic test pinned with
+    /// `# traversal:` asserts the other path's counter stayed zero and, for
+    /// a query that expands, the pinned one moved: the pin is a task-local
+    /// override, and mode equivalence alone cannot see a pin the executor
+    /// ignored or a scope that dropped it.
+    pub expand_indexed_runs: Arc<AtomicU64>,
+    pub expand_csr_runs: Arc<AtomicU64>,
     /// Expand emissions stopped early by a pushed-down `limit` cap. Same
     /// rationale: capped-subset validity alone cannot prove the cap fired.
     pub expand_cap_stops: Arc<AtomicU64>,
@@ -542,6 +551,19 @@ pub(crate) fn record_graph_build(edges: usize) {
 /// installed (production).
 pub(crate) fn record_traversal_mid_switch() {
     let _ = current(|p| p.traversal_mid_switches.fetch_add(1, Ordering::Relaxed));
+}
+
+/// Record which path one Expand ran (`indexed` true = the indexed scan,
+/// false = the CSR walk). No-op when no probes are installed (production).
+pub(crate) fn record_expand_path(indexed: bool) {
+    let _ = current(|p| {
+        let counter = if indexed {
+            &p.expand_indexed_runs
+        } else {
+            &p.expand_csr_runs
+        };
+        counter.fetch_add(1, Ordering::Relaxed)
+    });
 }
 
 /// Record one Expand stopping early at its pushed-down limit cap. No-op when

--- a/crates/omnigraph/tests/gq_logic_tests.rs
+++ b/crates/omnigraph/tests/gq_logic_tests.rs
@@ -10,6 +10,12 @@
 //! `OMNIGRAPH_GQ_LOGIC_TESTS=<substr>[,<substr>]` restricts the run to
 //! matching case files; `OMNIGRAPH_GQ_BLESS=1` rewrites the failing step's
 //! `--- expect` rows in place.
+//!
+//! Layout of the `run_query_step` future (an engine query under the traversal
+//! task-local, the timeout, and `catch_unwind`) exceeds the default
+//! `recursion_limit` on Linux CI; the same raise the other engine
+//! integration tests carry.
+#![recursion_limit = "512"]
 
 use std::collections::HashSet;
 use std::ffi::OsStr;

--- a/crates/omnigraph/tests/gq_logic_tests.rs
+++ b/crates/omnigraph/tests/gq_logic_tests.rs
@@ -162,6 +162,12 @@ fn parse_header(lines: &[&str]) -> Result<Header, String> {
                     let n = value.parse::<u64>().map_err(|_| {
                         format!("line {}: `# issue:` takes a number or `none`", idx + 1)
                     })?;
+                    if value != n.to_string() {
+                        return Err(format!(
+                            "line {}: `# issue:` number carries no sign or leading zeros",
+                            idx + 1
+                        ));
+                    }
                     IssueRef::Num(n)
                 });
             }
@@ -1918,6 +1924,14 @@ fn refuses_duplicate_issue_header() {
 fn refuses_empty_red_on_value() {
     let text = format!("# issue: 7\n# red_on:\n{SCHEMA}{SEED}{QUERY}{EXPECT}");
     assert!(refusal("issue_7_x", &text).contains("needs a value"));
+}
+
+#[test]
+fn refuses_noncanonical_issue_header_number() {
+    let text = format!("# issue: 0563\n# red_on: 2026-01-01, red.\n{SCHEMA}{SEED}{QUERY}{EXPECT}");
+    assert!(refusal("issue_563_x", &text).contains("no sign or leading zeros"));
+    let text = format!("# issue: +563\n# red_on: 2026-01-01, red.\n{SCHEMA}{SEED}{QUERY}{EXPECT}");
+    assert!(refusal("issue_563_x", &text).contains("no sign or leading zeros"));
 }
 
 #[test]

--- a/crates/omnigraph/tests/gq_logic_tests.rs
+++ b/crates/omnigraph/tests/gq_logic_tests.rs
@@ -1,0 +1,2087 @@
+//! GQ logic tests: walks `tests/gq_logic_tests/*.gqt` and runs each case
+//! against a fresh temporary store (init, load, index, then the steps in
+//! order). The file format, refusal set, comparison semantics, and bless
+//! workflow are specified in `docs/rfcs/0045-gq-logic-tests.md`.
+//!
+//! To libtest the whole walker is one test; case concurrency comes from a
+//! `JoinSet`. `OMNIGRAPH_GQ_LOGIC_TESTS=<substr>[,<substr>]` restricts the run
+//! to matching case files; `OMNIGRAPH_GQ_BLESS=1` rewrites the failing step's
+//! `--- expect` rows in place.
+
+use std::collections::HashSet;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use omnigraph::db::{Omnigraph, ReadTarget};
+use omnigraph::instrumentation::with_traversal_mode;
+use omnigraph::loader::{LoadMode, load_jsonl};
+use omnigraph_compiler::query::ast::{Clause, Expr, Literal, Param, QueryDecl};
+use omnigraph_compiler::query::parser::parse_query;
+use omnigraph_compiler::schema::ast::{Annotation, PropDecl, SchemaDecl};
+use omnigraph_compiler::schema::parser::parse_schema;
+use omnigraph_compiler::{JsonParamMode, json_params_to_param_map};
+use serde_json::Value;
+use tokio::task::JoinSet;
+
+#[derive(Debug)]
+struct Case {
+    schema: String,
+    seed: String,
+    traversal: &'static str,
+    items: Vec<Item>,
+    needs_indices: bool,
+}
+
+impl Case {
+    fn has_loops(&self) -> bool {
+        self.items.iter().any(|i| matches!(i, Item::Loop { .. }))
+    }
+}
+
+#[derive(Debug)]
+enum Item {
+    Step(Step),
+    Loop {
+        var: String,
+        values: Vec<String>,
+        steps: Vec<Step>,
+    },
+}
+
+#[derive(Debug)]
+enum Step {
+    Query(QueryStep),
+    Mutate(MutateStep),
+    Restart { ordinal: usize },
+}
+
+#[derive(Debug)]
+struct QueryStep {
+    ordinal: usize,
+    source: String,
+    name: String,
+    ast_params: Vec<Param>,
+    params_raw: Option<String>,
+    expect: QueryExpect,
+}
+
+#[derive(Debug)]
+struct MutateStep {
+    ordinal: usize,
+    source: String,
+    name: String,
+    ast_params: Vec<Param>,
+    params_raw: Option<String>,
+    expect: MutateExpect,
+}
+
+#[derive(Debug)]
+enum QueryExpect {
+    Rows {
+        ordered: bool,
+        body_raw: String,
+        span: BodySpan,
+    },
+    Error {
+        needle: String,
+    },
+}
+
+#[derive(Debug)]
+enum MutateExpect {
+    Ok,
+    Affected { nodes: usize, edges: usize },
+    Error { needle: String },
+}
+
+/// Line span of an expect section's body in the case file, for bless splicing.
+#[derive(Debug, Clone, Copy)]
+struct BodySpan {
+    start_line: usize,
+    len: usize,
+}
+
+#[derive(Debug)]
+struct Header {
+    issue: IssueRef,
+    traversal: Option<&'static str>,
+}
+
+#[derive(Debug, PartialEq)]
+enum IssueRef {
+    None,
+    Num(u64),
+}
+
+fn parse_header(lines: &[&str]) -> Result<Header, String> {
+    let mut issue: Option<IssueRef> = None;
+    let mut red_on = false;
+    let mut notes_seen = false;
+    let mut traversal: Option<&'static str> = None;
+    let mut have_key = false;
+    for (idx, line) in lines.iter().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Some(rest) = line.strip_prefix('#') else {
+            return Err(format!(
+                "line {}: only `#` header lines may precede the first section",
+                idx + 1
+            ));
+        };
+        let content = rest.trim_start();
+        let key = content
+            .split_once(':')
+            .map(|(k, _)| k)
+            .filter(|k| !k.is_empty() && k.chars().all(|c| c.is_ascii_lowercase() || c == '_'));
+        let Some(key) = key else {
+            if !have_key {
+                return Err(format!(
+                    "line {}: the first header line must start a key (`# issue:`, `# red_on:`, `# notes:`, `# traversal:`)",
+                    idx + 1
+                ));
+            }
+            continue;
+        };
+        let value = content[key.len() + 1..].trim();
+        let duplicate = match key {
+            "issue" => issue.is_some(),
+            "red_on" => red_on,
+            "notes" => notes_seen,
+            "traversal" => traversal.is_some(),
+            _ => false,
+        };
+        if duplicate {
+            return Err(format!("line {}: duplicate `# {key}:` header", idx + 1));
+        }
+        match key {
+            "issue" => {
+                issue = Some(if value == "none" {
+                    IssueRef::None
+                } else {
+                    let n = value.parse::<u64>().map_err(|_| {
+                        format!("line {}: `# issue:` takes a number or `none`", idx + 1)
+                    })?;
+                    IssueRef::Num(n)
+                });
+            }
+            "red_on" => {
+                if value.is_empty() {
+                    return Err(format!("line {}: `# red_on:` needs a value", idx + 1));
+                }
+                red_on = true;
+            }
+            "notes" => notes_seen = true,
+            "traversal" => {
+                traversal = Some(match value {
+                    "indexed" => "indexed",
+                    "csr" => "csr",
+                    other => {
+                        return Err(format!(
+                            "line {}: `# traversal:` takes `indexed` or `csr`, got `{other}`",
+                            idx + 1
+                        ));
+                    }
+                });
+            }
+            other => return Err(format!("line {}: unknown header key `# {other}:`", idx + 1)),
+        }
+        have_key = true;
+    }
+    let Some(issue) = issue else {
+        return Err("missing required `# issue:` header".into());
+    };
+    if matches!(issue, IssueRef::Num(_)) && !red_on {
+        return Err("`# red_on:` is required when `# issue:` names a number".into());
+    }
+    Ok(Header { issue, traversal })
+}
+
+fn check_file_name(stem: &str, issue: &IssueRef) -> Result<(), String> {
+    if let Some(rest) = stem.strip_prefix("issue_") {
+        let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
+        let tail = &rest[digits.len()..];
+        let short = tail.strip_prefix('_').unwrap_or("");
+        if digits.is_empty()
+            || short.is_empty()
+            || !short
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+        {
+            return Err("file name must be `issue_<N>_<short_name>.gqt`".into());
+        }
+        let n: u64 = digits
+            .parse()
+            .map_err(|_| "file name issue number does not parse".to_string())?;
+        if digits != n.to_string() {
+            return Err("file name issue number must not carry leading zeros".into());
+        }
+        if *issue != IssueRef::Num(n) {
+            return Err(format!(
+                "file name says issue {n} but the `# issue:` header disagrees"
+            ));
+        }
+    } else {
+        if stem.is_empty()
+            || !stem
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+        {
+            return Err("feature case file names are `<short_name>.gqt` over [a-z0-9_]".into());
+        }
+        if let IssueRef::Num(n) = issue {
+            return Err(format!(
+                "`# issue: {n}` requires the file name `issue_{n}_<short_name>.gqt`"
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+struct Section<'a> {
+    name: String,
+    header_line: usize,
+    body: Vec<(usize, &'a str)>,
+}
+
+fn split_sections<'a>(lines: &[&'a str]) -> (Vec<&'a str>, Vec<Section<'a>>) {
+    let mut starts: Vec<usize> = lines
+        .iter()
+        .enumerate()
+        .filter(|(_, l)| l.starts_with("--- "))
+        .map(|(i, _)| i)
+        .collect();
+    let header_end = starts.first().copied().unwrap_or(lines.len());
+    let header = lines[..header_end].to_vec();
+    starts.push(lines.len());
+    let mut sections = Vec::new();
+    for pair in starts.windows(2) {
+        let (start, end) = (pair[0], pair[1]);
+        if start >= lines.len() {
+            break;
+        }
+        sections.push(Section {
+            name: lines[start]["--- ".len()..].trim_end().to_string(),
+            header_line: start,
+            body: (start + 1..end).map(|i| (i, lines[i])).collect(),
+        });
+    }
+    (header, sections)
+}
+
+#[derive(Debug)]
+enum ExpectHeader {
+    Unordered,
+    Ordered,
+    Ok,
+    Error(String),
+    Affected { nodes: usize, edges: usize },
+}
+
+fn parse_expect_header(rest: &str) -> Result<ExpectHeader, String> {
+    let rest = rest.trim();
+    if rest.is_empty() {
+        return Err("a bare `--- expect` is refused; give a mode word".into());
+    }
+    if rest == "unordered" {
+        return Ok(ExpectHeader::Unordered);
+    }
+    if rest == "ordered" {
+        return Ok(ExpectHeader::Ordered);
+    }
+    if rest == "ok" {
+        return Ok(ExpectHeader::Ok);
+    }
+    if let Some(needle) = rest.strip_prefix("error:") {
+        let needle = needle.trim();
+        if needle.is_empty() {
+            return Err(
+                "`expect error:` needs a substring; a bare any-error expectation is refused".into(),
+            );
+        }
+        return Ok(ExpectHeader::Error(needle.to_string()));
+    }
+    if let Some(counts) = rest.strip_prefix("affected:") {
+        let parts: Vec<&str> = counts.split_whitespace().collect();
+        let parsed = match parts.as_slice() {
+            [n, e] => n
+                .strip_prefix("nodes=")
+                .zip(e.strip_prefix("edges="))
+                .and_then(|(n, e)| parse_plain_count(n).zip(parse_plain_count(e))),
+            _ => None,
+        };
+        let Some((nodes, edges)) = parsed else {
+            return Err(
+                "`expect affected:` must be exactly `affected: nodes=<N> edges=<M>`".into(),
+            );
+        };
+        return Ok(ExpectHeader::Affected { nodes, edges });
+    }
+    Err(format!("unknown expect mode `{rest}`"))
+}
+
+/// Exact-spelling numeric token: digits only, no sign, no leading zeros.
+fn parse_plain_count(token: &str) -> Option<usize> {
+    let n: usize = token.parse().ok()?;
+    (n.to_string() == token).then_some(n)
+}
+
+fn parse_loop_var(token: &str) -> Result<String, String> {
+    let Some(name) = token.strip_prefix('$') else {
+        return Err(format!("loop variable `{token}` must start with `$`"));
+    };
+    let mut chars = name.chars();
+    let head_ok = chars.next().is_some_and(|c| c.is_ascii_lowercase());
+    if !head_ok
+        || !name
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+    {
+        return Err(format!(
+            "loop variable `{token}` must match $[a-z][a-z0-9_]*"
+        ));
+    }
+    Ok(name.to_string())
+}
+
+fn parse_loop_header(rest: &str) -> Result<(String, Vec<String>), String> {
+    let parts: Vec<&str> = rest.split_whitespace().collect();
+    let [var, start, end] = parts.as_slice() else {
+        return Err("`--- loop` must be `loop $var <start> <end>`".into());
+    };
+    let var = parse_loop_var(var)?;
+    for bound in [start, end] {
+        if bound.starts_with('-') {
+            return Err("loop bounds must be non-negative".into());
+        }
+    }
+    let start = parse_plain_bound(start)?;
+    let end = parse_plain_bound(end)?;
+    if start >= end {
+        return Err("empty loop range is refused; zero iterations assert nothing".into());
+    }
+    if end - start > 10_000 {
+        return Err(format!(
+            "loop range of {} iterations exceeds the 10000 cap; a case needing more stays a Rust test",
+            end - start
+        ));
+    }
+    Ok((var, (start..end).map(|i| i.to_string()).collect()))
+}
+
+fn parse_plain_bound(token: &str) -> Result<u64, String> {
+    let n: u64 = token
+        .parse()
+        .map_err(|_| "loop bounds must be plain decimal integers".to_string())?;
+    if n.to_string() != token {
+        return Err("loop bounds must be plain decimal integers".into());
+    }
+    Ok(n)
+}
+
+fn parse_foreach_header(rest: &str) -> Result<(String, Vec<String>), String> {
+    let mut parts = rest.split_whitespace();
+    let Some(var) = parts.next() else {
+        return Err("`--- foreach` must be `foreach $var <v1> [<v2> ...]`".into());
+    };
+    let var = parse_loop_var(var)?;
+    let values: Vec<String> = parts.map(str::to_string).collect();
+    if values.is_empty() {
+        return Err(
+            "a `--- foreach` with no values is refused; zero iterations assert nothing".into(),
+        );
+    }
+    for v in &values {
+        if !v
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.' || c == '-')
+        {
+            return Err(format!(
+                "foreach value `{v}` is outside [A-Za-z0-9_.-]; a value needing more stays a Rust test"
+            ));
+        }
+    }
+    Ok((var, values))
+}
+
+fn refuse_comment_lines(body: &[(usize, &str)], section: &str) -> Result<(), String> {
+    for (idx, line) in body {
+        if line.trim_start().starts_with('#') {
+            return Err(format!(
+                "line {}: `#` lines are refused inside the {section} section; comments live in the header",
+                idx + 1
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn refuse_nonempty_body(body: &[(usize, &str)], what: &str) -> Result<(), String> {
+    for (idx, line) in body {
+        if !line.trim().is_empty() {
+            return Err(format!("line {}: {what} carries no body", idx + 1));
+        }
+    }
+    Ok(())
+}
+
+fn validate_subst_tokens(body: &str, loop_var: Option<&str>) -> Result<(), String> {
+    let mut rest = body;
+    while let Some(pos) = rest.find("${") {
+        let after = &rest[pos + 2..];
+        let Some(close) = after.find('}') else {
+            return Err("unterminated `${` substitution".into());
+        };
+        let name = &after[..close];
+        match loop_var {
+            None => {
+                return Err("`${` in a params or expect body is refused outside a loop".into());
+            }
+            Some(var) if name == var => {}
+            Some(var) => {
+                return Err(format!(
+                    "`${{{name}}}` does not name the enclosing loop's variable `${var}`"
+                ));
+            }
+        }
+        rest = &after[close + 1..];
+    }
+    Ok(())
+}
+
+/// Walks one expression for the index decision and the string-`nearest`
+/// refusal. Exhaustive over `Expr` so a newly added construct is a compile
+/// error, never a silent skip.
+fn walk_expr(expr: &Expr, params: &[Param], needs_indices: &mut bool) -> Result<(), String> {
+    match expr {
+        Expr::Now
+        | Expr::PropAccess {
+            variable: _,
+            property: _,
+        }
+        | Expr::Variable(_)
+        | Expr::Literal(_)
+        | Expr::AliasRef(_) => {}
+        Expr::Aggregate { func: _, arg } => walk_expr(arg, params, needs_indices)?,
+        Expr::Search { field, query }
+        | Expr::MatchText { field, query }
+        | Expr::Bm25 { field, query } => {
+            *needs_indices = true;
+            walk_expr(field, params, needs_indices)?;
+            walk_expr(query, params, needs_indices)?;
+        }
+        Expr::Fuzzy {
+            field,
+            query,
+            max_edits,
+        } => {
+            *needs_indices = true;
+            walk_expr(field, params, needs_indices)?;
+            walk_expr(query, params, needs_indices)?;
+            if let Some(max_edits) = max_edits {
+                walk_expr(max_edits, params, needs_indices)?;
+            }
+        }
+        Expr::Nearest {
+            variable: _,
+            property: _,
+            query,
+        } => {
+            *needs_indices = true;
+            refuse_string_nearest(query, params)?;
+            walk_expr(query, params, needs_indices)?;
+        }
+        Expr::Rrf {
+            primary,
+            secondary,
+            k,
+        } => {
+            *needs_indices = true;
+            walk_expr(primary, params, needs_indices)?;
+            walk_expr(secondary, params, needs_indices)?;
+            if let Some(k) = k {
+                walk_expr(k, params, needs_indices)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn refuse_string_nearest(query: &Expr, params: &[Param]) -> Result<(), String> {
+    let is_vector = match query {
+        Expr::Literal(Literal::List(_)) => true,
+        Expr::Variable(name) => {
+            let name = name.trim_start_matches('$');
+            params
+                .iter()
+                .any(|p| p.name.trim_start_matches('$') == name && p.type_name != "String")
+        }
+        _ => false,
+    };
+    if is_vector {
+        return Ok(());
+    }
+    Err(
+        "`nearest` takes an explicit vector literal or vector parameter; a string argument \
+         resolves an embedding provider from process environment and stays a Rust test"
+            .into(),
+    )
+}
+
+fn walk_clauses(
+    clauses: &[Clause],
+    params: &[Param],
+    needs_indices: &mut bool,
+) -> Result<(), String> {
+    for clause in clauses {
+        match clause {
+            Clause::Binding(_) | Clause::Traversal(_) => {}
+            Clause::Filter(f) => {
+                walk_expr(&f.left, params, needs_indices)?;
+                walk_expr(&f.right, params, needs_indices)?;
+            }
+            Clause::Negation(inner) => walk_clauses(inner, params, needs_indices)?,
+        }
+    }
+    Ok(())
+}
+
+fn inspect_decl(decl: &QueryDecl, needs_indices: &mut bool) -> Result<(), String> {
+    walk_clauses(&decl.match_clause, &decl.params, needs_indices)?;
+    for projection in &decl.return_clause {
+        walk_expr(&projection.expr, &decl.params, needs_indices)?;
+    }
+    for ordering in &decl.order_clause {
+        walk_expr(&ordering.expr, &decl.params, needs_indices)?;
+    }
+    Ok(())
+}
+
+fn props_use_embed(props: &[PropDecl]) -> bool {
+    props.iter().any(|p| anns_use_embed(&p.annotations))
+}
+
+fn anns_use_embed(annotations: &[Annotation]) -> bool {
+    annotations.iter().any(|a| a.name == "embed")
+}
+
+fn refuse_embed_schema(schema: &str, start_line: usize) -> Result<(), String> {
+    let file = parse_schema(schema)
+        .map_err(|e| format!("schema section starting at line {start_line} does not parse: {e}"))?;
+    let uses_embed = file.declarations.iter().any(|decl| match decl {
+        SchemaDecl::Interface(i) => props_use_embed(&i.properties),
+        SchemaDecl::Node(n) => anns_use_embed(&n.annotations) || props_use_embed(&n.properties),
+        SchemaDecl::Edge(e) => anns_use_embed(&e.annotations) || props_use_embed(&e.properties),
+    });
+    if uses_embed {
+        return Err(
+            "schemas using `@embed` resolve an embedding provider from process environment \
+             and stay Rust tests"
+                .into(),
+        );
+    }
+    Ok(())
+}
+
+/// A query or mutate section parsed and classified, awaiting its expect.
+struct PendingStep {
+    is_mutation: bool,
+    ordinal: usize,
+    source: String,
+    name: String,
+    ast_params: Vec<Param>,
+    has_order_clause: bool,
+    params_raw: Option<String>,
+}
+
+fn parse_case(stem: &str, text: &str) -> Result<Case, String> {
+    if text.contains('\r') {
+        return Err("case files are UTF-8 with `\\n` line endings; `\\r` found".into());
+    }
+    let lines: Vec<&str> = text.lines().collect();
+    let (header_lines, sections) = split_sections(&lines);
+    let header = parse_header(&header_lines)?;
+    check_file_name(stem, &header.issue)?;
+
+    if sections.first().map(|s| s.name.as_str()) != Some("schema") {
+        return Err("the first section must be `--- schema`".into());
+    }
+    if sections.get(1).map(|s| s.name.as_str()) != Some("seed") {
+        return Err("the second section must be `--- seed`".into());
+    }
+    let schema: String = sections[0]
+        .body
+        .iter()
+        .map(|(_, l)| *l)
+        .collect::<Vec<_>>()
+        .join("\n");
+    refuse_comment_lines(&sections[1].body, "seed")?;
+    let seed: String = sections[1]
+        .body
+        .iter()
+        .map(|(_, l)| *l)
+        .filter(|l| !l.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join("\n");
+    refuse_embed_schema(&schema, sections[0].header_line + 1)?;
+
+    // An explicit `# traversal:` pin makes the traversal path the case's
+    // subject, so the indexed executor must run covered, not on its fallback.
+    let mut needs_indices = header.traversal.is_some();
+    let mut items: Vec<Item> = Vec::new();
+    let mut open_loop: Option<(String, Vec<String>, Vec<Step>)> = None;
+    let mut pending: Option<PendingStep> = None;
+    let mut ordinal = 0usize;
+    let mut qm_steps = 0usize;
+    let mut substitutable_lines: HashSet<usize> = HashSet::new();
+
+    fn push_step(
+        items: &mut Vec<Item>,
+        open_loop: &mut Option<(String, Vec<String>, Vec<Step>)>,
+        step: Step,
+    ) {
+        match open_loop {
+            Some((_, _, steps)) => steps.push(step),
+            None => items.push(Item::Step(step)),
+        }
+    }
+
+    for section in &sections[2..] {
+        let (kind, rest) = match section.name.split_once(' ') {
+            Some((k, rest)) => (k, rest),
+            None => (section.name.as_str(), ""),
+        };
+        match kind {
+            "schema" | "seed" => {
+                return Err(format!(
+                    "line {}: `--- {kind}` is out of position; schema then seed lead the file, once each",
+                    section.header_line + 1
+                ));
+            }
+            "query" | "mutate" => {
+                if !rest.is_empty() {
+                    return Err(format!("`--- {kind}` takes no arguments"));
+                }
+                if pending.is_some() {
+                    return Err(format!(
+                        "line {}: the previous step is missing its `--- expect`",
+                        section.header_line + 1
+                    ));
+                }
+                let source: String = section
+                    .body
+                    .iter()
+                    .map(|(_, l)| *l)
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                let file = parse_query(&source).map_err(|e| {
+                    format!(
+                        "`--- {kind}` section starting at line {} does not parse: {e}",
+                        section.header_line + 1
+                    )
+                })?;
+                let [decl] = file.queries.as_slice() else {
+                    return Err(format!(
+                        "a `--- {kind}` section must hold exactly one declaration, got {}",
+                        file.queries.len()
+                    ));
+                };
+                let is_mutation = !decl.mutations.is_empty();
+                if kind == "query" && is_mutation {
+                    return Err(
+                        "a mutation declaration under `--- query` is refused; use `--- mutate`"
+                            .into(),
+                    );
+                }
+                if kind == "mutate" && !is_mutation {
+                    return Err(
+                        "a read declaration under `--- mutate` is refused; use `--- query`".into(),
+                    );
+                }
+                inspect_decl(decl, &mut needs_indices)?;
+                ordinal += 1;
+                qm_steps += 1;
+                pending = Some(PendingStep {
+                    is_mutation,
+                    ordinal,
+                    source: source.clone(),
+                    name: decl.name.clone(),
+                    ast_params: decl.params.clone(),
+                    has_order_clause: !decl.order_clause.is_empty(),
+                    params_raw: None,
+                });
+            }
+            "params" => {
+                if !rest.is_empty() {
+                    return Err(format!("unknown section `--- {}`", section.name));
+                }
+                let Some(step) = pending.as_mut() else {
+                    return Err(format!(
+                        "line {}: `--- params` must directly follow a query or mutate section",
+                        section.header_line + 1
+                    ));
+                };
+                if step.params_raw.is_some() {
+                    return Err(format!(
+                        "line {}: a second `--- params` for one step is refused",
+                        section.header_line + 1
+                    ));
+                }
+                let body: String = section
+                    .body
+                    .iter()
+                    .map(|(_, l)| *l)
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                validate_subst_tokens(&body, open_loop.as_ref().map(|(v, _, _)| v.as_str()))?;
+                substitutable_lines.extend(section.body.iter().map(|(i, _)| *i));
+                step.params_raw = Some(body);
+            }
+            "expect" => {
+                let Some(step) = pending.take() else {
+                    return Err(format!(
+                        "line {}: `--- expect` has no query or mutate step to bind to",
+                        section.header_line + 1
+                    ));
+                };
+                let mode = parse_expect_header(rest)?;
+                let completed = match (&mode, step.is_mutation) {
+                    (ExpectHeader::Unordered | ExpectHeader::Ordered, true) => {
+                        return Err(
+                            "a mutate step takes `ok`, `affected:`, or `error:`; mutation results carry no rows"
+                                .into(),
+                        );
+                    }
+                    (ExpectHeader::Ok | ExpectHeader::Affected { .. }, false) => {
+                        return Err("a query step takes `unordered`, `ordered`, or `error:`".into());
+                    }
+                    (ExpectHeader::Unordered | ExpectHeader::Ordered, false) => {
+                        let ordered = matches!(mode, ExpectHeader::Ordered);
+                        if ordered && !step.has_order_clause {
+                            return Err(
+                                "`expect ordered` is refused for a query without an `order` clause"
+                                    .into(),
+                            );
+                        }
+                        refuse_comment_lines(&section.body, "expect")?;
+                        let body: String = section
+                            .body
+                            .iter()
+                            .map(|(_, l)| *l)
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        validate_subst_tokens(
+                            &body,
+                            open_loop.as_ref().map(|(v, _, _)| v.as_str()),
+                        )?;
+                        substitutable_lines.extend(section.body.iter().map(|(i, _)| *i));
+                        Step::Query(QueryStep {
+                            ordinal: step.ordinal,
+                            source: step.source,
+                            name: step.name,
+                            ast_params: step.ast_params,
+                            params_raw: step.params_raw,
+                            expect: QueryExpect::Rows {
+                                ordered,
+                                body_raw: body,
+                                span: BodySpan {
+                                    start_line: section.header_line + 1,
+                                    len: section.body.len(),
+                                },
+                            },
+                        })
+                    }
+                    (ExpectHeader::Error(needle), is_mutation) => {
+                        refuse_nonempty_body(&section.body, "an `expect error:` section")?;
+                        if is_mutation {
+                            Step::Mutate(MutateStep {
+                                ordinal: step.ordinal,
+                                source: step.source,
+                                name: step.name,
+                                ast_params: step.ast_params,
+                                params_raw: step.params_raw,
+                                expect: MutateExpect::Error {
+                                    needle: needle.clone(),
+                                },
+                            })
+                        } else {
+                            Step::Query(QueryStep {
+                                ordinal: step.ordinal,
+                                source: step.source,
+                                name: step.name,
+                                ast_params: step.ast_params,
+                                params_raw: step.params_raw,
+                                expect: QueryExpect::Error {
+                                    needle: needle.clone(),
+                                },
+                            })
+                        }
+                    }
+                    (ExpectHeader::Ok, true) => {
+                        refuse_nonempty_body(&section.body, "an `expect ok` section")?;
+                        Step::Mutate(MutateStep {
+                            ordinal: step.ordinal,
+                            source: step.source,
+                            name: step.name,
+                            ast_params: step.ast_params,
+                            params_raw: step.params_raw,
+                            expect: MutateExpect::Ok,
+                        })
+                    }
+                    (ExpectHeader::Affected { nodes, edges }, true) => {
+                        refuse_nonempty_body(&section.body, "an `expect affected:` section")?;
+                        Step::Mutate(MutateStep {
+                            ordinal: step.ordinal,
+                            source: step.source,
+                            name: step.name,
+                            ast_params: step.ast_params,
+                            params_raw: step.params_raw,
+                            expect: MutateExpect::Affected {
+                                nodes: *nodes,
+                                edges: *edges,
+                            },
+                        })
+                    }
+                };
+                push_step(&mut items, &mut open_loop, completed);
+            }
+            "restart" => {
+                if !rest.is_empty() {
+                    return Err("`--- restart` takes no arguments".into());
+                }
+                if pending.is_some() {
+                    return Err(format!(
+                        "line {}: the previous step is missing its `--- expect`",
+                        section.header_line + 1
+                    ));
+                }
+                refuse_nonempty_body(&section.body, "`--- restart`")?;
+                ordinal += 1;
+                push_step(&mut items, &mut open_loop, Step::Restart { ordinal });
+            }
+            "loop" | "foreach" => {
+                if pending.is_some() {
+                    return Err(format!(
+                        "line {}: the previous step is missing its `--- expect`",
+                        section.header_line + 1
+                    ));
+                }
+                if open_loop.is_some() {
+                    return Err("loops may not nest".into());
+                }
+                refuse_nonempty_body(&section.body, "a loop header")?;
+                let (var, values) = if kind == "loop" {
+                    parse_loop_header(rest)?
+                } else {
+                    parse_foreach_header(rest)?
+                };
+                open_loop = Some((var, values, Vec::new()));
+            }
+            "endloop" => {
+                if !rest.is_empty() {
+                    return Err("`--- endloop` takes no arguments".into());
+                }
+                if pending.is_some() {
+                    return Err(format!(
+                        "line {}: the previous step is missing its `--- expect`",
+                        section.header_line + 1
+                    ));
+                }
+                refuse_nonempty_body(&section.body, "`--- endloop`")?;
+                let Some((var, values, steps)) = open_loop.take() else {
+                    return Err("`--- endloop` without an open loop".into());
+                };
+                if steps.is_empty() {
+                    return Err("a loop enclosing no steps is refused".into());
+                }
+                items.push(Item::Loop { var, values, steps });
+            }
+            _ => return Err(format!("unknown section `--- {}`", section.name)),
+        }
+    }
+    if pending.is_some() {
+        return Err("the final step is missing its `--- expect`".into());
+    }
+    if open_loop.is_some() {
+        return Err("a loop is not closed with `--- endloop`".into());
+    }
+    if qm_steps == 0 {
+        return Err(
+            "a case needs at least one query or mutate step; nothing would be asserted".into(),
+        );
+    }
+    for (idx, line) in lines.iter().enumerate() {
+        if line.contains("${") && !substitutable_lines.contains(&idx) {
+            return Err(format!(
+                "line {}: `${{` may appear only inside a params or expect body",
+                idx + 1
+            ));
+        }
+    }
+    Ok(Case {
+        schema,
+        seed,
+        traversal: header.traversal.unwrap_or("indexed"),
+        items,
+        needs_indices,
+    })
+}
+
+fn normalize_number(n: &serde_json::Number) -> String {
+    if let Some(i) = n.as_i64() {
+        return i.to_string();
+    }
+    if let Some(u) = n.as_u64() {
+        return u.to_string();
+    }
+    let f = n
+        .as_f64()
+        .expect("invariant: serde_json numbers are i64, u64, or f64");
+    let mut s = format!("{f:.12}");
+    if s.contains('.') {
+        while s.ends_with('0') {
+            s.pop();
+        }
+        if s.ends_with('.') {
+            s.pop();
+        }
+    }
+    if s == "-0" { "0".to_string() } else { s }
+}
+
+/// One canonical string per row: object keys sorted, every number rewritten to
+/// a scale-12 decimal with trailing zeros trimmed (integer-shaped numbers
+/// never route through f64), null cells explicit.
+fn canonical_json(value: &Value) -> String {
+    let mut out = String::new();
+    write_canonical(value, &mut out);
+    out
+}
+
+fn write_canonical(value: &Value, out: &mut String) {
+    match value {
+        Value::Null => out.push_str("null"),
+        Value::Bool(b) => {
+            let _ = write!(out, "{b}");
+        }
+        Value::Number(n) => out.push_str(&normalize_number(n)),
+        Value::String(s) => {
+            out.push_str(&Value::String(s.clone()).to_string());
+        }
+        Value::Array(items) => {
+            out.push('[');
+            for (i, item) in items.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                write_canonical(item, out);
+            }
+            out.push(']');
+        }
+        Value::Object(map) => {
+            let mut pairs: Vec<(&String, &Value)> = map.iter().collect();
+            pairs.sort_by_key(|(k, _)| k.as_str());
+            out.push('{');
+            for (i, (k, v)) in pairs.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                out.push_str(&Value::String((*k).clone()).to_string());
+                out.push(':');
+                write_canonical(v, out);
+            }
+            out.push('}');
+        }
+    }
+}
+
+fn parse_expect_rows(body: &str) -> Result<Vec<Value>, String> {
+    let mut rows = Vec::new();
+    for line in body.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let value: Value = serde_json::from_str(line)
+            .map_err(|e| format!("expected row is not valid JSON: {e}: {line}"))?;
+        if !value.is_object() {
+            return Err(format!("expected row must be a JSON object: {line}"));
+        }
+        rows.push(value);
+    }
+    Ok(rows)
+}
+
+/// Compares normalized rows; returns the actual rows in the order bless would
+/// write them alongside the mismatch message.
+fn compare_rows(
+    expected: &[Value],
+    actual: &[Value],
+    ordered: bool,
+) -> Result<(), (String, Vec<String>)> {
+    let mut expected: Vec<String> = expected.iter().map(canonical_json).collect();
+    let mut actual: Vec<String> = actual.iter().map(canonical_json).collect();
+    if !ordered {
+        expected.sort();
+        actual.sort();
+    }
+    if expected == actual {
+        return Ok(());
+    }
+    let mut msg = if expected.len() == actual.len() {
+        format!("row mismatch ({} rows)\nexpected:\n", expected.len())
+    } else {
+        format!(
+            "row mismatch: expected {} rows, got {}\nexpected:\n",
+            expected.len(),
+            actual.len()
+        )
+    };
+    for row in &expected {
+        let _ = writeln!(msg, "  {row}");
+    }
+    msg.push_str("actual:\n");
+    for row in &actual {
+        let _ = writeln!(msg, "  {row}");
+    }
+    Err((msg, actual))
+}
+
+struct StepFail {
+    label: String,
+    message: String,
+    bless_rows: Option<(BodySpan, Vec<String>)>,
+}
+
+fn step_label(ordinal: usize, kind: &str, binding: Option<(&str, &str)>) -> String {
+    match binding {
+        Some((var, value)) => format!("step {ordinal} ({kind}, ${var}={value})"),
+        None => format!("step {ordinal} ({kind})"),
+    }
+}
+
+fn substitute(text: &str, binding: Option<(&str, &str)>) -> String {
+    match binding {
+        Some((var, value)) => text.replace(&format!("${{{var}}}"), value),
+        None => text.to_string(),
+    }
+}
+
+fn build_params(
+    params_raw: Option<&String>,
+    ast_params: &[Param],
+    binding: Option<(&str, &str)>,
+) -> Result<omnigraph_compiler::ParamMap, String> {
+    let json = match params_raw {
+        Some(raw) => {
+            let substituted = substitute(raw, binding);
+            Some(
+                serde_json::from_str::<Value>(&substituted)
+                    .map_err(|e| format!("params are not valid JSON: {e}"))?,
+            )
+        }
+        None => None,
+    };
+    json_params_to_param_map(json.as_ref(), ast_params, JsonParamMode::Standard)
+        .map_err(|e| format!("params rejected: {e}"))
+}
+
+async fn run_query_step(
+    db: &Omnigraph,
+    mode: &'static str,
+    step: &QueryStep,
+    binding: Option<(&str, &str)>,
+) -> Result<(), StepFail> {
+    let label = step_label(step.ordinal, "query", binding);
+    let fail = |message: String| StepFail {
+        label: label.clone(),
+        message,
+        bless_rows: None,
+    };
+    // A params refusal is one of the ways "the query must fail": route it
+    // into an `error:` expectation instead of always failing the step.
+    let params = match build_params(step.params_raw.as_ref(), &step.ast_params, binding) {
+        Ok(params) => params,
+        Err(e) => {
+            return match &step.expect {
+                QueryExpect::Error { needle } if e.contains(needle) => Ok(()),
+                QueryExpect::Error { needle } => {
+                    Err(fail(format!("error does not contain \"{needle}\": {e}")))
+                }
+                QueryExpect::Rows { .. } => Err(fail(e)),
+            };
+        }
+    };
+    let outcome = with_traversal_mode(
+        mode,
+        db.query(
+            ReadTarget::branch("main"),
+            &step.source,
+            &step.name,
+            &params,
+        ),
+    )
+    .await;
+    match &step.expect {
+        QueryExpect::Rows {
+            ordered,
+            body_raw,
+            span,
+        } => {
+            let result = outcome.map_err(|e| fail(format!("query failed: {e}")))?;
+            let Value::Array(actual) = result.to_rust_json() else {
+                return Err(fail("engine returned a non-array row set".into()));
+            };
+            let expected = parse_expect_rows(&substitute(body_raw, binding)).map_err(&fail)?;
+            compare_rows(&expected, &actual, *ordered).map_err(|(message, rows)| StepFail {
+                label: label.clone(),
+                message,
+                bless_rows: Some((*span, rows)),
+            })
+        }
+        QueryExpect::Error { needle } => match outcome {
+            Ok(_) => Err(fail(format!(
+                "expected an error containing \"{needle}\", but the query succeeded"
+            ))),
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains(needle) {
+                    Ok(())
+                } else {
+                    Err(fail(format!("error does not contain \"{needle}\": {msg}")))
+                }
+            }
+        },
+    }
+}
+
+async fn run_mutate_step(
+    db: &Omnigraph,
+    mode: &'static str,
+    step: &MutateStep,
+    binding: Option<(&str, &str)>,
+) -> Result<(), StepFail> {
+    let label = step_label(step.ordinal, "mutate", binding);
+    let fail = |message: String| StepFail {
+        label: label.clone(),
+        message,
+        bless_rows: None,
+    };
+    let params = match build_params(step.params_raw.as_ref(), &step.ast_params, binding) {
+        Ok(params) => params,
+        Err(e) => {
+            return match &step.expect {
+                MutateExpect::Error { needle } if e.contains(needle) => Ok(()),
+                MutateExpect::Error { needle } => {
+                    Err(fail(format!("error does not contain \"{needle}\": {e}")))
+                }
+                MutateExpect::Ok | MutateExpect::Affected { .. } => Err(fail(e)),
+            };
+        }
+    };
+    let outcome =
+        with_traversal_mode(mode, db.mutate("main", &step.source, &step.name, &params)).await;
+    match &step.expect {
+        MutateExpect::Ok => outcome
+            .map(|_| ())
+            .map_err(|e| fail(format!("mutation failed: {e}"))),
+        MutateExpect::Affected { nodes, edges } => {
+            let result = outcome.map_err(|e| fail(format!("mutation failed: {e}")))?;
+            if result.affected_nodes == *nodes && result.affected_edges == *edges {
+                Ok(())
+            } else {
+                Err(fail(format!(
+                    "affected counts mismatch: expected nodes={nodes} edges={edges}, got nodes={} edges={}",
+                    result.affected_nodes, result.affected_edges
+                )))
+            }
+        }
+        MutateExpect::Error { needle } => match outcome {
+            Ok(_) => Err(fail(format!(
+                "expected an error containing \"{needle}\", but the mutation succeeded"
+            ))),
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains(needle) {
+                    Ok(())
+                } else {
+                    Err(fail(format!("error does not contain \"{needle}\": {msg}")))
+                }
+            }
+        },
+    }
+}
+
+async fn execute_case(case: &Case, path: &Path, bless: bool) -> Result<(), String> {
+    let dir = tempfile::tempdir().map_err(|e| format!("tempdir failed: {e}"))?;
+    let uri = dir
+        .path()
+        .to_str()
+        .ok_or_else(|| "temp path is not utf-8".to_string())?
+        .to_string();
+    let mut db = Omnigraph::init(&uri, &case.schema)
+        .await
+        .map_err(|e| format!("init failed: {e}"))?;
+    if !case.seed.trim().is_empty() {
+        load_jsonl(&db, &case.seed, LoadMode::Overwrite)
+            .await
+            .map_err(|e| format!("seed load failed: {e}"))?;
+    }
+    if case.needs_indices {
+        db.ensure_indices()
+            .await
+            .map_err(|e| format!("ensure_indices failed: {e}"))?;
+    }
+
+    let mut first_fail: Option<StepFail> = None;
+    'run: for item in &case.items {
+        let (values, var, steps): (Vec<Option<&str>>, Option<&str>, Vec<&Step>) = match item {
+            Item::Step(step) => (vec![None], None, vec![step]),
+            Item::Loop { var, values, steps } => (
+                values.iter().map(|v| Some(v.as_str())).collect(),
+                Some(var.as_str()),
+                steps.iter().collect(),
+            ),
+        };
+        for value in values {
+            let binding = var.zip(value);
+            for step in &steps {
+                let outcome = match step {
+                    Step::Query(q) => run_query_step(&db, case.traversal, q, binding).await,
+                    Step::Mutate(m) => run_mutate_step(&db, case.traversal, m, binding).await,
+                    Step::Restart { ordinal } => {
+                        drop(db);
+                        db = Omnigraph::open(&uri).await.map_err(|e| {
+                            format!(
+                                "{}: reopen failed: {e}",
+                                step_label(*ordinal, "restart", binding)
+                            )
+                        })?;
+                        Ok(())
+                    }
+                };
+                if let Err(fail) = outcome {
+                    first_fail = Some(fail);
+                    break 'run;
+                }
+            }
+        }
+    }
+    let Some(fail) = first_fail else {
+        return Ok(());
+    };
+    let mut detail = format!("{}: {}", fail.label, fail.message);
+    if bless {
+        if let Some((span, rows)) = &fail.bless_rows {
+            if case.has_loops() {
+                detail.push_str("\nbless: refused, the case contains loops");
+            } else {
+                bless_rewrite(path, *span, rows)?;
+                let _ = write!(
+                    detail,
+                    "\nbless: expect rewritten in place ({} rows), re-run to confirm",
+                    rows.len()
+                );
+            }
+        }
+    }
+    Err(detail)
+}
+
+fn splice_lines(original: &str, span: BodySpan, rows: &[String]) -> String {
+    let lines: Vec<&str> = original.lines().collect();
+    let body = &lines[span.start_line..span.start_line + span.len];
+    let trailing_blanks = body
+        .iter()
+        .rev()
+        .take_while(|l| l.trim().is_empty())
+        .count();
+    let mut out: Vec<&str> = lines[..span.start_line].to_vec();
+    out.extend(rows.iter().map(String::as_str));
+    out.extend(std::iter::repeat_n("", trailing_blanks));
+    out.extend(&lines[span.start_line + span.len..]);
+    let mut joined = out.join("\n");
+    joined.push('\n');
+    joined
+}
+
+fn bless_rewrite(path: &Path, span: BodySpan, rows: &[String]) -> Result<(), String> {
+    let original =
+        std::fs::read_to_string(path).map_err(|e| format!("bless: cannot re-read case: {e}"))?;
+    std::fs::write(path, splice_lines(&original, span, rows))
+        .map_err(|e| format!("bless: cannot write case: {e}"))
+}
+
+async fn run_case(path: PathBuf, bless: bool) -> Result<(), String> {
+    let stem = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| "case file name is not utf-8".to_string())?
+        .to_string();
+    let text = std::fs::read_to_string(&path).map_err(|e| format!("cannot read case file: {e}"))?;
+    let case = parse_case(&stem, &text).map_err(|e| format!("refused: {e}"))?;
+    execute_case(&case, &path, bless).await
+}
+
+fn corpus_root() -> PathBuf {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+    PathBuf::from(manifest_dir)
+        .join("tests")
+        .join("gq_logic_tests")
+}
+
+/// Splits the corpus dir into `.gqt` case files and foreign entries (anything
+/// else except dotfiles); a foreign entry is a mis-renamed or nested case that
+/// would otherwise silently never run.
+fn list_cases(root: &Path) -> (Vec<PathBuf>, Vec<String>) {
+    let mut files = Vec::new();
+    let mut foreign = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(root) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = entry.file_name().to_string_lossy().to_string();
+            if name.starts_with('.') {
+                continue;
+            }
+            if path.is_file() && path.extension().and_then(|s| s.to_str()) == Some("gqt") {
+                files.push(path);
+            } else {
+                foreign.push(name);
+            }
+        }
+    }
+    files.sort();
+    foreign.sort();
+    (files, foreign)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn gq_logic_tests() {
+    let root = corpus_root();
+    let (mut files, foreign) = list_cases(&root);
+    assert!(
+        foreign.is_empty(),
+        "non-.gqt entries under {}: {}; a mis-renamed or nested case must never silently skip",
+        root.display(),
+        foreign.join(", ")
+    );
+    assert!(
+        !files.is_empty(),
+        "no .gqt cases found under {}; a broken checkout must never read as green",
+        root.display()
+    );
+    if let Ok(filter) = std::env::var("OMNIGRAPH_GQ_LOGIC_TESTS") {
+        let needles: Vec<String> = filter
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .collect();
+        if !needles.is_empty() {
+            files.retain(|p| {
+                p.file_name()
+                    .and_then(|s| s.to_str())
+                    .is_some_and(|name| needles.iter().any(|n| name.contains(n.as_str())))
+            });
+            assert!(
+                !files.is_empty(),
+                "OMNIGRAPH_GQ_LOGIC_TESTS={filter} matched no cases"
+            );
+        }
+    }
+    let bless = match std::env::var("OMNIGRAPH_GQ_BLESS") {
+        Err(_) => false,
+        Ok(v) if v == "1" => true,
+        Ok(v) if v == "0" || v.is_empty() => false,
+        Ok(v) => panic!("OMNIGRAPH_GQ_BLESS takes 1 (or 0/unset), got `{v}`"),
+    };
+
+    let total = files.len();
+    let mut names: std::collections::HashMap<tokio::task::Id, String> =
+        std::collections::HashMap::new();
+    let mut set: JoinSet<(String, Result<(), String>)> = JoinSet::new();
+    for path in files {
+        let stem = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("<non-utf8>")
+            .to_string();
+        let task_stem = stem.clone();
+        let handle = set.spawn(async move {
+            let result = run_case(path, bless).await;
+            (task_stem, result)
+        });
+        names.insert(handle.id(), stem);
+    }
+
+    let mut failures: Vec<(String, String)> = Vec::new();
+    while let Some(joined) = set.join_next_with_id().await {
+        match joined {
+            Ok((_, (stem, Ok(())))) => println!("ok {stem}"),
+            Ok((_, (stem, Err(detail)))) => {
+                println!("FAIL {stem}");
+                failures.push((stem, detail));
+            }
+            Err(join_err) => {
+                let stem = names
+                    .get(&join_err.id())
+                    .cloned()
+                    .unwrap_or_else(|| "<unknown case>".to_string());
+                println!("FAIL {stem}");
+                failures.push((stem, format!("case panicked: {join_err}")));
+            }
+        }
+    }
+
+    if !failures.is_empty() {
+        failures.sort();
+        let mut msg = format!(
+            "{} of {total} gq logic test cases failed:\n",
+            failures.len()
+        );
+        for (stem, detail) in &failures {
+            let _ = write!(msg, "\n{stem}:\n  {}\n", detail.replace('\n', "\n  "));
+        }
+        panic!("{msg}");
+    }
+}
+
+const HDR: &str = "# issue: none\n";
+const SCHEMA: &str = "--- schema\nnode Person {\n    name: String @key\n}\n";
+const SEED: &str = "--- seed\n{\"type\":\"Person\",\"data\":{\"name\":\"alice\"}}\n";
+const QUERY: &str =
+    "--- query\nquery all() {\n    match { $p: Person }\n    return { $p.name }\n}\n";
+const EXPECT: &str = "--- expect unordered\n{\"p.name\": \"alice\"}\n";
+const MUTATE: &str = "--- mutate\nquery ins($n: String) {\n    insert Person { name: $n }\n}\n";
+const PARAMS: &str = "--- params\n{\"n\": \"bob\"}\n";
+const EXPECT_OK: &str = "--- expect ok\n";
+
+fn refusal(stem: &str, text: &str) -> String {
+    parse_case(stem, text).expect_err("expected the case to be refused")
+}
+
+#[test]
+fn parses_a_minimal_case() {
+    let text = format!("{HDR}{SCHEMA}{SEED}{QUERY}{EXPECT}");
+    let case = parse_case("minimal", &text).unwrap();
+    assert_eq!(case.items.len(), 1);
+    assert!(!case.needs_indices);
+    assert_eq!(case.traversal, "indexed");
+}
+
+#[test]
+fn header_continuation_lines_extend_the_previous_key() {
+    let text = format!(
+        "# issue: 7\n# red_on: 2026-01-01, the run\n#   returned 8: not 20.\n{SCHEMA}{SEED}{QUERY}{EXPECT}"
+    );
+    parse_case("issue_7_continued", &text).unwrap();
+}
+
+#[test]
+fn refuses_missing_issue_header() {
+    let text = format!("# notes: no anchor\n{SCHEMA}{SEED}{QUERY}{EXPECT}");
+    assert!(refusal("x", &text).contains("# issue:"));
+}
+
+#[test]
+fn refuses_numbered_issue_without_red_on() {
+    let text = format!("# issue: 7\n{SCHEMA}{SEED}{QUERY}{EXPECT}");
+    assert!(refusal("issue_7_x", &text).contains("red_on"));
+}
+
+#[test]
+fn refuses_first_header_line_without_a_key() {
+    let text = format!("# stray continuation\n{HDR}{SCHEMA}{SEED}{QUERY}{EXPECT}");
+    assert!(refusal("x", &text).contains("first header line"));
+}
+
+#[test]
+fn refuses_unknown_header_key() {
+    let text = format!("{HDR}# owner: me\n{SCHEMA}{SEED}{QUERY}{EXPECT}");
+    assert!(refusal("x", &text).contains("unknown header key"));
+}
+
+#[test]
+fn refuses_bad_traversal_mode() {
+    let text = format!("{HDR}# traversal: bogus\n{SCHEMA}{SEED}{QUERY}{EXPECT}");
+    assert!(refusal("x", &text).contains("indexed"));
+}
+
+#[test]
+fn refuses_non_header_line_before_first_section() {
+    let text = format!("{HDR}stray\n{SCHEMA}{SEED}{QUERY}{EXPECT}");
+    assert!(refusal("x", &text).contains("precede the first section"));
+}
+
+#[test]
+fn refuses_comment_line_in_seed() {
+    let text = format!("{HDR}{SCHEMA}--- seed\n# a comment\n{QUERY}{EXPECT}");
+    assert!(refusal("x", &text).contains("seed"));
+}
+
+#[test]
+fn refuses_comment_line_in_expect_body() {
+    let text = format!("{HDR}{SCHEMA}{SEED}{QUERY}--- expect unordered\n# nope\n");
+    assert!(refusal("x", &text).contains("expect"));
+}
+
+#[test]
+fn refuses_seed_before_schema() {
+    let text = format!("{HDR}{SEED}{SCHEMA}{QUERY}{EXPECT}");
+    assert!(refusal("x", &text).contains("first section"));
+}
+
+#[test]
+fn refuses_missing_seed_section() {
+    let text = format!("{HDR}{SCHEMA}{QUERY}{EXPECT}");
+    assert!(refusal("x", &text).contains("second section"));
+}
+
+#[test]
+fn refuses_case_without_a_query_or_mutate_step() {
+    let text = format!("{HDR}{SCHEMA}{SEED}");
+    assert!(refusal("x", &text).contains("at least one query or mutate step"));
+}
+
+#[test]
+fn refuses_restart_only_step_list() {
+    let text = format!("{HDR}{SCHEMA}{SEED}--- restart\n");
+    assert!(refusal("x", &text).contains("at least one query or mutate step"));
+}
+
+#[test]
+fn refuses_second_declaration_in_one_section() {
+    let two = "--- query\nquery a() {\n    match { $p: Person }\n    return { $p.name }\n}\nquery b() {\n    match { $p: Person }\n    return { $p.name }\n}\n";
+    let text = format!("{HDR}{SCHEMA}{SEED}{two}{EXPECT}");
+    assert!(refusal("x", &text).contains("exactly one declaration"));
+}
+
+#[test]
+fn refuses_mutation_declaration_under_query() {
+    let text = format!(
+        "{HDR}{SCHEMA}{SEED}--- query\nquery ins($n: String) {{\n    insert Person {{ name: $n }}\n}}\n{EXPECT}"
+    );
+    assert!(refusal("x", &text).contains("use `--- mutate`"));
+}
+
+#[test]
+fn refuses_read_declaration_under_mutate() {
+    let text = format!(
+        "{HDR}{SCHEMA}{SEED}--- mutate\nquery all() {{\n    match {{ $p: Person }}\n    return {{ $p.name }}\n}}\n{EXPECT_OK}"
+    );
+    assert!(refusal("x", &text).contains("use `--- query`"));
+}
+
+#[test]
+fn refuses_bare_expect() {
+    let text = format!("{HDR}{SCHEMA}{SEED}{QUERY}--- expect\n");
+    assert!(refusal("x", &text).contains("mode word"));
+}
+
+#[test]
+fn refuses_error_expect_without_substring() {
+    let text = format!("{HDR}{SCHEMA}{SEED}{QUERY}--- expect error:\n");
+    assert!(refusal("x", &text).contains("substring"));
+}
+
+#[test]
+fn refuses_error_expect_with_body() {
+    let text = format!("{HDR}{SCHEMA}{SEED}{QUERY}--- expect error: boom\nbody\n");
+    assert!(refusal("x", &text).contains("carries no body"));
+}
+
+#[test]
+fn refuses_affected_expect_missing_a_count() {
+    let text = format!("{HDR}{SCHEMA}{SEED}{MUTATE}{PARAMS}--- expect affected: nodes=1\n");
+    assert!(refusal("x", &text).contains("nodes=<N> edges=<M>"));
+}
+
+#[test]
+fn refuses_unknown_expect_mode() {
+    let text = format!("{HDR}{SCHEMA}{SEED}{QUERY}--- expect sorted\n");
+    assert!(refusal("x", &text).contains("unknown expect mode"));
+}
+
+#[test]
+fn refuses_row_expect_on_a_mutate_step() {
+    let text = format!("{HDR}{SCHEMA}{SEED}{MUTATE}{PARAMS}{EXPECT}");
+    assert!(refusal("x", &text).contains("carry no rows"));
+}
+
+#[test]
+fn refuses_ok_expect_on_a_query_step() {
+    let text = format!("{HDR}{SCHEMA}{SEED}{QUERY}{EXPECT_OK}");
+    assert!(refusal("x", &text).contains("a query step takes"));
+}
+
+#[test]
+fn refuses_query_step_without_expect() {
+    let text = format!("{HDR}{SCHEMA}{SEED}{QUERY}");
+    assert!(refusal("x", &text).contains("missing its `--- expect`"));
+}
+
+#[test]
+fn refuses_expect_with_no_step_to_bind_to() {
+    let text = format!("{HDR}{SCHEMA}{SEED}--- restart\n{EXPECT}{QUERY}{EXPECT}");
+    assert!(refusal("x", &text).contains("no query or mutate step to bind to"));
+}
+
+#[test]
+fn refuses_params_without_a_step() {
+    let text = format!("{HDR}{SCHEMA}{SEED}{PARAMS}{QUERY}{EXPECT}");
+    assert!(refusal("x", &text).contains("directly follow"));
+}
+
+#[test]
+fn refuses_second_params_for_one_step() {
+    let text = format!("{HDR}{SCHEMA}{SEED}{MUTATE}{PARAMS}{PARAMS}{EXPECT_OK}");
+    assert!(refusal("x", &text).contains("second `--- params`"));
+}
+
+#[test]
+fn refuses_restart_with_a_body() {
+    let text = format!("{HDR}{SCHEMA}{SEED}{QUERY}{EXPECT}--- restart\nstray\n");
+    assert!(refusal("x", &text).contains("carries no body"));
+}
+
+#[test]
+fn refuses_unknown_section() {
+    let text = format!("{HDR}{SCHEMA}{SEED}{QUERY}{EXPECT}--- teardown\n");
+    assert!(refusal("x", &text).contains("unknown section"));
+}
+
+#[test]
+fn refuses_schema_out_of_position() {
+    let text = format!("{HDR}{SCHEMA}{SEED}{QUERY}{EXPECT}{SCHEMA}");
+    assert!(refusal("x", &text).contains("out of position"));
+}
+
+#[test]
+fn refuses_negative_loop_bound() {
+    let text = format!("{HDR}{SCHEMA}{SEED}--- loop $i -1 2\n{QUERY}{EXPECT}--- endloop\n");
+    assert!(refusal("x", &text).contains("non-negative"));
+}
+
+#[test]
+fn refuses_empty_loop_range() {
+    let text = format!("{HDR}{SCHEMA}{SEED}--- loop $i 3 3\n{QUERY}{EXPECT}--- endloop\n");
+    assert!(refusal("x", &text).contains("empty loop range"));
+}
+
+#[test]
+fn refuses_foreach_without_values() {
+    let text = format!("{HDR}{SCHEMA}{SEED}--- foreach $x\n{QUERY}{EXPECT}--- endloop\n");
+    assert!(refusal("x", &text).contains("no values"));
+}
+
+#[test]
+fn refuses_foreach_value_outside_charset() {
+    let text = format!("{HDR}{SCHEMA}{SEED}--- foreach $x a\"b\n{QUERY}{EXPECT}--- endloop\n");
+    assert!(refusal("x", &text).contains("[A-Za-z0-9_.-]"));
+}
+
+#[test]
+fn refuses_bad_loop_variable_name() {
+    let text = format!("{HDR}{SCHEMA}{SEED}--- loop $I 0 2\n{QUERY}{EXPECT}--- endloop\n");
+    assert!(refusal("x", &text).contains("$[a-z][a-z0-9_]*"));
+}
+
+#[test]
+fn refuses_nested_loops() {
+    let text = format!(
+        "{HDR}{SCHEMA}{SEED}--- loop $i 0 2\n--- loop $j 0 2\n{QUERY}{EXPECT}--- endloop\n--- endloop\n"
+    );
+    assert!(refusal("x", &text).contains("may not nest"));
+}
+
+#[test]
+fn refuses_endloop_without_a_loop() {
+    let text = format!("{HDR}{SCHEMA}{SEED}{QUERY}{EXPECT}--- endloop\n");
+    assert!(refusal("x", &text).contains("without an open loop"));
+}
+
+#[test]
+fn refuses_unclosed_loop() {
+    let text = format!("{HDR}{SCHEMA}{SEED}--- loop $i 0 2\n{QUERY}{EXPECT}");
+    assert!(refusal("x", &text).contains("not closed"));
+}
+
+#[test]
+fn refuses_loop_enclosing_no_steps() {
+    let text = format!("{HDR}{SCHEMA}{SEED}--- loop $i 0 2\n--- endloop\n{QUERY}{EXPECT}");
+    assert!(refusal("x", &text).contains("enclosing no steps"));
+}
+
+#[test]
+fn refuses_substitution_marker_in_query_body() {
+    let query = "--- query\nquery all() {\n    match { $p: Person }\n    return { $p.name }\n}\n";
+    let text =
+        format!("{HDR}{SCHEMA}{SEED}{query}{EXPECT}").replace("$p.name }", "$p.name } // ${i}");
+    assert!(refusal("x", &text).contains("only inside a params or expect body"));
+}
+
+#[test]
+fn refuses_substitution_marker_in_seed() {
+    let text = format!(
+        "{HDR}{SCHEMA}--- seed\n{{\"type\":\"Person\",\"data\":{{\"name\":\"${{i}}\"}}}}\n{QUERY}{EXPECT}"
+    );
+    assert!(refusal("x", &text).contains("only inside a params or expect body"));
+}
+
+#[test]
+fn refuses_substitution_outside_a_loop() {
+    let text =
+        format!("{HDR}{SCHEMA}{SEED}{MUTATE}--- params\n{{\"n\": \"${{who}}\"}}\n{EXPECT_OK}");
+    assert!(refusal("x", &text).contains("outside a loop"));
+}
+
+#[test]
+fn refuses_substitution_naming_the_wrong_variable() {
+    let text = format!(
+        "{HDR}{SCHEMA}{SEED}--- foreach $who bob\n{MUTATE}--- params\n{{\"n\": \"${{other}}\"}}\n{EXPECT_OK}--- endloop\n"
+    );
+    assert!(refusal("x", &text).contains("enclosing loop's variable"));
+}
+
+#[test]
+fn refuses_unterminated_substitution() {
+    let text = format!(
+        "{HDR}{SCHEMA}{SEED}--- foreach $who bob\n{MUTATE}--- params\n{{\"n\": \"${{who\n{EXPECT_OK}--- endloop\n"
+    );
+    assert!(refusal("x", &text).contains("unterminated"));
+}
+
+#[test]
+fn refuses_file_name_disagreeing_with_issue_header() {
+    let text = format!("# issue: 7\n# red_on: 2026-01-01, red.\n{SCHEMA}{SEED}{QUERY}{EXPECT}");
+    assert!(refusal("issue_8_wrong", &text).contains("disagrees"));
+}
+
+#[test]
+fn refuses_issue_prefix_without_number_or_short_name() {
+    let text = format!("# issue: 7\n# red_on: 2026-01-01, red.\n{SCHEMA}{SEED}{QUERY}{EXPECT}");
+    assert!(refusal("issue_7", &text).contains("issue_<N>_<short_name>"));
+    assert!(refusal("issue_x", &text).contains("issue_<N>_<short_name>"));
+}
+
+#[test]
+fn refuses_feature_name_with_numbered_issue_header() {
+    let text = format!("# issue: 7\n# red_on: 2026-01-01, red.\n{SCHEMA}{SEED}{QUERY}{EXPECT}");
+    assert!(refusal("feature_name", &text).contains("issue_7_<short_name>"));
+}
+
+#[test]
+fn refuses_file_name_outside_charset() {
+    let text = format!("{HDR}{SCHEMA}{SEED}{QUERY}{EXPECT}");
+    assert!(refusal("Bad-Name", &text).contains("[a-z0-9_]"));
+}
+
+#[test]
+fn refuses_ordered_expect_without_an_order_clause() {
+    let text = format!("{HDR}{SCHEMA}{SEED}{QUERY}--- expect ordered\n{{\"p.name\": \"alice\"}}\n");
+    assert!(refusal("x", &text).contains("order` clause"));
+}
+
+#[test]
+fn refuses_embed_schema() {
+    let schema = "--- schema\nnode Doc {\n    slug: String @key\n    text: String\n    vec: Vector(4) @embed(\"text\")\n}\n";
+    let seed = "--- seed\n";
+    let text = format!("{HDR}{schema}{seed}{QUERY}{EXPECT}")
+        .replace("$p: Person", "$p: Doc")
+        .replace("$p.name", "$p.slug");
+    assert!(refusal("x", &text).contains("@embed"));
+}
+
+#[test]
+fn refuses_nearest_over_a_string_literal() {
+    let query = "--- query\nquery q() {\n    match { $p: Person }\n    return { $p.name }\n    order { nearest($p.name, \"alpha\") }\n}\n";
+    let text = format!("{HDR}{SCHEMA}{SEED}{query}--- expect unordered\n");
+    assert!(refusal("x", &text).contains("string argument"));
+}
+
+#[test]
+fn refuses_nearest_over_a_string_param() {
+    let query = "--- query\nquery q($q: String) {\n    match { $p: Person }\n    return { $p.name }\n    order { nearest($p.name, $q) }\n}\n";
+    let text = format!(
+        "{HDR}{SCHEMA}{SEED}{query}--- params\n{{\"q\": \"alpha\"}}\n--- expect unordered\n"
+    );
+    assert!(refusal("x", &text).contains("string argument"));
+}
+
+#[test]
+fn accepts_empty_expect_body_as_empty_result_assertion() {
+    let text = format!("{HDR}{SCHEMA}{SEED}{QUERY}--- expect unordered\n");
+    parse_case("x", &text).unwrap();
+}
+
+#[test]
+fn search_construct_sets_the_index_decision() {
+    let schema = "--- schema\nnode Doc {\n    slug: String @key\n    text: String @index\n}\n";
+    let query = "--- query\nquery q($q: String) {\n    match {\n        $d: Doc\n        search($d.text, $q)\n    }\n    return { $d.slug }\n}\n";
+    let text = format!(
+        "{HDR}{schema}--- seed\n{query}--- params\n{{\"q\": \"needle\"}}\n--- expect unordered\n"
+    );
+    let case = parse_case("x", &text).unwrap();
+    assert!(case.needs_indices);
+}
+
+#[test]
+fn normalization_equates_integer_and_float_spellings() {
+    let a: Value = serde_json::from_str("{\"total\": 2}").unwrap();
+    let b: Value = serde_json::from_str("{\"total\": 2.0}").unwrap();
+    assert_eq!(canonical_json(&a), canonical_json(&b));
+}
+
+#[test]
+fn normalization_does_not_collapse_large_integers() {
+    let a: Value = serde_json::from_str("{\"n\": 9007199254740993}").unwrap();
+    let b: Value = serde_json::from_str("{\"n\": 9007199254740992}").unwrap();
+    assert_ne!(canonical_json(&a), canonical_json(&b));
+}
+
+#[test]
+fn normalization_ignores_noise_below_scale_12() {
+    let a: Value = serde_json::from_str("{\"x\": 0.1000000000000001}").unwrap();
+    let b: Value = serde_json::from_str("{\"x\": 0.1}").unwrap();
+    assert_eq!(canonical_json(&a), canonical_json(&b));
+}
+
+#[test]
+fn canonical_form_sorts_object_keys_and_recurses() {
+    let a: Value = serde_json::from_str("{\"b\": [{\"z\": 1, \"a\": 2}], \"a\": null}").unwrap();
+    assert_eq!(canonical_json(&a), "{\"a\":null,\"b\":[{\"a\":2,\"z\":1}]}");
+}
+
+#[test]
+fn unordered_comparison_is_multiset_equality() {
+    let rows = |s: &str| -> Vec<Value> {
+        s.lines()
+            .map(|l| serde_json::from_str(l).unwrap())
+            .collect()
+    };
+    let expected = rows("{\"n\": 1}\n{\"n\": 1}\n{\"n\": 2}");
+    let actual = rows("{\"n\": 2}\n{\"n\": 1}\n{\"n\": 1}");
+    compare_rows(&expected, &actual, false).unwrap();
+    let missing_dup = rows("{\"n\": 1}\n{\"n\": 2}");
+    assert!(compare_rows(&expected, &missing_dup, false).is_err());
+}
+
+#[test]
+fn ordered_comparison_is_positional() {
+    let rows = |s: &str| -> Vec<Value> {
+        s.lines()
+            .map(|l| serde_json::from_str(l).unwrap())
+            .collect()
+    };
+    let expected = rows("{\"n\": 1}\n{\"n\": 2}");
+    let swapped = rows("{\"n\": 2}\n{\"n\": 1}");
+    assert!(compare_rows(&expected, &swapped, true).is_err());
+    compare_rows(&expected, &expected.clone(), true).unwrap();
+}
+
+#[tokio::test]
+async fn execution_reports_a_row_mismatch() {
+    let text =
+        format!("{HDR}{SCHEMA}{SEED}{QUERY}--- expect unordered\n{{\"p.name\": \"nobody\"}}\n");
+    let case = parse_case("mismatch", &text).unwrap();
+    let err = execute_case(&case, Path::new("unused.gqt"), false)
+        .await
+        .unwrap_err();
+    assert!(err.contains("row mismatch"), "got: {err}");
+    assert!(err.contains("step 1 (query)"), "got: {err}");
+}
+
+#[tokio::test]
+async fn bless_rewrites_the_failing_expect_and_converges() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("bless_case.gqt");
+    let text =
+        format!("{HDR}{SCHEMA}{SEED}{QUERY}--- expect unordered\n{{\"p.name\": \"nobody\"}}\n");
+    std::fs::write(&path, &text).unwrap();
+    let case = parse_case("bless_case", &text).unwrap();
+    let err = execute_case(&case, &path, true).await.unwrap_err();
+    assert!(err.contains("expect rewritten"), "got: {err}");
+
+    let blessed = std::fs::read_to_string(&path).unwrap();
+    assert!(blessed.contains("{\"p.name\":\"alice\"}"), "got: {blessed}");
+    let case = parse_case("bless_case", &blessed).unwrap();
+    execute_case(&case, &path, false).await.unwrap();
+}
+
+#[test]
+fn refuses_duplicate_issue_header() {
+    let text = format!("{HDR}# issue: none\n{SCHEMA}{SEED}{QUERY}{EXPECT}");
+    assert!(refusal("x", &text).contains("duplicate"));
+}
+
+#[test]
+fn refuses_empty_red_on_value() {
+    let text = format!("# issue: 7\n# red_on:\n{SCHEMA}{SEED}{QUERY}{EXPECT}");
+    assert!(refusal("issue_7_x", &text).contains("needs a value"));
+}
+
+#[test]
+fn refuses_leading_zero_issue_digits() {
+    let text = format!("# issue: 7\n# red_on: 2026-01-01, red.\n{SCHEMA}{SEED}{QUERY}{EXPECT}");
+    assert!(refusal("issue_007_x", &text).contains("leading zeros"));
+}
+
+#[test]
+fn refuses_arguments_on_bare_sections() {
+    let text = format!("{HDR}{SCHEMA}{SEED}{QUERY}{EXPECT}--- restart now\n");
+    assert!(refusal("x", &text).contains("takes no arguments"));
+    let junk_query =
+        "--- query fast\nquery all() {\n    match { $p: Person }\n    return { $p.name }\n}\n";
+    let text = format!("{HDR}{SCHEMA}{SEED}{junk_query}{EXPECT}");
+    assert!(refusal("x", &text).contains("takes no arguments"));
+}
+
+#[test]
+fn refuses_crlf_line_endings() {
+    let text = format!("{HDR}{SCHEMA}{SEED}{QUERY}{EXPECT}").replace('\n', "\r\n");
+    assert!(refusal("x", &text).contains("line endings"));
+}
+
+#[test]
+fn refuses_loop_range_over_the_cap() {
+    let text = format!("{HDR}{SCHEMA}{SEED}--- loop $i 0 10001\n{QUERY}{EXPECT}--- endloop\n");
+    assert!(refusal("x", &text).contains("10000 cap"));
+}
+
+#[test]
+fn refuses_signed_or_padded_numeric_tokens() {
+    let text =
+        format!("{HDR}{SCHEMA}{SEED}{MUTATE}{PARAMS}--- expect affected: nodes=+1 edges=0\n");
+    assert!(refusal("x", &text).contains("nodes=<N> edges=<M>"));
+    let text = format!("{HDR}{SCHEMA}{SEED}--- loop $i 00 2\n{QUERY}{EXPECT}--- endloop\n");
+    assert!(refusal("x", &text).contains("plain decimal"));
+}
+
+#[test]
+fn refuses_ok_expect_with_body() {
+    let text = format!("{HDR}{SCHEMA}{SEED}{MUTATE}{PARAMS}--- expect ok\nstray\n");
+    assert!(refusal("x", &text).contains("carries no body"));
+}
+
+#[test]
+fn refuses_affected_expect_with_body() {
+    let text =
+        format!("{HDR}{SCHEMA}{SEED}{MUTATE}{PARAMS}--- expect affected: nodes=1 edges=0\nstray\n");
+    assert!(refusal("x", &text).contains("carries no body"));
+}
+
+#[test]
+fn refuses_schema_inside_a_loop() {
+    let text = format!("{HDR}{SCHEMA}{SEED}--- foreach $x a\n{SCHEMA}{QUERY}{EXPECT}--- endloop\n");
+    assert!(refusal("x", &text).contains("out of position"));
+}
+
+#[test]
+fn refuses_loop_headers_with_a_body() {
+    let text = format!("{HDR}{SCHEMA}{SEED}--- loop $i 0 2\nstray\n{QUERY}{EXPECT}--- endloop\n");
+    assert!(refusal("x", &text).contains("carries no body"));
+    let text = format!("{HDR}{SCHEMA}{SEED}--- loop $i 0 2\n{QUERY}{EXPECT}--- endloop\nstray\n");
+    assert!(refusal("x", &text).contains("carries no body"));
+}
+
+#[test]
+fn refuses_nearest_over_a_string_property() {
+    let query = "--- query\nquery q() {\n    match { $p: Person }\n    return { $p.name }\n    order { nearest($p.name, $p.name) }\n}\n";
+    let text = format!("{HDR}{SCHEMA}{SEED}{query}--- expect unordered\n");
+    assert!(refusal("x", &text).contains("vector parameter"));
+}
+
+#[test]
+fn traversal_header_forces_index_builds() {
+    let text = format!("{HDR}# traversal: indexed\n{SCHEMA}{SEED}{QUERY}{EXPECT}");
+    let case = parse_case("x", &text).unwrap();
+    assert!(case.needs_indices);
+}
+
+#[test]
+fn walker_flags_foreign_corpus_entries() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("a.gqt"), "x").unwrap();
+    std::fs::write(dir.path().join("b.txt"), "x").unwrap();
+    std::fs::write(dir.path().join(".hidden"), "x").unwrap();
+    std::fs::create_dir(dir.path().join("nested")).unwrap();
+    let (files, foreign) = list_cases(dir.path());
+    assert_eq!(files.len(), 1);
+    assert_eq!(foreign, vec!["b.txt".to_string(), "nested".to_string()]);
+}
+
+#[tokio::test]
+async fn bless_refuses_cases_containing_loops() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("bless_loop_case.gqt");
+    let text = format!(
+        "{HDR}{SCHEMA}{SEED}--- foreach $x a b\n{QUERY}--- expect unordered\n{{\"p.name\": \"nobody\"}}\n--- endloop\n"
+    );
+    std::fs::write(&path, &text).unwrap();
+    let case = parse_case("bless_loop_case", &text).unwrap();
+    let err = execute_case(&case, &path, true).await.unwrap_err();
+    assert!(err.contains("bless: refused"), "got: {err}");
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), text);
+}
+
+#[tokio::test]
+async fn bless_never_rewrites_on_a_kind_mismatch() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("bless_kind_case.gqt");
+    let query = "--- query\nquery q() {\n    match { $p: Person }\n    return { $p.nope }\n}\n";
+    let text = format!("{HDR}{SCHEMA}{SEED}{query}--- expect unordered\n{{\"p.nope\": \"x\"}}\n");
+    std::fs::write(&path, &text).unwrap();
+    let case = parse_case("bless_kind_case", &text).unwrap();
+    let err = execute_case(&case, &path, true).await.unwrap_err();
+    assert!(err.contains("query failed"), "got: {err}");
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), text);
+}
+
+#[tokio::test]
+async fn params_refusal_satisfies_an_error_expect() {
+    let query = "--- query\nquery q($q: String) {\n    match {\n        $p: Person\n        $p.name = $q\n    }\n    return { $p.name }\n}\n";
+    let text = format!("{HDR}{SCHEMA}{SEED}{query}--- expect error: q\n");
+    let case = parse_case("x", &text).unwrap();
+    execute_case(&case, Path::new("unused.gqt"), false)
+        .await
+        .unwrap();
+}
+
+#[test]
+fn bless_splice_preserves_the_trailing_blank_separator() {
+    let original = "--- expect unordered\nold\n\n--- restart\n";
+    let span = BodySpan {
+        start_line: 1,
+        len: 2,
+    };
+    let rows = vec!["{\"n\":1}".to_string()];
+    let out = splice_lines(original, span, &rows);
+    assert_eq!(out, "--- expect unordered\n{\"n\":1}\n\n--- restart\n");
+}
+
+#[test]
+fn bless_splice_replaces_only_the_expect_body() {
+    let original = "--- query\nq\n--- expect unordered\nold row\nold row 2\n--- restart\n";
+    let span = BodySpan {
+        start_line: 3,
+        len: 2,
+    };
+    let rows = vec!["{\"n\":1}".to_string()];
+    let out = splice_lines(original, span, &rows);
+    assert_eq!(
+        out,
+        "--- query\nq\n--- expect unordered\n{\"n\":1}\n--- restart\n"
+    );
+}
+
+#[test]
+fn bless_splice_inserts_into_an_empty_expect_body() {
+    let original = "--- expect unordered\n--- restart\n";
+    let span = BodySpan {
+        start_line: 1,
+        len: 0,
+    };
+    let rows = vec!["{\"n\":1}".to_string()];
+    let out = splice_lines(original, span, &rows);
+    assert_eq!(out, "--- expect unordered\n{\"n\":1}\n--- restart\n");
+}

--- a/crates/omnigraph/tests/gq_logic_tests.rs
+++ b/crates/omnigraph/tests/gq_logic_tests.rs
@@ -25,12 +25,12 @@ use std::panic::AssertUnwindSafe;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use futures::FutureExt as _;
 use omnigraph::db::{Omnigraph, ReadTarget};
-use omnigraph::instrumentation::with_traversal_mode;
+use omnigraph::instrumentation::{QueryIoProbes, with_query_io_probes, with_traversal_mode};
 use omnigraph::loader::{LoadMode, load_jsonl};
 use omnigraph_compiler::query::ast::{Clause, Expr, Literal, Param, QueryDecl};
 use omnigraph_compiler::query::parser::parse_query;
@@ -86,6 +86,9 @@ struct QueryStep {
     ast_params: Vec<Param>,
     params_raw: Option<String>,
     expect: QueryExpect,
+    /// The match clause carries an unbound traversal, so a successful run
+    /// must show at least one Expand on the pinned path.
+    expects_expand: bool,
 }
 
 #[derive(Debug)]
@@ -136,41 +139,66 @@ enum IssueRef {
     Num(u64),
 }
 
+/// The four header keys, in the spelling the canonical form requires.
+const HEADER_KEYS: [&str; 4] = ["issue", "red_on", "notes", "traversal"];
+
+/// The one accepted spelling of a header line. A line is accepted exactly
+/// when it equals this for some key in `HEADER_KEYS` and a value with no
+/// leading or trailing whitespace: no continuation lines exist (a
+/// multi-line note repeats `# notes:`), so a misspelled key has no prose
+/// branch to fall into and is refused with the others.
+fn canonical_header_line(key: &str, value: &str) -> String {
+    format!("# {key}: {value}")
+}
+
+/// Splits a header line into its key and value, or names why it is not
+/// canonical. `# ` and `: ` are matched literally, so the key cannot carry
+/// whitespace; the value is refused when it does at either end. A line that
+/// passes prints back to itself through `canonical_header_line`.
+fn split_header_line(line: &str) -> Result<(&str, &str), String> {
+    let Some(rest) = line.strip_prefix("# ") else {
+        return Err("header line is not `# <key>: <value>`".into());
+    };
+    let Some((key, value)) = rest.split_once(": ") else {
+        return Err("header line is not `# <key>: <value>`".into());
+    };
+    if !HEADER_KEYS.contains(&key) {
+        return Err(format!(
+            "unknown header key `{key}`; keys are {}",
+            HEADER_KEYS.join(", ")
+        ));
+    }
+    if value.trim().is_empty() {
+        return Err(format!("`# {key}:` needs a value"));
+    }
+    if value.trim() != value {
+        return Err(format!(
+            "header value carries leading or trailing whitespace; write `{}`",
+            canonical_header_line(key, value.trim())
+        ));
+    }
+    debug_assert_eq!(canonical_header_line(key, value), line);
+    Ok((key, value))
+}
+
 fn parse_header(lines: &[&str]) -> Result<Header, String> {
     let mut issue: Option<IssueRef> = None;
     let mut red_on = false;
-    let mut notes_seen = false;
     let mut traversal: Option<&'static str> = None;
-    let mut have_key = false;
     for (idx, line) in lines.iter().enumerate() {
         if line.trim().is_empty() {
             continue;
         }
-        let Some(rest) = line.strip_prefix('#') else {
+        if !line.starts_with('#') {
             return Err(format!(
                 "line {}: only `#` header lines may precede the first section",
                 idx + 1
             ));
-        };
-        let content = rest.trim_start();
-        let key = content
-            .split_once(':')
-            .map(|(k, _)| k)
-            .filter(|k| !k.is_empty() && k.chars().all(|c| c.is_ascii_lowercase() || c == '_'));
-        let Some(key) = key else {
-            if !have_key {
-                return Err(format!(
-                    "line {}: the first header line must start a key (`# issue:`, `# red_on:`, `# notes:`, `# traversal:`)",
-                    idx + 1
-                ));
-            }
-            continue;
-        };
-        let value = content[key.len() + 1..].trim();
+        }
+        let (key, value) = split_header_line(line).map_err(|e| format!("line {}: {e}", idx + 1))?;
         let duplicate = match key {
             "issue" => issue.is_some(),
             "red_on" => red_on,
-            "notes" => notes_seen,
             "traversal" => traversal.is_some(),
             _ => false,
         };
@@ -194,13 +222,8 @@ fn parse_header(lines: &[&str]) -> Result<Header, String> {
                     IssueRef::Num(n)
                 });
             }
-            "red_on" => {
-                if value.is_empty() {
-                    return Err(format!("line {}: `# red_on:` needs a value", idx + 1));
-                }
-                red_on = true;
-            }
-            "notes" => notes_seen = true,
+            "red_on" => red_on = true,
+            "notes" => {}
             "traversal" => {
                 traversal = Some(match value {
                     "indexed" => "indexed",
@@ -213,9 +236,8 @@ fn parse_header(lines: &[&str]) -> Result<Header, String> {
                     }
                 });
             }
-            other => return Err(format!("line {}: unknown header key `# {other}:`", idx + 1)),
+            other => unreachable!("split_header_line admits only HEADER_KEYS, got `{other}`"),
         }
-        have_key = true;
     }
     let Some(issue) = issue else {
         return Err("missing required `# issue:` header".into());
@@ -658,6 +680,7 @@ struct PendingStep {
     name: String,
     ast_params: Vec<Param>,
     ordered_refusal: Option<String>,
+    expects_expand: bool,
     params_raw: Option<String>,
 }
 
@@ -775,6 +798,7 @@ fn parse_case(stem: &str, text: &str) -> Result<Case, String> {
                     name: decl.name.clone(),
                     ast_params: decl.params.clone(),
                     ordered_refusal: ordered_refusal(decl),
+                    expects_expand: expects_expand(&decl.match_clause),
                     params_raw: None,
                 });
             }
@@ -847,6 +871,7 @@ fn parse_case(stem: &str, text: &str) -> Result<Case, String> {
                             name: step.name,
                             ast_params: step.ast_params,
                             params_raw: step.params_raw,
+                            expects_expand: step.expects_expand,
                             expect: QueryExpect::Rows {
                                 ordered,
                                 body_raw: body,
@@ -877,6 +902,7 @@ fn parse_case(stem: &str, text: &str) -> Result<Case, String> {
                                 name: step.name,
                                 ast_params: step.ast_params,
                                 params_raw: step.params_raw,
+                                expects_expand: step.expects_expand,
                                 expect: QueryExpect::Error {
                                     needle: needle.clone(),
                                 },
@@ -1151,13 +1177,93 @@ fn build_params(
         .map_err(|e| format!("params rejected: {e}"))
 }
 
-/// Runs `fut` under the case's `# traversal:` pin, or unscoped on the
-/// production path when the case pins nothing.
-async fn under_traversal<F: Future>(mode: Option<&'static str>, fut: F) -> F::Output {
+/// Expand executions observed while a pinned step ran, by path.
+struct PathCounts {
+    indexed: Arc<AtomicU64>,
+    csr: Arc<AtomicU64>,
+}
+
+/// Runs `fut` under the case's `# traversal:` pin with expand-path probes
+/// attached, or unscoped on the production path when the case pins
+/// nothing. A pinned step gets its observed path counts back so the caller
+/// can check the pin took effect: the pin is a task-local override, and a
+/// step whose rows match its expect proves nothing about which path ran.
+async fn under_traversal<F: Future>(
+    mode: Option<&'static str>,
+    fut: F,
+) -> (F::Output, Option<PathCounts>) {
     match mode {
-        Some(mode) => with_traversal_mode(mode, fut).await,
-        None => fut.await,
+        Some(mode) => {
+            let counts = PathCounts {
+                indexed: Arc::new(AtomicU64::new(0)),
+                csr: Arc::new(AtomicU64::new(0)),
+            };
+            let probes = QueryIoProbes {
+                expand_indexed_runs: Arc::clone(&counts.indexed),
+                expand_csr_runs: Arc::clone(&counts.csr),
+                ..Default::default()
+            };
+            let out = with_traversal_mode(mode, with_query_io_probes(probes, fut)).await;
+            (out, Some(counts))
+        }
+        None => (fut.await, None),
     }
+}
+
+/// Why a pinned step's observed expand paths violate its pin, if they do.
+/// Any expand on the other path means the pinned mode was not honored. When
+/// the step is known to expand (`require_expand`: its match clause carries
+/// an unbound traversal and the query succeeded), zero expands on the pinned
+/// path is a violation too: the pin and the probes are both task-locals, so
+/// a boundary that drops the pin drops the probes with it and would
+/// otherwise read as a clean 0/0.
+fn pin_violation(mode: &str, indexed: u64, csr: u64, require_expand: bool) -> Option<String> {
+    let (other, ran, pinned) = match mode {
+        "indexed" => ("csr", csr, indexed),
+        "csr" => ("indexed", indexed, csr),
+        _ => return None,
+    };
+    if ran > 0 {
+        return Some(format!(
+            "pinned `{mode}`, ran `{other}` on {ran} expand(s); the pinned mode was not honored"
+        ));
+    }
+    if require_expand && pinned == 0 {
+        return Some(format!(
+            "pinned `{mode}`, but no expand ran on it; the pin was lost before the \
+             executor or the traversal did not execute"
+        ));
+    }
+    None
+}
+
+/// The pin check for one finished step: `None` when the step was unpinned
+/// or ran only, and at least once when required, on its pinned path.
+fn check_pin(
+    mode: Option<&'static str>,
+    counts: &Option<PathCounts>,
+    require_expand: bool,
+) -> Option<String> {
+    let (mode, counts) = mode.zip(counts.as_ref())?;
+    pin_violation(
+        mode,
+        counts.indexed.load(Ordering::Relaxed),
+        counts.csr.load(Ordering::Relaxed),
+        require_expand,
+    )
+}
+
+/// Whether a match clause list runs at least one Expand: a traversal
+/// without an edge binding, outside `not { }`. A bound edge scans the edge
+/// dataset on a path of its own that no mode pins, and a single-hop
+/// negation runs as a CSR existence check that never reaches the expand
+/// dispatch; a multi-hop negation does expand, and the other-path check
+/// still covers it.
+fn expects_expand(clauses: &[Clause]) -> bool {
+    clauses.iter().any(|c| match c {
+        Clause::Traversal(t) => t.edge_binding.is_none(),
+        Clause::Negation(_) | Clause::Binding(_) | Clause::Filter(_) => false,
+    })
 }
 
 async fn run_query_step(
@@ -1186,7 +1292,7 @@ async fn run_query_step(
             };
         }
     };
-    let outcome = under_traversal(
+    let (outcome, counts) = under_traversal(
         mode,
         db.query(
             ReadTarget::branch("main"),
@@ -1196,6 +1302,11 @@ async fn run_query_step(
         ),
     )
     .await;
+    let require_expand =
+        step.expects_expand && outcome.is_ok() && matches!(step.expect, QueryExpect::Rows { .. });
+    if let Some(violation) = check_pin(mode, &counts, require_expand) {
+        return Err(fail(violation));
+    }
     match &step.expect {
         QueryExpect::Rows {
             ordered,
@@ -1253,7 +1364,11 @@ async fn run_mutate_step(
             };
         }
     };
-    let outcome = under_traversal(mode, db.mutate("main", &step.source, &step.name, &params)).await;
+    let (outcome, counts) =
+        under_traversal(mode, db.mutate("main", &step.source, &step.name, &params)).await;
+    if let Some(violation) = check_pin(mode, &counts, false) {
+        return Err(fail(violation));
+    }
     match &step.expect {
         MutateExpect::Ok => outcome
             .map(|_| ())
@@ -1285,14 +1400,17 @@ async fn run_mutate_step(
     }
 }
 
-async fn execute_case(case: &Case, path: &Path, bless: bool) -> Result<(), String> {
+/// A fresh store for one case: init from the schema, seed, and build indices
+/// when the case needs them. The tempdir rides along so the store outlives
+/// the call.
+async fn open_case_store(case: &Case) -> Result<(Omnigraph, String, tempfile::TempDir), String> {
     let dir = tempfile::tempdir().map_err(|e| format!("tempdir failed: {e}"))?;
     let uri = dir
         .path()
         .to_str()
         .ok_or_else(|| "temp path is not utf-8".to_string())?
         .to_string();
-    let mut db = Omnigraph::init(&uri, &case.schema)
+    let db = Omnigraph::init(&uri, &case.schema)
         .await
         .map_err(|e| format!("init failed: {e}"))?;
     if !case.seed.trim().is_empty() {
@@ -1305,6 +1423,11 @@ async fn execute_case(case: &Case, path: &Path, bless: bool) -> Result<(), Strin
             .await
             .map_err(|e| format!("ensure_indices failed: {e}"))?;
     }
+    Ok((db, uri, dir))
+}
+
+async fn execute_case(case: &Case, path: &Path, bless: bool) -> Result<(), String> {
+    let (mut db, uri, _dir) = open_case_store(case).await?;
 
     let mut first_fail: Option<StepFail> = None;
     'run: for item in &case.items {
@@ -1403,9 +1526,14 @@ fn corpus_root() -> PathBuf {
         .join("gq_logic_tests")
 }
 
-/// Splits the corpus dir into `.gqt` case files and foreign entries (anything
-/// else except dotfiles); a foreign entry is a mis-renamed or nested case that
-/// would otherwise silently never run.
+/// Splits the corpus dir into `.gqt` case files and foreign entries; a
+/// foreign entry is a mis-renamed, nested, or dot-prefixed case that would
+/// otherwise silently never run. A case is a top-level file whose name ends
+/// in `.gqt` and does not start with `.`; `scripts/check-fix-regression.py`
+/// (`corpus_case`) applies the same rule, and both self-tests walk one name
+/// battery. Dot-prefixed entries without a `.gqt` extension (`.DS_Store`,
+/// `.gitkeep`, and a file named exactly `.gqt`, which has no extension)
+/// are neither cases nor foreign: they are skipped.
 fn list_cases(root: &Path) -> (Vec<PathBuf>, Vec<String>) {
     let mut files = Vec::new();
     let mut foreign = Vec::new();
@@ -1413,10 +1541,11 @@ fn list_cases(root: &Path) -> (Vec<PathBuf>, Vec<String>) {
         for entry in entries.flatten() {
             let path = entry.path();
             let name = entry.file_name().to_string_lossy().to_string();
-            if name.starts_with('.') {
+            let is_gqt = path.is_file() && path.extension().and_then(|s| s.to_str()) == Some("gqt");
+            if name.starts_with('.') && !is_gqt {
                 continue;
             }
-            if path.is_file() && path.extension().and_then(|s| s.to_str()) == Some("gqt") {
+            if is_gqt && !name.starts_with('.') {
                 files.push(path);
             } else {
                 foreign.push(name);
@@ -1544,7 +1673,7 @@ async fn gq_logic_tests() {
     let (mut files, foreign) = list_cases(&root);
     assert!(
         foreign.is_empty(),
-        "non-.gqt entries under {}: {}; a mis-renamed or nested case must never silently skip",
+        "foreign entries under {}: {}; a mis-renamed, nested, or dot-prefixed case must never silently skip",
         root.display(),
         foreign.join(", ")
     );
@@ -1658,11 +1787,78 @@ fn parses_a_minimal_case() {
 }
 
 #[test]
-fn header_continuation_lines_extend_the_previous_key() {
+fn header_notes_repeat_and_continuation_lines_are_refused() {
+    let text = format!(
+        "# issue: 7\n# red_on: 2026-01-01, the run\n# notes: returned 8,\n# notes: not 20.\n{SCHEMA}{SEED}{QUERY}{EXPECT}"
+    );
+    parse_case("issue_7_notes", &text).unwrap();
     let text = format!(
         "# issue: 7\n# red_on: 2026-01-01, the run\n#   returned 8: not 20.\n{SCHEMA}{SEED}{QUERY}{EXPECT}"
     );
-    parse_case("issue_7_continued", &text).unwrap();
+    assert!(refusal("issue_7_x", &text).contains("unknown header key"));
+    // The three misspellings that the old prose branch swallowed silently.
+    for typo in [
+        "# Traversal: indexed",
+        "# traversal : indexed",
+        "# traversal=csr",
+    ] {
+        let text = format!("{HDR}{typo}\n{SCHEMA}{SEED}{QUERY}{EXPECT}");
+        let reason = refusal("x", &text);
+        assert!(
+            reason.contains("unknown header key") || reason.contains("not `# <key>: <value>`"),
+            "{typo}: {reason}"
+        );
+    }
+}
+
+/// Bounded exhaustive walk of the header-line typo space: key spelling,
+/// separator, leading and trailing whitespace, and the gap before the value.
+/// A line is accepted exactly when it equals the canonical
+/// `# traversal: indexed`, so a future key inherits the same proof.
+#[test]
+fn header_lines_are_accepted_only_in_canonical_form() {
+    let keys = [
+        "traversal",
+        "Traversal",
+        "TRAVERSAL",
+        "traversa1",
+        "traversal_",
+        " traversal",
+    ];
+    let seps = [":", " :", "=", "", "::"];
+    let leads = ["# ", "#", "#  ", " # "];
+    let gaps = [" ", "", "  ", "\t"];
+    let trails = ["", " ", "\t"];
+    let canonical = canonical_header_line("traversal", "indexed");
+    // Distinct lines: two lead/key pairs collide (`#` + ` traversal` = `# ` +
+    // `traversal`, and `# ` + ` traversal` = `#  ` + `traversal`), 120
+    // duplicates over the 1440 grid points, so the set is what gets walked.
+    let mut lines = std::collections::BTreeSet::new();
+    for lead in leads {
+        for key in keys {
+            for sep in seps {
+                for gap in gaps {
+                    for trail in trails {
+                        lines.insert(format!("{lead}{key}{sep}{gap}indexed{trail}"));
+                    }
+                }
+            }
+        }
+    }
+    assert_eq!(lines.len(), 1320, "the typo space is 1320 distinct lines");
+    let mut accepted = 0;
+    for line in &lines {
+        let text = format!("{HDR}{line}\n{SCHEMA}{SEED}{QUERY}{EXPECT}");
+        match parse_case("x", &text) {
+            Ok(case) => {
+                assert_eq!(line, &canonical, "accepted a non-canonical line");
+                assert_eq!(case.traversal, Some("indexed"));
+                accepted += 1;
+            }
+            Err(e) => assert_ne!(line, &canonical, "refused the canonical line: {e}"),
+        }
+    }
+    assert_eq!(accepted, 1);
 }
 
 #[test]
@@ -1678,9 +1874,9 @@ fn refuses_numbered_issue_without_red_on() {
 }
 
 #[test]
-fn refuses_first_header_line_without_a_key() {
-    let text = format!("# stray continuation\n{HDR}{SCHEMA}{SEED}{QUERY}{EXPECT}");
-    assert!(refusal("x", &text).contains("first header line"));
+fn refuses_header_line_without_a_key() {
+    let text = format!("# stray prose\n{HDR}{SCHEMA}{SEED}{QUERY}{EXPECT}");
+    assert!(refusal("x", &text).contains("not `# <key>: <value>`"));
 }
 
 #[test]
@@ -2104,8 +2300,10 @@ fn refuses_duplicate_issue_header() {
 
 #[test]
 fn refuses_empty_red_on_value() {
-    let text = format!("# issue: 7\n# red_on:\n{SCHEMA}{SEED}{QUERY}{EXPECT}");
+    let text = format!("# issue: 7\n# red_on: \n{SCHEMA}{SEED}{QUERY}{EXPECT}");
     assert!(refusal("issue_7_x", &text).contains("needs a value"));
+    let text = format!("# issue: 7\n# red_on:\n{SCHEMA}{SEED}{QUERY}{EXPECT}");
+    assert!(refusal("issue_7_x", &text).contains("not `# <key>: <value>`"));
 }
 
 #[test]
@@ -2193,6 +2391,105 @@ fn traversal_header_forces_index_builds() {
     let case = parse_case("x", &text).unwrap();
     assert!(case.needs_indices);
     assert_eq!(case.traversal, Some("indexed"));
+}
+
+#[test]
+fn pin_violation_names_the_path_that_ran() {
+    assert_eq!(pin_violation("indexed", 3, 0, true), None);
+    assert_eq!(pin_violation("csr", 0, 2, true), None);
+    assert_eq!(pin_violation("indexed", 0, 0, false), None);
+    let v = pin_violation("indexed", 1, 2, false).unwrap();
+    assert!(
+        v.contains("pinned `indexed`, ran `csr` on 2 expand(s)"),
+        "{v}"
+    );
+    let v = pin_violation("csr", 4, 0, false).unwrap();
+    assert!(
+        v.contains("pinned `csr`, ran `indexed` on 4 expand(s)"),
+        "{v}"
+    );
+    // A step that must expand and shows nothing on the pinned path: the
+    // pin and the probes were dropped together.
+    let v = pin_violation("indexed", 0, 0, true).unwrap();
+    assert!(v.contains("no expand ran on it"), "{v}");
+    let v = pin_violation("csr", 0, 0, true).unwrap();
+    assert!(v.contains("no expand ran on it"), "{v}");
+}
+
+#[test]
+fn expects_expand_ignores_bound_edges_and_plain_bindings() {
+    let unbound = parse_query(TRAVERSAL_QUERY.trim_start_matches("--- query\n")).unwrap();
+    assert!(expects_expand(&unbound.queries[0].match_clause));
+    let bound = "query f($n: String) {\n    match {\n        $a: Person\n        $a.name = $n\n        \
+                 $a $k:knows $b\n    }\n    return { $b.name }\n}\n";
+    let bound = parse_query(bound).unwrap();
+    assert!(!expects_expand(&bound.queries[0].match_clause));
+    let plain = parse_query(QUERY.trim_start_matches("--- query\n")).unwrap();
+    assert!(!expects_expand(&plain.queries[0].match_clause));
+    let negated = "query f() {\n    match {\n        $a: Person\n        not { $a knows $x }\n    }\n    \
+                   return { $a.name }\n}\n";
+    let negated = parse_query(negated).unwrap();
+    assert!(!expects_expand(&negated.queries[0].match_clause));
+}
+
+/// A two-node, one-edge graph with a one-hop traversal, for the pin tests.
+const TRAVERSAL_SCHEMA: &str = "--- schema\nnode Person {\n    name: String @key\n}\n\n\
+                                edge Knows: Person -> Person {\n    since: I64\n}\n";
+const TRAVERSAL_SEED: &str = "--- seed\n{\"type\":\"Person\",\"data\":{\"name\":\"alice\"}}\n\
+                              {\"type\":\"Person\",\"data\":{\"name\":\"bob\"}}\n\
+                              {\"edge\":\"Knows\",\"from\":\"alice\",\"to\":\"bob\",\"data\":{\"id\":\"k-1\",\"since\":2020}}\n";
+const TRAVERSAL_QUERY: &str = "--- query\nquery friends($n: String) {\n    match {\n        $a: Person\n        \
+                               $a.name = $n\n        $a knows $b\n    }\n    return { $b.name }\n}\n";
+const TRAVERSAL_PARAMS: &str = "--- params\n{\"n\": \"alice\"}\n";
+const TRAVERSAL_EXPECT: &str = "--- expect unordered\n{\"b.name\": \"bob\"}\n";
+
+/// The pin reaches the executor on both paths: a pinned step runs its
+/// expands on the pinned path only, and the probes see them (a zero count
+/// on both paths would make the check vacuous).
+#[tokio::test]
+async fn pinned_step_runs_only_its_pinned_path() {
+    for (mode, expect_indexed) in [("indexed", true), ("csr", false)] {
+        let text = format!(
+            "{HDR}# traversal: {mode}\n{TRAVERSAL_SCHEMA}{TRAVERSAL_SEED}{TRAVERSAL_QUERY}{TRAVERSAL_PARAMS}{TRAVERSAL_EXPECT}"
+        );
+        let case = parse_case("pinned", &text).unwrap();
+        execute_case(&case, Path::new("unused.gqt"), false)
+            .await
+            .unwrap_or_else(|e| panic!("{mode}: {e}"));
+
+        let (db, _uri, _dir) = open_case_store(&case).await.unwrap();
+        let Some(Item::Step(Step::Query(step))) = case.items.first() else {
+            panic!("first item is the query step");
+        };
+        let params = build_params(step.params_raw.as_ref(), &step.ast_params, None).unwrap();
+        let (outcome, counts) = under_traversal(
+            Some(mode),
+            db.query(
+                ReadTarget::branch("main"),
+                &step.source,
+                &step.name,
+                &params,
+            ),
+        )
+        .await;
+        outcome.unwrap();
+        let counts = counts.unwrap();
+        let (indexed, csr) = (
+            counts.indexed.load(Ordering::Relaxed),
+            counts.csr.load(Ordering::Relaxed),
+        );
+        if expect_indexed {
+            assert!(
+                indexed >= 1 && csr == 0,
+                "{mode}: indexed={indexed} csr={csr}"
+            );
+        } else {
+            assert!(
+                csr >= 1 && indexed == 0,
+                "{mode}: indexed={indexed} csr={csr}"
+            );
+        }
+    }
 }
 
 #[test]
@@ -2369,16 +2666,29 @@ fn walker_refuses_a_process_traversal_override() {
     assert!(reason.contains("# traversal:"), "{reason}");
 }
 
+/// Same name battery as `scripts/check-fix-regression.py --self-test`
+/// (`corpus_case`): the walker and the gate must agree on what a case is.
 #[test]
 fn walker_flags_foreign_corpus_entries() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(dir.path().join("a.gqt"), "x").unwrap();
     std::fs::write(dir.path().join("b.txt"), "x").unwrap();
-    std::fs::write(dir.path().join(".hidden"), "x").unwrap();
+    std::fs::write(dir.path().join(".hidden.gqt"), "x").unwrap();
+    std::fs::write(dir.path().join(".DS_Store"), "x").unwrap();
+    std::fs::write(dir.path().join("c.GQT"), "x").unwrap();
     std::fs::create_dir(dir.path().join("nested")).unwrap();
+    std::fs::write(dir.path().join("nested").join("d.gqt"), "x").unwrap();
     let (files, foreign) = list_cases(dir.path());
-    assert_eq!(files.len(), 1);
-    assert_eq!(foreign, vec!["b.txt".to_string(), "nested".to_string()]);
+    assert_eq!(files, vec![dir.path().join("a.gqt")]);
+    assert_eq!(
+        foreign,
+        vec![
+            ".hidden.gqt".to_string(),
+            "b.txt".to_string(),
+            "c.GQT".to_string(),
+            "nested".to_string()
+        ]
+    );
 }
 
 #[tokio::test]

--- a/crates/omnigraph/tests/gq_logic_tests.rs
+++ b/crates/omnigraph/tests/gq_logic_tests.rs
@@ -4,14 +4,25 @@
 //! workflow are specified in `docs/rfcs/0045-gq-logic-tests.md`.
 //!
 //! To libtest the whole walker is one test; case concurrency comes from a
-//! `JoinSet`. `OMNIGRAPH_GQ_LOGIC_TESTS=<substr>[,<substr>]` restricts the run
-//! to matching case files; `OMNIGRAPH_GQ_BLESS=1` rewrites the failing step's
+//! `JoinSet` bounded by a semaphore (`OMNIGRAPH_GQ_JOBS=<n>` overrides the
+//! default of the machine's available parallelism), and every case runs under
+//! a per-case budget (`OMNIGRAPH_GQ_CASE_TIMEOUT_SECS=<n>`, default 10).
+//! `OMNIGRAPH_GQ_LOGIC_TESTS=<substr>[,<substr>]` restricts the run to
+//! matching case files; `OMNIGRAPH_GQ_BLESS=1` rewrites the failing step's
 //! `--- expect` rows in place.
 
 use std::collections::HashSet;
+use std::ffi::OsStr;
 use std::fmt::Write as _;
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
 
+use futures::FutureExt as _;
 use omnigraph::db::{Omnigraph, ReadTarget};
 use omnigraph::instrumentation::with_traversal_mode;
 use omnigraph::loader::{LoadMode, load_jsonl};
@@ -21,13 +32,19 @@ use omnigraph_compiler::schema::ast::{Annotation, PropDecl, SchemaDecl};
 use omnigraph_compiler::schema::parser::parse_schema;
 use omnigraph_compiler::{JsonParamMode, json_params_to_param_map};
 use serde_json::Value;
+use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
+
+const CASE_TIMEOUT_ENV: &str = "OMNIGRAPH_GQ_CASE_TIMEOUT_SECS";
+const DEFAULT_CASE_TIMEOUT_SECS: u64 = 10;
+const JOBS_ENV: &str = "OMNIGRAPH_GQ_JOBS";
 
 #[derive(Debug)]
 struct Case {
     schema: String,
     seed: String,
-    traversal: &'static str,
+    /// The `# traversal:` pin; `None` runs the production path unscoped.
+    traversal: Option<&'static str>,
     items: Vec<Item>,
     needs_indices: bool,
 }
@@ -553,6 +570,43 @@ fn walk_clauses(
     Ok(())
 }
 
+/// Why `expect ordered` is refused for this declaration, if it is. The
+/// engine's order is total only where `apply_ordering` appends the `<var>.id`
+/// tie-breaks (RFC 0045, Comparison semantics): no `order` clause, an
+/// `rrf()`-led one (fusion sorts by score alone), or an aggregate in the
+/// `return` list (group rows carry no `<var>.id`) each fail that condition.
+/// The tie-break is stable within a run only (ids are minted per load), so
+/// a case's `order` keys must be total over its rows: an authoring rule the
+/// parser cannot check.
+fn ordered_refusal(decl: &QueryDecl) -> Option<String> {
+    if decl.order_clause.is_empty() {
+        return Some("`expect ordered` is refused for a query without an `order` clause".into());
+    }
+    if matches!(
+        decl.order_clause.first().map(|o| &o.expr),
+        Some(Expr::Rrf { .. })
+    ) {
+        return Some(
+            "`expect ordered` is refused for an `order` clause led by `rrf()`; fusion sorts by \
+             score alone, with no tie-break"
+                .into(),
+        );
+    }
+    if decl
+        .return_clause
+        .iter()
+        .any(|p| matches!(p.expr, Expr::Aggregate { .. }))
+    {
+        return Some(
+            "`expect ordered` is refused for a query with an aggregate in its `return` list; \
+             group rows carry no `<var>.id` tie-break, and a search-led aggregate query is \
+             not ordered at all"
+                .into(),
+        );
+    }
+    None
+}
+
 fn inspect_decl(decl: &QueryDecl, needs_indices: &mut bool) -> Result<(), String> {
     walk_clauses(&decl.match_clause, &decl.params, needs_indices)?;
     for projection in &decl.return_clause {
@@ -597,7 +651,7 @@ struct PendingStep {
     source: String,
     name: String,
     ast_params: Vec<Param>,
-    has_order_clause: bool,
+    ordered_refusal: Option<String>,
     params_raw: Option<String>,
 }
 
@@ -714,7 +768,7 @@ fn parse_case(stem: &str, text: &str) -> Result<Case, String> {
                     source: source.clone(),
                     name: decl.name.clone(),
                     ast_params: decl.params.clone(),
-                    has_order_clause: !decl.order_clause.is_empty(),
+                    ordered_refusal: ordered_refusal(decl),
                     params_raw: None,
                 });
             }
@@ -764,11 +818,10 @@ fn parse_case(stem: &str, text: &str) -> Result<Case, String> {
                     }
                     (ExpectHeader::Unordered | ExpectHeader::Ordered, false) => {
                         let ordered = matches!(mode, ExpectHeader::Ordered);
-                        if ordered && !step.has_order_clause {
-                            return Err(
-                                "`expect ordered` is refused for a query without an `order` clause"
-                                    .into(),
-                            );
+                        if ordered {
+                            if let Some(reason) = step.ordered_refusal {
+                                return Err(reason);
+                            }
                         }
                         refuse_comment_lines(&section.body, "expect")?;
                         let body: String = section
@@ -928,7 +981,7 @@ fn parse_case(stem: &str, text: &str) -> Result<Case, String> {
     Ok(Case {
         schema,
         seed,
-        traversal: header.traversal.unwrap_or("indexed"),
+        traversal: header.traversal,
         items,
         needs_indices,
     })
@@ -1092,9 +1145,18 @@ fn build_params(
         .map_err(|e| format!("params rejected: {e}"))
 }
 
+/// Runs `fut` under the case's `# traversal:` pin, or unscoped on the
+/// production path when the case pins nothing.
+async fn under_traversal<F: Future>(mode: Option<&'static str>, fut: F) -> F::Output {
+    match mode {
+        Some(mode) => with_traversal_mode(mode, fut).await,
+        None => fut.await,
+    }
+}
+
 async fn run_query_step(
     db: &Omnigraph,
-    mode: &'static str,
+    mode: Option<&'static str>,
     step: &QueryStep,
     binding: Option<(&str, &str)>,
 ) -> Result<(), StepFail> {
@@ -1118,7 +1180,7 @@ async fn run_query_step(
             };
         }
     };
-    let outcome = with_traversal_mode(
+    let outcome = under_traversal(
         mode,
         db.query(
             ReadTarget::branch("main"),
@@ -1163,7 +1225,7 @@ async fn run_query_step(
 
 async fn run_mutate_step(
     db: &Omnigraph,
-    mode: &'static str,
+    mode: Option<&'static str>,
     step: &MutateStep,
     binding: Option<(&str, &str)>,
 ) -> Result<(), StepFail> {
@@ -1185,8 +1247,7 @@ async fn run_mutate_step(
             };
         }
     };
-    let outcome =
-        with_traversal_mode(mode, db.mutate("main", &step.source, &step.name, &params)).await;
+    let outcome = under_traversal(mode, db.mutate("main", &step.source, &step.name, &params)).await;
     match &step.expect {
         MutateExpect::Ok => outcome
             .map(|_| ())
@@ -1361,6 +1422,116 @@ fn list_cases(root: &Path) -> (Vec<PathBuf>, Vec<String>) {
     (files, foreign)
 }
 
+fn stem_of(path: &Path) -> String {
+    path.file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("<non-utf8>")
+        .to_string()
+}
+
+/// A positive-integer environment override; unset or empty means none.
+fn env_positive(name: &str) -> Option<u64> {
+    let value = std::env::var(name).ok()?;
+    if value.trim().is_empty() {
+        return None;
+    }
+    match value.trim().parse::<u64>() {
+        Ok(n) if n > 0 => Some(n),
+        _ => panic!("{name} takes a positive integer, got `{value}`"),
+    }
+}
+
+/// The production traversal path consults `OMNIGRAPH_TRAVERSAL_MODE`, so a set
+/// variable would silently decide which path an unpinned case exercises.
+fn traversal_override_refusal(value: Option<&OsStr>) -> Option<String> {
+    value.map(|v| {
+        format!(
+            "OMNIGRAPH_TRAVERSAL_MODE={} is set; logic tests run the production traversal \
+             path, unset it (a case that must run one path pins it with `# traversal:`)",
+            v.to_string_lossy()
+        )
+    })
+}
+
+fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "non-string panic payload".to_string()
+    }
+}
+
+type CaseFuture = Pin<Box<dyn Future<Output = Result<(), String>> + Send>>;
+type CaseRunner = Arc<dyn Fn(PathBuf) -> CaseFuture + Send + Sync>;
+
+#[derive(Debug)]
+struct CaseOutcome {
+    stem: String,
+    elapsed: Duration,
+    result: Result<(), String>,
+}
+
+/// Runs every case as its own task with at most `permits` in flight (each
+/// case holds a store and may build indexes) and `budget` of wall time per
+/// case, timed from the moment it holds a permit; a case over budget is
+/// dropped, store included, before its permit is released. A panic or a
+/// timeout is an ordinary failed case, so the whole corpus always runs.
+/// `report` sees each outcome as it completes; the returned list is sorted
+/// by case name.
+async fn run_bounded(
+    cases: Vec<(String, PathBuf)>,
+    permits: usize,
+    budget: Duration,
+    run: CaseRunner,
+    report: &(dyn Fn(&CaseOutcome) + Sync),
+) -> Vec<CaseOutcome> {
+    let semaphore = Arc::new(Semaphore::new(permits));
+    let mut set: JoinSet<CaseOutcome> = JoinSet::new();
+    for (stem, path) in cases {
+        let semaphore = Arc::clone(&semaphore);
+        let run = Arc::clone(&run);
+        set.spawn(async move {
+            let _permit = semaphore
+                .acquire_owned()
+                .await
+                .expect("the case semaphore is never closed");
+            let started = Instant::now();
+            let case = AssertUnwindSafe(run(path)).catch_unwind();
+            let result = match tokio::time::timeout(budget, case).await {
+                Ok(Ok(result)) => result,
+                Ok(Err(payload)) => Err(format!(
+                    "case panicked: {}",
+                    panic_message(payload.as_ref())
+                )),
+                Err(_) => Err(format!(
+                    "case exceeded its budget of {:.2}s while up to {permits} cases ran \
+                     concurrently ({CASE_TIMEOUT_ENV} overrides the default of \
+                     {DEFAULT_CASE_TIMEOUT_SECS}s, {JOBS_ENV} the concurrency; a case over \
+                     budget belongs in a `heavy-repro:` `#[ignore]`d test, not the corpus)",
+                    budget.as_secs_f64()
+                )),
+            };
+            CaseOutcome {
+                stem,
+                elapsed: started.elapsed(),
+                result,
+            }
+        });
+    }
+    let mut outcomes = Vec::new();
+    while let Some(joined) = set.join_next().await {
+        // The case itself is caught by `catch_unwind`; the task around it
+        // holds nothing that can panic.
+        let outcome = joined.expect("a case task never panics");
+        report(&outcome);
+        outcomes.push(outcome);
+    }
+    outcomes.sort_by(|a, b| a.stem.cmp(&b.stem));
+    outcomes
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn gq_logic_tests() {
     let root = corpus_root();
@@ -1402,42 +1573,47 @@ async fn gq_logic_tests() {
         Ok(v) => panic!("OMNIGRAPH_GQ_BLESS takes 1 (or 0/unset), got `{v}`"),
     };
 
-    let total = files.len();
-    let mut names: std::collections::HashMap<tokio::task::Id, String> =
-        std::collections::HashMap::new();
-    let mut set: JoinSet<(String, Result<(), String>)> = JoinSet::new();
-    for path in files {
-        let stem = path
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("<non-utf8>")
-            .to_string();
-        let task_stem = stem.clone();
-        let handle = set.spawn(async move {
-            let result = run_case(path, bless).await;
-            (task_stem, result)
+    if let Some(reason) =
+        traversal_override_refusal(std::env::var_os("OMNIGRAPH_TRAVERSAL_MODE").as_deref())
+    {
+        panic!("{reason}");
+    }
+    let permits = env_positive(JOBS_ENV)
+        .map(|n| {
+            usize::try_from(n)
+                .unwrap_or(usize::MAX)
+                .min(Semaphore::MAX_PERMITS)
+        })
+        .unwrap_or_else(|| {
+            std::thread::available_parallelism()
+                .map(std::num::NonZeroUsize::get)
+                .unwrap_or(1)
         });
-        names.insert(handle.id(), stem);
-    }
+    let budget =
+        Duration::from_secs(env_positive(CASE_TIMEOUT_ENV).unwrap_or(DEFAULT_CASE_TIMEOUT_SECS));
 
-    let mut failures: Vec<(String, String)> = Vec::new();
-    while let Some(joined) = set.join_next_with_id().await {
-        match joined {
-            Ok((_, (stem, Ok(())))) => println!("ok {stem}"),
-            Ok((_, (stem, Err(detail)))) => {
-                println!("FAIL {stem}");
-                failures.push((stem, detail));
-            }
-            Err(join_err) => {
-                let stem = names
-                    .get(&join_err.id())
-                    .cloned()
-                    .unwrap_or_else(|| "<unknown case>".to_string());
-                println!("FAIL {stem}");
-                failures.push((stem, format!("case panicked: {join_err}")));
-            }
+    let total = files.len();
+    let cases = files
+        .into_iter()
+        .map(|path| (stem_of(&path), path))
+        .collect();
+    let runner: CaseRunner = Arc::new(move |path| Box::pin(run_case(path, bless)));
+    let report = |outcome: &CaseOutcome| {
+        let secs = outcome.elapsed.as_secs_f64();
+        match &outcome.result {
+            Ok(()) => println!("ok {} {secs:.2}s", outcome.stem),
+            Err(_) => println!("FAIL {} {secs:.2}s", outcome.stem),
         }
-    }
+    };
+    let outcomes = run_bounded(cases, permits, budget, runner, &report).await;
+
+    let mut failures: Vec<(String, String)> = outcomes
+        .into_iter()
+        .filter_map(|outcome| {
+            let CaseOutcome { stem, result, .. } = outcome;
+            result.err().map(|detail| (stem, detail))
+        })
+        .collect();
 
     if !failures.is_empty() {
         failures.sort();
@@ -1472,7 +1648,7 @@ fn parses_a_minimal_case() {
     let case = parse_case("minimal", &text).unwrap();
     assert_eq!(case.items.len(), 1);
     assert!(!case.needs_indices);
-    assert_eq!(case.traversal, "indexed");
+    assert_eq!(case.traversal, None);
 }
 
 #[test]
@@ -2010,6 +2186,181 @@ fn traversal_header_forces_index_builds() {
     let text = format!("{HDR}# traversal: indexed\n{SCHEMA}{SEED}{QUERY}{EXPECT}");
     let case = parse_case("x", &text).unwrap();
     assert!(case.needs_indices);
+    assert_eq!(case.traversal, Some("indexed"));
+}
+
+#[test]
+fn refuses_ordered_expect_on_an_rrf_led_order() {
+    let query = "--- query\nquery q($v: Vector(4), $t: String) {\n    match { $p: Person }\n    \
+                 return { $p.name }\n    order { rrf(nearest($p.vec, $v), bm25($p.name, $t)) }\n}\n";
+    let text = format!("{HDR}{SCHEMA}{SEED}{query}--- expect ordered\n");
+    let message = refusal("x", &text);
+    assert!(message.contains("led by `rrf()`"), "{message}");
+    let text = format!("{HDR}{SCHEMA}{SEED}{query}--- expect unordered\n");
+    parse_case("x", &text).unwrap();
+}
+
+#[test]
+fn refuses_ordered_expect_with_an_aggregate_in_return() {
+    let query = "--- query\nquery q($t: String) {\n    match { $p: Person\n        search($p.name, $t) }\n    \
+                 return { count($p) as total }\n    order { bm25($p.name, $t) }\n}\n";
+    let text = format!("{HDR}{SCHEMA}{SEED}{query}--- expect ordered\n");
+    assert!(refusal("x", &text).contains("aggregate in its `return` list"));
+    let text = format!("{HDR}{SCHEMA}{SEED}{query}--- expect unordered\n");
+    parse_case("x", &text).unwrap();
+}
+
+fn synthetic_cases(names: &[&str]) -> Vec<(String, PathBuf)> {
+    names
+        .iter()
+        .map(|n| ((*n).to_string(), PathBuf::from(format!("{n}.gqt"))))
+        .collect()
+}
+
+fn no_report(_: &CaseOutcome) {}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn walker_bounds_cases_in_flight() {
+    let in_flight = Arc::new(AtomicUsize::new(0));
+    let max_seen = Arc::new(AtomicUsize::new(0));
+    let names: Vec<String> = (0..12).map(|i| format!("c{i:02}")).collect();
+    let cases = synthetic_cases(&names.iter().map(String::as_str).collect::<Vec<_>>());
+    // Every permit holder waits at a 3-party barrier, so the three are in
+    // flight together (max == 3) or the walker admitted fewer than three
+    // and the barrier never releases: the outer timeout turns that hang
+    // into a failure instead of a stall. Twelve cases = four generations.
+    let barrier = Arc::new(tokio::sync::Barrier::new(3));
+    let (counter, max) = (Arc::clone(&in_flight), Arc::clone(&max_seen));
+    let runner: CaseRunner = Arc::new(move |_| {
+        let (counter, max, barrier) =
+            (Arc::clone(&counter), Arc::clone(&max), Arc::clone(&barrier));
+        Box::pin(async move {
+            let now = counter.fetch_add(1, Ordering::SeqCst) + 1;
+            max.fetch_max(now, Ordering::SeqCst);
+            barrier.wait().await;
+            counter.fetch_sub(1, Ordering::SeqCst);
+            Ok(())
+        })
+    });
+    let outcomes = tokio::time::timeout(
+        Duration::from_secs(30),
+        run_bounded(cases, 3, Duration::from_secs(10), runner, &no_report),
+    )
+    .await
+    .expect("fewer than three cases in flight: the barrier never released");
+    assert_eq!(outcomes.len(), 12);
+    assert!(outcomes.iter().all(|o| o.result.is_ok()), "{outcomes:?}");
+    assert_eq!(max_seen.load(Ordering::SeqCst), 3);
+    assert_eq!(in_flight.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn walker_reports_in_completion_order_and_returns_sorted() {
+    // Completion is forced into the order c2, c1, c0 by hand-offs, not by
+    // sleep lengths: c2 returns at once; c1 waits until c2 is reported;
+    // c0 waits until c1 is reported.
+    let gates: Arc<[tokio::sync::Notify; 2]> =
+        Arc::new([tokio::sync::Notify::new(), tokio::sync::Notify::new()]);
+    let runner_gates = Arc::clone(&gates);
+    let runner: CaseRunner = Arc::new(move |path| {
+        let gates = Arc::clone(&runner_gates);
+        let idx: usize = path.file_stem().unwrap().to_str().unwrap()[1..]
+            .parse()
+            .unwrap();
+        Box::pin(async move {
+            if idx < 2 {
+                gates[idx].notified().await;
+            }
+            Ok(())
+        })
+    });
+    let reported = std::sync::Mutex::new(Vec::new());
+    let report = |o: &CaseOutcome| {
+        reported.lock().unwrap().push(o.stem.clone());
+        match o.stem.as_str() {
+            "c2" => gates[1].notify_one(),
+            "c1" => gates[0].notify_one(),
+            _ => {}
+        }
+    };
+    let cases = synthetic_cases(&["c0", "c1", "c2"]);
+    let outcomes = tokio::time::timeout(
+        Duration::from_secs(30),
+        run_bounded(cases, 3, Duration::from_secs(10), runner, &report),
+    )
+    .await
+    .expect("a hand-off never arrived");
+    let returned: Vec<&str> = outcomes.iter().map(|o| o.stem.as_str()).collect();
+    assert_eq!(returned, ["c0", "c1", "c2"]);
+    assert_eq!(*reported.lock().unwrap(), ["c2", "c1", "c0"]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn walker_budget_starts_at_the_permit_not_at_spawn() {
+    let runner: CaseRunner = Arc::new(|_| {
+        Box::pin(async {
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            Ok(())
+        })
+    });
+    let cases = synthetic_cases(&["a", "b", "c"]);
+    // One permit: the third case waits ~600 ms in the queue, past the
+    // 500 ms budget that its own 300 ms of work stays under; the margins
+    // are wide because libtest runs this beside the corpus walker.
+    let outcomes = run_bounded(cases, 1, Duration::from_millis(500), runner, &no_report).await;
+    assert!(outcomes.iter().all(|o| o.result.is_ok()), "{outcomes:?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn walker_fails_a_case_over_its_budget_and_runs_the_rest() {
+    let runner: CaseRunner = Arc::new(|path| {
+        Box::pin(async move {
+            if path.starts_with("slow.gqt") {
+                tokio::time::sleep(Duration::from_secs(30)).await;
+            }
+            Ok(())
+        })
+    });
+    let cases = synthetic_cases(&["slow", "quick"]);
+    let outcomes = run_bounded(cases, 1, Duration::from_millis(50), runner, &no_report).await;
+    let quick = &outcomes[0];
+    assert_eq!(quick.stem, "quick");
+    assert!(quick.result.is_ok(), "{quick:?}");
+    let slow = &outcomes[1];
+    assert_eq!(slow.stem, "slow");
+    assert!(
+        slow.elapsed < Duration::from_secs(5),
+        "timeout did not cut the case short"
+    );
+    let err = slow.result.as_ref().unwrap_err();
+    assert!(err.contains("budget of 0.05s"), "{err}");
+    assert!(err.contains("up to 1 cases"), "{err}");
+    assert!(err.contains(CASE_TIMEOUT_ENV), "{err}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn walker_records_a_panicking_case_and_runs_the_rest() {
+    let runner: CaseRunner = Arc::new(|path| {
+        Box::pin(async move {
+            if path.starts_with("p.gqt") {
+                panic!("boom");
+            }
+            Ok(())
+        })
+    });
+    let cases = synthetic_cases(&["p", "q"]);
+    let outcomes = run_bounded(cases, 1, Duration::from_secs(10), runner, &no_report).await;
+    let err = outcomes[0].result.as_ref().unwrap_err();
+    assert!(err.starts_with("case panicked: boom"), "{err}");
+    assert!(outcomes[1].result.is_ok(), "{:?}", outcomes[1]);
+}
+
+#[test]
+fn walker_refuses_a_process_traversal_override() {
+    assert!(traversal_override_refusal(None).is_none());
+    let reason = traversal_override_refusal(Some(OsStr::new("csr"))).unwrap();
+    assert!(reason.contains("OMNIGRAPH_TRAVERSAL_MODE=csr"), "{reason}");
+    assert!(reason.contains("# traversal:"), "{reason}");
 }
 
 #[test]

--- a/crates/omnigraph/tests/gq_logic_tests/issue_563_aggregate_uncapped.gqt
+++ b/crates/omnigraph/tests/gq_logic_tests/issue_563_aggregate_uncapped.gqt
@@ -62,5 +62,5 @@ query recall_count($q: String) {
 --- params
 {"q": "needle"}
 
---- expect ordered
+--- expect unordered
 {"total": 20}

--- a/crates/omnigraph/tests/gq_logic_tests/issue_563_aggregate_uncapped.gqt
+++ b/crates/omnigraph/tests/gq_logic_tests/issue_563_aggregate_uncapped.gqt
@@ -1,0 +1,66 @@
+# issue: 563
+# red_on: 2026-08-29, pre-fix build: the bm25 scan cap (limit 2 x 4 = 8 rows)
+#   fed count() only the capped window, so total was 8, not 20.
+# notes: an aggregate's value is computed over the matching rows, so the BM25
+#   scan cap must never apply to aggregate returns. Rust twin:
+#   bm25_ordered_aggregate_counts_all_matches_not_the_capped_scan (tests/search.rs).
+#   Seed geometry: 20 chunks all matching "needle", strict tf gradient
+#   (tf = 20 - c) so BM25 has a real order with no ties.
+
+--- schema
+node Chunk {
+    slug: String @key
+    text: String @index
+}
+
+node Artifact {
+    slug: String @key
+}
+
+edge ChunkOfArtifact: Chunk -> Artifact {
+    label: String
+}
+
+--- seed
+{"type":"Artifact","data":{"slug":"art-0"}}
+{"type":"Chunk","data":{"slug":"chunk-00","text":"needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-01","text":"needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-02","text":"needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-03","text":"needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-04","text":"needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-05","text":"needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-06","text":"needle needle needle needle needle needle needle needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-07","text":"needle needle needle needle needle needle needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-08","text":"needle needle needle needle needle needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-09","text":"needle needle needle needle needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-10","text":"needle needle needle needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-11","text":"needle needle needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-12","text":"needle needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-13","text":"needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-14","text":"needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-15","text":"needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-16","text":"needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-17","text":"needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-18","text":"needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-19","text":"needle filler"}}
+{"edge":"ChunkOfArtifact","from":"chunk-08","to":"art-0","data":{"id":"e-08","label":"of"}}
+{"edge":"ChunkOfArtifact","from":"chunk-09","to":"art-0","data":{"id":"e-09","label":"of"}}
+{"edge":"ChunkOfArtifact","from":"chunk-10","to":"art-0","data":{"id":"e-10","label":"of"}}
+{"edge":"ChunkOfArtifact","from":"chunk-11","to":"art-0","data":{"id":"e-11","label":"of"}}
+
+--- query
+query recall_count($q: String) {
+    match {
+        $c: Chunk
+        search($c.text, $q)
+    }
+    return { count($c) as total }
+    order { bm25($c.text, $q) }
+    limit 2
+}
+
+--- params
+{"q": "needle"}
+
+--- expect ordered
+{"total": 20}

--- a/crates/omnigraph/tests/gq_logic_tests/issue_563_aggregate_uncapped.gqt
+++ b/crates/omnigraph/tests/gq_logic_tests/issue_563_aggregate_uncapped.gqt
@@ -1,11 +1,10 @@
 # issue: 563
-# red_on: 2026-08-29, pre-fix build: the bm25 scan cap (limit 2 x 4 = 8 rows)
-#   fed count() only the capped window, so total was 8, not 20.
+# red_on: 2026-08-29, pre-fix build: the bm25 scan cap (limit 2 x 4 = 8 rows) fed count() only the capped window, so total was 8, not 20.
 # notes: an aggregate's value is computed over the matching rows, so the BM25
-#   scan cap must never apply to aggregate returns. Rust twin:
-#   bm25_ordered_aggregate_counts_all_matches_not_the_capped_scan (tests/search.rs).
-#   Seed geometry: 20 chunks all matching "needle", strict tf gradient
-#   (tf = 20 - c) so BM25 has a real order with no ties.
+# notes: scan cap must never apply to aggregate returns. Rust twin:
+# notes: bm25_ordered_aggregate_counts_all_matches_not_the_capped_scan (tests/search.rs).
+# notes: Seed geometry: 20 chunks all matching "needle", strict tf gradient
+# notes: (tf = 20 - c) so BM25 has a real order with no ties.
 
 --- schema
 node Chunk {

--- a/crates/omnigraph/tests/gq_logic_tests/issue_563_underfill_retry.gqt
+++ b/crates/omnigraph/tests/gq_logic_tests/issue_563_underfill_retry.gqt
@@ -1,12 +1,11 @@
 # issue: 563
-# red_on: 2026-08-28, retry disabled: the capped 8-row scan window held no
-#   edge-bearing chunk and the query returned 0 rows instead of 2.
+# red_on: 2026-08-28, retry disabled: the capped 8-row scan window held no edge-bearing chunk and the query returned 0 rows instead of 2.
 # notes: chunks 8..=11 carry the only edges; the limit 2 x 4 = 8-row cap
-#   window (either scan direction) excludes them, so filling the limit proves
-#   the uncapped retry ran. Passes on pre-cap code too (an unbounded scan
-#   finds everything): this case guards the retry GIVEN the cap, not the cap
-#   itself; the cap is the aggregate case's job. Rust twin:
-#   bm25_join_fills_limit_when_capped_scan_underfills_issue_563 (tests/search.rs).
+# notes: window (either scan direction) excludes them, so filling the limit proves
+# notes: the uncapped retry ran. Passes on pre-cap code too (an unbounded scan
+# notes: finds everything): this case guards the retry GIVEN the cap, not the cap
+# notes: itself; the cap is the aggregate case's job. Rust twin:
+# notes: bm25_join_fills_limit_when_capped_scan_underfills_issue_563 (tests/search.rs).
 
 --- schema
 node Chunk {

--- a/crates/omnigraph/tests/gq_logic_tests/issue_563_underfill_retry.gqt
+++ b/crates/omnigraph/tests/gq_logic_tests/issue_563_underfill_retry.gqt
@@ -1,0 +1,69 @@
+# issue: 563
+# red_on: 2026-08-28, retry disabled: the capped 8-row scan window held no
+#   edge-bearing chunk and the query returned 0 rows instead of 2.
+# notes: chunks 8..=11 carry the only edges; the limit 2 x 4 = 8-row cap
+#   window (either scan direction) excludes them, so filling the limit proves
+#   the uncapped retry ran. Passes on pre-cap code too (an unbounded scan
+#   finds everything): this case guards the retry GIVEN the cap, not the cap
+#   itself; the cap is the aggregate case's job. Rust twin:
+#   bm25_join_fills_limit_when_capped_scan_underfills_issue_563 (tests/search.rs).
+
+--- schema
+node Chunk {
+    slug: String @key
+    text: String @index
+}
+
+node Artifact {
+    slug: String @key
+}
+
+edge ChunkOfArtifact: Chunk -> Artifact {
+    label: String
+}
+
+--- seed
+{"type":"Artifact","data":{"slug":"art-0"}}
+{"type":"Chunk","data":{"slug":"chunk-00","text":"needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-01","text":"needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-02","text":"needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-03","text":"needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-04","text":"needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-05","text":"needle needle needle needle needle needle needle needle needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-06","text":"needle needle needle needle needle needle needle needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-07","text":"needle needle needle needle needle needle needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-08","text":"needle needle needle needle needle needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-09","text":"needle needle needle needle needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-10","text":"needle needle needle needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-11","text":"needle needle needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-12","text":"needle needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-13","text":"needle needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-14","text":"needle needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-15","text":"needle needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-16","text":"needle needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-17","text":"needle needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-18","text":"needle needle filler"}}
+{"type":"Chunk","data":{"slug":"chunk-19","text":"needle filler"}}
+{"edge":"ChunkOfArtifact","from":"chunk-08","to":"art-0","data":{"id":"e-08","label":"of"}}
+{"edge":"ChunkOfArtifact","from":"chunk-09","to":"art-0","data":{"id":"e-09","label":"of"}}
+{"edge":"ChunkOfArtifact","from":"chunk-10","to":"art-0","data":{"id":"e-10","label":"of"}}
+{"edge":"ChunkOfArtifact","from":"chunk-11","to":"art-0","data":{"id":"e-11","label":"of"}}
+
+--- query
+query recall($q: String) {
+    match {
+        $c: Chunk
+        $c chunkOfArtifact $a
+        search($c.text, $q)
+    }
+    return { $c.slug, $a.slug }
+    order { bm25($c.text, $q) }
+    limit 2
+}
+
+--- params
+{"q": "needle"}
+
+--- expect ordered
+{"c.slug": "chunk-08", "a.slug": "art-0"}
+{"c.slug": "chunk-09", "a.slug": "art-0"}

--- a/crates/omnigraph/tests/gq_logic_tests/mutation_error_typed.gqt
+++ b/crates/omnigraph/tests/gq_logic_tests/mutation_error_typed.gqt
@@ -1,0 +1,34 @@
+# issue: none
+# notes: a mutation inserting a node that omits its non-nullable @key property
+#   is refused at typecheck, pinned by its stable code. A mutation whose match
+#   merely misses is not an error: delete on an absent key succeeds with zero
+#   affected counts.
+
+--- schema
+node Person {
+    name: String @key
+    age: I32
+}
+
+--- seed
+{"type":"Person","data":{"name":"alice","age":30}}
+
+--- mutate
+query insert_missing_key($age: I32) {
+    insert Person { age: $age }
+}
+
+--- params
+{"age": 41}
+
+--- expect error: T12
+
+--- mutate
+query delete_absent($name: String) {
+    delete Person where name = $name
+}
+
+--- params
+{"name": "ghost"}
+
+--- expect affected: nodes=0 edges=0

--- a/crates/omnigraph/tests/gq_logic_tests/mutation_error_typed.gqt
+++ b/crates/omnigraph/tests/gq_logic_tests/mutation_error_typed.gqt
@@ -1,8 +1,8 @@
 # issue: none
 # notes: a mutation inserting a node that omits its non-nullable @key property
-#   is refused at typecheck, pinned by its stable code. A mutation whose match
-#   merely misses is not an error: delete on an absent key succeeds with zero
-#   affected counts.
+# notes: is refused at typecheck, pinned by its stable code. A mutation whose match
+# notes: merely misses is not an error: delete on an absent key succeeds with zero
+# notes: affected counts.
 
 --- schema
 node Person {

--- a/crates/omnigraph/tests/gq_logic_tests/order_clause_aggregate_refused.gqt
+++ b/crates/omnigraph/tests/gq_logic_tests/order_clause_aggregate_refused.gqt
@@ -1,0 +1,22 @@
+# issue: none
+# notes: pins the order-clause refusal shape: an aggregate written out in
+#   full inside order { } is refused; ordering by its projection alias is the
+#   supported spelling. The refusal message carries no error-code prefix, so
+#   the raw fragment is the pin.
+
+--- schema
+node Person {
+    name: String @key
+}
+
+--- seed
+{"type":"Person","data":{"name":"alice"}}
+
+--- query
+query count_ordered() {
+    match { $p: Person }
+    return { count($p) as total }
+    order { count($p) }
+}
+
+--- expect error: unsupported ordering expression

--- a/crates/omnigraph/tests/gq_logic_tests/order_clause_aggregate_refused.gqt
+++ b/crates/omnigraph/tests/gq_logic_tests/order_clause_aggregate_refused.gqt
@@ -1,8 +1,8 @@
 # issue: none
 # notes: pins the order-clause refusal shape: an aggregate written out in
-#   full inside order { } is refused; ordering by its projection alias is the
-#   supported spelling. The refusal message carries no error-code prefix, so
-#   the raw fragment is the pin.
+# notes: full inside order { } is refused; ordering by its projection alias is the
+# notes: supported spelling. The refusal message carries no error-code prefix, so
+# notes: the raw fragment is the pin.
 
 --- schema
 node Person {

--- a/crates/omnigraph/tests/gq_logic_tests/ordered_two_key_sort.gqt
+++ b/crates/omnigraph/tests/gq_logic_tests/ordered_two_key_sort.gqt
@@ -1,0 +1,30 @@
+# issue: none
+# notes: an `expect ordered` step's `order` keys must be total over the rows it
+#   returns. Node ids are minted per load, so the engine's `<var>.id` tie-break
+#   is stable within a run but not across runs; the second key here is what
+#   makes the order reproducible.
+
+--- schema
+node Person {
+    name: String @key
+    rank: I64
+}
+
+--- seed
+{"type":"Person","data":{"name":"alice","rank":2}}
+{"type":"Person","data":{"name":"bob","rank":1}}
+{"type":"Person","data":{"name":"carol","rank":2}}
+{"type":"Person","data":{"name":"dave","rank":1}}
+
+--- query
+query ranked() {
+    match { $p: Person }
+    return { $p.name, $p.rank }
+    order { $p.rank asc, $p.name asc }
+}
+
+--- expect ordered
+{"p.name": "bob", "p.rank": 1}
+{"p.name": "dave", "p.rank": 1}
+{"p.name": "alice", "p.rank": 2}
+{"p.name": "carol", "p.rank": 2}

--- a/crates/omnigraph/tests/gq_logic_tests/ordered_two_key_sort.gqt
+++ b/crates/omnigraph/tests/gq_logic_tests/ordered_two_key_sort.gqt
@@ -1,8 +1,8 @@
 # issue: none
 # notes: an `expect ordered` step's `order` keys must be total over the rows it
-#   returns. Node ids are minted per load, so the engine's `<var>.id` tie-break
-#   is stable within a run but not across runs; the second key here is what
-#   makes the order reproducible.
+#   returns. The engine's `<var>.id` tie-break is an implementation detail no
+#   expect may depend on: it is the `@key` value for keyed node types and a
+#   per-load ULID otherwise; the second key here is what makes the order total.
 
 --- schema
 node Person {

--- a/crates/omnigraph/tests/gq_logic_tests/ordered_two_key_sort.gqt
+++ b/crates/omnigraph/tests/gq_logic_tests/ordered_two_key_sort.gqt
@@ -1,8 +1,8 @@
 # issue: none
 # notes: an `expect ordered` step's `order` keys must be total over the rows it
-#   returns. The engine's `<var>.id` tie-break is an implementation detail no
-#   expect may depend on: it is the `@key` value for keyed node types and a
-#   per-load ULID otherwise; the second key here is what makes the order total.
+# notes: returns. The engine's `<var>.id` tie-break is an implementation detail no
+# notes: expect may depend on: it is the `@key` value for keyed node types and a
+# notes: per-load ULID otherwise; the second key here is what makes the order total.
 
 --- schema
 node Person {

--- a/crates/omnigraph/tests/gq_logic_tests/restart_survives_reopen.gqt
+++ b/crates/omnigraph/tests/gq_logic_tests/restart_survives_reopen.gqt
@@ -1,0 +1,39 @@
+# issue: none
+# notes: pins that committed mutations survive a store reopen; exercises
+#   mutate, loop, restart, and read steps in one case.
+
+--- schema
+node Person {
+    name: String @key
+    age: I32
+}
+
+--- seed
+{"type":"Person","data":{"name":"alice","age":30}}
+
+--- foreach $who bob carol
+
+--- mutate
+query insert_person($name: String) {
+    insert Person { name: $name, age: 40 }
+}
+
+--- params
+{"name": "${who}"}
+
+--- expect affected: nodes=1 edges=0
+
+--- endloop
+
+--- restart
+
+--- query
+query all_names() {
+    match { $p: Person }
+    return { $p.name }
+}
+
+--- expect unordered
+{"p.name": "alice"}
+{"p.name": "bob"}
+{"p.name": "carol"}

--- a/crates/omnigraph/tests/gq_logic_tests/restart_survives_reopen.gqt
+++ b/crates/omnigraph/tests/gq_logic_tests/restart_survives_reopen.gqt
@@ -1,6 +1,6 @@
 # issue: none
 # notes: pins that committed mutations survive a store reopen; exercises
-#   mutate, loop, restart, and read steps in one case.
+# notes: mutate, loop, restart, and read steps in one case.
 
 --- schema
 node Person {

--- a/docs/dev/branch-protection.md
+++ b/docs/dev/branch-protection.md
@@ -15,6 +15,7 @@ protection.
 - `Test omnigraph-server --features aws`
 - `Format (rustfmt)`
 - `Lint (clippy)`
+- `GQ Logic Tests`
 
 Checks are strict, so a PR must be current with `main`. `Graph Vocabulary
 Guard` remains as an always-reporting context but reports a successful skip on

--- a/docs/dev/branch-protection.md
+++ b/docs/dev/branch-protection.md
@@ -16,6 +16,7 @@ protection.
 - `Format (rustfmt)`
 - `Lint (clippy)`
 - `GQ Logic Tests`
+- `Fix Regression Gate`
 
 Checks are strict, so a PR must be current with `main`. `Graph Vocabulary
 Guard` remains as an always-reporting context but reports a successful skip on

--- a/docs/dev/ci.md
+++ b/docs/dev/ci.md
@@ -24,12 +24,19 @@ inside the full workspace suite. It takes the documentation-only skip the way
 the AWS job does and reports success without building; its workflow carries a
 verbatim copy of the `Classify Changes` job under the name
 `Classify Changes (GQ Logic Tests)`, and `scripts/check-classify-copy.py`
-holds that copy identical to `ci.yml`. `Fix Regression Gate` (same workflow,
-every PR event, no documentation-only skip) holds every issue the PR body
-closes by keyword to a matching `.gqt` case or `#[test]`-attributed `issue_N`
-function in the diff,
-waivable per PR with the `no-repro` label; `scripts/check-fix-regression.py`
-is the check.
+holds that copy identical to `ci.yml`. `Fix Regression Gate`
+(`fix-regression-gate.yml`) holds every issue the PR body closes by keyword to
+a regression in the diff: a `.gqt` case or a `#[test]`-attributed `issue_N`
+function, added or strengthened, in a top-level test target or `src/` module
+under `crates/*` or `tools/*` (an owner test not yet named for the issue is
+renamed to carry `issue_N` when extended). Owners the gate does not recognize
+(Python and shell scripts, helper and fixture modules) go through the
+`no-repro` label, which a maintainer applies to waive the check per PR;
+`scripts/check-fix-regression.py` is the check. It is a policy check, so it runs on `pull_request_target`: the
+workflow and the script come from `main`, and the pull request head is fetched
+only as data for the diff range, never checked out or executed. It runs on
+body edits and label changes as well as pushes, builds nothing, and takes no
+documentation-only skip.
 
 The `Check AGENTS.md Links` context also runs `scripts/check-docs.py`, which
 validates local documentation links, user/developer audience boundaries, RFC

--- a/docs/dev/ci.md
+++ b/docs/dev/ci.md
@@ -26,7 +26,8 @@ verbatim copy of the `Classify Changes` job under the name
 `Classify Changes (GQ Logic Tests)`, and `scripts/check-classify-copy.py`
 holds that copy identical to `ci.yml`. `Fix Regression Gate` (same workflow,
 every PR event, no documentation-only skip) holds every issue the PR body
-closes by keyword to a matching `issue_N` function or `.gqt` case in the diff,
+closes by keyword to a matching `.gqt` case or `#[test]`-attributed `issue_N`
+function in the diff,
 waivable per PR with the `no-repro` label; `scripts/check-fix-regression.py`
 is the check.
 

--- a/docs/dev/ci.md
+++ b/docs/dev/ci.md
@@ -20,10 +20,15 @@ Branch protection currently requires these reporting contexts:
 
 `GQ Logic Tests` (`gq-logic-tests.yml`) runs the `.gqt` logic-test corpus on
 every pull request; `Test Workspace` still picks the same target up post-merge
-inside the full workspace suite. `Fix Regression Gate` (same workflow, PR
-events only) holds every issue the PR body closes by keyword to a matching
-`issue_N` test or `.gqt` case in the diff, waivable per PR with the `no-repro`
-label; `scripts/check-fix-regression.py` is the check.
+inside the full workspace suite. It takes the documentation-only skip the way
+the AWS job does and reports success without building; its workflow carries a
+verbatim copy of the `Classify Changes` job under the name
+`Classify Changes (GQ Logic Tests)`, and `scripts/check-classify-copy.py`
+holds that copy identical to `ci.yml`. `Fix Regression Gate` (same workflow,
+every PR event, no documentation-only skip) holds every issue the PR body
+closes by keyword to a matching `issue_N` function or `.gqt` case in the diff,
+waivable per PR with the `no-repro` label; `scripts/check-fix-regression.py`
+is the check.
 
 The `Check AGENTS.md Links` context also runs `scripts/check-docs.py`, which
 validates local documentation links, user/developer audience boundaries, RFC

--- a/docs/dev/ci.md
+++ b/docs/dev/ci.md
@@ -16,10 +16,14 @@ Branch protection currently requires these reporting contexts:
 - `Format (rustfmt)`
 - `Lint (clippy)`
 - `GQ Logic Tests`
+- `Fix Regression Gate`
 
 `GQ Logic Tests` (`gq-logic-tests.yml`) runs the `.gqt` logic-test corpus on
 every pull request; `Test Workspace` still picks the same target up post-merge
-inside the full workspace suite.
+inside the full workspace suite. `Fix Regression Gate` (same workflow, PR
+events only) holds every issue the PR body closes by keyword to a matching
+`issue_N` test or `.gqt` case in the diff, waivable per PR with the `no-repro`
+label; `scripts/check-fix-regression.py` is the check.
 
 The `Check AGENTS.md Links` context also runs `scripts/check-docs.py`, which
 validates local documentation links, user/developer audience boundaries, RFC

--- a/docs/dev/ci.md
+++ b/docs/dev/ci.md
@@ -15,6 +15,11 @@ Branch protection currently requires these reporting contexts:
 - `Test omnigraph-server --features aws`
 - `Format (rustfmt)`
 - `Lint (clippy)`
+- `GQ Logic Tests`
+
+`GQ Logic Tests` (`gq-logic-tests.yml`) runs the `.gqt` logic-test corpus on
+every pull request; `Test Workspace` still picks the same target up post-merge
+inside the full workspace suite.
 
 The `Check AGENTS.md Links` context also runs `scripts/check-docs.py`, which
 validates local documentation links, user/developer audience boundaries, RFC

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -105,7 +105,13 @@ cargo test -p omnigraph-bench --locked
 
 `OMNIGRAPH_GQ_LOGIC_TESTS=<substr>[,<substr>]` restricts the gq logic-test run
 to case files whose name contains a value; `OMNIGRAPH_GQ_BLESS=1` rewrites the
-failing step's expect rows in place (local workflow only, never CI).
+failing step's expect rows in place (local workflow only, never CI). The walker
+keeps at most `OMNIGRAPH_GQ_JOBS=<n>` cases in flight (default: the machine's
+available parallelism) and fails a case that exceeds
+`OMNIGRAPH_GQ_CASE_TIMEOUT_SECS=<n>` seconds (default 10); every `ok`/`FAIL`
+line carries the case's elapsed time, and a case over budget belongs in a
+`heavy-repro:` `#[ignore]`d test under `tests/repro_issue_*.rs`, not the
+corpus.
 
 Canonical workspace graph:
 

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -35,7 +35,7 @@ The engine integration suite is grouped by behavior, not implementation module:
 | Concern | Existing owners |
 |---|---|
 | Initialization and representative journeys | `lifecycle.rs`, `end_to_end.rs`, `composite_flow.rs`, `consistency.rs` |
-| Query results and operators | `aggregation.rs`, `literal_filters.rs`, `ordering.rs`, `traversal.rs`, `traversal_indexed.rs`, `proptest_equivalence.rs` |
+| Query results and operators | `aggregation.rs`, `literal_filters.rs`, `ordering.rs`, `traversal.rs`, `traversal_indexed.rs`, `proptest_equivalence.rs`, `gq_logic_tests.rs` (walks the `.gqt` cases under `tests/gq_logic_tests/`) |
 | Search and physical indexes | `search.rs`, `scalar_indexes.rs`, `lance_surface_guards.rs`, `rrf_prefilter_gate.rs` (the rrf plan gate's differential oracle and fences), `repro_issue_563.rs` (`#[ignore]`d overflow-scale symptom tier) |
 | Writes, validation, schema, and policy | `writes.rs`, `validators.rs`, `schema_apply.rs`, `policy_engine_chassis.rs` |
 | Branches, snapshots, diffs, and merges | `branching.rs`, `point_in_time.rs`, `changes.rs`, `merge_truth_table.rs`, `merge_fast_forward.rs` |
@@ -96,11 +96,16 @@ Focused iteration:
 ```bash
 cargo test -p omnigraph-engine --test traversal
 cargo test -p omnigraph-engine --test writes concurrent
+cargo test -p omnigraph-engine --test gq_logic_tests
 cargo test -p omnigraph-server --test data_routes
 cargo test -p omnigraph-cli --test cli_data
 cargo test -p omnigraph-cluster --test failpoints --features failpoints
 cargo test -p omnigraph-bench --locked
 ```
+
+`OMNIGRAPH_GQ_LOGIC_TESTS=<substr>[,<substr>]` restricts the gq logic-test run
+to case files whose name contains a value; `OMNIGRAPH_GQ_BLESS=1` rewrites the
+failing step's expect rows in place (local workflow only, never CI).
 
 Canonical workspace graph:
 

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -5,7 +5,7 @@ This is the ownership map for OmniGraph's tests. Read it before changing code: f
 ## Rules
 
 1. Test at the boundary that owns the promise. Compiler behavior belongs in compiler tests; engine guarantees belong at the public engine API; HTTP and CLI behavior belongs at those transports.
-2. Prefer one new assertion, fixture row, or parameter over another `init_and_load` test.
+2. Prefer one new assertion, fixture row, or parameter over another `init_and_load` test. When the change fixes an issue, the `Fix Regression Gate` keys on `issue_N` in the test's name or the `.gqt` case's file name: extend an owner test by renaming it to carry `issue_N` in the same change, or add a row to the `issue_N_*.gqt` case (`docs/dev/ci.md`).
 3. Test logical results and durable state. Inspect Lance internals only for a compatibility fence, recovery fault, or physical-cost contract.
 4. Every failure path must prove what did *not* move: manifest head, table head, lineage, sidecar, or external I/O as appropriate.
 5. Time and RSS measurements are decision instruments, not ordinary correctness gates. Deterministic operation counts may be CI contracts.

--- a/docs/rfcs/0045-gq-logic-tests.md
+++ b/docs/rfcs/0045-gq-logic-tests.md
@@ -856,15 +856,100 @@ listed in Compatibility and reversibility.
     `no-repro`, and the AGENTS.md contract sentence is present; a corpus
     match means the case ran green in the required job, and a Rust match
     means a test-attributed function of that name was added.
+  - Fix-PR gate, owners and strengthened regressions (User and operational
+    behavior: "an added `.gqt` case", "`crates/*/tests/<name>.rs`",
+    "`crates/*/src/**`"; the first 2026-09-02 entry's "matches only
+    top-level `crates/*/tests/<name>.rs` targets and `crates/*/src/**`").
+    The gate's paths cover `tools/*` workspace members the same way as
+    `crates/*`. A regression counts when added or strengthened: a `.gqt`
+    case named `issue_N_*`, new, or modified with at least one added body
+    line (not a `#` header line or a `//` comment), or an added line
+    carrying an alphanumeric character, not a comment or attribute, inside
+    the body of an existing test-attributed function named for `issue_N`,
+    located by the hunk's new-file line number in the file at the head
+    commit (the enclosing item found by brace counting with literals and
+    `//` comments blanked; raw strings and block comments are a named
+    residue, and a non-function item found open first ends the search).
+    An owner test not named for the issue is extended by renaming it to
+    carry `issue_N` in the same change: the rename alone never counts, the
+    rename plus the assertion does. The "added `# issue: N` header line"
+    shape of the quotable guarantee is subsumed: the walker requires the
+    file name to match and refuses a second `# issue:`, so that line only
+    ever appears in a new case named for the issue, which the name rule
+    already credits; the gate no longer names it. The merged shape
+    required an added definition, so a fix that extended an existing
+    assertion, the testing guide's preferred form, could pass only through
+    `no-repro`. Owners the gate does not recognize, Python and shell
+    scripts among them, satisfy it only through `no-repro`, which a
+    maintainer applies; the docstring, `ci.md`, and `testing.md` say so.
   - Workflow layout (User and operational behavior: "a second job in the
-    same workflow", "honors the docs-only classification that `ci.yml`'s
-    `Classify Changes` job defines"; Rollout: "the workflow with both
-    jobs"). GitHub Actions cannot make a job depend on another workflow's
-    job, so `gq-logic-tests.yml` carries a verbatim copy of `ci.yml`'s
-    classification as a job of its own, `Classify Changes (GQ Logic
-    Tests)`, and the required `Classify Changes` context keeps one
-    reporter. The workflow carries three jobs. `ci.yml` is the source of
-    truth; `scripts/check-classify-copy.py`, a gate step, refuses drift.
+    same workflow", "running only on `pull_request` events", "`pull_request`
+    with its types declared explicitly (`opened`, `synchronize`,
+    `reopened`, `edited`, `labeled`, `unlabeled`)", "label and body-edit
+    events also re-run the test job", "honors the docs-only classification
+    that `ci.yml`'s `Classify Changes` job defines"; Rollout: "the workflow
+    with both jobs"). The gate is a policy check on the pull request, so it
+    runs code the pull request cannot edit: it lives in its own workflow,
+    `.github/workflows/fix-regression-gate.yml`, on `pull_request_target`,
+    which takes the workflow file and `scripts/check-fix-regression.py`
+    from the base branch and fetches the head only as data for the diff
+    range, never checking it out or executing it. Under `pull_request` a PR
+    could replace the check with `true` while keeping the required context
+    name, and branch protection requires no approving review. One residue
+    is accepted: a pull request can add a job of its own under the
+    required name in a `pull_request` workflow, and branch protection keys
+    on the name alone. That evasion is dominated by the `no-repro` label,
+    which any committer can apply in one click: the gate guards against
+    forgetting a regression, not against a committer who decides to skip
+    one, and the base-owned workflow closes the forgetting-shaped hole (a
+    PR that edits the workflow or the script cannot weaken the copy that
+    runs). Gating the label itself would be a ruleset that identifies the
+    gate by file rather than by name, and would gate both at once. The
+    base-branch workflow does not exist until this change merges, so the
+    gate first runs on the next pull request after it. The gate
+    workflow declares the `edited`, `labeled`, and `unlabeled` types and
+    builds nothing; `gq-logic-tests.yml` keeps only the code-bearing types
+    (`opened`, `synchronize`, `reopened`), so a body edit or label change
+    no longer re-runs the Rust build. GitHub Actions cannot make a job
+    depend on another workflow's job, so `gq-logic-tests.yml` carries a
+    verbatim copy of `ci.yml`'s classification as a job of its own,
+    `Classify Changes (GQ Logic Tests)`, and the required `Classify
+    Changes` context keeps one reporter. That workflow carries two jobs.
+    `ci.yml` is the source of truth; `scripts/check-classify-copy.py`, an
+    unconditional step at the top of the `GQ Logic Tests` job right after
+    checkout (so it runs on documentation-only pull requests too), refuses
+    drift.
+  - Header grammar (Format: "a `#` line not starting a key continues the
+    previous entry (a first header line starting no key is refused); any
+    other `# <word>:` key is refused; a key given twice is refused"). No
+    header line continues a previous entry: a multi-line note repeats
+    `# notes:`, which is the one key allowed more than once. A header line
+    is accepted exactly when it equals `# <key>: <value>` byte for byte,
+    for one of the four keys in that spelling and a value with no leading
+    or trailing whitespace; every other line is refused: a value with stray
+    whitespace is answered with the canonical line, a bad shape with the
+    grammar, an unknown key with the key list. The merged grammar sent a
+    misspelled key
+    (`# Traversal:`, `# traversal :`, `# traversal=csr`) into the
+    continuation branch, where it was read as prose and dropped, so a case
+    meant to pin one traversal path ran on the default path and passed.
+    With no continuation branch there is no prose to fall into; the
+    harness walks the typo space exhaustively (key spelling, separator,
+    leading and trailing whitespace, gap) and asserts that exactly one
+    line is accepted. The pin is also checked at execution time: a pinned
+    step runs with expand-path probes attached (`QueryIoProbes`'
+    `expand_indexed_runs` and `expand_csr_runs`, incremented where the
+    executor commits to a path), and any expand on the other path fails
+    the step with the message `pinned <mode>, ran <other> on N
+    expand(s)`. The pin and the probes are both task-local scopes, so a
+    boundary that dropped the pin would drop the probes with it and read
+    as a clean zero; for that reason a pinned query step whose match
+    clause carries an unbound traversal must also show at least one expand
+    on the pinned path once it succeeds, else it fails with `pinned
+    <mode>, but no expand ran on it`. A bound edge (`$a $k:knows $b`) scans
+    the edge dataset on a path no mode pins and is exempt. A header that
+    parses correctly proves the pin was requested; this proves the
+    executor honored it. The `.gqt` grammar gains nothing.
   - Runner mechanics and Execution semantics (Runner mechanics: "the cap
     is a walker implementation detail, not format contract", "an
     environment variable overrides the default"; Execution semantics:

--- a/docs/rfcs/0045-gq-logic-tests.md
+++ b/docs/rfcs/0045-gq-logic-tests.md
@@ -3,7 +3,7 @@ rfc: "0045"
 title: "GQ logic tests"
 track: maintainer
 status: draft
-implementation: in-progress
+implementation: partial
 authors:
   - azimafroozeh
 created: 2026-08-29
@@ -824,3 +824,64 @@ listed in Compatibility and reversibility.
   flight and budgets each case (10 seconds by default, env-overridable);
   the per-PR corpus is the fast tier; a case runs on the production
   traversal path unless `# traversal:` pins one.
+- 2026-09-02, amendment from the implementation PR (#596), after this RFC
+  merged. Where the body above or an earlier entry differs from this
+  entry, this entry holds. Each item names the section and the sentences
+  it supersedes.
+  - Fix-PR gate, Rust shape (User and operational behavior: "an added
+    Rust line defining a function whose name carries `issue_N`", "a Rust
+    shape is a naming check only", "no Rust test target other than
+    `gq_logic_tests` runs on a pull request", the quotable guarantee; and
+    the first 2026-09-02 entry's "a Rust match is a naming check"). An
+    added function named for `issue_N` counts only when an added `#[test]`
+    or `#[<path>::test]` attribute line (`#[tokio::test(...)]` included)
+    sits directly above it in the same hunk. Other `#[...]` attribute and
+    `//` comment lines may sit between; a blank line, a block comment, or
+    an attribute split across lines breaks adjacency. A plain function,
+    however named, never satisfies the gate. The merged shape accepted a
+    plain `fn` named for the issue, which no pull-request job ever runs,
+    so the gate could pass on a function that asserted nothing. The Rust
+    shape is thereby a test-attributed definition, not a run. A pull
+    request runs only the corpus walker and `Test omnigraph-server
+    --features aws` among Rust test targets (`Test Workspace` runs
+    post-merge). Workspace clippy on the pull request refuses an
+    unreferenced private function but not an `#[ignore]`d or cfg-gated
+    one, so whether that test runs in the suite and asserts the right
+    thing stays with review. One named residue stays with review too: a
+    definition inside an added multi-line block comment or raw string
+    still matches, since the parse is line-based. The quotable guarantee
+    reads, as amended: exit 0 exactly when every issue the body closes by
+    keyword has an added `issue_N_*.gqt`, an added `# issue: N` line, or
+    an added `#[test]`-attributed `issue_N` function, or the PR carries
+    `no-repro`, and the AGENTS.md contract sentence is present; a corpus
+    match means the case ran green in the required job, and a Rust match
+    means a test-attributed function of that name was added.
+  - Workflow layout (User and operational behavior: "a second job in the
+    same workflow", "honors the docs-only classification that `ci.yml`'s
+    `Classify Changes` job defines"; Rollout: "the workflow with both
+    jobs"). GitHub Actions cannot make a job depend on another workflow's
+    job, so `gq-logic-tests.yml` carries a verbatim copy of `ci.yml`'s
+    classification as a job of its own, `Classify Changes (GQ Logic
+    Tests)`, and the required `Classify Changes` context keeps one
+    reporter. The workflow carries three jobs. `ci.yml` is the source of
+    truth; `scripts/check-classify-copy.py`, a gate step, refuses drift.
+  - Runner mechanics and Execution semantics (Runner mechanics: "the cap
+    is a walker implementation detail, not format contract", "an
+    environment variable overrides the default"; Execution semantics:
+    "the `OMNIGRAPH_TRAVERSAL_MODE` process variable never reaches a logic
+    test either way"). The in-flight cap defaults to the machine's
+    available parallelism and `OMNIGRAPH_GQ_JOBS` overrides it; the cap is
+    a documented runner knob, still no format contract.
+    `OMNIGRAPH_GQ_CASE_TIMEOUT_SECS` overrides the per-case budget. The
+    variable does reach an unpinned case, so the walker refuses to run
+    while `OMNIGRAPH_TRAVERSAL_MODE` is set.
+  - Comparison semantics, `ordered` (qualifies "the engine's order is
+    total: an `order` clause qualifies when the source batch carries
+    `<var>.id` columns"). Authoring rule for every `ordered` step: the
+    `order` keys must be total over the rows the step returns. The
+    `<var>.id` tie-break is an implementation detail no expect may depend
+    on: it is the `@key` value for keyed node types and a per-load ULID
+    otherwise, so an unkeyed type's order changes across runs. A tie on
+    the sort keys is an authoring error that surfaces as flakiness, and
+    the harness cannot see it statically (`ordered_two_key_sort.gqt` is
+    the corpus example).

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -171,5 +171,5 @@ This table is the human index for the canonical RFC corpus.
 | [0042](0042-incarnation-suffixed-branch-refs.md) | Incarnation-suffixed native branch refs | maintainer | accepted | complete |
 | [0043](0043-full-text-index-compatibility.md) | Full-text index compatibility and explicit rebuild | maintainer | accepted | complete |
 | [0044](0044-edge-keys.md) | Edge keys: derived edge identity | maintainer | draft | in-progress |
-| [0045](0045-gq-logic-tests.md) | GQ logic tests | maintainer | draft | in-progress |
+| [0045](0045-gq-logic-tests.md) | GQ logic tests | maintainer | draft | partial |
 | [0046](0046-index-status.md) | Read-only index status | maintainer | draft | not-started |

--- a/scripts/check-classify-copy.py
+++ b/scripts/check-classify-copy.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Asserts that `gq-logic-tests.yml`'s `classify_changes` job is a verbatim
+copy of `ci.yml`'s, modulo the job's display `name:` line. A job cannot
+depend on another workflow's job, so the documentation-only classification
+lives in both files; `ci.yml` is the source of truth, and this check is what
+makes the copy enforced rather than promised. Run from the repository root.
+Exit 0 exactly when the two job blocks match.
+"""
+
+from __future__ import annotations
+
+import difflib
+import re
+import sys
+from pathlib import Path
+
+SOURCE = Path(".github/workflows/ci.yml")
+COPY = Path(".github/workflows/gq-logic-tests.yml")
+# The job block: from its key to the next two-space-indented key.
+JOB_BLOCK = re.compile(r"^  classify_changes:\n(?:(?!^(?:  \S|\S)).*\n?)*", re.MULTILINE)
+DISPLAY_NAME = re.compile(r"^    name: .*$", re.MULTILINE)
+
+
+def job_block(path: Path) -> list[str]:
+    match = JOB_BLOCK.search(path.read_text(encoding="utf-8"))
+    if not match:
+        sys.exit(f"FAIL: no `classify_changes` job in {path}")
+    lines = DISPLAY_NAME.sub("    name: <display name>", match.group(0), count=1).splitlines()
+    while lines and not lines[-1].strip():
+        lines.pop()
+    return lines
+
+
+def main() -> int:
+    source = job_block(SOURCE)
+    copy = job_block(COPY)
+    if source == copy:
+        print(f"ok: {COPY} classify_changes matches {SOURCE} ({len(source)} lines)")
+        return 0
+    diff = difflib.unified_diff(source, copy, str(SOURCE), str(COPY), lineterm="")
+    print("\n".join(diff))
+    print(f"FAIL: {COPY} classify_changes drifted from {SOURCE}, the source of truth")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-fix-regression.py
+++ b/scripts/check-fix-regression.py
@@ -15,12 +15,19 @@ contains a comma could smuggle the waiver token; creating labels needs the
 same triage rights as applying the real one. Run from the repository root:
 AGENTS.md and git are resolved relative to the working directory.
 
-A closed issue N is satisfied only by an EXECUTABLE addition under
-`crates/*/tests/**`: an added `.gqt` case in the logic-test corpus whose
-file name carries `issue_N` (the harness executes it and enforces the
-name-to-header agreement), an added `# issue: N` header line in a corpus
-`.gqt`, or an added Rust function definition whose name carries `issue_N`
-(the `_issue_NNN` convention; workspace clippy refuses a dead fn).
+A closed issue N is satisfied by an added `.gqt` case named `issue_N_*` at
+the top level of the logic-test corpus, an added `# issue: N` header line
+in a corpus `.gqt`, or an added Rust function definition whose name
+carries `issue_N` in a top-level test target `crates/*/tests/<name>.rs` or
+an in-source module under `crates/*/src/`; helper and fixture modules
+under `tests/<dir>/` never match. What a match guarantees differs by
+shape: a corpus match ran green in the required `GQ Logic Tests` job; a
+Rust match is a naming check. A pull request runs only the corpus walker
+and the `omnigraph-server` aws-feature suite among Rust test targets
+(`Test Workspace` runs post-merge), and workspace clippy refuses an
+unreferenced private function but not an `#[ignore]`d or cfg-gated one,
+so whether that test is registered, runs, and asserts the right thing
+stays with review.
 Comments, strings, and fixture lines mentioning the issue do not count.
 N is always followed by a non-digit or the end. Named residue: a
 definition inside an added block comment or raw string still matches
@@ -49,7 +56,7 @@ CLOSING_KEYWORD = re.compile(
 )
 CORPUS_PATH_SENTENCE = "crates/omnigraph/tests/gq_logic_tests/"
 WAIVER_LABEL = "no-repro"
-TEST_PATHSPEC = ":(glob)crates/*/tests/**"
+PATHSPECS = (":(glob)crates/*/tests/**", ":(glob)crates/*/src/**")
 
 
 def closed_issues(body: str) -> list[str]:
@@ -61,6 +68,8 @@ def issue_token(n: str) -> re.Pattern[str]:
 
 
 CORPUS_DIR_PREFIX = "crates/omnigraph/tests/gq_logic_tests/"
+# One path segment after `tests/` (a top-level target) or any `.rs` under `src/`.
+RUST_FN_PATH = re.compile(r"^crates/[^/]+/(?:tests/[^/]+\.rs|src/.+\.rs)$")
 RUST_FN_DEF = re.compile(
     r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:const\s+)?(?:async\s+)?(?:unsafe\s+)?"
     r'(?:extern\s+"[^"]*"\s+)?fn\s+([A-Za-z0-9_]+)'
@@ -78,7 +87,7 @@ def added_files(range_: str) -> list[str]:
             "--diff-filter=A",
             range_,
             "--",
-            TEST_PATHSPEC,
+            *PATHSPECS,
         ],
         check=True,
         capture_output=True,
@@ -109,7 +118,7 @@ def parse_diff(diff_text: str) -> tuple[list[tuple[str, str]], list[str]]:
 
 def diff_changes(range_: str) -> tuple[list[tuple[str, str]], list[str]]:
     out = subprocess.run(
-        ["git", "-c", "core.quotePath=false", "diff", "-U0", range_, "--", TEST_PATHSPEC],
+        ["git", "-c", "core.quotePath=false", "diff", "-U0", range_, "--", *PATHSPECS],
         check=True,
         capture_output=True,
         text=True,
@@ -137,12 +146,11 @@ def issue_satisfied(
         if corpus_case(path) and Path(path).name.startswith(f"issue_{n}_"):
             return True
     header = re.compile(rf"^\s*#\s*issue:\s*{n}(?!\d)\s*$")
-    test_target = re.compile(r"^crates/[^/]+/tests/[^/]+\.rs$")
     for path, text in lines:
         if corpus_case(path):
             if header.match(text):
                 return True
-        elif test_target.match(path):
+        elif RUST_FN_PATH.match(path):
             m = RUST_FN_DEF.match(text)
             if (
                 m
@@ -193,8 +201,10 @@ def run_gate(body: str, labels: list[str], range_: str) -> int:
             print(f"ok: issue #{n} has a matching regression addition")
         else:
             print(
-                f"FAIL: the body closes #{n} but the diff adds no `issue_{n}` "
-                f"test or `.gqt` case under crates/*/tests/; add one or apply "
+                f"FAIL: the body closes #{n} but the diff adds no `.gqt` case "
+                f"named `issue_{n}_*` or carrying `# issue: {n}` under "
+                f"{CORPUS_DIR_PREFIX}, and no function named for `issue_{n}` in "
+                f"crates/*/tests/<name>.rs or crates/*/src/; add one or apply "
                 f"the `{WAIVER_LABEL}` label"
             )
             ok = False
@@ -259,6 +269,19 @@ def self_test() -> int:
     assert not issue_satisfied(
         "563", [], [(rust, "fn t_issue_563_case() {")], removed_fns={"t_issue_563_case"}
     )
+    src = "crates/omnigraph/src/exec/query.rs"
+    assert issue_satisfied("563", [], [(src, "    fn regression_issue_563() {")])
+    assert issue_satisfied("563", [], [("crates/omnigraph-dst/src/lib.rs", "async fn issue_563() {")])
+    assert not issue_satisfied("563", [], [(src, "// regression_issue_563 lives below")])
+    assert not issue_satisfied("563", [], [("crates/omnigraph/src/query.pest", "fn t_issue_563() {")])
+    assert not issue_satisfied("563", [], [("crates/omnigraph/benches/b.rs", "fn t_issue_563() {")])
+    assert not issue_satisfied("563", ["crates/omnigraph/src/gq_logic_tests/issue_563_x.gqt"], [])
+    assert RUST_FN_PATH.match("crates/omnigraph/tests/search.rs")
+    assert RUST_FN_PATH.match("crates/omnigraph/src/a/b/c.rs")
+    assert not RUST_FN_PATH.match("crates/omnigraph/tests/helpers/mod.rs")
+    assert not RUST_FN_PATH.match("crates/omnigraph/src/lib.md")
+    assert RUST_FN_PATH.match("crates/omnigraph/src/bin/omnigraph.rs")
+    assert not RUST_FN_PATH.match("crates/omnigraph/tests/search/main.rs")
 
     spoof_diff = "\n".join(
         [

--- a/scripts/check-fix-regression.py
+++ b/scripts/check-fix-regression.py
@@ -15,9 +15,17 @@ contains a comma could smuggle the waiver token; creating labels needs the
 same triage rights as applying the real one. Run from the repository root:
 AGENTS.md and git are resolved relative to the working directory.
 
-A closed issue N is satisfied by an addition under `crates/*/tests/**`:
-an added file whose path contains `issue_N`, or an added line containing
-`issue_N` or `issue: N`, where N is followed by a non-digit or the end.
+A closed issue N is satisfied only by an EXECUTABLE addition under
+`crates/*/tests/**`: an added `.gqt` case in the logic-test corpus whose
+file name carries `issue_N` (the harness executes it and enforces the
+name-to-header agreement), an added `# issue: N` header line in a corpus
+`.gqt`, or an added Rust function definition whose name carries `issue_N`
+(the `_issue_NNN` convention; workspace clippy refuses a dead fn).
+Comments, strings, and fixture lines mentioning the issue do not count.
+N is always followed by a non-digit or the end. Named residue: a
+definition inside an added block comment or raw string still matches
+(line-based parsing cannot see multi-line context); that evasion, like a
+test that asserts nothing, is deliberate and stays with review.
 
 Exit 0 exactly when every keyword-closed issue has its match or the PR
 carries `no-repro`, and AGENTS.md still names the logic-test corpus path.
@@ -26,6 +34,8 @@ Usage:
   check-fix-regression.py --body-file F --labels "a,b" --range BASE...HEAD
   check-fix-regression.py --self-test
 """
+
+from __future__ import annotations
 
 import argparse
 import re
@@ -50,13 +60,26 @@ def issue_token(n: str) -> re.Pattern[str]:
     return re.compile(rf"issue_{n}(?!\d)")
 
 
-def issue_line_patterns(n: str) -> list[re.Pattern[str]]:
-    return [issue_token(n), re.compile(rf"issue: {n}(?!\d)")]
+CORPUS_DIR_PREFIX = "crates/omnigraph/tests/gq_logic_tests/"
+RUST_FN_DEF = re.compile(
+    r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:const\s+)?(?:async\s+)?(?:unsafe\s+)?"
+    r'(?:extern\s+"[^"]*"\s+)?fn\s+([A-Za-z0-9_]+)'
+)
 
 
 def added_files(range_: str) -> list[str]:
     out = subprocess.run(
-        ["git", "diff", "--name-only", "--diff-filter=A", range_, "--", TEST_PATHSPEC],
+        [
+            "git",
+            "-c",
+            "core.quotePath=false",
+            "diff",
+            "--name-only",
+            "--diff-filter=A",
+            range_,
+            "--",
+            TEST_PATHSPEC,
+        ],
         check=True,
         capture_output=True,
         text=True,
@@ -64,26 +87,77 @@ def added_files(range_: str) -> list[str]:
     return [line for line in out.stdout.splitlines() if line]
 
 
-def added_lines(range_: str) -> list[str]:
+def parse_diff(diff_text: str) -> tuple[list[tuple[str, str]], list[str]]:
+    """Splits a -U0 diff into path-attributed added lines and bare removed
+    lines. A `+++ b/` marker counts as a file header only directly after a
+    `--- ` line: an added CONTENT line `++ b/x` also renders as `+++ b/x`,
+    and honoring it would let a diff spoof its own file attribution."""
+    current: str | None = None
+    previous = ""
+    added: list[tuple[str, str]] = []
+    removed: list[str] = []
+    for line in diff_text.splitlines():
+        if line.startswith("+++") and previous.startswith("--- "):
+            current = line[len("+++ b/") :] if line.startswith("+++ b/") else None
+        elif line.startswith("+") and not line.startswith("+++") and current is not None:
+            added.append((current, line[1:]))
+        elif line.startswith("-") and not line.startswith("---"):
+            removed.append(line[1:])
+        previous = line
+    return added, removed
+
+
+def diff_changes(range_: str) -> tuple[list[tuple[str, str]], list[str]]:
     out = subprocess.run(
-        ["git", "diff", "-U0", range_, "--", TEST_PATHSPEC],
+        ["git", "-c", "core.quotePath=false", "diff", "-U0", range_, "--", TEST_PATHSPEC],
         check=True,
         capture_output=True,
         text=True,
     )
-    return [
-        line[1:]
-        for line in out.stdout.splitlines()
-        if line.startswith("+") and not line.startswith("+++")
-    ]
+    return parse_diff(out.stdout)
 
 
-def issue_satisfied(n: str, files: list[str], lines: list[str]) -> bool:
+def removed_fn_names(removed: list[str]) -> set[str]:
+    names = set()
+    for text in removed:
+        m = RUST_FN_DEF.match(text)
+        if m:
+            names.add(m.group(1))
+    return names
+
+
+def issue_satisfied(
+    n: str,
+    files: list[str],
+    lines: list[tuple[str, str]],
+    removed_fns: frozenset[str] | set[str] = frozenset(),
+) -> bool:
     token = issue_token(n)
-    if any(token.search(path) for path in files):
-        return True
-    patterns = issue_line_patterns(n)
-    return any(p.search(line) for line in lines for p in patterns)
+    for path in files:
+        if corpus_case(path) and Path(path).name.startswith(f"issue_{n}_"):
+            return True
+    header = re.compile(rf"^\s*#\s*issue:\s*{n}(?!\d)\s*$")
+    test_target = re.compile(r"^crates/[^/]+/tests/[^/]+\.rs$")
+    for path, text in lines:
+        if corpus_case(path):
+            if header.match(text):
+                return True
+        elif test_target.match(path):
+            m = RUST_FN_DEF.match(text)
+            if (
+                m
+                and token.search(m.group(1))
+                and not m.group(1).startswith("_")
+                and m.group(1) not in removed_fns
+                and not text.rstrip().endswith(";")
+            ):
+                return True
+    return False
+
+
+def corpus_case(path: str) -> bool:
+    rest = path[len(CORPUS_DIR_PREFIX) :] if path.startswith(CORPUS_DIR_PREFIX) else ""
+    return bool(rest) and "/" not in rest and rest.endswith(".gqt")
 
 
 def check_agents_md() -> bool:
@@ -108,13 +182,14 @@ def run_gate(body: str, labels: list[str], range_: str) -> int:
         return 0 if ok else 1
     try:
         files = added_files(range_)
-        lines = added_lines(range_)
+        lines, removed = diff_changes(range_)
     except subprocess.CalledProcessError as e:
         stderr = (e.stderr or "").strip()
         print(f"FAIL: git diff {range_} failed: {stderr or e}")
         return 1
+    removed_fns = removed_fn_names(removed)
     for n in issues:
-        if issue_satisfied(n, files, lines):
+        if issue_satisfied(n, files, lines, removed_fns):
             print(f"ok: issue #{n} has a matching regression addition")
         else:
             print(
@@ -149,12 +224,77 @@ def self_test() -> int:
     for body, expected in cases:
         got = closed_issues(body)
         assert got == expected, f"closed_issues({body!r}) = {got}, expected {expected}"
-    assert issue_satisfied("563", ["crates/omnigraph/tests/gq_logic_tests/issue_563_x.gqt"], [])
-    assert not issue_satisfied("563", ["crates/omnigraph/tests/issue_5630_x.rs"], [])
-    assert issue_satisfied("563", [], ["fn t_issue_563_case() {"])
-    assert issue_satisfied("563", [], ["# issue: 563"])
-    assert not issue_satisfied("563", [], ["# issue: 5630"])
-    assert not issue_satisfied("563", [], ["# issue:563"])
+    corpus = "crates/omnigraph/tests/gq_logic_tests/issue_563_x.gqt"
+    rust = "crates/omnigraph/tests/search.rs"
+    assert issue_satisfied("563", [corpus], [])
+    assert not issue_satisfied("563", ["crates/omnigraph/tests/fixtures/issue_563_x.gqt"], [])
+    assert not issue_satisfied("563", ["crates/omnigraph/tests/repro_issue_563.rs"], [])
+    assert issue_satisfied("563", [], [(rust, "fn t_issue_563_case() {")])
+    assert issue_satisfied("563", [], [(rust, "    async fn repro_issue_563() {")])
+    assert not issue_satisfied("563", [], [(rust, "// see issue_563")])
+    assert not issue_satisfied("563", [], [(rust, "let s = \"issue_563\";")])
+    assert not issue_satisfied("563", [], [(rust, "fn t_issue_5630() {")])
+    assert issue_satisfied("563", [], [(corpus, "# issue: 563")])
+    assert not issue_satisfied("563", [], [(corpus, "# issue: 0563")])
+    assert not issue_satisfied("563", [], [(corpus, "# issue: 5630")])
+    assert not issue_satisfied("563", [], [(corpus, "issue: 563 in prose")])
+    assert not issue_satisfied(
+        "563", ["crates/omnigraph-cli/tests/gq_logic_tests/issue_563_x.gqt"], []
+    )
+    assert not issue_satisfied(
+        "563", ["crates/omnigraph/tests/gq_logic_tests/nested/issue_563_x.gqt"], []
+    )
+    assert not issue_satisfied(
+        "563", ["crates/omnigraph/tests/gq_logic_tests/regression_issue_563.gqt"], []
+    )
+    assert not issue_satisfied(
+        "563", [], [("crates/omnigraph/tests/fixtures/issue_563_gen.rs", "fn t_issue_563() {}")]
+    )
+    assert not issue_satisfied(
+        "563", [], [("crates/omnigraph/tests/helpers/mod.rs", "fn t_issue_563() {}")]
+    )
+    assert not issue_satisfied("563", [], [(rust, "fn _issue_563() {}")])
+    assert issue_satisfied("563", [], [(rust, "const fn check_issue_563() {}")])
+    assert not issue_satisfied("563", [], [(rust, "fn t_issue_563(&self);")])
+    assert not issue_satisfied(
+        "563", [], [(rust, "fn t_issue_563_case() {")], removed_fns={"t_issue_563_case"}
+    )
+
+    spoof_diff = "\n".join(
+        [
+            "diff --git a/crates/omnigraph/tests/search.rs b/crates/omnigraph/tests/search.rs",
+            "--- a/crates/omnigraph/tests/search.rs",
+            "+++ b/crates/omnigraph/tests/search.rs",
+            "@@ -0,0 +1,3 @@",
+            "+/*",
+            "+++ b/crates/omnigraph/tests/gq_logic_tests/fake.gqt",
+            "+# issue: 999",
+            "+*/",
+        ]
+    )
+    added, removed = parse_diff(spoof_diff)
+    assert all(path == "crates/omnigraph/tests/search.rs" for path, _ in added), added
+    assert not issue_satisfied("999", [], added)
+
+    multi_diff = "\n".join(
+        [
+            "diff --git a/a.gqt b/a.gqt",
+            "--- a/crates/omnigraph/tests/gq_logic_tests/a.gqt",
+            "+++ b/crates/omnigraph/tests/gq_logic_tests/a.gqt",
+            "@@ -0,0 +1 @@",
+            "+# issue: 7",
+            "diff --git a/old.rs b/old.rs",
+            "--- a/crates/omnigraph/tests/old.rs",
+            "+++ /dev/null",
+            "@@ -1,2 +0,0 @@",
+            "-fn t_issue_8_gone() {}",
+            "-fn keep() {}",
+        ]
+    )
+    added, removed = parse_diff(multi_diff)
+    assert added == [("crates/omnigraph/tests/gq_logic_tests/a.gqt", "# issue: 7")], added
+    assert removed_fn_names(removed) == {"t_issue_8_gone", "keep"}, removed
+
     print("self-test ok")
     return 0
 

--- a/scripts/check-fix-regression.py
+++ b/scripts/check-fix-regression.py
@@ -17,17 +17,22 @@ AGENTS.md and git are resolved relative to the working directory.
 
 A closed issue N is satisfied by an added `.gqt` case named `issue_N_*` at
 the top level of the logic-test corpus, an added `# issue: N` header line
-in a corpus `.gqt`, or an added Rust function definition whose name
-carries `issue_N` in a top-level test target `crates/*/tests/<name>.rs` or
-an in-source module under `crates/*/src/`; helper and fixture modules
-under `tests/<dir>/` never match. What a match guarantees differs by
-shape: a corpus match ran green in the required `GQ Logic Tests` job; a
-Rust match is a naming check. A pull request runs only the corpus walker
-and the `omnigraph-server` aws-feature suite among Rust test targets
-(`Test Workspace` runs post-merge), and workspace clippy refuses an
-unreferenced private function but not an `#[ignore]`d or cfg-gated one,
-so whether that test is registered, runs, and asserts the right thing
-stays with review.
+in a corpus `.gqt`, or an added Rust test definition: a function whose
+name carries `issue_N`, with an added `#[test]` or `#[<path>::test]`
+attribute line (`#[tokio::test(...)]` included) directly above it in the
+same hunk, other `#[...]` attribute and `//` comment lines allowed in
+between (a blank line, a block comment, or an attribute split across
+lines breaks adjacency), in a
+top-level test target `crates/*/tests/<name>.rs` or an in-source module
+under `crates/*/src/`; helper and fixture modules under `tests/<dir>/`
+never match, and a plain function, however named, never matches. What a
+match guarantees differs by shape: a corpus match ran green in the
+required `GQ Logic Tests` job; a Rust match is a test-attributed
+definition, not a run. A pull request runs only the corpus walker and the
+`omnigraph-server` aws-feature suite among Rust test targets (`Test
+Workspace` runs post-merge), and workspace clippy refuses an unreferenced
+private function but not an `#[ignore]`d or cfg-gated one, so whether
+that test runs in the suite and asserts the right thing stays with review.
 Comments, strings, and fixture lines mentioning the issue do not count.
 N is always followed by a non-digit or the end. Named residue: a
 definition inside an added block comment or raw string still matches
@@ -74,6 +79,14 @@ RUST_FN_DEF = re.compile(
     r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:const\s+)?(?:async\s+)?(?:unsafe\s+)?"
     r'(?:extern\s+"[^"]*"\s+)?fn\s+([A-Za-z0-9_]+)'
 )
+# `#[test]`, `#[tokio::test]`, `#[tokio::test(flavor = "...")]`; not
+# `#[cfg(test)]`, `#[test_case(...)]`, or `#[serial_test::serial]`.
+TEST_ATTR = re.compile(r"^\s*#\[(?:[A-Za-z0-9_]+::)*test\b(?!_)")
+# Lines the attribute lookback may step over: other attributes and comments.
+ATTR_OR_COMMENT = re.compile(r"^\s*(?:#\[|//)")
+# Inserted into the added-line list at every hunk header, so the lookback
+# never joins lines that are not adjacent in the new file.
+HUNK_BREAK = ("", "")
 
 
 def added_files(range_: str) -> list[str]:
@@ -100,7 +113,8 @@ def parse_diff(diff_text: str) -> tuple[list[tuple[str, str]], list[str]]:
     """Splits a -U0 diff into path-attributed added lines and bare removed
     lines. A `+++ b/` marker counts as a file header only directly after a
     `--- ` line: an added CONTENT line `++ b/x` also renders as `+++ b/x`,
-    and honoring it would let a diff spoof its own file attribution."""
+    and honoring it would let a diff spoof its own file attribution. Every
+    `@@` hunk header contributes a `HUNK_BREAK` entry to the added list."""
     current: str | None = None
     previous = ""
     added: list[tuple[str, str]] = []
@@ -108,6 +122,8 @@ def parse_diff(diff_text: str) -> tuple[list[tuple[str, str]], list[str]]:
     for line in diff_text.splitlines():
         if line.startswith("+++") and previous.startswith("--- "):
             current = line[len("+++ b/") :] if line.startswith("+++ b/") else None
+        elif line.startswith("@@"):
+            added.append(HUNK_BREAK)
         elif line.startswith("+") and not line.startswith("+++") and current is not None:
             added.append((current, line[1:]))
         elif line.startswith("-") and not line.startswith("---"):
@@ -146,7 +162,7 @@ def issue_satisfied(
         if corpus_case(path) and Path(path).name.startswith(f"issue_{n}_"):
             return True
     header = re.compile(rf"^\s*#\s*issue:\s*{n}(?!\d)\s*$")
-    for path, text in lines:
+    for i, (path, text) in enumerate(lines):
         if corpus_case(path):
             if header.match(text):
                 return True
@@ -158,8 +174,23 @@ def issue_satisfied(
                 and not m.group(1).startswith("_")
                 and m.group(1) not in removed_fns
                 and not text.rstrip().endswith(";")
+                and test_attributed(lines, i)
             ):
                 return True
+    return False
+
+
+def test_attributed(lines: list[tuple[str, str]], i: int) -> bool:
+    """True when an added test attribute sits directly above added line `i`
+    in the same file and hunk, stepping over other attributes and comments.
+    A `HUNK_BREAK` or a different path ends the walk: an attribute that is
+    not adjacent in the new file cannot vouch for the definition."""
+    path = lines[i][0]
+    j = i - 1
+    while j >= 0 and lines[j][0] == path and ATTR_OR_COMMENT.match(lines[j][1]):
+        if TEST_ATTR.match(lines[j][1]):
+            return True
+        j -= 1
     return False
 
 
@@ -203,9 +234,9 @@ def run_gate(body: str, labels: list[str], range_: str) -> int:
             print(
                 f"FAIL: the body closes #{n} but the diff adds no `.gqt` case "
                 f"named `issue_{n}_*` or carrying `# issue: {n}` under "
-                f"{CORPUS_DIR_PREFIX}, and no function named for `issue_{n}` in "
-                f"crates/*/tests/<name>.rs or crates/*/src/; add one or apply "
-                f"the `{WAIVER_LABEL}` label"
+                f"{CORPUS_DIR_PREFIX}, and no `#[test]`-attributed function named "
+                f"for `issue_{n}` in crates/*/tests/<name>.rs or crates/*/src/; "
+                f"add one or apply the `{WAIVER_LABEL}` label"
             )
             ok = False
     return 0 if ok else 1
@@ -239,8 +270,46 @@ def self_test() -> int:
     assert issue_satisfied("563", [corpus], [])
     assert not issue_satisfied("563", ["crates/omnigraph/tests/fixtures/issue_563_x.gqt"], [])
     assert not issue_satisfied("563", ["crates/omnigraph/tests/repro_issue_563.rs"], [])
-    assert issue_satisfied("563", [], [(rust, "fn t_issue_563_case() {")])
-    assert issue_satisfied("563", [], [(rust, "    async fn repro_issue_563() {")])
+    assert issue_satisfied("563", [], [(rust, "#[test]"), (rust, "fn t_issue_563_case() {")])
+    assert issue_satisfied(
+        "563", [], [(rust, "    #[tokio::test]"), (rust, "    async fn repro_issue_563() {")]
+    )
+    # A plain function, however named, is not a regression test.
+    assert not issue_satisfied("563", [], [(rust, "fn t_issue_563_case() {")])
+    assert not issue_satisfied("563", [], [(rust, "    async fn repro_issue_563() {")])
+    assert not issue_satisfied("563", [], [(rust, "pub fn issue_563_helper(x: u32) -> u32 {")])
+    # Attribute variants: flavor args, stacked attributes, doc comments between.
+    assert issue_satisfied(
+        "563",
+        [],
+        [
+            (rust, '#[tokio::test(flavor = "multi_thread")]'),
+            (rust, "#[ignore]"),
+            (rust, "/// Regression for the capped-scan underfill."),
+            (rust, "async fn issue_563_underfill() {"),
+        ],
+    )
+    assert issue_satisfied("563", [], [(rust, "#[test]"), (rust, "#[serial_test::serial]"), (rust, "fn issue_563() {")])
+    # Not test attributes: cfg gates, look-alike names, unrelated attributes.
+    assert not issue_satisfied("563", [], [(rust, "#[cfg(test)]"), (rust, "fn issue_563() {")])
+    assert not issue_satisfied("563", [], [(rust, "#[test_case(1)]"), (rust, "fn issue_563() {")])
+    assert not issue_satisfied("563", [], [(rust, "#[serial_test::serial]"), (rust, "fn issue_563() {")])
+    assert not issue_satisfied("563", [], [(rust, "#[allow(dead_code)]"), (rust, "fn issue_563() {")])
+    # The attribute must be adjacent: a blank line, a hunk break, or another
+    # file between attribute and definition breaks the vouching.
+    assert not issue_satisfied("563", [], [(rust, "#[test]"), (rust, ""), (rust, "fn issue_563() {")])
+    assert not issue_satisfied("563", [], [(rust, "#[test]"), HUNK_BREAK, (rust, "fn issue_563() {")])
+    assert not issue_satisfied(
+        "563", [], [("crates/omnigraph/tests/other.rs", "#[test]"), (rust, "fn issue_563() {")]
+    )
+    assert not issue_satisfied("563", [], [(rust, "fn issue_563() {"), (rust, "#[test]")])
+    assert TEST_ATTR.match("#[test]") and TEST_ATTR.match("  #[tokio::test]")
+    assert TEST_ATTR.match('#[tokio::test(flavor = "multi_thread", worker_threads = 2)]')
+    assert TEST_ATTR.match("#[async_std::test]")
+    assert not TEST_ATTR.match("#[cfg(test)]")
+    assert not TEST_ATTR.match("#[test_case(1)]")
+    assert not TEST_ATTR.match("#[serial_test::serial]")
+    assert not TEST_ATTR.match("#[tests]")
     assert not issue_satisfied("563", [], [(rust, "// see issue_563")])
     assert not issue_satisfied("563", [], [(rust, "let s = \"issue_563\";")])
     assert not issue_satisfied("563", [], [(rust, "fn t_issue_5630() {")])
@@ -263,18 +332,30 @@ def self_test() -> int:
     assert not issue_satisfied(
         "563", [], [("crates/omnigraph/tests/helpers/mod.rs", "fn t_issue_563() {}")]
     )
-    assert not issue_satisfied("563", [], [(rust, "fn _issue_563() {}")])
-    assert issue_satisfied("563", [], [(rust, "const fn check_issue_563() {}")])
-    assert not issue_satisfied("563", [], [(rust, "fn t_issue_563(&self);")])
+    assert not issue_satisfied("563", [], [(rust, "#[test]"), (rust, "fn _issue_563() {}")])
+    assert issue_satisfied("563", [], [(rust, "#[test]"), (rust, "const fn check_issue_563() {}")])
+    assert not issue_satisfied("563", [], [(rust, "#[test]"), (rust, "fn t_issue_563(&self);")])
     assert not issue_satisfied(
-        "563", [], [(rust, "fn t_issue_563_case() {")], removed_fns={"t_issue_563_case"}
+        "563",
+        [],
+        [(rust, "#[test]"), (rust, "fn t_issue_563_case() {")],
+        removed_fns={"t_issue_563_case"},
     )
     src = "crates/omnigraph/src/exec/query.rs"
-    assert issue_satisfied("563", [], [(src, "    fn regression_issue_563() {")])
-    assert issue_satisfied("563", [], [("crates/omnigraph-dst/src/lib.rs", "async fn issue_563() {")])
+    assert issue_satisfied("563", [], [(src, "    #[test]"), (src, "    fn regression_issue_563() {")])
+    assert issue_satisfied(
+        "563",
+        [],
+        [("crates/omnigraph-dst/src/lib.rs", "#[tokio::test]"), ("crates/omnigraph-dst/src/lib.rs", "async fn issue_563() {")],
+    )
+    assert not issue_satisfied("563", [], [(src, "    fn regression_issue_563() {")])
     assert not issue_satisfied("563", [], [(src, "// regression_issue_563 lives below")])
-    assert not issue_satisfied("563", [], [("crates/omnigraph/src/query.pest", "fn t_issue_563() {")])
-    assert not issue_satisfied("563", [], [("crates/omnigraph/benches/b.rs", "fn t_issue_563() {")])
+    assert not issue_satisfied(
+        "563", [], [("crates/omnigraph/src/query.pest", "#[test]"), ("crates/omnigraph/src/query.pest", "fn t_issue_563() {")]
+    )
+    assert not issue_satisfied(
+        "563", [], [("crates/omnigraph/benches/b.rs", "#[test]"), ("crates/omnigraph/benches/b.rs", "fn t_issue_563() {")]
+    )
     assert not issue_satisfied("563", ["crates/omnigraph/src/gq_logic_tests/issue_563_x.gqt"], [])
     assert RUST_FN_PATH.match("crates/omnigraph/tests/search.rs")
     assert RUST_FN_PATH.match("crates/omnigraph/src/a/b/c.rs")
@@ -296,8 +377,38 @@ def self_test() -> int:
         ]
     )
     added, removed = parse_diff(spoof_diff)
-    assert all(path == "crates/omnigraph/tests/search.rs" for path, _ in added), added
+    assert all(
+        path == "crates/omnigraph/tests/search.rs" for path, _ in added if (path, _) != HUNK_BREAK
+    ), added
     assert not issue_satisfied("999", [], added)
+
+    # A real -U0 shape: attribute and definition in one hunk count; the same
+    # definition after a hunk break, with the attribute in the prior hunk, does not.
+    adjacent_diff = "\n".join(
+        [
+            "diff --git a/crates/omnigraph/tests/search.rs b/crates/omnigraph/tests/search.rs",
+            "--- a/crates/omnigraph/tests/search.rs",
+            "+++ b/crates/omnigraph/tests/search.rs",
+            "@@ -40,0 +41,2 @@",
+            "+#[tokio::test]",
+            "+async fn issue_563_adjacent() {",
+        ]
+    )
+    added, _ = parse_diff(adjacent_diff)
+    assert issue_satisfied("563", [], added)
+    split_diff = "\n".join(
+        [
+            "diff --git a/crates/omnigraph/tests/search.rs b/crates/omnigraph/tests/search.rs",
+            "--- a/crates/omnigraph/tests/search.rs",
+            "+++ b/crates/omnigraph/tests/search.rs",
+            "@@ -40,0 +41 @@",
+            "+#[tokio::test]",
+            "@@ -60,0 +62 @@",
+            "+async fn issue_563_split() {",
+        ]
+    )
+    added, _ = parse_diff(split_diff)
+    assert not issue_satisfied("563", [], added)
 
     multi_diff = "\n".join(
         [
@@ -315,7 +426,9 @@ def self_test() -> int:
         ]
     )
     added, removed = parse_diff(multi_diff)
-    assert added == [("crates/omnigraph/tests/gq_logic_tests/a.gqt", "# issue: 7")], added
+    assert [a for a in added if a != HUNK_BREAK] == [
+        ("crates/omnigraph/tests/gq_logic_tests/a.gqt", "# issue: 7")
+    ], added
     assert removed_fn_names(removed) == {"t_issue_8_gone", "keep"}, removed
 
     print("self-test ok")

--- a/scripts/check-fix-regression.py
+++ b/scripts/check-fix-regression.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Fix Regression Gate: every issue a PR body closes by keyword needs a
+matching regression addition in the diff, or the PR carries the `no-repro`
+label. Specified in docs/rfcs/0045-gq-logic-tests.md (User and operational
+behavior, "Fix-PR gate").
+
+The gate reads only GitHub's own closing-keyword form (`fixes #123`,
+`fixes: #123`, `fixes:#123`): case-insensitive, a word boundary before the
+keyword, an optional colon, whitespace unless the colon is present, then
+`#N`. Closings by URL, `owner/repo#N`, `GH-N`, a bare `fixes#123`, commit
+message, or manual close pass unexamined and belong to review.
+
+Label names are read as a comma-joined list, so a label whose own name
+contains a comma could smuggle the waiver token; creating labels needs the
+same triage rights as applying the real one. Run from the repository root:
+AGENTS.md and git are resolved relative to the working directory.
+
+A closed issue N is satisfied by an addition under `crates/*/tests/**`:
+an added file whose path contains `issue_N`, or an added line containing
+`issue_N` or `issue: N`, where N is followed by a non-digit or the end.
+
+Exit 0 exactly when every keyword-closed issue has its match or the PR
+carries `no-repro`, and AGENTS.md still names the logic-test corpus path.
+
+Usage:
+  check-fix-regression.py --body-file F --labels "a,b" --range BASE...HEAD
+  check-fix-regression.py --self-test
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+CLOSING_KEYWORD = re.compile(
+    r"(?<![A-Za-z0-9_])(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?)(?::\s*|\s+)#(\d+)",
+    re.IGNORECASE,
+)
+CORPUS_PATH_SENTENCE = "crates/omnigraph/tests/gq_logic_tests/"
+WAIVER_LABEL = "no-repro"
+TEST_PATHSPEC = ":(glob)crates/*/tests/**"
+
+
+def closed_issues(body: str) -> list[str]:
+    return sorted({str(int(n)) for n in CLOSING_KEYWORD.findall(body)}, key=int)
+
+
+def issue_token(n: str) -> re.Pattern[str]:
+    return re.compile(rf"issue_{n}(?!\d)")
+
+
+def issue_line_patterns(n: str) -> list[re.Pattern[str]]:
+    return [issue_token(n), re.compile(rf"issue: {n}(?!\d)")]
+
+
+def added_files(range_: str) -> list[str]:
+    out = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=A", range_, "--", TEST_PATHSPEC],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line for line in out.stdout.splitlines() if line]
+
+
+def added_lines(range_: str) -> list[str]:
+    out = subprocess.run(
+        ["git", "diff", "-U0", range_, "--", TEST_PATHSPEC],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [
+        line[1:]
+        for line in out.stdout.splitlines()
+        if line.startswith("+") and not line.startswith("+++")
+    ]
+
+
+def issue_satisfied(n: str, files: list[str], lines: list[str]) -> bool:
+    token = issue_token(n)
+    if any(token.search(path) for path in files):
+        return True
+    patterns = issue_line_patterns(n)
+    return any(p.search(line) for line in lines for p in patterns)
+
+
+def check_agents_md() -> bool:
+    agents = Path("AGENTS.md")
+    return agents.is_file() and CORPUS_PATH_SENTENCE in agents.read_text(encoding="utf-8")
+
+
+def run_gate(body: str, labels: list[str], range_: str) -> int:
+    ok = True
+    if not check_agents_md():
+        print(
+            f"FAIL: AGENTS.md no longer names the corpus path `{CORPUS_PATH_SENTENCE}`; "
+            "the contract sentence and this gate leave together"
+        )
+        ok = False
+    issues = closed_issues(body)
+    if not issues:
+        print("ok: the PR body closes no issue by keyword")
+        return 0 if ok else 1
+    if WAIVER_LABEL in labels:
+        print(f"ok: `{WAIVER_LABEL}` label waives the regression requirement for this PR")
+        return 0 if ok else 1
+    try:
+        files = added_files(range_)
+        lines = added_lines(range_)
+    except subprocess.CalledProcessError as e:
+        stderr = (e.stderr or "").strip()
+        print(f"FAIL: git diff {range_} failed: {stderr or e}")
+        return 1
+    for n in issues:
+        if issue_satisfied(n, files, lines):
+            print(f"ok: issue #{n} has a matching regression addition")
+        else:
+            print(
+                f"FAIL: the body closes #{n} but the diff adds no `issue_{n}` "
+                f"test or `.gqt` case under crates/*/tests/; add one or apply "
+                f"the `{WAIVER_LABEL}` label"
+            )
+            ok = False
+    return 0 if ok else 1
+
+
+def self_test() -> int:
+    cases = [
+        ("Closes #563", ["563"]),
+        ("closes: #12 and fixes #7", ["7", "12"]),
+        ("Resolved #99", ["99"]),
+        ("hotfix #563", []),
+        ("prefix #5", []),
+        ("9fixes #5", []),
+        ("_fixes #5", []),
+        ("Closing #1", []),
+        ("fixes:#123", ["123"]),
+        ("fixes#123", []),
+        ("fixes #0563", ["563"]),
+        ("fixes #7 fixes #07", ["7"]),
+        ("Fixes #563\r\nmore text", ["563"]),
+        ("see https://github.com/o/r/issues/4", []),
+        ("fixes o/r#4", []),
+        ("fixes GH-4", []),
+        ("FIX #8", ["8"]),
+    ]
+    for body, expected in cases:
+        got = closed_issues(body)
+        assert got == expected, f"closed_issues({body!r}) = {got}, expected {expected}"
+    assert issue_satisfied("563", ["crates/omnigraph/tests/gq_logic_tests/issue_563_x.gqt"], [])
+    assert not issue_satisfied("563", ["crates/omnigraph/tests/issue_5630_x.rs"], [])
+    assert issue_satisfied("563", [], ["fn t_issue_563_case() {"])
+    assert issue_satisfied("563", [], ["# issue: 563"])
+    assert not issue_satisfied("563", [], ["# issue: 5630"])
+    assert not issue_satisfied("563", [], ["# issue:563"])
+    print("self-test ok")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--body-file")
+    parser.add_argument("--labels", default="")
+    parser.add_argument("--range")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        return self_test()
+    if not args.body_file or not args.range:
+        parser.error("--body-file and --range are required unless --self-test")
+    body = Path(args.body_file).read_text(encoding="utf-8")
+    labels = [label.strip() for label in args.labels.split(",") if label.strip()]
+    return run_gate(body, labels, args.range)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-fix-regression.py
+++ b/scripts/check-fix-regression.py
@@ -15,20 +15,30 @@ contains a comma could smuggle the waiver token; creating labels needs the
 same triage rights as applying the real one. Run from the repository root:
 AGENTS.md and git are resolved relative to the working directory.
 
-A closed issue N is satisfied by an added `.gqt` case named `issue_N_*` at
-the top level of the logic-test corpus, an added `# issue: N` header line
-in a corpus `.gqt`, or an added Rust test definition: a function whose
-name carries `issue_N`, with an added `#[test]` or `#[<path>::test]`
-attribute line (`#[tokio::test(...)]` included) directly above it in the
-same hunk, other `#[...]` attribute and `//` comment lines allowed in
-between (a blank line, a block comment, or an attribute split across
-lines breaks adjacency), in a
-top-level test target `crates/*/tests/<name>.rs` or an in-source module
-under `crates/*/src/`; helper and fixture modules under `tests/<dir>/`
-never match, and a plain function, however named, never matches. What a
-match guarantees differs by shape: a corpus match ran green in the
-required `GQ Logic Tests` job; a Rust match is a test-attributed
-definition, not a run. A pull request runs only the corpus walker and the
+A closed issue N is satisfied by a regression that is added or
+strengthened. Corpus shape: a `.gqt` case named `issue_N_*` at the top
+level of the logic-test corpus, new, or modified with at least one added
+body line (a line that is neither a `#` header line nor a `//` comment).
+Rust shapes, in a top-level test target `<crates|tools>/*/tests/<name>.rs`
+or an in-source module under `<crates|tools>/*/src/`: an added test
+definition, a function whose name carries `issue_N`, with an added
+`#[test]` or `#[<path>::test]` attribute line (`#[tokio::test(...)]`
+included) directly above it in the same hunk, other `#[...]` attribute
+and `//` comment lines allowed in between (a blank line, a block comment,
+or an attribute split across lines breaks adjacency); or a strengthened
+one, an added line carrying at least one alphanumeric character, not a
+comment or an attribute, inside the body of an existing test-attributed
+function whose name carries `issue_N`, located by the hunk's new-file line
+number in the file at the head commit. An owner test not named for the
+issue is extended by renaming it to carry `issue_N` in the same change
+(the rename alone never counts; the rename plus the assertion does).
+Helper and fixture modules under `tests/<dir>/` never match, and a plain
+function, however named, never matches. Owners the gate does not
+recognize, Python and shell scripts among them, satisfy it only through
+the `no-repro` label, which a maintainer applies. What a match guarantees
+differs by shape: a corpus match ran green in the required `GQ Logic
+Tests` job; a Rust match is a test-attributed definition or an edit inside
+one, not a run. A pull request runs only the corpus walker and the
 `omnigraph-server` aws-feature suite among Rust test targets (`Test
 Workspace` runs post-merge), and workspace clippy refuses an unreferenced
 private function but not an `#[ignore]`d or cfg-gated one, so whether
@@ -36,8 +46,11 @@ that test runs in the suite and asserts the right thing stays with review.
 Comments, strings, and fixture lines mentioning the issue do not count.
 N is always followed by a non-digit or the end. Named residue: a
 definition inside an added block comment or raw string still matches
-(line-based parsing cannot see multi-line context); that evasion, like a
-test that asserts nothing, is deliberate and stays with review.
+(line-based parsing cannot see multi-line context); the enclosing item of
+a strengthened line is found by brace counting with string literals, char
+literals, and `//` comments blanked, so a brace inside a raw string or a
+multi-line block comment can mislead it; those evasions, like a test that
+asserts nothing, are deliberate and stay with review.
 
 Exit 0 exactly when every keyword-closed issue has its match or the PR
 carries `no-repro`, and AGENTS.md still names the logic-test corpus path.
@@ -61,7 +74,12 @@ CLOSING_KEYWORD = re.compile(
 )
 CORPUS_PATH_SENTENCE = "crates/omnigraph/tests/gq_logic_tests/"
 WAIVER_LABEL = "no-repro"
-PATHSPECS = (":(glob)crates/*/tests/**", ":(glob)crates/*/src/**")
+PATHSPECS = (
+    ":(glob)crates/*/tests/**",
+    ":(glob)crates/*/src/**",
+    ":(glob)tools/*/tests/**",
+    ":(glob)tools/*/src/**",
+)
 
 
 def closed_issues(body: str) -> list[str]:
@@ -73,8 +91,9 @@ def issue_token(n: str) -> re.Pattern[str]:
 
 
 CORPUS_DIR_PREFIX = "crates/omnigraph/tests/gq_logic_tests/"
-# One path segment after `tests/` (a top-level target) or any `.rs` under `src/`.
-RUST_FN_PATH = re.compile(r"^crates/[^/]+/(?:tests/[^/]+\.rs|src/.+\.rs)$")
+# One path segment after `tests/` (a top-level target) or any `.rs` under
+# `src/`, in a `crates/` or `tools/` workspace member.
+RUST_FN_PATH = re.compile(r"^(?:crates|tools)/[^/]+/(?:tests/[^/]+\.rs|src/.+\.rs)$")
 RUST_FN_DEF = re.compile(
     r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:const\s+)?(?:async\s+)?(?:unsafe\s+)?"
     r'(?:extern\s+"[^"]*"\s+)?fn\s+([A-Za-z0-9_]+)'
@@ -109,30 +128,55 @@ def added_files(range_: str) -> list[str]:
     return [line for line in out.stdout.splitlines() if line]
 
 
-def parse_diff(diff_text: str) -> tuple[list[tuple[str, str]], list[str]]:
-    """Splits a -U0 diff into path-attributed added lines and bare removed
-    lines. A `+++ b/` marker counts as a file header only directly after a
-    `--- ` line: an added CONTENT line `++ b/x` also renders as `+++ b/x`,
-    and honoring it would let a diff spoof its own file attribution. Every
-    `@@` hunk header contributes a `HUNK_BREAK` entry to the added list."""
+HUNK_HEADER = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+
+
+def parse_diff(
+    diff_text: str,
+) -> tuple[list[tuple[str, str]], list[str], list[tuple[str, int, str]]]:
+    """Splits a -U0 diff into path-attributed added lines, bare removed
+    lines, and added lines positioned by their new-file line number. A
+    `+++ b/` marker counts as a file header only in a file's preamble (after
+    its `diff --git` line and before its first `@@`) and directly after a
+    `--- ` line: inside a hunk, an added CONTENT line `++ b/x` renders as
+    `+++ b/x` and a removed content line `-- x` renders as `--- x`, and
+    honoring that pair would let a diff spoof its own file attribution.
+    Every `@@` hunk header contributes a `HUNK_BREAK` entry to the added
+    list."""
     current: str | None = None
     previous = ""
+    preamble = False
+    new_line = 0
     added: list[tuple[str, str]] = []
     removed: list[str] = []
+    positioned: list[tuple[str, int, str]] = []
     for line in diff_text.splitlines():
-        if line.startswith("+++") and previous.startswith("--- "):
+        if line.startswith("diff --git "):
+            preamble = True
+            current = None
+        elif preamble and line.startswith("+++") and previous.startswith("--- "):
             current = line[len("+++ b/") :] if line.startswith("+++ b/") else None
         elif line.startswith("@@"):
+            preamble = False
             added.append(HUNK_BREAK)
-        elif line.startswith("+") and not line.startswith("+++") and current is not None:
+            m = HUNK_HEADER.match(line)
+            new_line = int(m.group(1)) if m else 0
+        elif line.startswith("+") and current is not None:
+            # Includes an added CONTENT line that itself starts with `++`
+            # (rendered `+++...`): it is a new-file line and advances the
+            # position like any other.
             added.append((current, line[1:]))
+            positioned.append((current, new_line, line[1:]))
+            new_line += 1
         elif line.startswith("-") and not line.startswith("---"):
             removed.append(line[1:])
         previous = line
-    return added, removed
+    return added, removed, positioned
 
 
-def diff_changes(range_: str) -> tuple[list[tuple[str, str]], list[str]]:
+def diff_changes(
+    range_: str,
+) -> tuple[list[tuple[str, str]], list[str], list[tuple[str, int, str]]]:
     out = subprocess.run(
         ["git", "-c", "core.quotePath=false", "diff", "-U0", range_, "--", *PATHSPECS],
         check=True,
@@ -140,6 +184,29 @@ def diff_changes(range_: str) -> tuple[list[tuple[str, str]], list[str]]:
         text=True,
     )
     return parse_diff(out.stdout)
+
+
+def head_file_reader(range_: str):
+    """Returns a reader of new-file contents at the range's head commit
+    (`BASE...HEAD` or `BASE..HEAD`), memoized per path; `None` when the
+    path does not exist there."""
+    head = range_.split("...")[-1].split("..")[-1]
+    cache: dict[str, list[str] | None] = {}
+
+    def read(path: str) -> list[str] | None:
+        # An empty head (`A...`) would make `git show :path` read the index.
+        if not head:
+            return None
+        if path not in cache:
+            out = subprocess.run(
+                ["git", "-c", "core.quotePath=false", "show", f"{head}:{path}"],
+                capture_output=True,
+                text=True,
+            )
+            cache[path] = out.stdout.splitlines() if out.returncode == 0 else None
+        return cache[path]
+
+    return read
 
 
 def removed_fn_names(removed: list[str]) -> set[str]:
@@ -156,15 +223,27 @@ def issue_satisfied(
     files: list[str],
     lines: list[tuple[str, str]],
     removed_fns: frozenset[str] | set[str] = frozenset(),
+    positioned: list[tuple[str, int, str]] = (),
+    read_file=None,
 ) -> bool:
     token = issue_token(n)
     for path in files:
         if corpus_case(path) and Path(path).name.startswith(f"issue_{n}_"):
             return True
-    header = re.compile(rf"^\s*#\s*issue:\s*{n}(?!\d)\s*$")
     for i, (path, text) in enumerate(lines):
         if corpus_case(path):
-            if header.match(text):
+            # A strengthened case: a body line added to a case named for the
+            # issue, new or modified. Header (`#`) and GQ comment (`//`)
+            # lines carry no assertion. (An added `# issue: N` header line
+            # is not a shape of its own: the walker requires the file name
+            # to match and refuses a second `# issue:`, so that line only
+            # ever appears in a new case named for the issue.)
+            stripped = text.strip()
+            if (
+                stripped
+                and not stripped.startswith(("#", "//"))
+                and Path(path).name.startswith(f"issue_{n}_")
+            ):
                 return True
         elif RUST_FN_PATH.match(path):
             m = RUST_FN_DEF.match(text)
@@ -177,6 +256,87 @@ def issue_satisfied(
                 and test_attributed(lines, i)
             ):
                 return True
+    if read_file is not None:
+        for path, lineno, text in positioned:
+            if RUST_FN_PATH.match(path) and strengthens_test(token, path, lineno, text, read_file):
+                return True
+    return False
+
+
+# Brace-opening items that are not functions: an added line inside one of
+# these sits in that item, never in a function above it. Items, `use`
+# groups, `extern` blocks, and macro invocations (`lazy_static! {`,
+# `proptest! {`); a match counts only on a line that opens a brace, so a
+# function-local `const N: usize = 3;` is not an item boundary.
+RUST_ITEM_DEF = re.compile(
+    r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:unsafe\s+)?"
+    r"(?:(?:mod|impl|struct|enum|union|trait|const|static|type|use|extern)\b"
+    r"|[A-Za-z_][A-Za-z0-9_:]*!\s*[{(\[])"
+)
+# Brace-bearing text that is not code: string literals, char literals, and
+# `//` comments. Blanked before counting braces.
+BRACE_NOISE = re.compile(r'"(?:\\.|[^"\\])*"' + r"|'(?:\\.|[^'\\])'" + r"|//.*$")
+
+
+def brace_delta(line: str) -> int:
+    """`}` minus `{` on one line, ignoring braces inside literals and
+    comments. Raw strings and block comments spanning lines are not
+    understood (a named residue)."""
+    code = BRACE_NOISE.sub("", line)
+    return code.count("}") - code.count("{")
+
+
+def strengthens_test(token: re.Pattern[str], path: str, lineno: int, text: str, read_file) -> bool:
+    """True when added line `lineno` (1-based, new file) is a body line
+    carrying at least one alphanumeric character, not a comment or an
+    attribute, inside an existing test-attributed function named for the
+    issue. The enclosing item is the nearest definition above whose brace
+    is still open at the added line (counted upward, literals and comments
+    blanked); a non-function item (`mod`, `impl`, `struct`, ...) found open
+    first means the line is in that item, not in a function. The function's
+    attribute stack is read from the file itself."""
+    stripped = text.strip()
+    if (
+        not any(c.isalnum() for c in stripped)
+        or stripped.startswith("//")
+        or stripped.startswith("#[")
+        or stripped.startswith("#!")
+        or RUST_FN_DEF.match(text)
+    ):
+        return False
+    file_lines = read_file(path)
+    if file_lines is None or not 1 <= lineno <= len(file_lines):
+        return False
+    depth = 0
+    for j in range(lineno - 2, -1, -1):
+        line = file_lines[j]
+        delta = brace_delta(line)
+        depth += delta
+        m = RUST_FN_DEF.match(line)
+        if m and depth < 0:
+            name = m.group(1)
+            return (
+                bool(token.search(name))
+                and not name.startswith("_")
+                and file_test_attributed(file_lines, j)
+            )
+        opens_item = delta < 0 and RUST_ITEM_DEF.match(line)
+        if opens_item and depth < 0:
+            return False
+        if m or opens_item:
+            depth = 0
+    return False
+
+
+def file_test_attributed(file_lines: list[str], fn_index: int) -> bool:
+    """The same adjacency rule as `test_attributed`, read from a whole file:
+    attribute and comment lines directly above the definition, one of them
+    a test attribute."""
+    j = fn_index - 1
+    while j >= 0 and ATTR_OR_COMMENT.match(file_lines[j]):
+        if TEST_ATTR.match(file_lines[j]):
+            return True
+        j -= 1
     return False
 
 
@@ -195,8 +355,13 @@ def test_attributed(lines: list[tuple[str, str]], i: int) -> bool:
 
 
 def corpus_case(path: str) -> bool:
+    """A case is a top-level corpus file whose name ends in `.gqt` and does
+    not start with `.`: the same rule the walker's `list_cases` applies
+    (`crates/omnigraph/tests/gq_logic_tests.rs`), so nothing the gate
+    credits can be a file the walker never runs. Both self-tests walk one
+    name battery."""
     rest = path[len(CORPUS_DIR_PREFIX) :] if path.startswith(CORPUS_DIR_PREFIX) else ""
-    return bool(rest) and "/" not in rest and rest.endswith(".gqt")
+    return bool(rest) and "/" not in rest and rest.endswith(".gqt") and not rest.startswith(".")
 
 
 def check_agents_md() -> bool:
@@ -221,22 +386,31 @@ def run_gate(body: str, labels: list[str], range_: str) -> int:
         return 0 if ok else 1
     try:
         files = added_files(range_)
-        lines, removed = diff_changes(range_)
+        lines, removed, positioned = diff_changes(range_)
     except subprocess.CalledProcessError as e:
         stderr = (e.stderr or "").strip()
         print(f"FAIL: git diff {range_} failed: {stderr or e}")
         return 1
     removed_fns = removed_fn_names(removed)
+    read_file = head_file_reader(range_)
+    for path in sorted({p for p, _, _ in positioned if RUST_FN_PATH.match(p)}):
+        if read_file(path) is None:
+            print(
+                f"warn: {path} could not be read at the head commit; an added line "
+                "inside an existing test there cannot count as a strengthened regression"
+            )
     for n in issues:
-        if issue_satisfied(n, files, lines, removed_fns):
+        if issue_satisfied(n, files, lines, removed_fns, positioned, read_file):
             print(f"ok: issue #{n} has a matching regression addition")
         else:
             print(
-                f"FAIL: the body closes #{n} but the diff adds no `.gqt` case "
-                f"named `issue_{n}_*` or carrying `# issue: {n}` under "
-                f"{CORPUS_DIR_PREFIX}, and no `#[test]`-attributed function named "
-                f"for `issue_{n}` in crates/*/tests/<name>.rs or crates/*/src/; "
-                f"add one or apply the `{WAIVER_LABEL}` label"
+                f"FAIL: the body closes #{n} but the diff neither adds nor extends a "
+                f"`.gqt` case named `issue_{n}_*` under {CORPUS_DIR_PREFIX}, and "
+                f"neither adds nor extends a `#[test]`-attributed function named for "
+                f"`issue_{n}` in crates/*/tests/<name>.rs, tools/*/tests/<name>.rs, or "
+                f"their src/. Add one; to extend an existing owner test, rename it to "
+                f"carry `issue_{n}` and add the assertion; or ask a maintainer for the "
+                f"`{WAIVER_LABEL}` label"
             )
             ok = False
     return 0 if ok else 1
@@ -313,10 +487,14 @@ def self_test() -> int:
     assert not issue_satisfied("563", [], [(rust, "// see issue_563")])
     assert not issue_satisfied("563", [], [(rust, "let s = \"issue_563\";")])
     assert not issue_satisfied("563", [], [(rust, "fn t_issue_5630() {")])
-    assert issue_satisfied("563", [], [(corpus, "# issue: 563")])
-    assert not issue_satisfied("563", [], [(corpus, "# issue: 0563")])
-    assert not issue_satisfied("563", [], [(corpus, "# issue: 5630")])
-    assert not issue_satisfied("563", [], [(corpus, "issue: 563 in prose")])
+    # An added `# issue: N` line is not a shape: the walker requires the file
+    # name to match and refuses a second `# issue:`, so a case not named for
+    # the issue never counts, whatever header line it gains.
+    other = "crates/omnigraph/tests/gq_logic_tests/ranked_join.gqt"
+    assert not issue_satisfied("563", [], [(other, "# issue: 563")])
+    assert not issue_satisfied("563", [], [(other, "# issue: 0563")])
+    assert not issue_satisfied("563", [], [(other, "{\"c.slug\": \"chunk-12\"}")])
+    assert not issue_satisfied("563", [], [(other, "issue: 563 in prose")])
     assert not issue_satisfied(
         "563", ["crates/omnigraph-cli/tests/gq_logic_tests/issue_563_x.gqt"], []
     )
@@ -326,6 +504,22 @@ def self_test() -> int:
     assert not issue_satisfied(
         "563", ["crates/omnigraph/tests/gq_logic_tests/regression_issue_563.gqt"], []
     )
+    # Name battery shared with the walker's `walker_flags_foreign_corpus_entries`:
+    # a dot-prefixed `.gqt` is never a case, by name or by header line.
+    hidden = "crates/omnigraph/tests/gq_logic_tests/.hidden.gqt"
+    assert not issue_satisfied("563", [hidden], [])
+    assert not issue_satisfied("563", [], [(hidden, "# issue: 563")])
+    assert not issue_satisfied("563", ["crates/omnigraph/tests/gq_logic_tests/.issue_563_x.gqt"], [])
+    for name, expected in [
+        ("a.gqt", True),
+        ("b.txt", False),
+        (".hidden.gqt", False),
+        (".DS_Store", False),
+        ("c.GQT", False),
+        ("nested/d.gqt", False),
+    ]:
+        got = corpus_case(CORPUS_DIR_PREFIX + name)
+        assert got == expected, f"corpus_case({name!r}) = {got}, expected {expected}"
     assert not issue_satisfied(
         "563", [], [("crates/omnigraph/tests/fixtures/issue_563_gen.rs", "fn t_issue_563() {}")]
     )
@@ -376,7 +570,7 @@ def self_test() -> int:
             "+*/",
         ]
     )
-    added, removed = parse_diff(spoof_diff)
+    added, removed, _ = parse_diff(spoof_diff)
     assert all(
         path == "crates/omnigraph/tests/search.rs" for path, _ in added if (path, _) != HUNK_BREAK
     ), added
@@ -394,8 +588,12 @@ def self_test() -> int:
             "+async fn issue_563_adjacent() {",
         ]
     )
-    added, _ = parse_diff(adjacent_diff)
+    added, _, positioned = parse_diff(adjacent_diff)
     assert issue_satisfied("563", [], added)
+    assert positioned == [
+        ("crates/omnigraph/tests/search.rs", 41, "#[tokio::test]"),
+        ("crates/omnigraph/tests/search.rs", 42, "async fn issue_563_adjacent() {"),
+    ], positioned
     split_diff = "\n".join(
         [
             "diff --git a/crates/omnigraph/tests/search.rs b/crates/omnigraph/tests/search.rs",
@@ -407,7 +605,7 @@ def self_test() -> int:
             "+async fn issue_563_split() {",
         ]
     )
-    added, _ = parse_diff(split_diff)
+    added, _, _ = parse_diff(split_diff)
     assert not issue_satisfied("563", [], added)
 
     multi_diff = "\n".join(
@@ -425,11 +623,189 @@ def self_test() -> int:
             "-fn keep() {}",
         ]
     )
-    added, removed = parse_diff(multi_diff)
+    added, removed, _ = parse_diff(multi_diff)
     assert [a for a in added if a != HUNK_BREAK] == [
         ("crates/omnigraph/tests/gq_logic_tests/a.gqt", "# issue: 7")
     ], added
     assert removed_fn_names(removed) == {"t_issue_8_gone", "keep"}, removed
+
+    # Workspace members under tools/ are owners too.
+    tool = "tools/omnigraph-vocabulary-guard/tests/guard.rs"
+    assert RUST_FN_PATH.match(tool)
+    assert RUST_FN_PATH.match("tools/omnigraph-vocabulary-guard/src/main.rs")
+    assert not RUST_FN_PATH.match("tools/omnigraph-vocabulary-guard/tests/helpers/mod.rs")
+    assert not RUST_FN_PATH.match("scripts/check-docs.py")
+    assert issue_satisfied("563", [], [(tool, "#[test]"), (tool, "fn issue_563_guard() {")])
+
+    # A strengthened corpus case: a modified `issue_N_*.gqt` with an added
+    # body line counts; blank, header, and GQ-comment additions do not.
+    assert issue_satisfied("563", [], [(corpus, "{\"c.slug\": \"chunk-12\"}")])
+    assert issue_satisfied("563", [], [(corpus, "    $c chunkOfArtifact $a")])
+    assert not issue_satisfied("563", [], [(corpus, "   ")])
+    assert not issue_satisfied("563", [], [(corpus, "# notes: reworded prose")])
+    assert not issue_satisfied("563", [], [(corpus, "# issue: 563")])
+    assert not issue_satisfied("563", [], [(corpus, "    // a GQ comment")])
+    assert not issue_satisfied(
+        "563", [], [("crates/omnigraph/tests/gq_logic_tests/other_case.gqt", "{\"x\": 1}")]
+    )
+
+    # A strengthened Rust test: an added body line inside an existing
+    # test-attributed `issue_N` function, located in the head-commit file.
+    head_file = [
+        "use x;",
+        "",
+        "#[tokio::test]",
+        "async fn bm25_underfill_issue_563() {",
+        "    let db = setup().await;",
+        "    assert_eq!(rows(&db).len(), 2);",
+        "    assert_eq!(rows(&db)[0].slug, \"chunk-12\");",
+        "}",
+        "",
+        "fn helper_issue_563() {",
+        "    let y = 1;",
+        "}",
+        "",
+        "#[test]",
+        "fn unrelated() {",
+        "    let z = 2;",
+        "}",
+    ]
+    reader = lambda path: head_file if path == rust else None  # noqa: E731
+    inside = [(rust, 7, "    assert_eq!(rows(&db)[0].slug, \"chunk-12\");")]
+    assert issue_satisfied("563", [], [], positioned=inside, read_file=reader)
+    assert not issue_satisfied("563", [], [], positioned=inside)  # no reader, no lookup
+    assert not issue_satisfied("564", [], [], positioned=inside, read_file=reader)
+    in_plain = [(rust, 11, "    let y = 1;")]
+    assert not issue_satisfied("563", [], [], positioned=in_plain, read_file=reader)
+    in_other = [(rust, 16, "    let z = 2;")]
+    assert not issue_satisfied("563", [], [], positioned=in_other, read_file=reader)
+    between = [(rust, 9, "")]
+    assert not issue_satisfied("563", [], [], positioned=between, read_file=reader)
+    comment_only = [(rust, 5, "    // touched issue_563")]
+    assert not issue_satisfied("563", [], [], positioned=comment_only, read_file=reader)
+    missing = [("crates/omnigraph/tests/gone.rs", 3, "    let q = 1;")]
+    assert not issue_satisfied("563", [], [], positioned=missing, read_file=reader)
+    fixture_path = [("crates/omnigraph/tests/helpers/mod.rs", 7, "    let q = 1;")]
+    assert not issue_satisfied("563", [], [], positioned=fixture_path, read_file=reader)
+    # Punctuation-only lines carry no assertion; a line after the closing
+    # brace is outside the function (brace counting).
+    brace_only = [(rust, 8, "}")]
+    assert not issue_satisfied("563", [], [], positioned=brace_only, read_file=reader)
+    after_close = [(rust, 9, "let outside = 1;")]
+    assert not issue_satisfied("563", [], [], positioned=after_close, read_file=reader)
+    # Braces inside literals and comments do not count; a non-function item
+    # after the test owns the lines inside it.
+    noisy = [
+        "#[test]",
+        "fn issue_563_noisy() {",
+        "    assert_eq!(s, \"}\");",
+        "    let c = '{';",
+        "    // }",
+        "    let added = 1;",
+        "}",
+        "",
+        "struct Fixture {",
+        "    rows: usize,",
+        "}",
+        "",
+        "mod issue_563_later {",
+        "    fn helper() {}",
+        "}",
+        "",
+        "const K: Foo = Foo {",
+        "    a: 1,",
+        "};",
+    ]
+    noisy_reader = lambda path: noisy if path == rust else None  # noqa: E731
+    assert issue_satisfied("563", [], [], positioned=[(rust, 6, "    let added = 1;")], read_file=noisy_reader)
+    assert not issue_satisfied("563", [], [], positioned=[(rust, 10, "    rows: usize,")], read_file=noisy_reader)
+    assert not issue_satisfied("563", [], [], positioned=[(rust, 14, "    fn helper() {}")], read_file=noisy_reader)
+    assert not issue_satisfied("563", [], [], positioned=[(rust, 18, "    a: 1,")], read_file=noisy_reader)
+    assert brace_delta('let s = "{{{"; // }') == 0
+    assert brace_delta("if x { y } else {") == -1
+    # The honest route for an owner test not named for the issue: rename it
+    # to carry the token and add the assertion in the same change.
+    renamed = [
+        "#[tokio::test]",
+        "async fn deferred_reads_issue_563() {",
+        "    let db = setup().await;",
+        "    assert!(rows(&db).len() <= 10);",
+        "}",
+    ]
+    renamed_reader = lambda path: renamed if path == rust else None  # noqa: E731
+    rename_lines = [(rust, "async fn deferred_reads_issue_563() {"), (rust, "    assert!(rows(&db).len() <= 10);")]
+    assert issue_satisfied(
+        "563",
+        [],
+        rename_lines,
+        removed_fns={"deferred_reads"},
+        positioned=[(rust, 2, rename_lines[0][1]), (rust, 4, rename_lines[1][1])],
+        read_file=renamed_reader,
+    )
+    assert not issue_satisfied(
+        "563", [], rename_lines[:1], removed_fns={"deferred_reads"}, positioned=[(rust, 2, rename_lines[0][1])], read_file=renamed_reader
+    )
+    # An added content line that starts with `++` still advances the position.
+    plus_diff = "\n".join(
+        [
+            "diff --git a/crates/omnigraph/tests/search.rs b/crates/omnigraph/tests/search.rs",
+            "--- a/crates/omnigraph/tests/search.rs",
+            "+++ b/crates/omnigraph/tests/search.rs",
+            "@@ -10,0 +11,3 @@",
+            "+++x",
+            "+let a = 1;",
+            "+let b = 2;",
+        ]
+    )
+    _, _, plus_positioned = parse_diff(plus_diff)
+    assert [n for _, n, _ in plus_positioned] == [11, 12, 13], plus_positioned
+    # Inside a hunk, a removed `-- x` line then an added `++ b/...` line is
+    # content, never a file header: attribution stays with the real file.
+    sql_diff = "\n".join(
+        [
+            "diff --git a/crates/omnigraph/tests/fixtures/q.sql b/crates/omnigraph/tests/fixtures/q.sql",
+            "--- a/crates/omnigraph/tests/fixtures/q.sql",
+            "+++ b/crates/omnigraph/tests/fixtures/q.sql",
+            "@@ -1 +1,2 @@",
+            "--- old sql comment",
+            "+++ b/crates/omnigraph/tests/gq_logic_tests/issue_563_x.gqt",
+            "+{\"c.slug\": \"chunk-12\"}",
+        ]
+    )
+    sql_added, _, sql_positioned = parse_diff(sql_diff)
+    assert all(p == "crates/omnigraph/tests/fixtures/q.sql" for p, _ in sql_added if (p, _) != HUNK_BREAK), sql_added
+    assert [n for _, n, _ in sql_positioned] == [1, 2], sql_positioned
+    assert not issue_satisfied("563", [], sql_added)
+    # Macro-invocation blocks and `use` groups after a test are not the test;
+    # a function-local `const` without a brace is not an item boundary.
+    macro_file = [
+        "#[tokio::test]",
+        "async fn bm25_underfill_issue_563() {",
+        "    const N: usize = 3;",
+        "    for i in 0..N {",
+        "        assert!(i < N);",
+        "    }",
+        "}",
+        "",
+        "lazy_static! {",
+        "    static ref DB: usize = 1;",
+        "}",
+        "",
+        "proptest! {",
+        "    #![proptest_config(Config::default())]",
+        "    fn prop_issue_563(x in 0..3usize) { assert!(x < 3); }",
+        "}",
+        "",
+        "use crate::{",
+        "    a,",
+        "    b,",
+        "};",
+    ]
+    macro_reader = lambda path: macro_file if path == rust else None  # noqa: E731
+    assert issue_satisfied("563", [], [], positioned=[(rust, 5, "        assert!(i < N);")], read_file=macro_reader)
+    assert not issue_satisfied("563", [], [], positioned=[(rust, 10, "    static ref DB: usize = 1;")], read_file=macro_reader)
+    assert not issue_satisfied("563", [], [], positioned=[(rust, 14, "    #![proptest_config(Config::default())]")], read_file=macro_reader)
+    assert not issue_satisfied("563", [], [], positioned=[(rust, 20, "    b,")], read_file=macro_reader)
 
     print("self-test ok")
     return 0


### PR DESCRIPTION
## What & why

Implements RFC 0045 (GQ logic tests, #584): a query-level regression becomes one small text file instead of a Rust test, and issue-closing PRs are held to carrying one.

- `crates/omnigraph/tests/gq_logic_tests.rs` walks `tests/gq_logic_tests/*.gqt`: one self-contained case per file (issue anchor and `red_on:` provenance, then schema, seed, and query / mutate / restart steps with per-step params and expect).
- Each case runs on the real engine: fresh store, init, load, index builds only when the case needs them, steps in order under a pinned traversal mode.
- Expect modes: `unordered` (multiset), `ordered`, `error: <substring>`, `affected: nodes=<N> edges=<M>`; number normalization never routes integers through f64.
- The parser is fail-closed: every malformed input is a refusal, and every refusal has a self-test.
- `OMNIGRAPH_GQ_BLESS=1` rewrites a failing case's expect rows in place; `OMNIGRAPH_GQ_LOGIC_TESTS=<substring>` filters cases by file name.
- First corpus, five cases: the two #563 regressions, an ordering-refusal pin, a foreach + mutation + restart round-trip, and a typed mutation error.
- Two new required PR checks in `gq-logic-tests.yml`: `GQ Logic Tests` runs the target pre-merge (the workspace job keeps covering it post-merge), and `Fix Regression Gate` (`scripts/check-fix-regression.py`) holds every issue the body closes by keyword to a matching `issue_N` test or `.gqt` case in the diff, waivable per PR with the `no-repro` label.
- AGENTS.md gains the contract sentences: logic tests are the default query-behavior medium, every issue fix lands a regression at the cheapest tier that catches it, and `#[ignore]` messages open with their species.

The nightly heavy-repro job stays deferred until its first `tests/repro_issue_*.rs` member lands (the job fails on an empty glob by design).

## Backing issue / RFC

- [x] Implements RFC 0045, `docs/rfcs/0045-gq-logic-tests.md` (#584). #584 merges first; its `implementation:` flip rides that branch.

## Checklist

- [x] Change is focused (one test target, its corpus, its two CI checks, the AGENTS.md contract, dev-doc edits; no `src/` changes)
- [x] Tests added/updated for behavior changes (84 harness tests: 5 corpus cases plus one self-test per refusal; the gate script carries a self-test the CI job runs first)
- [x] Public docs updated if user-facing surface changed (dev-facing only: `testing.md`, `ci.md`, `branch-protection.md`, AGENTS.md)
- [x] Reviewed against [docs/dev/invariants.md](../blob/main/docs/dev/invariants.md) (test-and-CI diff; no invariant or deny-list item touched)

## Local verification

- `cargo test -p omnigraph-engine --test gq_logic_tests` — 84/84
- `cargo clippy -p omnigraph-engine --all-targets -- -D warnings -W clippy::dbg_macro`, `cargo fmt --all` — clean
- `scripts/check-fix-regression.py --self-test` — ok; plus three scenario runs against this branch's own diff: closing #563 passes (the corpus matches), closing an issue with no test exits 1, the `no-repro` label waives
- `scripts/check-docs.py`, `scripts/check-agents-md.sh`, `scripts/check-workflow-action-pins.py` — all OK
- `cargo test --workspace` — not run locally (no `src/` changes); CI covers it

## Notes for reviewers

- The only engine seam used is the test-only `with_traversal_mode` pin.
- Two maintainer actions after merge: create the `no-repro` label, then run `scripts/apply-branch-protection.sh` (running it earlier leaves open PRs pending on contexts they cannot receive; both new checks already report on this PR).
- The gate reads GitHub's keyword forms `fixes #N`, `fixes: #N`, and `fixes:#N` (leading zeros normalized); URL, cross-repo, `GH-N`, and no-space `fixes#N` closings pass unexamined and stay review's job.
- The `edited`/`labeled`/`unlabeled` PR types re-run the gate when a body edit or the label changes its answer; the test job re-runs on them too (accepted cost).
- The PR cache restores but never saves (`save-if: push`), so per-PR caches cannot evict main's.
- Stricter than the RFC on small points (traversal pin forces index builds, 10000-iteration loop cap, exact-spelling numeric tokens, CRLF and foreign corpus files refused); each flagged on #584.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a GQ logic-test harness and corpus together with required CI and branch-protection checks. It also introduces a fix-regression gate, but the gate’s attempted executable-shape validation still accepts ordinary Rust functions.
- Adds the `.gqt` parser, runner, expectations, filtering, blessing, and initial regression corpus.
- Adds pre-merge GQ testing and issue-fix regression enforcement.
- Documents the new testing tiers and branch-protection requirements.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because the required fix-regression check can pass when an issue-closing change adds no executable regression test.

The gate accepts any suitably named function definition in Rust source files, including ordinary production or helper functions, while the pre-merge workflow only executes the GQ corpus and therefore does not close that enforcement gap.

**Files Needing Attention:** scripts/check-fix-regression.py

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/check-fix-regression.py | Adds the issue-fix regression gate, but Rust matches remain naming checks that can accept non-test functions. |
| crates/omnigraph/tests/gq_logic_tests.rs | Adds the parser and execution harness for query-level logic-test cases. |
| .github/workflows/gq-logic-tests.yml | Adds required pre-merge logic-test and regression-gate jobs. |
| AGENTS.md | Defines the repository contract for selecting and naming regression-test tiers. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  PR[Pull request] --> Body[Parse closing keywords]
  Body --> Gate[Fix Regression Gate]
  Gate --> Corpus[Match added .gqt case]
  Gate --> Rust[Match added Rust function name]
  Corpus --> Pass[Required check passes]
  Rust --> Pass
  Corpus --> GQ[Run GQ logic corpus]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20modernrelay%2Fomnigraph%20PR%20%23596%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=modernrelay%2Fomnigraph&pr=596&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Ascripts%2Fcheck-fix-regression.py%3A153-162%0A**Non-tests%20satisfy%20regression%20gate**%0A%0AWhen%20an%20issue-closing%20PR%20adds%20an%20ordinary%20function%20under%20%60crates%2F*%2Fsrc%2F%60%20or%20a%20non-test%20function%20in%20a%20top-level%20Rust%20test%20target%20whose%20name%20contains%20%60issue_N%60%2C%20%60issue_satisfied%60%20returns%20true%20without%20establishing%20that%20the%20function%20is%20a%20registered%20test%2C%20causing%20the%20required%20gate%20to%20pass%20with%20no%20executable%20regression.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=modernrelay%2Fomnigraph&pr=596&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["test(gq): bound the walker, refuse unsaf..."](https://github.com/modernrelay/omnigraph/commit/c0857c1a75bfaa3577eeb12375255339c834626e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59064774)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->