### PR TITLE
Check docs conflict markers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,27 +93,32 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          # The marker check diffs the PR merge commit against its first
+          # parent (the current base tip), so both parents must be present.
+          fetch-depth: 2
 
-      # Whole-tree belt over check-docs.py's Markdown scan: markers in data
-      # files (fixtures, cost tables, inventories) are caught by no other PR
-      # gate. Runs before the documentation checks so every hit is annotated
-      # inline even when the Markdown scan would fail the job first.
-      # Twin pattern: CONFLICT_MARKER in scripts/check-docs.py — keep in sync.
-      - name: Verify no committed merge-conflict markers
+      # Diff-scoped belt over check-docs.py's Markdown scan: flags only
+      # conflict-marker lines this pull request ADDS, in any file type, via
+      # git's own --check detector (which also respects conflict-marker-size
+      # and catches a lone `=======` on added lines). Markers already on the
+      # base branch never fail someone else's PR. Runs before the
+      # documentation checks so hits are annotated inline even when the
+      # Markdown scan would fail the job first.
+      - name: Verify the PR adds no merge-conflict markers
+        if: github.event_name == 'pull_request'
         run: |
           set -euo pipefail
-          status=0
-          hits=$(git grep -nIE '^(<{7,}|>{7,}|\|{7,})([[:space:]]|$)') || status=$?
-          if [ "$status" -gt 1 ]; then
-            echo "::error::git grep failed (exit $status)"
-            exit "$status"
-          fi
+          # `git diff --check` exits non-zero on findings, so the pipeline
+          # needs the `|| true`; grep narrows to markers (drops whitespace
+          # complaints). Output shape: path:line: leftover conflict marker
+          hits=$(git diff --check HEAD^1 HEAD | grep 'leftover conflict marker' || true)
           if [ -n "$hits" ]; then
             printf '%s\n' "$hits" | while IFS=: read -r file line rest; do
               printf '::error file=%s,line=%s::Committed merge-conflict marker\n' "$file" "$line"
             done
             count=$(printf '%s\n' "$hits" | wc -l | tr -d ' ')
-            echo "::error::found $count committed merge-conflict marker line(s)"
+            echo "::error::this pull request adds $count merge-conflict marker line(s)"
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,29 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
+      # Whole-tree belt over check-docs.py's Markdown scan: markers in data
+      # files (fixtures, cost tables, inventories) are caught by no other PR
+      # gate. Runs before the documentation checks so every hit is annotated
+      # inline even when the Markdown scan would fail the job first.
+      # Twin pattern: CONFLICT_MARKER in scripts/check-docs.py — keep in sync.
+      - name: Verify no committed merge-conflict markers
+        run: |
+          set -euo pipefail
+          status=0
+          hits=$(git grep -nIE '^(<{7,}|>{7,}|\|{7,})([[:space:]]|$)') || status=$?
+          if [ "$status" -gt 1 ]; then
+            echo "::error::git grep failed (exit $status)"
+            exit "$status"
+          fi
+          if [ -n "$hits" ]; then
+            printf '%s\n' "$hits" | while IFS=: read -r file line rest; do
+              printf '::error file=%s,line=%s::Committed merge-conflict marker\n' "$file" "$line"
+            done
+            count=$(printf '%s\n' "$hits" | wc -l | tr -d ' ')
+            echo "::error::found $count committed merge-conflict marker line(s)"
+            exit 1
+          fi
+
       - name: Verify AGENTS.md ↔ docs/ cross-links
         run: bash scripts/check-agents-md.sh
 

--- a/docs/dev/ci.md
+++ b/docs/dev/ci.md
@@ -19,11 +19,12 @@ Branch protection currently requires these reporting contexts:
 The `Check AGENTS.md Links` context also runs `scripts/check-docs.py`, which
 validates local documentation links, user/developer audience boundaries, RFC
 location and metadata, registry agreement, and the absence of committed
-merge-conflict markers in Markdown. The same context greps every tracked
-text file for conflict-marker lines before the documentation checks run,
-annotating each offending file and line in the pull request. There is no
-exemption; a document that must quote a conflict block indents the markers
-one space.
+merge-conflict markers in Markdown. Before the documentation checks run,
+the same context also rejects any pull request whose own diff adds a
+conflict-marker line in any file type, annotating each offending file and
+line; markers already on the base branch never fail an unrelated pull
+request. There is no exemption; a document that must quote a conflict block
+indents the markers one space.
 
 `Graph Vocabulary Guard` remains a required reporting context, but its
 substrate-sized audit steps are currently disabled everywhere (decision of

--- a/docs/dev/ci.md
+++ b/docs/dev/ci.md
@@ -18,7 +18,12 @@ Branch protection currently requires these reporting contexts:
 
 The `Check AGENTS.md Links` context also runs `scripts/check-docs.py`, which
 validates local documentation links, user/developer audience boundaries, RFC
-location and metadata, and registry agreement.
+location and metadata, registry agreement, and the absence of committed
+merge-conflict markers in Markdown. The same context greps every tracked
+text file for conflict-marker lines before the documentation checks run,
+annotating each offending file and line in the pull request. There is no
+exemption; a document that must quote a conflict block indents the markers
+one space.
 
 `Graph Vocabulary Guard` remains a required reporting context, but its
 substrate-sized audit steps are currently disabled everywhere (decision of

--- a/scripts/check-docs.py
+++ b/scripts/check-docs.py
@@ -42,6 +42,13 @@ RFC_IMPLEMENTATION = {
     "n/a",
 }
 
+# Leftover merge-conflict markers at line start. git always labels them; the
+# `\s|$` arm also catches hand-mangled label-less leftovers. A lone `=======`
+# is excluded (legal setext heading underline). Twin pattern: the marker step
+# in .github/workflows/ci.yml — keep the two in sync. A doc quoting a
+# conflict block indents the markers one space; there is no exemption.
+CONFLICT_MARKER = re.compile(r"^(?:<{7,}|>{7,}|\|{7,})(?:\s|$)")
+
 USER_FORBIDDEN = {
     r"\b__manifest\b": "internal table names belong in developer docs",
     r"\bManifestCoordinator\b": "code symbols belong in developer docs",
@@ -391,6 +398,16 @@ def check_locations(files: list[Path], errors: list[str]) -> None:
                 )
 
 
+def check_conflict_markers(files: list[Path], errors: list[str]) -> None:
+    for path in files:
+        text = path.read_text(encoding="utf-8")
+        for number, line in enumerate(text.splitlines(), start=1):
+            if CONFLICT_MARKER.match(line):
+                errors.append(
+                    f"{path.relative_to(ROOT)}:{number}: committed merge-conflict marker"
+                )
+
+
 def check_user_boundary(files: list[Path], errors: list[str]) -> None:
     for path in files:
         try:
@@ -461,6 +478,7 @@ def main() -> int:
     ]
     check_links(link_files, errors)
     check_rfcs(errors)
+    check_conflict_markers(files, errors)
     check_user_boundary(files, errors)
     check_skill_version(errors)
 

--- a/scripts/check-docs.py
+++ b/scripts/check-docs.py
@@ -44,9 +44,9 @@ RFC_IMPLEMENTATION = {
 
 # Leftover merge-conflict markers at line start. git always labels them; the
 # `\s|$` arm also catches hand-mangled label-less leftovers. A lone `=======`
-# is excluded (legal setext heading underline). Twin pattern: the marker step
-# in .github/workflows/ci.yml — keep the two in sync. A doc quoting a
-# conflict block indents the markers one space; there is no exemption.
+# is excluded (legal setext heading underline). CI's diff-scoped companion
+# (the marker step in .github/workflows/ci.yml) uses `git diff --check`. A
+# doc quoting a conflict block indents the markers one space; no exemption.
 CONFLICT_MARKER = re.compile(r"^(?:<{7,}|>{7,}|\|{7,})(?:\s|$)")
 
 USER_FORBIDDEN = {


### PR DESCRIPTION
## What & why

This PR makes CI fail on committed merge-conflict markers, in two layers.

- Proven escape: #546 squash-merged literal conflict markers into `docs/rfcs/README.md` on main, where they shipped until #598 removed them. Markers in Rust die in compile; markers in Markdown, fixtures, and data files pass every existing PR check, because no PR gate reads those files.
- Layer 1: `scripts/check-docs.py` gains a marker scan over every Markdown file it already checks, reporting exact file:line.
- Layer 2: a step in the same job rejects any pull request whose own diff adds a conflict-marker line, in any file type, using git's built-in detector (`git diff --check`, which respects `conflict-marker-size` and also flags a lone `=======` on added lines). It emits an inline `::error` annotation per offending line plus a count, runs before the documentation checks, and never fails a pull request for markers already on the base branch.
- Both ride the existing required `Check AGENTS.md Links` context, which runs on every PR including documentation-only ones: no new job, no branch-protection change.

## Backing issue / RFC

- [x] none; trivial fast-lane: closes the gap #598 noted (check-docs.py did not scan for conflict markers) after the #546 escape.

## Checklist

- [x] Change is focused (one scan in check-docs.py, one CI step, their mention in docs/dev/ci.md)
- [x] Tests added/updated for behavior changes (check-docs.py has no test harness; verified red-then-green locally, see Local verification)
- [x] Public docs updated if user-facing surface changed (developer-facing only; docs/dev/ci.md updated)
- [x] Reviewed against docs/dev/invariants.md — no Hard Invariant weakened, no deny-list item hit (docs tooling only, no engine surface)

## Local verification

- `python3 scripts/check-docs.py`: Documentation OK (121 Markdown files checked)
- Red phase: same command with a probe file carrying #546-shaped markers (`<<<<<<< HEAD` … `>>>>>>> 463fd70e (review)`) exits 1 with two exact `file:line: committed merge-conflict marker` errors; probe removed, green again
- The CI step's script body, run verbatim over real history: on the #546 commit (the one that introduced the markers) it emits three `::error file=docs/rfcs/README.md,line=..` annotations plus a count and exits 1; on the #598 removal commit and on a clean multi-commit range it is silent with exit 0
- Markdown-scan pattern battery: labeled/bare/tab-followed/8-wide markers and `|||||||` matched as designed; `=======` and marker-chars-then-text correctly not matched
- Workflow file re-validated: YAML parses, `scripts/check-workflow-action-pins.py` green
- `bash scripts/check-agents-md.sh`: AGENTS.md ↔ docs indexes OK (45 links, 43 docs)
- `cargo test`: not run, no Rust touched

## Notes for reviewers

- The two layers complement each other: the script scans all Markdown and runs locally for anyone invoking `check-docs.py`; the diff gate covers every file type but judges only lines a pull request adds, via git's own detector — no hand-rolled second pattern to keep in sync.
- There is no exemption, by design: an opt-out either dies at the other layer or silences whole files. A document that must quote a conflict block indents the markers one space (only column-0 markers match). The tree has zero marker lines today, so both layers start green.
- A lone `=======` line is deliberately not matched by the Markdown scan (it is a legal setext heading underline); the diff gate does flag one on added lines, where git's detector owns the ambiguity.
- Scope choice: the diff gate deliberately does not scan the whole tree, so a marker landing on the base branch through a path that bypasses PRs would not turn other pull requests red; the Markdown scan still covers that case for docs.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two complementary CI checks that reject committed merge-conflict markers and documents the new behavior.
- Scans all checked Markdown files for column-zero conflict-marker lines.
- Checks added lines across every file type using `git diff --check`.
- Emits inline CI annotations and documents how legitimate conflict examples should be indented.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable correctness or security failures identified.

The Markdown scan and pull-request diff gate consistently enforce the intended conflict-marker policy while preserving existing required CI reporting behavior.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds sufficient checkout depth and a pull-request-only diff check that annotates and rejects newly added conflict-marker lines. |
| scripts/check-docs.py | Adds a focused regex scan over the existing Markdown file set and reports exact locations for committed conflict markers. |
| docs/dev/ci.md | Accurately documents the two marker-detection layers, their scope, and the indentation convention for quoted examples. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: reject committed merge-conflict mark..."](https://github.com/modernrelay/omnigraph/commit/44ae22ca9de20100229531b2794a62140cf4504e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59199337)</sub>

<!-- /greptile_comment -->