### PR TITLE
fix(compiler): resolve each pattern variable to one column binding

### DIFF
--- a/crates/omnigraph-compiler/src/ir/lower.rs
+++ b/crates/omnigraph-compiler/src/ir/lower.rs
@@ -8,6 +8,29 @@ use crate::types::{Direction, PropType, ScalarType};
 
 use super::*;
 
+/// Fresh synthetic variable names for one query, shared across negation
+/// inners (their pipelines run over the outer batch, so a name must be
+/// unique query-wide). The executor names every column `<var>.<prop>` and
+/// never reconciles two producers of one variable (#605), so each anonymous
+/// `_` endpoint and each cycle-closing temp gets its own name.
+#[derive(Default)]
+struct FreshNames {
+    anon: usize,
+    temp: usize,
+}
+
+impl FreshNames {
+    fn anon(&mut self) -> String {
+        self.anon += 1;
+        format!("__anon_{}", self.anon)
+    }
+
+    fn temp(&mut self, dst: &str) -> String {
+        self.temp += 1;
+        format!("__temp_{}_{}", dst, self.temp)
+    }
+}
+
 pub fn lower_query(
     catalog: &Catalog,
     query: &QueryDecl,
@@ -31,6 +54,7 @@ pub fn lower_query(
 
     let mut pipeline = Vec::new();
     let mut bound_vars = HashSet::new();
+    let mut fresh = FreshNames::default();
 
     lower_clauses(
         catalog,
@@ -40,6 +64,7 @@ pub fn lower_query(
         &mut bound_vars,
         &param_names,
         &param_types,
+        &mut fresh,
     )?;
 
     let return_exprs: Vec<IRProjection> = query
@@ -60,14 +85,16 @@ pub fn lower_query(
         })
         .collect();
 
-    Ok(QueryIR {
+    let ir = QueryIR {
         name: query.name.clone(),
         params: query.params.clone(),
         pipeline,
         return_exprs,
         order_by,
         limit: query.limit,
-    })
+    };
+    super::validate::validate_query(&ir)?;
+    Ok(ir)
 }
 
 pub fn lower_mutation_query(query: &QueryDecl) -> Result<MutationIR> {
@@ -142,6 +169,7 @@ fn lower_clauses(
     bound_vars: &mut HashSet<String>,
     param_names: &HashSet<String>,
     param_types: &HashMap<String, PropType>,
+    fresh: &mut FreshNames,
 ) -> Result<()> {
     // Separate clause types for ordering: bindings first, then traversals, then filters
     let mut bindings = Vec::new();
@@ -225,6 +253,12 @@ fn lower_clauses(
     // Build deferred filters map for variables introduced by traversals
     let mut deferred_filters: HashMap<String, Vec<IRFilter>> = HashMap::new();
 
+    // A variable bound again after its first binding (`$p: Person` twice in
+    // one match, or inside `not { }` over an outer `$p`): the typechecker
+    // admits it as the same type, so it is a constraint on the existing
+    // rows, not a second scan. Its inline filters become plain Filter ops.
+    let mut rebind_filters: Vec<IRFilter> = Vec::new();
+
     // Lower bindings into NodeScan ops (skip deferred ones)
     for binding in &bindings {
         let node_type = catalog
@@ -234,11 +268,24 @@ fn lower_clauses(
 
         let binding_filters = build_binding_filters(binding, node_type, param_names);
 
+        // A variable the outer pattern already bound (a negation's inner
+        // clauses run over the outer batch) is never deferred, whatever its
+        // place in the component walk: deferred filters are emitted by the
+        // Expand that introduces a variable, and nothing introduces this one
+        // again, so they would be lost (#605).
+        if bound_vars.contains(&binding.variable) {
+            rebind_filters.extend(binding_filters);
+            continue;
+        }
+
         if deferred_set.contains(&binding.variable) {
             // Save filters for emission after the Expand that introduces
             // this variable.
             if !binding_filters.is_empty() {
-                deferred_filters.insert(binding.variable.clone(), binding_filters);
+                deferred_filters
+                    .entry(binding.variable.clone())
+                    .or_default()
+                    .extend(binding_filters);
             }
             continue;
         }
@@ -307,7 +354,8 @@ fn lower_clauses(
 
             if src_bound && dst_bound {
                 // Cycle closing: expand to a temp var, then filter temp.id = dst.id
-                let temp_var = format!("__temp_{}", traversal.dst);
+                // (temp fresh per traversal, #605).
+                let temp_var = fresh.temp(&traversal.dst);
                 pipeline.push(IROp::Expand {
                     src_var: traversal.src.clone(),
                     dst_var: temp_var.clone(),
@@ -349,9 +397,14 @@ fn lower_clauses(
                 };
                 let introduced_filters =
                     deferred_filters.remove(&traversal.src).unwrap_or_default();
+                let dst_var = if traversal.src == "_" {
+                    fresh.anon()
+                } else {
+                    traversal.src.clone()
+                };
                 pipeline.push(IROp::Expand {
                     src_var: traversal.dst.clone(),
-                    dst_var: traversal.src.clone(),
+                    dst_var,
                     edge_type: edge.name.clone(),
                     direction: reverse_dir,
                     dst_type: src_type,
@@ -368,12 +421,18 @@ fn lower_clauses(
                     bound_vars.insert(traversal.src.clone());
                 }
             } else {
-                // Normal expand: src is bound, dst is not.
+                // Normal expand: src is bound, dst is not (an anonymous `_`
+                // destination gets a fresh name per occurrence, #605).
                 let introduced_filters =
                     deferred_filters.remove(&traversal.dst).unwrap_or_default();
+                let dst_var = if traversal.dst == "_" {
+                    fresh.anon()
+                } else {
+                    traversal.dst.clone()
+                };
                 pipeline.push(IROp::Expand {
                     src_var: traversal.src.clone(),
-                    dst_var: traversal.dst.clone(),
+                    dst_var,
                     edge_type: edge.name.clone(),
                     direction,
                     dst_type,
@@ -436,6 +495,11 @@ fn lower_clauses(
         );
     }
 
+    // Re-binding filters run after every variable is introduced, like the
+    // explicit filters below; the executor hoists the pushable ones onto the
+    // introducing scan.
+    pipeline.extend(rebind_filters.into_iter().map(IROp::Filter));
+
     // Lower explicit filters
     for filter in &filters {
         pipeline.push(IROp::Filter(IRFilter {
@@ -460,6 +524,7 @@ fn lower_clauses(
             &mut inner_bound,
             param_names,
             param_types,
+            fresh,
         )?;
 
         pipeline.push(IROp::AntiJoin {

--- a/crates/omnigraph-compiler/src/ir/lower_tests.rs
+++ b/crates/omnigraph-compiler/src/ir/lower_tests.rs
@@ -39,6 +39,170 @@ return { $f.name, $f.age }
     assert_eq!(ir.return_exprs.len(), 2);
 }
 
+fn lower(catalog: &Catalog, text: &str) -> QueryIR {
+    let qf = parse_query(text).unwrap();
+    let tc = typecheck_query(catalog, &qf.queries[0]).unwrap();
+    lower_query(catalog, &qf.queries[0], &tc).unwrap()
+}
+
+fn expand_dsts(ir: &QueryIR) -> Vec<&str> {
+    ir.pipeline
+        .iter()
+        .filter_map(|op| match op {
+            IROp::Expand { dst_var, .. } => Some(dst_var.as_str()),
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn test_lower_anonymous_destinations_get_distinct_names() {
+    let ir = lower(
+        &setup(),
+        "query q() { match { $p: Person  $p knows $_  $p knows $_ } return { $p.name } }",
+    );
+    let dsts = expand_dsts(&ir);
+    assert_eq!(dsts.len(), 2);
+    assert!(dsts.iter().all(|d| d.starts_with("__anon_")), "{dsts:?}");
+    assert_ne!(dsts[0], dsts[1]);
+}
+
+#[test]
+fn test_lower_anonymous_sources_get_distinct_names() {
+    // Reverse expand: the bound end is the destination, `_` the source.
+    let ir = lower(
+        &setup(),
+        "query q() { match { $p: Person  $_ knows $p  $_ knows $p } return { $p.name } }",
+    );
+    let dsts = expand_dsts(&ir);
+    assert_eq!(dsts.len(), 2);
+    assert!(dsts.iter().all(|d| d.starts_with("__anon_")), "{dsts:?}");
+    assert_ne!(dsts[0], dsts[1]);
+}
+
+#[test]
+fn test_lower_rebinding_a_scanned_variable_filters_instead_of_rescanning() {
+    let ir = lower(
+        &setup(),
+        "query q() { match { $p: Person  $p: Person { name: \"x\" } } return { $p.name } }",
+    );
+    let scans = ir
+        .pipeline
+        .iter()
+        .filter(|op| matches!(op, IROp::NodeScan { .. }))
+        .count();
+    let filters_on_p_name = ir
+        .pipeline
+        .iter()
+        .filter(|op| {
+            matches!(
+                op,
+                IROp::Filter(IRFilter {
+                    left: IRExpr::PropAccess { variable, property },
+                    ..
+                }) if variable == "p" && property == "name"
+            )
+        })
+        .count();
+    assert_eq!((scans, filters_on_p_name), (1, 1), "{:?}", ir.pipeline);
+}
+
+#[test]
+fn test_lower_repeated_deferred_binding_keeps_both_filter_sets() {
+    let ir = lower(
+        &setup(),
+        "query q() { match { $p: Person  $p knows $f  $f: Person { age: 40 }  $f: Person { name: \"x\" } } return { $f.name } }",
+    );
+    let dst_filter_props: Vec<Vec<&str>> = ir
+        .pipeline
+        .iter()
+        .filter_map(|op| match op {
+            IROp::Expand { dst_filters, .. } => Some(
+                dst_filters
+                    .iter()
+                    .map(|f| match &f.left {
+                        IRExpr::PropAccess { variable, property } if variable == "f" => {
+                            property.as_str()
+                        }
+                        other => panic!("unexpected filter operand {other:?}"),
+                    })
+                    .collect(),
+            ),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        dst_filter_props,
+        vec![vec!["age", "name"]],
+        "{:?}",
+        ir.pipeline
+    );
+}
+
+#[test]
+fn test_lower_cycle_closing_temps_are_distinct() {
+    let ir = lower(
+        &setup(),
+        "query q() { match { $p: Person  $p knows $p  $p knows $p } return { $p.name } }",
+    );
+    let dsts = expand_dsts(&ir);
+    assert_eq!(dsts.len(), 2);
+    assert!(dsts.iter().all(|d| d.starts_with("__temp_p_")), "{dsts:?}");
+    assert_ne!(dsts[0], dsts[1]);
+}
+
+#[test]
+fn test_lower_rebinding_an_outer_variable_inside_negation_keeps_its_filter() {
+    // `$q` is outer-bound and, inside the negation, not the root of its
+    // component; its inline filter must survive as a Filter in the inner
+    // pipeline, never be deferred onto an Expand that will not introduce it.
+    let ir = lower(
+        &setup(),
+        "query q() { match { $p: Person  $p knows $q  not { $r: Person  $r knows $q  $q: Person { name: \"zzz\" } } } return { $p.name } }",
+    );
+    let inner = ir
+        .pipeline
+        .iter()
+        .find_map(|op| match op {
+            IROp::AntiJoin { inner, .. } => Some(inner),
+            _ => None,
+        })
+        .expect("an AntiJoin");
+    let filters_on_q_name = inner
+        .iter()
+        .filter(|op| {
+            matches!(
+                op,
+                IROp::Filter(IRFilter {
+                    left: IRExpr::PropAccess { variable, property },
+                    ..
+                }) if variable == "q" && property == "name"
+            )
+        })
+        .count();
+    assert_eq!(filters_on_q_name, 1, "{inner:?}");
+}
+
+#[test]
+fn test_typecheck_refuses_reserved_variable_prefix() {
+    // A user variable spelled like a minted name would collide with it in
+    // the plan check; the typechecker refuses the spelling with the reason.
+    let catalog = setup();
+    for text in [
+        "query q() { match { $__anon_1: Person } return { $__anon_1.name } }",
+        "query q() { match { $p: Person  $p knows $__temp_p_1 } return { $p.name } }",
+        "query q() { match { $p: Person  not { $p knows $__x } } return { $p.name } }",
+        "query q() { match { $p: Person  $__x knows $p } return { $p.name } }",
+        "query q() { match { $p: Person  $p $__w:knows $q } return { $q.name } }",
+    ] {
+        let qf = parse_query(text).unwrap();
+        let err = typecheck_query(&catalog, &qf.queries[0])
+            .expect_err("reserved prefix must be refused")
+            .to_string();
+        assert!(err.contains("reserved for the compiler"), "{err}");
+    }
+}
+
 #[test]
 fn test_lower_resolves_contains_overload_by_left_operand_type() {
     // `contains` on a scalar String left operand lowers to StringContains
@@ -591,7 +755,7 @@ return { $p.name, $c.name }
     assert!(matches!(
         &ir.pipeline[2],
         IROp::Expand { src_var, dst_var, .. }
-        if src_var == "p" && dst_var == "_"
+        if src_var == "p" && dst_var.starts_with("__anon_")
     ));
 }
 
@@ -702,13 +866,13 @@ return { $a.name }
         IROp::Expand { src_var, dst_var, dst_filters, .. }
         if src_var == "a" && dst_var == "b" && dst_filters.len() == 1
     ));
-    // Cycle-closing expand to __temp_a
+    // Cycle-closing expand to __temp_a_1
     assert!(matches!(
         &ir.pipeline[2],
         IROp::Expand { src_var, dst_var, dst_filters, .. }
         if src_var == "b" && dst_var.starts_with("__temp_") && dst_filters.is_empty()
     ));
-    // Cycle-closing filter: __temp_a.id == a.id
+    // Cycle-closing filter: __temp_a_1.id == a.id
     assert!(matches!(&ir.pipeline[3], IROp::Filter(_)));
 }
 

--- a/crates/omnigraph-compiler/src/ir/mod.rs
+++ b/crates/omnigraph-compiler/src/ir/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod lower;
+pub(crate) mod validate;
 
 use std::collections::HashMap;
 

--- a/crates/omnigraph-compiler/src/ir/validate.rs
+++ b/crates/omnigraph-compiler/src/ir/validate.rs
@@ -1,0 +1,257 @@
+//! Plan well-formedness: every variable the executor will turn into a column
+//! prefix is introduced by exactly one operator, and every reference to a
+//! variable comes after its introduction.
+//!
+//! The executor names columns `<variable>.<property>` and appends batches by
+//! position (`hconcat_batches`), so two operators producing one variable put
+//! two columns of one name into the wide batch (#605). Lowering keeps that
+//! from happening for the shapes it knows; this check holds for every plan,
+//! so a new lowering shape fails here with the variable named, not in the
+//! executor after a scan has run.
+
+use std::collections::HashSet;
+
+use crate::error::{CompilerError, Result};
+
+use super::{IRExpr, IRFilter, IROp, QueryIR};
+
+/// Checks a lowered read query. A negation's inner pipeline runs over the
+/// outer batch, so it sees the outer variables and may not introduce one of
+/// them again; what it introduces stays inside it.
+pub(crate) fn validate_query(ir: &QueryIR) -> Result<()> {
+    let mut introduced = HashSet::new();
+    validate_pipeline(&ir.pipeline, &mut introduced)?;
+    for projection in &ir.return_exprs {
+        check_expr(&projection.expr, &introduced)?;
+    }
+    for ordering in &ir.order_by {
+        check_expr(&ordering.expr, &introduced)?;
+    }
+    Ok(())
+}
+
+fn validate_pipeline(pipeline: &[IROp], introduced: &mut HashSet<String>) -> Result<()> {
+    for op in pipeline {
+        match op {
+            // Every field spelled, so a field added later that carries a
+            // variable is a compile error here, not an unchecked reference.
+            IROp::NodeScan {
+                variable,
+                type_name: _,
+                filters,
+            } => {
+                introduce(variable, introduced)?;
+                check_filters(filters, introduced)?;
+            }
+            IROp::Expand {
+                src_var,
+                dst_var,
+                edge_type: _,
+                direction: _,
+                dst_type: _,
+                min_hops: _,
+                max_hops: _,
+                dst_filters,
+                edge_binding,
+            } => {
+                check_reference(src_var, introduced)?;
+                introduce(dst_var, introduced)?;
+                if let Some(edge) = edge_binding {
+                    introduce(edge, introduced)?;
+                }
+                check_filters(dst_filters, introduced)?;
+            }
+            IROp::Filter(filter) => check_filter(filter, introduced)?,
+            IROp::AntiJoin { outer_var, inner } => {
+                // Lowering leaves `outer_var` empty when the negation shares
+                // no variable with the outer pattern.
+                if !outer_var.is_empty() {
+                    check_reference(outer_var, introduced)?;
+                }
+                let mut inner_scope = introduced.clone();
+                validate_pipeline(inner, &mut inner_scope)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn introduce(variable: &str, introduced: &mut HashSet<String>) -> Result<()> {
+    if !introduced.insert(variable.to_string()) {
+        return Err(CompilerError::Plan(format!(
+            "plan introduces variable `{variable}` twice; each variable is produced by one operator"
+        )));
+    }
+    Ok(())
+}
+
+fn check_reference(variable: &str, introduced: &HashSet<String>) -> Result<()> {
+    if !introduced.contains(variable) {
+        return Err(CompilerError::Plan(format!(
+            "plan references variable `{variable}` before any operator introduces it; \
+             bind it (`${variable}: <Type>`) or reach it by a traversal from a bound variable"
+        )));
+    }
+    Ok(())
+}
+
+fn check_filters(filters: &[IRFilter], introduced: &HashSet<String>) -> Result<()> {
+    filters.iter().try_for_each(|f| check_filter(f, introduced))
+}
+
+fn check_filter(filter: &IRFilter, introduced: &HashSet<String>) -> Result<()> {
+    check_expr(&filter.left, introduced)?;
+    check_expr(&filter.right, introduced)
+}
+
+/// Exhaustive over `IRExpr`, so a new variant that carries a variable is a
+/// compile error here rather than an unchecked reference.
+fn check_expr(expr: &IRExpr, introduced: &HashSet<String>) -> Result<()> {
+    match expr {
+        IRExpr::PropAccess { variable, .. } | IRExpr::Nearest { variable, .. } => {
+            check_reference(variable, introduced)?;
+            if let IRExpr::Nearest { query, .. } = expr {
+                check_expr(query, introduced)?;
+            }
+            Ok(())
+        }
+        IRExpr::Variable(variable) => check_reference(variable, introduced),
+        IRExpr::Search { field, query }
+        | IRExpr::MatchText { field, query }
+        | IRExpr::Bm25 { field, query } => {
+            check_expr(field, introduced)?;
+            check_expr(query, introduced)
+        }
+        IRExpr::Fuzzy {
+            field,
+            query,
+            max_edits,
+        } => {
+            check_expr(field, introduced)?;
+            check_expr(query, introduced)?;
+            max_edits
+                .as_deref()
+                .map_or(Ok(()), |e| check_expr(e, introduced))
+        }
+        IRExpr::Rrf {
+            primary,
+            secondary,
+            k,
+        } => {
+            check_expr(primary, introduced)?;
+            check_expr(secondary, introduced)?;
+            k.as_deref().map_or(Ok(()), |e| check_expr(e, introduced))
+        }
+        IRExpr::Aggregate { arg, .. } => check_expr(arg, introduced),
+        IRExpr::Param(_) | IRExpr::Literal(_) | IRExpr::AliasRef(_) => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::ast::CompOp;
+    use crate::types::Direction;
+
+    fn scan(variable: &str) -> IROp {
+        IROp::NodeScan {
+            variable: variable.to_string(),
+            type_name: "Person".to_string(),
+            filters: Vec::new(),
+        }
+    }
+
+    fn expand(src: &str, dst: &str) -> IROp {
+        IROp::Expand {
+            src_var: src.to_string(),
+            dst_var: dst.to_string(),
+            edge_type: "Knows".to_string(),
+            direction: Direction::Out,
+            dst_type: "Person".to_string(),
+            min_hops: 1,
+            max_hops: Some(1),
+            dst_filters: Vec::new(),
+            edge_binding: None,
+        }
+    }
+
+    fn prop(variable: &str) -> IRExpr {
+        IRExpr::PropAccess {
+            variable: variable.to_string(),
+            property: "name".to_string(),
+        }
+    }
+
+    fn run(pipeline: Vec<IROp>) -> Result<()> {
+        validate_pipeline(&pipeline, &mut HashSet::new())
+    }
+
+    fn refusal(pipeline: Vec<IROp>) -> String {
+        run(pipeline)
+            .expect_err("expected the plan to be refused")
+            .to_string()
+    }
+
+    #[test]
+    fn accepts_a_scan_and_an_expand() {
+        run(vec![scan("p"), expand("p", "q")]).unwrap();
+    }
+
+    #[test]
+    fn refuses_a_second_producer_of_one_variable() {
+        // The plan the pre-#605 lowering produced for `$p knows $_` twice.
+        assert!(refusal(vec![scan("p"), expand("p", "_"), expand("p", "_")]).contains("`_` twice"));
+        // And for `$p: Person` twice.
+        assert!(refusal(vec![scan("p"), scan("p")]).contains("`p` twice"));
+        // Fresh names per occurrence are what the fixed lowering emits.
+        run(vec![
+            scan("p"),
+            expand("p", "__anon_1"),
+            expand("p", "__anon_2"),
+        ])
+        .unwrap();
+    }
+
+    #[test]
+    fn refuses_a_reference_before_introduction() {
+        assert!(refusal(vec![expand("p", "q")]).contains("`p` before"));
+        let filter = IROp::Filter(IRFilter {
+            left: prop("q"),
+            op: CompOp::Eq,
+            right: IRExpr::Literal(crate::query::ast::Literal::String("x".to_string())),
+        });
+        assert!(refusal(vec![scan("p"), filter]).contains("`q` before"));
+    }
+
+    #[test]
+    fn edge_binding_is_a_producer_too() {
+        let mut bound = expand("p", "q");
+        if let IROp::Expand { edge_binding, .. } = &mut bound {
+            *edge_binding = Some("k".to_string());
+        }
+        run(vec![scan("p"), bound.clone()]).unwrap();
+        assert!(refusal(vec![scan("p"), scan("k"), bound]).contains("`k` twice"));
+    }
+
+    #[test]
+    fn negation_inner_sees_the_outer_scope_and_keeps_its_own() {
+        let anti = |inner: Vec<IROp>| IROp::AntiJoin {
+            outer_var: "p".to_string(),
+            inner,
+        };
+        // The inner pipeline may expand from the outer variable.
+        run(vec![scan("p"), anti(vec![expand("p", "q")])]).unwrap();
+        // It may not produce the outer variable again (the second #605 shape
+        // inside `not { }`, before the fix lowered it to a filter).
+        assert!(refusal(vec![scan("p"), anti(vec![scan("p")])]).contains("`p` twice"));
+        // What it introduces does not leak: `q` is free again after it.
+        run(vec![
+            scan("p"),
+            anti(vec![expand("p", "q")]),
+            expand("p", "q"),
+        ])
+        .unwrap();
+        // An anti-join over a variable nobody introduced is refused.
+        assert!(refusal(vec![anti(vec![scan("q")])]).contains("`p` before"));
+    }
+}

--- a/crates/omnigraph-compiler/src/query/typecheck.rs
+++ b/crates/omnigraph-compiler/src/query/typecheck.rs
@@ -159,6 +159,37 @@ fn parse_declared_param_types(params: &[Param]) -> Result<HashMap<String, PropTy
     Ok(out)
 }
 
+/// Names beginning with `__` are the compiler's: lowering mints `__anon_N`
+/// for anonymous traversal endpoints and `__temp_<var>_N` for cycle-closing
+/// traversals, and the plan check refuses a name introduced twice, so a user
+/// variable spelled like one would fail there with a message about the
+/// plan. Refuse it here, once, with the reason.
+fn refuse_reserved_variable_names(clauses: &[Clause]) -> Result<()> {
+    fn check(name: &str) -> Result<()> {
+        if name.starts_with("__") {
+            return Err(CompilerError::Type(format!(
+                "variable `${name}`: names beginning with `__` are reserved for the compiler"
+            )));
+        }
+        Ok(())
+    }
+    for clause in clauses {
+        match clause {
+            Clause::Binding(binding) => check(&binding.variable)?,
+            Clause::Traversal(traversal) => {
+                check(&traversal.src)?;
+                check(&traversal.dst)?;
+                if let Some(edge) = &traversal.edge_binding {
+                    check(edge)?;
+                }
+            }
+            Clause::Filter(_) => {}
+            Clause::Negation(inner) => refuse_reserved_variable_names(inner)?,
+        }
+    }
+    Ok(())
+}
+
 fn typecheck_read_query(catalog: &Catalog, query: &QueryDecl) -> Result<TypeContext> {
     let mut ctx = TypeContext {
         bindings: HashMap::new(),
@@ -168,6 +199,8 @@ fn typecheck_read_query(catalog: &Catalog, query: &QueryDecl) -> Result<TypeCont
     let mut alias_exprs: HashMap<String, &Expr> = HashMap::new();
 
     let params = parse_declared_param_types(&query.params)?;
+
+    refuse_reserved_variable_names(&query.match_clause)?;
 
     // Typecheck match clauses
     typecheck_clauses(catalog, &query.match_clause, &mut ctx, &params, false)?;

--- a/crates/omnigraph-gqt/cases/issue_605_two_anonymous_destinations.gqt
+++ b/crates/omnigraph-gqt/cases/issue_605_two_anonymous_destinations.gqt
@@ -1,0 +1,87 @@
+# issue: 605
+# red_on: 2026-09-03, pre-fix build: panicked at hconcat_batches `duplicate column`, '_.id' (step 1), 'p.id' (steps 2, 3), '__temp_p.id' (step 4); step 5 returned no rows.
+# notes: four shapes that hand the executor one column twice, plus a rebound
+# notes: outer variable inside not {} whose filter was dropped; one outgoing
+# notes: edge per source keeps each step at one row per source.
+
+--- schema
+node Person {
+    name: String @key
+}
+
+edge Knows: Person -> Person
+
+--- seed
+{"type":"Person","data":{"name":"alice"}}
+{"type":"Person","data":{"name":"bob"}}
+{"edge":"Knows","from":"alice","to":"bob"}
+{"edge":"Knows","from":"bob","to":"bob"}
+
+--- query
+query knows_anyone_twice() {
+    match {
+        $p: Person
+        $p knows $_
+        $p knows $_
+    }
+    return { $p.name }
+}
+
+--- expect unordered
+{"p.name": "alice"}
+{"p.name": "bob"}
+
+--- query
+query bound_twice() {
+    match {
+        $p: Person
+        $p: Person { name: "bob" }
+    }
+    return { $p.name }
+}
+
+--- expect unordered
+{"p.name": "bob"}
+
+--- query
+query bound_twice_in_negation() {
+    match {
+        $p: Person
+        not { $p: Person { name: "bob" } }
+    }
+    return { $p.name }
+}
+
+--- expect unordered
+{"p.name": "alice"}
+
+--- query
+query self_loop_twice() {
+    match {
+        $p: Person
+        $p knows $p
+        $p knows $p
+    }
+    return { $p.name }
+}
+
+--- expect unordered
+{"p.name": "bob"}
+
+--- query
+query rebind_inside_negation_non_root() {
+    match {
+        $p: Person
+        $p knows $q
+        not {
+            $r: Person
+            $r knows $q
+            $q: Person { name: "zzz" }
+        }
+    }
+    return { $p.name }
+}
+
+--- expect unordered
+{"p.name": "alice"}
+{"p.name": "bob"}

--- a/crates/omnigraph/src/exec/query.rs
+++ b/crates/omnigraph/src/exec/query.rs
@@ -4377,10 +4377,34 @@ fn prefix_batch(batch: &RecordBatch, variable: &str) -> Result<RecordBatch> {
     RecordBatch::try_new(schema, batch.columns().to_vec()).map_err(OmniError::arrow_internal)
 }
 
+/// A column name present on both sides would let `column_by_name` silently
+/// pick the left one (Arrow admits duplicate field names). The compiler's
+/// plan check keeps this unreachable for lowered plans; this is the last
+/// line, in every build (#605).
+fn refuse_duplicate_columns(left: &RecordBatch, right: &RecordBatch) -> Result<()> {
+    let left_schema = left.schema();
+    let left_names: HashSet<&str> = left_schema
+        .fields()
+        .iter()
+        .map(|f| f.name().as_str())
+        .collect();
+    let right_schema = right.schema();
+    for f in right_schema.fields() {
+        if left_names.contains(f.name().as_str()) {
+            return Err(OmniError::manifest_internal(format!(
+                "duplicate column '{}' when joining batches",
+                f.name()
+            )));
+        }
+    }
+    Ok(())
+}
+
 fn cross_join_batches(left: &RecordBatch, right: &RecordBatch) -> Result<RecordBatch> {
     let n = left.num_rows();
     let m = right.num_rows();
     if n == 0 || m == 0 {
+        refuse_duplicate_columns(left, right)?;
         let mut fields: Vec<Field> = left
             .schema()
             .fields()
@@ -4406,22 +4430,10 @@ fn hconcat_batches(left: &RecordBatch, right: &RecordBatch) -> Result<RecordBatc
         .iter()
         .map(|f| f.as_ref().clone())
         .collect();
-    if cfg!(debug_assertions) {
-        let left_schema = left.schema();
-        let left_names: HashSet<&str> = left_schema
-            .fields()
-            .iter()
-            .map(|f| f.name().as_str())
-            .collect();
-        let right_schema = right.schema();
-        for f in right_schema.fields() {
-            debug_assert!(
-                !left_names.contains(f.name().as_str()),
-                "hconcat_batches: duplicate column '{}'",
-                f.name()
-            );
-        }
-    }
+    // Arrow allows duplicate field names and `column_by_name` returns the
+    // first match, so a duplicate here would silently shadow a column; the
+    // refusal holds in every build (#605).
+    refuse_duplicate_columns(left, right)?;
     fields.extend(right.schema().fields().iter().map(|f| f.as_ref().clone()));
     let mut columns: Vec<ArrayRef> = left.columns().to_vec();
     columns.extend(right.columns().to_vec());

--- a/docs/releases/v0.11.0.md
+++ b/docs/releases/v0.11.0.md
@@ -23,6 +23,22 @@ Notes accumulate here until the release is cut.
   classifications are unchanged; ordered-by-`id` exports and the change feed
   keep v0.10's full-row sort and its row-width limit.
 
+- **Repeated variables and anonymous endpoints no longer collide in the
+  executor.** Three typechecker-legal shapes (`$p knows $_` twice, `$p:
+  Person` bound twice at the top level or inside `not { }`, and `$p knows
+  $p` twice) handed the executor two producers of one column: a debug build
+  panicked at `hconcat_batches: duplicate column`, and a release build ran
+  the second binding as a cross join over a silently shadowed column. Each
+  `$_` now gets its own column, a second binding of a bound variable becomes
+  a constraint on the existing rows, and the compiler refuses any plan that
+  would introduce a variable twice. A variable introduced by a traversal
+  and then bound twice with property matches (`$p knows $f  $f: Person {
+  age: 40 }  $f: Person { name: "x" }`) keeps both sets of matches; before,
+  the second replaced the first. A variable rebound inside
+  `not { }` that is not the root of its inner pattern kept none of its
+  property matches before; it keeps them now. Variable names beginning with
+  `__` are reserved. Fixes #605.
+
 - **Adaptive traversals with a persisted adjacency index.** The traversal
   cost decision now reruns at every hop with the observed frontier, and a
   traversal that outgrows the indexed path switches to the in-memory CSR

--- a/docs/user/queries/index.md
+++ b/docs/user/queries/index.md
@@ -53,6 +53,13 @@ An unbound traversal has set semantics for endpoint pairs. Binding the edge
 returns one result per matching edge, so parallel edges remain distinct. Edge
 bindings are available only for a single hop.
 
+Each `$_` is a distinct anonymous node: two anonymous traversals from one
+variable are independent, so a source with two neighbours matches two by two
+rows. Binding a variable a second time (`$p: Person` after `$p` is already
+bound, at the top level or inside `not { }`) adds the second binding's
+property matches as constraints on the same rows; it never introduces a
+second `$p`. Variable names beginning with `__` are reserved.
+
 Traversal spelling begins with a lowercase letter (`worksAt` for the declared
 edge `WorksAt`); edge lookup itself is case-insensitive.
 

--- a/skills/omnigraph/references/queries.md
+++ b/skills/omnigraph/references/queries.md
@@ -156,6 +156,13 @@ traversals keep set-of-pairs semantics). Rejected with `T23`: binding a
 `{min,max}` multi-hop, rebinding a taken variable name, or projecting bare
 `$w` (project a property instead).
 
+Node variables: each `$_` is a distinct anonymous node, so two anonymous
+traversals from one variable are independent (a source with two neighbours
+matches two by two rows). Binding a node variable a second time (`$p:
+Person` after `$p` is bound, at the top level or inside `not { }`) adds the
+second binding's property matches as constraints on the same rows; it never
+introduces a second `$p`. Variable names beginning with `__` are reserved.
+
 Composes with hop bounds (`$a <knows>{1,3} $b`) and `not { }` ("no edge in
 either direction"). Asymmetric edges (e.g. `Comment -> Issue`) are rejected at
 typecheck (T22) — use the directional form there.


### PR DESCRIPTION
## What & why

Closes #605.

The executor names columns `<var>.<prop>` and never reconciles two producers of one variable. Three typechecker-legal shapes handed it two: `$p knows $_` twice, `$p: Person` bound twice (top level or inside `not { }`), and `$p knows $p` twice. Debug builds panicked at `hconcat_batches: duplicate column`; release builds shadowed a column silently.

- Lowering mints a fresh name per `_` endpoint and per cycle-closing temp; a repeated binding of a bound variable becomes a filter on the existing rows.
- `lower_query` ends with a plan check: one producer per variable, references only after introduction. A future lowering shape fails in the compiler with the variable named.
- Review surfaced two more: a variable rebound inside `not { }` (not its inner pattern's root) silently lost its property matches, now kept; names beginning with `__` are reserved, since the minted names share the grammar's alphabet.
- The executor refuses a duplicate column in every build, on both join paths.

## Backing issue / RFC

- [x] Fixes an **accepted** issue: Closes #605

## Checklist

- [x] Change is focused (lowering, one plan check, one typecheck rule, one executor guard)
- [x] Tests added/updated (`issue_605_two_anonymous_destinations.gqt`, five steps, all red on `16f7ba39`; 7 lowering tests; 5 plan-check tests)
- [x] Public docs updated (`docs/user/queries/index.md`, `skills/omnigraph/references/queries.md`, release note)
- [x] Reviewed against docs/dev/invariants.md (removes a panic and a silent shadowing; no invariant weakened)

## Local verification

- `cargo test -p omnigraph-compiler`: 331 passed
- `cargo test -p omnigraph-engine --test gq_logic_tests --test end_to_end --test traversal --test traversal_indexed --test traversal_adaptive --test proptest_equivalence --test literal_filters`: 97, 68, 28, 8, 13, 3, 13 passed
- `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check`, `scripts/check-agents-md.sh`, `python3 scripts/check-docs.py`: clean

## Notes for reviewers

- Two result changes beyond the panic: a traversal-introduced variable bound twice keeps both filter sets (the second used to replace the first), and a rebound outer variable inside `not { }` keeps its property matches (they used to be dropped, so the negation removed too many rows).
- Two `$_` are independent (two neighbours give two by two rows), matching SPARQL and Gremlin; Cypher would return empty because patterns in one `MATCH` must use different edges.