### PR TITLE
fix(cluster): refuse `..` segments and symbolic links in declared config paths

### DIFF
--- a/crates/omnigraph-cluster/src/config.rs
+++ b/crates/omnigraph-cluster/src/config.rs
@@ -74,6 +74,25 @@ pub(crate) fn resolve_query_decls(
                     .flatten()
                     .map(|entry| entry.path())
                     .filter(|path| path.extension().is_some_and(|ext| ext == "gq"))
+                    // A discovered entry is checked with no-follow metadata
+                    // before anything reads it: a symbolic link inside a
+                    // checked directory is refused the same way as one on the
+                    // way to it.
+                    .filter(|path| {
+                        let is_symlink = fs::symlink_metadata(path)
+                            .is_ok_and(|meta| meta.file_type().is_symlink());
+                        if is_symlink {
+                            diagnostics.push(Diagnostic::error(
+                                "config_path_symlink",
+                                format!("graphs.{graph_id}.queries"),
+                                format!(
+                                    "query file '{}' is a symbolic link; declare the target directly",
+                                    path.display()
+                                ),
+                            ));
+                        }
+                        !is_symlink
+                    })
                     .collect(),
                 Err(err) => {
                     diagnostics.push(Diagnostic::error(
@@ -1224,18 +1243,22 @@ pub(crate) fn resolve_config_path(config_dir: &Path, path: &Path) -> PathBuf {
     }
 }
 
-/// Refuse a declared path that leaves the configuration directory through a
-/// `..` segment or reaches its target through a symbolic link. A bundle is
-/// one directory of files read exactly as declared; either shape makes what
-/// gets applied depend on something outside it. The diagnostic names the
-/// setting that declared the path. Absolute paths stay accepted as before.
-/// Returns whether the path may be read.
+/// Refuse a relative declared path that leaves the configuration directory
+/// through a `..` segment or reaches its target through a symbolic link. A
+/// bundle is one directory of files read exactly as declared; either shape
+/// makes what gets applied depend on something outside it. The diagnostic
+/// names the setting that declared the path. Absolute paths stay accepted
+/// as before, `..` segments and symbolic links included: they were never
+/// confined to the bundle. Returns whether the path may be read.
 pub(crate) fn check_config_path(
     config_dir: &Path,
     declared: &Path,
     setting: &str,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> bool {
+    if declared.is_absolute() {
+        return true;
+    }
     if declared
         .components()
         .any(|component| matches!(component, std::path::Component::ParentDir))
@@ -1249,9 +1272,6 @@ pub(crate) fn check_config_path(
             ),
         ));
         return false;
-    }
-    if declared.is_absolute() {
-        return true;
     }
     let mut current = config_dir.to_path_buf();
     for component in declared.components() {

--- a/crates/omnigraph-cluster/src/config.rs
+++ b/crates/omnigraph-cluster/src/config.rs
@@ -59,6 +59,14 @@ pub(crate) fn resolve_query_decls(
 
     let mut files: Vec<(PathBuf, PathBuf)> = Vec::new(); // (declared-relative, resolved)
     for declared in &paths {
+        if !check_config_path(
+            config_dir,
+            declared,
+            &format!("graphs.{graph_id}.queries"),
+            diagnostics,
+        ) {
+            continue;
+        }
         let resolved = resolve_config_path(config_dir, declared);
         if resolved.is_dir() {
             let mut entries: Vec<PathBuf> = match fs::read_dir(&resolved) {
@@ -660,7 +668,17 @@ pub(crate) fn load_desired(config_dir: &Path) -> LoadOutcome {
         }
 
         let schema_path = resolve_config_path(&config_dir, &graph.schema);
-        let schema_source = match fs::read_to_string(&schema_path) {
+        let schema_readable = check_config_path(
+            &config_dir,
+            &graph.schema,
+            &format!("graphs.{graph_id}.schema"),
+            &mut diagnostics,
+        );
+        let schema_source = match if schema_readable {
+            fs::read_to_string(&schema_path)
+        } else {
+            Err(std::io::Error::other("path refused"))
+        } {
             Ok(source) => {
                 let digest = sha256_hex(source.as_bytes());
                 graph_schema_digests.insert(graph_id.clone(), digest.clone());
@@ -676,14 +694,16 @@ pub(crate) fn load_desired(config_dir: &Path) -> LoadOutcome {
                 Some(source)
             }
             Err(err) => {
-                diagnostics.push(Diagnostic::error(
-                    "schema_file_missing",
-                    format!("graphs.{graph_id}.schema"),
-                    format!(
-                        "could not read schema file '{}': {err}",
-                        schema_path.display()
-                    ),
-                ));
+                if schema_readable {
+                    diagnostics.push(Diagnostic::error(
+                        "schema_file_missing",
+                        format!("graphs.{graph_id}.schema"),
+                        format!(
+                            "could not read schema file '{}': {err}",
+                            schema_path.display()
+                        ),
+                    ));
+                }
                 None
             }
         };
@@ -729,6 +749,14 @@ pub(crate) fn load_desired(config_dir: &Path) -> LoadOutcome {
                 to: schema_address.clone(),
             });
 
+            if !check_config_path(
+                &config_dir,
+                &query.file,
+                &format!("graphs.{graph_id}.queries.{query_name}.file"),
+                &mut diagnostics,
+            ) {
+                continue;
+            }
             let query_path = resolve_config_path(&config_dir, &query.file);
             let source = match query_contents.get(&query.file) {
                 Some(cached) => Ok(cached.clone()),
@@ -877,6 +905,14 @@ pub(crate) fn load_desired(config_dir: &Path) -> LoadOutcome {
             }
         }
 
+        if !check_config_path(
+            &config_dir,
+            &policy.file,
+            &format!("policies.{policy_name}.file"),
+            &mut diagnostics,
+        ) {
+            continue;
+        }
         let policy_path = resolve_config_path(&config_dir, &policy.file);
         match fs::read_to_string(&policy_path) {
             Ok(source) => {
@@ -1186,4 +1222,52 @@ pub(crate) fn resolve_config_path(config_dir: &Path, path: &Path) -> PathBuf {
     } else {
         config_dir.join(path)
     }
+}
+
+/// Refuse a declared path that leaves the configuration directory through a
+/// `..` segment or reaches its target through a symbolic link. A bundle is
+/// one directory of files read exactly as declared; either shape makes what
+/// gets applied depend on something outside it. The diagnostic names the
+/// setting that declared the path. Absolute paths stay accepted as before.
+/// Returns whether the path may be read.
+pub(crate) fn check_config_path(
+    config_dir: &Path,
+    declared: &Path,
+    setting: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> bool {
+    if declared
+        .components()
+        .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
+        diagnostics.push(Diagnostic::error(
+            "config_path_escape",
+            setting.to_string(),
+            format!(
+                "path '{}' contains a `..` segment; declare paths inside the configuration directory",
+                declared.display()
+            ),
+        ));
+        return false;
+    }
+    if declared.is_absolute() {
+        return true;
+    }
+    let mut current = config_dir.to_path_buf();
+    for component in declared.components() {
+        current.push(component);
+        if fs::symlink_metadata(&current).is_ok_and(|meta| meta.file_type().is_symlink()) {
+            diagnostics.push(Diagnostic::error(
+                "config_path_symlink",
+                setting.to_string(),
+                format!(
+                    "path '{}' crosses a symbolic link at '{}'; declare the target directly",
+                    declared.display(),
+                    current.display()
+                ),
+            ));
+            return false;
+        }
+    }
+    true
 }

--- a/crates/omnigraph-cluster/src/tests.rs
+++ b/crates/omnigraph-cluster/src/tests.rs
@@ -4771,3 +4771,65 @@ async fn plan_annotates_apply_dispositions() {
         Some(ApplyDisposition::Applied)
     );
 }
+
+#[cfg(unix)]
+#[tokio::test]
+async fn validate_refuses_paths_that_escape_or_cross_a_symlink() {
+    let dir = fixture();
+    // A `..` segment leaves the bundle.
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        r#"
+version: 1
+metadata:
+  name: test
+graphs:
+  knowledge:
+    schema: ../people.pg
+"#,
+    )
+    .unwrap();
+    let out = validate_config_dir(dir.path());
+    assert!(!out.ok);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|d| d.code == "config_path_escape" && d.path == "graphs.knowledge.schema"),
+        "{:?}",
+        out.diagnostics
+    );
+    assert!(
+        !out.diagnostics
+            .iter()
+            .any(|d| d.code == "schema_file_missing"),
+        "a refused path is reported once: {:?}",
+        out.diagnostics
+    );
+
+    // A symbolic link reaches outside the bundle.
+    let elsewhere = tempdir().unwrap();
+    fs::write(elsewhere.path().join("people.gq"), QUERY).unwrap();
+    std::os::unix::fs::symlink(elsewhere.path(), dir.path().join("linked")).unwrap();
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        r#"
+version: 1
+metadata:
+  name: test
+graphs:
+  knowledge:
+    schema: ./people.pg
+    queries: ./linked/
+"#,
+    )
+    .unwrap();
+    let out = validate_config_dir(dir.path());
+    assert!(!out.ok);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|d| d.code == "config_path_symlink" && d.path == "graphs.knowledge.queries"),
+        "{:?}",
+        out.diagnostics
+    );
+}

--- a/crates/omnigraph-cluster/src/tests.rs
+++ b/crates/omnigraph-cluster/src/tests.rs
@@ -4832,4 +4832,62 @@ graphs:
         "{:?}",
         out.diagnostics
     );
+
+    // A symbolic link *inside* a real directory is refused before it is read.
+    fs::create_dir_all(dir.path().join("queries")).unwrap();
+    std::os::unix::fs::symlink(
+        elsewhere.path().join("people.gq"),
+        dir.path().join("queries/linked.gq"),
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        r#"
+version: 1
+metadata:
+  name: test
+graphs:
+  knowledge:
+    schema: ./people.pg
+    queries: ./queries/
+"#,
+    )
+    .unwrap();
+    let out = validate_config_dir(dir.path());
+    assert!(!out.ok);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|d| d.code == "config_path_symlink"
+                && d.path == "graphs.knowledge.queries"
+                && d.message.contains("linked.gq")),
+        "{:?}",
+        out.diagnostics
+    );
+    assert!(
+        !out.resources.iter().any(|r| r.address.contains("linked")),
+        "a refused entry is never a resource: {:?}",
+        out.resources
+    );
+
+    // An absolute path keeps its old behavior, `..` included.
+    let absolute = elsewhere.path().join("sub/../people.pg");
+    fs::create_dir_all(elsewhere.path().join("sub")).unwrap();
+    fs::write(elsewhere.path().join("people.pg"), SCHEMA).unwrap();
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        format!(
+            "version: 1\nmetadata:\n  name: test\ngraphs:\n  knowledge:\n    schema: {}\n",
+            absolute.display()
+        ),
+    )
+    .unwrap();
+    let out = validate_config_dir(dir.path());
+    assert!(
+        !out.diagnostics
+            .iter()
+            .any(|d| d.code.starts_with("config_path_")),
+        "{:?}",
+        out.diagnostics
+    );
 }

--- a/docs/releases/v0.11.0.md
+++ b/docs/releases/v0.11.0.md
@@ -95,3 +95,14 @@ Notes accumulate here until the release is cut.
   admission checks and falls back rather than change results);
   `OMNIGRAPH_RRF_GATE_RATIO` / `OMNIGRAPH_RRF_GATE_MAX_IDS` tune the
   threshold.
+
+
+## Cluster configuration
+
+- **`..` segments and symbolic links in declared paths are refused.** A
+  schema, query, or policy path in `cluster.yaml` that contains a `..`
+  segment now fails validation with `config_path_escape`, and one that
+  reaches its file through a symbolic link fails with
+  `config_path_symlink`, each naming the setting that declared it. A bundle
+  is one directory of files read exactly as declared. Absolute paths are
+  still accepted.

--- a/docs/releases/v0.11.0.md
+++ b/docs/releases/v0.11.0.md
@@ -99,10 +99,11 @@ Notes accumulate here until the release is cut.
 
 ## Cluster configuration
 
-- **`..` segments and symbolic links in declared paths are refused.** A
-  schema, query, or policy path in `cluster.yaml` that contains a `..`
-  segment now fails validation with `config_path_escape`, and one that
-  reaches its file through a symbolic link fails with
-  `config_path_symlink`, each naming the setting that declared it. A bundle
-  is one directory of files read exactly as declared. Absolute paths are
-  still accepted.
+- **`..` segments and symbolic links in declared relative paths are
+  refused.** A relative schema, query, or policy path in `cluster.yaml` that
+  contains a `..` segment now fails validation with `config_path_escape`,
+  and one that reaches its file through a symbolic link, on the way to it or
+  as a discovered query file, fails with `config_path_symlink`, each naming
+  the setting that declared it. A bundle is one directory of files read
+  exactly as declared. Absolute paths keep their old behavior: they are
+  accepted as given and are not checked for either shape.

--- a/docs/user/clusters/config.md
+++ b/docs/user/clusters/config.md
@@ -160,6 +160,20 @@ Use the standard storage credential environment for the chosen backend. Azure
 is a qualification preview and requires the admission wrapper for every writer;
 see [Deployment](../deployment.md#azure-blob-preview).
 
+## Declared paths
+
+Every `schema`, `queries`, and policy `file` path is resolved against the
+directory that holds `cluster.yaml`. A relative path must stay inside that
+directory: a `..` segment is refused with `config_path_escape`, and a path
+that reaches its file through a symbolic link, on the way to it or as a
+query file discovered inside a declared directory, is refused with
+`config_path_symlink`. Each diagnostic names the setting that declared the
+path. The bundle is one directory of files read exactly as declared, so what
+gets applied never depends on something outside it.
+
+An absolute path is accepted as given and is not checked for either shape.
+Prefer relative paths; they are what keep a bundle portable and hermetic.
+
 ## Command behavior
 
 | Command | Changes graph or cluster state? | Use |


### PR DESCRIPTION
## What & why

Refuse a relative schema, query, or policy path that leaves the configuration directory through a `..` segment (`config_path_escape`) or reaches its file through a symbolic link (`config_path_symlink`), on the way to the file or as a `.gq` discovered inside a declared directory. Each diagnostic names the setting that declared the path. A bundle is one directory of files read exactly as declared; either shape made what gets applied depend on something outside it. Absolute paths keep their old behavior: accepted as given, `..` and symlinks included, and not checked.

## Backing issue / RFC

- [ ] Fixes an **accepted** issue: Closes #
- [ ] Is an RFC PR, or implements an **accepted** RFC
- [ ] **Trivial fast-lane**

None of the three: a small validation change, opened as a draft for the maintainer's call on whether it needs an issue first.

## Checklist

- [x] Change is focused (one logical change)
- [x] Tests added/updated for behavior changes (`..`, a symlinked directory, a symlinked discovered query file refused before it is read, an absolute path with `..` still accepted)
- [x] Public docs updated: a "Declared paths" section in docs/user/clusters/config.md; release notes
- [x] Reviewed against docs/dev/invariants.md — hard invariant 8 (loud, typed refusal); no deny-list item

## Local verification

- `cargo clippy -p omnigraph-cluster --all-targets --locked --features failpoints -- -D warnings -W clippy::dbg_macro` — clean
- `cargo test -p omnigraph-cluster --lib --locked --features failpoints` — 135 passed
- `cargo fmt --all --check` — clean
- `python3 scripts/check-docs.py` — OK

## Notes for reviewers

Two changes from review: the absolute-path exemption now precedes the `..` check, so `/srv/current/../schemas/main.pg` is still accepted; and discovered `.gq` entries are checked with no-follow metadata before anything reads them, so a symlink inside a checked directory is refused rather than followed. The schema site suppresses its `schema_file_missing` diagnostic when the path was refused, so a refused path is reported once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cD8PEeUfrzpqYuU1jaZBq
