### PR TITLE
docs(rfcs): remove committed merge-conflict markers from the registry

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -38,14 +38,8 @@ issue and implementation PR are usually enough.
 - Do not create `pre-merge`, `final`, `v2`, `internal`, or review-ledger copies.
   Revise the canonical file; preserve meaningful changes in its decision log.
 
-<<<<<<< HEAD
-The next available number is **0045**. RFC 0040 is reserved by
-[PR #546](https://github.com/ModernRelay/omnigraph/pull/546); lower gaps are
-historical and must not be reused.
-=======
 The next available number is **0045**; lower gaps are historical and must
 not be reused.
->>>>>>> 463fd70e (review)
 
 ## Required frontmatter
 


### PR DESCRIPTION
Main's `docs/rfcs/README.md` carries literal conflict markers (`<<<<<<< HEAD` … `>>>>>>> 463fd70e (review)`) from the #546 registry landing — visible in the rendered registry. Resolved to the post-#546 truth: RFC 0040 has landed, so the reservation sentence is retired and only the next-available line (0045) remains. Docs-only; `python3 scripts/check-docs.py` passes (it does not scan for markers — possibly worth adding).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only cleanup with no runtime or contract impact.
> 
> **Overview**
> Removes **committed Git merge-conflict markers** from `docs/rfcs/README.md` so the RFC registry renders correctly.
> 
> The resolved “next available number” line keeps only that **0045** is next and that lower gaps must not be reused, dropping the obsolete note that RFC 0040 was reserved by PR #546 now that 0040 has landed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4499599df83511520c6cbfabafc81791f3a5563. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes committed merge-conflict markers and obsolete RFC 0040 reservation wording from the RFC registry while preserving the correct next-available number.

- Resolves the registry text to a single clean statement.
- Keeps RFC 0045 as the next available number.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable issues identified.

The documentation now reflects the existing RFC registry: RFC 0040 has landed, RFC 0044 is the highest assigned entry, and RFC 0045 remains the correct next available number.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/rfcs/README.md | Correctly removes conflict artifacts and stale reservation text without changing the registry's valid numbering guidance. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(rfcs): remove committed merge-confl..."](https://github.com/modernrelay/omnigraph/commit/f4499599df83511520c6cbfabafc81791f3a5563) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59145390)</sub>

<!-- /greptile_comment -->