### PR TITLE
fix(query): skip the null-mask fold when the match array has no null buffer

### DIFF
--- a/crates/omnigraph/src/exec/projection.rs
+++ b/crates/omnigraph/src/exec/projection.rs
@@ -168,8 +168,13 @@ fn evaluate_string_match_filter(
 
     // A NULL operand yields a NULL result; normalize to `false` so the mask
     // explicitly excludes those rows (NULL is not a match) rather than relying
-    // on the downstream filter's null handling.
-    Ok(arrow_select::filter::prep_null_mask_filter(&matches))
+    // on the downstream filter's null handling. `prep_null_mask_filter` unwraps
+    // the null buffer, so skip it when there is none (#603).
+    if matches.nulls().is_some() {
+        Ok(arrow_select::filter::prep_null_mask_filter(&matches))
+    } else {
+        Ok(matches)
+    }
 }
 
 fn array_value_eq(

--- a/crates/omnigraph/tests/gq_logic_tests/issue_603_negation_string_predicate_outer_var.gqt
+++ b/crates/omnigraph/tests/gq_logic_tests/issue_603_negation_string_predicate_outer_var.gqt
@@ -1,0 +1,26 @@
+# issue: 603
+# red_on: 2026-09-02, pre-fix build: panicked in arrow's prep_null_mask_filter (Option::unwrap on None) instead of returning bob.
+# notes: a starts_with / contains predicate on the outer variable inside `not { }`
+# notes: runs in the anti-join's inner pipeline, whose string column carries no
+# notes: null buffer; the in-memory arm folded nulls unconditionally.
+
+--- schema
+node Person {
+    name: String @key
+}
+
+--- seed
+{"type":"Person","data":{"name":"alice"}}
+{"type":"Person","data":{"name":"bob"}}
+
+--- query
+query not_prefixed() {
+    match {
+        $p: Person
+        not { $p.name starts_with "a" }
+    }
+    return { $p.name }
+}
+
+--- expect unordered
+{"p.name": "bob"}


### PR DESCRIPTION
## What & why

Closes #603.

A `starts_with` or `contains` predicate on the outer variable inside `not { }` panicked the query. Expected: the matching rows.

Cause: `evaluate_string_match_filter` in `crates/omnigraph/src/exec/projection.rs` always called arrow's `prep_null_mask_filter` to turn NULL matches into `false`. That function unwraps the array's null buffer. Inside `not { }` the column arrives without one, so the unwrap panicked. At the top level the same predicate is pushed into the scan and never reaches this code.

Fix: call `prep_null_mask_filter` only when the array has a null buffer. Without one there are no NULLs to fold and the array is returned as is.

## Backing issue / RFC

- [x] Fixes an **accepted** issue: Closes #603

## Checklist

- [x] Change is focused (one guard, one function)
- [x] Tests added/updated for behavior changes (the `.gqt` regression case follows in the next commit)
- [x] Public docs updated if user-facing surface changed (none)
- [x] Reviewed against docs/dev/invariants.md (removes a panic, changes no result)

## Local verification

- `cargo test -p omnigraph-engine --test gq_logic_tests` — 97 passed (with the regression case present locally; red at arrow-select `filter.rs:172` without the guard)
- `cargo test -p omnigraph-engine --test literal_filters` — 13 passed
- `cargo clippy --workspace --all-targets` — clean
- `cargo fmt --all -- --check` — clean
- `scripts/check-agents-md.sh` — OK

## Notes for reviewers

- Existing negation tests never hit this: their predicate is on a traversed variable, whose column comes fresh from Lance with a null buffer. The regression case puts it on the outer variable.
- `contains` takes the same path as `starts_with`.