### PR TITLE
feat(cluster): observe without the lock (RFC 0049)

### DIFF
--- a/crates/omnigraph-cli/src/cli.rs
+++ b/crates/omnigraph-cli/src/cli.rs
@@ -514,6 +514,10 @@ pub(crate) enum ClusterCommand {
         /// Emit JSON instead of human text.
         #[arg(long)]
         json: bool,
+        /// Plan without taking the cluster lock: read the ledger once, report
+        /// any lock instead of refusing, and label the output `observed`.
+        #[arg(long)]
+        observe: bool,
     },
     /// Converge the cluster to its config: create graphs, apply schema updates
     /// (soft drops), write stored-query/policy catalog resources, and execute
@@ -541,6 +545,17 @@ pub(crate) enum ClusterCommand {
     },
     /// Read the local JSON state ledger without scanning live graph resources.
     Status {
+        /// Cluster config directory containing cluster.yaml.
+        #[arg(long, default_value = ".")]
+        config: PathBuf,
+        /// Emit JSON instead of human text.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Observe declared graphs and catalog payloads without the lock, the
+    /// recovery sweep, or a write: what `refresh` would record, labeled
+    /// `observed`, with the exact ledger CAS it read.
+    Observe {
         /// Cluster config directory containing cluster.yaml.
         #[arg(long, default_value = ".")]
         config: PathBuf,

--- a/crates/omnigraph-cli/src/main.rs
+++ b/crates/omnigraph-cli/src/main.rs
@@ -10,10 +10,10 @@ use omnigraph_api_types::{
     SnapshotDatasetOutput,
 };
 use omnigraph_cluster::{
-    ApplyOptions, ApplyOutput, ApproveOutput, DiagnosticSeverity, ForceUnlockOutput, PlanOutput,
-    StateSyncOutput, StatusOutput, ValidateOutput, apply_config_dir_with_options,
-    approve_config_dir, force_unlock_config_dir, import_config_dir, plan_config_dir,
-    refresh_config_dir, status_config_dir, validate_config_dir,
+    ApplyOptions, ApplyOutput, ApproveOutput, DiagnosticSeverity, ForceUnlockOutput, PlanOptions,
+    PlanOutput, StateSyncOutput, StatusOutput, ValidateOutput, apply_config_dir_with_options,
+    approve_config_dir, force_unlock_config_dir, import_config_dir, observe_config_dir,
+    plan_config_dir_with_options, refresh_config_dir, status_config_dir, validate_config_dir,
 };
 use omnigraph_compiler::query::parser::parse_query;
 use omnigraph_compiler::schema::parser::parse_schema;
@@ -1591,9 +1591,17 @@ async fn main() -> Result<()> {
                 let output = validate_config_dir(config);
                 finish_cluster_validate(&output, json)?;
             }
-            ClusterCommand::Plan { config, json } => {
-                let output = plan_config_dir(config).await;
+            ClusterCommand::Plan {
+                config,
+                json,
+                observe,
+            } => {
+                let output = plan_config_dir_with_options(config, PlanOptions { observe }).await;
                 finish_cluster_plan(&output, json)?;
+            }
+            ClusterCommand::Observe { config, json } => {
+                let output = observe_config_dir(config).await;
+                finish_cluster_state_sync(&output, json)?;
             }
             ClusterCommand::Apply { config, json } => {
                 // The actor attributes graph-moving operations (sidecars,

--- a/crates/omnigraph-cli/src/output.rs
+++ b/crates/omnigraph-cli/src/output.rs
@@ -206,6 +206,15 @@ pub(crate) fn print_cluster_plan_human(output: &PlanOutput) {
             output.changes.len(),
             output.approvals_required.len()
         );
+        match output.authority {
+            omnigraph_cluster::LedgerAuthority::Observed => {
+                println!("  authority: observed (no lock taken, nothing written)");
+            }
+            omnigraph_cluster::LedgerAuthority::Unlocked => {
+                println!("  authority: unlocked (state.lock is false)");
+            }
+            omnigraph_cluster::LedgerAuthority::Locked => {}
+        }
         for change in &output.changes {
             let bindings = if change.binding_change {
                 " [bindings]"
@@ -312,6 +321,7 @@ pub(crate) fn print_cluster_state_sync_human(output: &StateSyncOutput) {
     let operation = match output.operation {
         omnigraph_cluster::StateSyncOperation::Refresh => "refresh",
         omnigraph_cluster::StateSyncOperation::Import => "import",
+        omnigraph_cluster::StateSyncOperation::Observe => "observe",
     };
     if output.ok {
         let state = &output.state_observations;
@@ -319,11 +329,25 @@ pub(crate) fn print_cluster_state_sync_human(output: &StateSyncOutput) {
             "cluster {operation}: revision {}, {} resource(s)",
             state.state_revision, state.resource_count
         );
+        match output.authority {
+            omnigraph_cluster::LedgerAuthority::Observed => {
+                println!("  authority: observed (no lock taken, nothing written)");
+            }
+            omnigraph_cluster::LedgerAuthority::Unlocked => {
+                println!("  authority: unlocked (state.lock is false)");
+            }
+            omnigraph_cluster::LedgerAuthority::Locked => {}
+        }
         if let Some(cas) = state.state_cas.as_deref() {
             println!("  state_cas: {cas}");
         }
-        if state.locked {
+        if state.lock_acquired {
             println!("  lock: acquired{}", cluster_lock_summary(state));
+        } else if state.locked {
+            println!(
+                "  lock: held by another process{}",
+                cluster_lock_summary(state)
+            );
         } else {
             println!("  lock: not acquired");
         }

--- a/crates/omnigraph-cluster/src/lib.rs
+++ b/crates/omnigraph-cluster/src/lib.rs
@@ -124,6 +124,22 @@ pub fn validate_config_dir(config_dir: impl AsRef<Path>) -> ValidateOutput {
 }
 
 pub async fn plan_config_dir(config_dir: impl AsRef<Path>) -> PlanOutput {
+    plan_config_dir_with_options(config_dir, PlanOptions::default()).await
+}
+
+/// `plan`, optionally without the cluster lock (RFC 0048). An observed plan
+/// reads the ledger once, reports any lock it finds instead of refusing, and
+/// labels its output `authority: observed`; it is never authority for an
+/// effect.
+pub async fn plan_config_dir_with_options(
+    config_dir: impl AsRef<Path>,
+    options: PlanOptions,
+) -> PlanOutput {
+    let mut authority = if options.observe {
+        LedgerAuthority::Observed
+    } else {
+        LedgerAuthority::Locked
+    };
     let outcome = load_desired(config_dir.as_ref());
     let mut diagnostics = outcome.diagnostics;
     let storage_root = outcome
@@ -142,6 +158,7 @@ pub async fn plan_config_dir(config_dir: impl AsRef<Path>) -> PlanOutput {
     let Some(desired) = outcome.desired else {
         return PlanOutput {
             ok: false,
+            authority,
             config_dir: display_path(&outcome.config_dir),
             desired_revision: DesiredRevision {
                 config_digest: None,
@@ -159,6 +176,7 @@ pub async fn plan_config_dir(config_dir: impl AsRef<Path>) -> PlanOutput {
     if has_errors(&diagnostics) {
         return PlanOutput {
             ok: false,
+            authority,
             config_dir: display_path(&desired.config_dir),
             desired_revision: DesiredRevision {
                 config_digest: Some(desired.config_digest),
@@ -173,7 +191,15 @@ pub async fn plan_config_dir(config_dir: impl AsRef<Path>) -> PlanOutput {
         };
     }
 
-    let _lock_guard = if desired.state_lock {
+    if !options.observe && !desired.state_lock {
+        authority = LedgerAuthority::Unlocked;
+    }
+    let _lock_guard = if options.observe {
+        backend
+            .observe_lock(&mut observations, &mut diagnostics)
+            .await;
+        None
+    } else if desired.state_lock {
         match backend.acquire_lock("plan", &mut observations).await {
             Ok(guard) => Some(guard),
             Err(diagnostic) => {
@@ -267,6 +293,7 @@ pub async fn plan_config_dir(config_dir: impl AsRef<Path>) -> PlanOutput {
 
     PlanOutput {
         ok,
+        authority,
         config_dir: display_path(&desired.config_dir),
         desired_revision: DesiredRevision {
             config_digest: Some(desired.config_digest),
@@ -1477,7 +1504,21 @@ pub async fn import_config_dir(config_dir: impl AsRef<Path>) -> StateSyncOutput 
     sync_config_dir(config_dir.as_ref(), StateSyncOperation::Import).await
 }
 
+/// `refresh` without the lock, the recovery sweep, or the write (RFC 0049):
+/// verify catalog payloads and observe every declared graph through the
+/// read-only open, and report the statuses and observations `refresh` would
+/// have recorded. The ledger's bytes and revision are untouched; the output
+/// is labeled `authority: observed` and names the `state_cas` it read.
+pub async fn observe_config_dir(config_dir: impl AsRef<Path>) -> StateSyncOutput {
+    sync_config_dir(config_dir.as_ref(), StateSyncOperation::Observe).await
+}
+
 async fn sync_config_dir(config_dir: &Path, operation: StateSyncOperation) -> StateSyncOutput {
+    let mut authority = if operation == StateSyncOperation::Observe {
+        LedgerAuthority::Observed
+    } else {
+        LedgerAuthority::Locked
+    };
     let outcome = load_desired(config_dir);
     let mut diagnostics = outcome.diagnostics;
     let storage_root = outcome
@@ -1497,6 +1538,7 @@ async fn sync_config_dir(config_dir: &Path, operation: StateSyncOperation) -> St
         return StateSyncOutput {
             ok: false,
             operation,
+            authority,
             config_dir: display_path(&outcome.config_dir),
             state_observations: observations,
             resource_digests: BTreeMap::new(),
@@ -1510,6 +1552,7 @@ async fn sync_config_dir(config_dir: &Path, operation: StateSyncOperation) -> St
         return StateSyncOutput {
             ok: false,
             operation,
+            authority,
             config_dir: display_path(&desired.config_dir),
             state_observations: observations,
             resource_digests: desired.resource_digests,
@@ -1520,7 +1563,15 @@ async fn sync_config_dir(config_dir: &Path, operation: StateSyncOperation) -> St
     }
 
     let operation_label = state_sync_operation_label(operation);
-    let _lock_guard = if desired.state_lock {
+    if operation != StateSyncOperation::Observe && !desired.state_lock {
+        authority = LedgerAuthority::Unlocked;
+    }
+    let _lock_guard = if operation == StateSyncOperation::Observe {
+        backend
+            .observe_lock(&mut observations, &mut diagnostics)
+            .await;
+        None
+    } else if desired.state_lock {
         match backend
             .acquire_lock(operation_label, &mut observations)
             .await
@@ -1546,6 +1597,7 @@ async fn sync_config_dir(config_dir: &Path, operation: StateSyncOperation) -> St
         return StateSyncOutput {
             ok: false,
             operation,
+            authority,
             config_dir: display_path(&desired.config_dir),
             state_observations: observations,
             resource_digests: desired.resource_digests,
@@ -1562,6 +1614,7 @@ async fn sync_config_dir(config_dir: &Path, operation: StateSyncOperation) -> St
             return StateSyncOutput {
                 ok: false,
                 operation,
+                authority,
                 config_dir: display_path(&desired.config_dir),
                 state_observations: observations,
                 resource_digests: desired.resource_digests,
@@ -1584,6 +1637,26 @@ async fn sync_config_dir(config_dir: &Path, operation: StateSyncOperation) -> St
             return StateSyncOutput {
                 ok: false,
                 operation,
+                authority,
+                config_dir: display_path(&desired.config_dir),
+                state_observations: observations,
+                resource_digests: BTreeMap::new(),
+                resource_statuses: BTreeMap::new(),
+                observations: BTreeMap::new(),
+                diagnostics,
+            };
+        }
+        (StateSyncOperation::Observe, Some(state)) => state,
+        (StateSyncOperation::Observe, None) => {
+            diagnostics.push(Diagnostic::error(
+                "state_missing",
+                CLUSTER_STATE_FILE,
+                "observe requires an existing state.json; run `cluster import` to bootstrap state",
+            ));
+            return StateSyncOutput {
+                ok: false,
+                operation,
+                authority,
                 config_dir: display_path(&desired.config_dir),
                 state_observations: observations,
                 resource_digests: BTreeMap::new(),
@@ -1601,6 +1674,7 @@ async fn sync_config_dir(config_dir: &Path, operation: StateSyncOperation) -> St
             return StateSyncOutput {
                 ok: false,
                 operation,
+                authority,
                 config_dir: display_path(&desired.config_dir),
                 state_observations: observations,
                 resource_digests: state_resource_digests(&state),
@@ -1619,6 +1693,7 @@ async fn sync_config_dir(config_dir: &Path, operation: StateSyncOperation) -> St
         return StateSyncOutput {
             ok: false,
             operation,
+            authority,
             config_dir: display_path(&desired.config_dir),
             state_observations: observations,
             resource_digests: state_resource_digests(&state),
@@ -1631,62 +1706,74 @@ async fn sync_config_dir(config_dir: &Path, operation: StateSyncOperation) -> St
     // Recovery sweep first (RFC-004 §D3): classify any interrupted graph
     // operation before observation/verification so a rolled-forward outcome
     // is what those passes see.
-    let sweep = sweep_recovery_sidecars(&backend, &mut state, &mut diagnostics).await;
+    let sweep = match operation {
+        StateSyncOperation::Refresh | StateSyncOperation::Import => {
+            Some(sweep_recovery_sidecars(&backend, &mut state, &mut diagnostics).await)
+        }
+        // Observe never sweeps: pending sidecars are reported, not acted on.
+        StateSyncOperation::Observe => {
+            warn_pending_recovery_sidecars(&backend, &mut diagnostics).await;
+            None
+        }
+    };
 
-    // Catalog payload verification must run BEFORE graph observation: removing
-    // a drifted query digest first means the live-graph composite recompute
-    // below already excludes it, so the persisted graph.<id> composite stays
-    // consistent and the next plan shows exactly the create + derived update.
-    for (address, finding) in verify_catalog_payloads(&backend, &state).await {
-        diagnostics.push(payload_finding_diagnostic(&address, &finding));
-        match finding {
-            PayloadFinding::Missing => {
-                state.applied_revision.resources.remove(&address);
-                set_resource_status(
-                    &mut state,
-                    &address,
-                    ResourceLifecycleStatus::Drifted,
-                    "payload_missing",
-                    "catalog payload blob is missing; re-run `cluster apply` to republish",
-                );
-            }
-            PayloadFinding::Mismatch { .. } => {
-                state.applied_revision.resources.remove(&address);
-                set_resource_status(
-                    &mut state,
-                    &address,
-                    ResourceLifecycleStatus::Drifted,
-                    "payload_mismatch",
-                    "catalog payload blob does not match the recorded digest; re-run `cluster apply` to republish",
-                );
-            }
-            // Transient IO must not trigger a spurious republish: keep the
-            // digest, surface the error, let a later clean refresh converge.
-            PayloadFinding::ReadError(error) => {
-                set_resource_status(
-                    &mut state,
-                    &address,
-                    ResourceLifecycleStatus::Error,
-                    "payload_read_error",
-                    &error,
-                );
+    {
+        // Catalog payload verification must run BEFORE graph observation: removing
+        // a drifted query digest first means the live-graph composite recompute
+        // below already excludes it, so the persisted graph.<id> composite stays
+        // consistent and the next plan shows exactly the create + derived update.
+        for (address, finding) in verify_catalog_payloads(&backend, &state).await {
+            diagnostics.push(payload_finding_diagnostic(&address, &finding));
+            match finding {
+                PayloadFinding::Missing => {
+                    state.applied_revision.resources.remove(&address);
+                    set_resource_status(
+                        &mut state,
+                        &address,
+                        ResourceLifecycleStatus::Drifted,
+                        "payload_missing",
+                        "catalog payload blob is missing; re-run `cluster apply` to republish",
+                    );
+                }
+                PayloadFinding::Mismatch { .. } => {
+                    state.applied_revision.resources.remove(&address);
+                    set_resource_status(
+                        &mut state,
+                        &address,
+                        ResourceLifecycleStatus::Drifted,
+                        "payload_mismatch",
+                        "catalog payload blob does not match the recorded digest; re-run `cluster apply` to republish",
+                    );
+                }
+                // Transient IO must not trigger a spurious republish: keep the
+                // digest, surface the error, let a later clean refresh converge.
+                PayloadFinding::ReadError(error) => {
+                    set_resource_status(
+                        &mut state,
+                        &address,
+                        ResourceLifecycleStatus::Error,
+                        "payload_read_error",
+                        &error,
+                    );
+                }
             }
         }
-    }
 
-    let graph_error_count = observe_declared_graphs(&desired, &backend, &mut state).await;
-    if graph_error_count > 0 {
-        diagnostics.push(Diagnostic::error(
-            "graph_observation_error",
-            CLUSTER_GRAPHS_DIR,
-            format!("{graph_error_count} graph observation(s) failed"),
-        ));
+        let graph_error_count = observe_declared_graphs(&desired, &backend, &mut state).await;
+        if graph_error_count > 0 {
+            diagnostics.push(Diagnostic::error(
+                "graph_observation_error",
+                CLUSTER_GRAPHS_DIR,
+                format!("{graph_error_count} graph observation(s) failed"),
+            ));
+        }
     }
 
     if operation == StateSyncOperation::Import && has_errors(&diagnostics) {
         return StateSyncOutput {
             ok: false,
             operation,
+            authority,
             config_dir: display_path(&desired.config_dir),
             state_observations: observations,
             resource_digests: state_resource_digests(&state),
@@ -1696,25 +1783,51 @@ async fn sync_config_dir(config_dir: &Path, operation: StateSyncOperation) -> St
         };
     }
 
-    if operation == StateSyncOperation::Import {
-        state.state_revision = 1;
-    } else {
-        state.state_revision = state.state_revision.saturating_add(1);
+    match operation {
+        StateSyncOperation::Import => state.state_revision = 1,
+        StateSyncOperation::Refresh => match state.state_revision.checked_add(1) {
+            Some(next) => state.state_revision = next,
+            None => {
+                diagnostics.push(Diagnostic::error(
+                    "state_revision_overflow",
+                    CLUSTER_STATE_FILE,
+                    "state_revision is at u64::MAX and cannot advance; the ledger was left unchanged",
+                ));
+                return StateSyncOutput {
+                    ok: false,
+                    operation,
+                    authority,
+                    config_dir: display_path(&desired.config_dir),
+                    state_observations: observations,
+                    resource_digests: state_resource_digests(&state),
+                    resource_statuses: state.resource_statuses,
+                    observations: state.observations,
+                    diagnostics,
+                };
+            }
+        },
+        // Observe never moves the revision.
+        StateSyncOperation::Observe => {}
     }
 
-    match backend
-        .write_state(&state, expected_cas.as_deref(), &mut observations)
-        .await
-    {
-        Ok(()) => {
-            // Completed sweep sidecars are deleted only after their outcome
-            // is durably recorded; on failure they stay and re-sweep.
-            for sidecar_uri in &sweep.completed_sidecars {
-                backend.delete_object(sidecar_uri).await;
+    if operation != StateSyncOperation::Observe {
+        match backend
+            .write_state(&state, expected_cas.as_deref(), &mut observations)
+            .await
+        {
+            Ok(()) => {
+                if let Some(sweep) = &sweep {
+                    // Completed sweep sidecars are deleted only after their
+                    // outcome is durably recorded; on failure they stay and
+                    // re-sweep.
+                    for sidecar_uri in &sweep.completed_sidecars {
+                        backend.delete_object(sidecar_uri).await;
+                    }
+                    mark_approvals_consumed(&backend, &sweep.consumed_approvals).await;
+                }
             }
-            mark_approvals_consumed(&backend, &sweep.consumed_approvals).await;
+            Err(diagnostic) => diagnostics.push(diagnostic),
         }
-        Err(diagnostic) => diagnostics.push(diagnostic),
     }
 
     let resource_digests = state_resource_digests(&state);
@@ -1723,6 +1836,7 @@ async fn sync_config_dir(config_dir: &Path, operation: StateSyncOperation) -> St
     StateSyncOutput {
         ok,
         operation,
+        authority,
         config_dir: display_path(&desired.config_dir),
         state_observations: observations,
         resource_digests,
@@ -2291,6 +2405,7 @@ fn state_sync_operation_label(operation: StateSyncOperation) -> &'static str {
     match operation {
         StateSyncOperation::Refresh => "refresh",
         StateSyncOperation::Import => "import",
+        StateSyncOperation::Observe => "observe",
     }
 }
 

--- a/crates/omnigraph-cluster/src/tests.rs
+++ b/crates/omnigraph-cluster/src/tests.rs
@@ -4891,3 +4891,186 @@ graphs:
         out.diagnostics
     );
 }
+
+#[tokio::test]
+async fn plan_observe_takes_no_lock_and_reports_observed_authority() {
+    let dir = fixture();
+    let state_dir = dir.path().join(CLUSTER_STATE_DIR);
+    fs::create_dir_all(&state_dir).unwrap();
+    let state = r#"{
+  "version": 1,
+  "state_revision": 7,
+  "applied_revision": {
+    "config_digest": "old",
+    "resources": {
+      "graph.knowledge": { "digest": "old-graph" }
+    }
+  }
+}"#;
+    fs::write(state_dir.join("state.json"), state).unwrap();
+    // Another process holds the lock; an observer reports it and proceeds.
+    fs::write(
+        dir.path().join(CLUSTER_LOCK_FILE),
+        r#"{"version":1,"lock_id":"01OTHER","operation":"apply","created_at":"2026-09-03T00:00:00Z","pid":1}"#,
+    )
+    .unwrap();
+
+    let out = plan_config_dir_with_options(dir.path(), PlanOptions { observe: true }).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert_eq!(out.authority, LedgerAuthority::Observed);
+    assert_eq!(out.state_observations.state_revision, 7);
+    assert_eq!(
+        out.state_observations.state_cas.as_deref(),
+        Some(format!("sha256:{}", sha256_hex(state.as_bytes())).as_str())
+    );
+    assert!(out.state_observations.locked);
+    assert_eq!(out.state_observations.lock_id.as_deref(), Some("01OTHER"));
+    assert!(!out.state_observations.lock_acquired);
+    assert!(
+        !out.diagnostics
+            .iter()
+            .any(|d| d.code == "state_lock_disabled" || d.code == "state_lock_held"),
+        "{:?}",
+        out.diagnostics
+    );
+    // The foreign lock is exactly as it was: nothing created, nothing removed.
+    assert!(
+        fs::read_to_string(dir.path().join(CLUSTER_LOCK_FILE))
+            .unwrap()
+            .contains("01OTHER")
+    );
+    // The locked path still labels itself.
+    fs::remove_file(dir.path().join(CLUSTER_LOCK_FILE)).unwrap();
+    let locked = plan_config_dir(dir.path()).await;
+    assert_eq!(locked.authority, LedgerAuthority::Locked);
+    assert!(locked.state_observations.lock_acquired);
+}
+
+#[tokio::test]
+async fn observe_reports_drift_without_writing_the_ledger() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    let state_dir = dir.path().join(CLUSTER_STATE_DIR);
+    fs::create_dir_all(&state_dir).unwrap();
+    let graph_digest = historical_graph_digest("knowledge", None, &[]);
+    let ledger = serde_json::to_string(&json!({
+        "version": 1,
+        "state_revision": 3,
+        "applied_revision": {
+            "config_digest": "old",
+            "resources": { "graph.knowledge": { "digest": graph_digest } }
+        }
+    }))
+    .unwrap();
+    fs::write(state_dir.join("state.json"), &ledger).unwrap();
+
+    let out = observe_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert_eq!(out.operation, StateSyncOperation::Observe);
+    assert_eq!(out.authority, LedgerAuthority::Observed);
+    assert_eq!(out.state_observations.state_revision, 3);
+    assert!(!out.state_observations.lock_acquired);
+    assert_eq!(
+        out.resource_statuses["graph.knowledge"].status,
+        ResourceLifecycleStatus::Applied
+    );
+    // Nothing was written: the bytes, the revision, and the absence of a lock.
+    assert_eq!(
+        fs::read_to_string(state_dir.join("state.json")).unwrap(),
+        ledger
+    );
+    assert!(!dir.path().join(CLUSTER_LOCK_FILE).exists());
+
+    // A graph that disappeared is reported as drifted, still without a write.
+    fs::remove_dir_all(dir.path().join(CLUSTER_GRAPHS_DIR)).unwrap();
+    let out = observe_config_dir(dir.path()).await;
+    assert!(out.ok, "{:?}", out.diagnostics);
+    assert_eq!(
+        out.resource_statuses["graph.knowledge"].status,
+        ResourceLifecycleStatus::Drifted
+    );
+    assert_eq!(
+        fs::read_to_string(state_dir.join("state.json")).unwrap(),
+        ledger
+    );
+}
+
+#[tokio::test]
+async fn a_bundle_without_the_lock_is_labeled_unlocked() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    fs::write(
+        dir.path().join(CLUSTER_CONFIG_FILE),
+        fs::read_to_string(dir.path().join(CLUSTER_CONFIG_FILE))
+            .unwrap()
+            .replace("lock: true", "lock: false"),
+    )
+    .unwrap();
+    let state_dir = dir.path().join(CLUSTER_STATE_DIR);
+    fs::create_dir_all(&state_dir).unwrap();
+    let graph_digest = historical_graph_digest("knowledge", None, &[]);
+    fs::write(
+        state_dir.join("state.json"),
+        serde_json::to_string(&json!({
+            "version": 1,
+            "state_revision": 3,
+            "applied_revision": {
+                "config_digest": "old",
+                "resources": { "graph.knowledge": { "digest": graph_digest } }
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let plan = plan_config_dir(dir.path()).await;
+    assert!(plan.ok, "{:?}", plan.diagnostics);
+    assert_eq!(plan.authority, LedgerAuthority::Unlocked);
+    assert!(!plan.state_observations.lock_acquired);
+    let refresh = refresh_config_dir(dir.path()).await;
+    assert!(refresh.ok, "{:?}", refresh.diagnostics);
+    assert_eq!(refresh.authority, LedgerAuthority::Unlocked);
+    assert!(
+        refresh
+            .diagnostics
+            .iter()
+            .any(|d| d.code == "state_lock_disabled")
+    );
+    // An observer stays an observer whatever the bundle says.
+    let observe = observe_config_dir(dir.path()).await;
+    assert_eq!(observe.authority, LedgerAuthority::Observed);
+}
+
+#[tokio::test]
+async fn refresh_refuses_to_advance_past_the_last_revision() {
+    let dir = fixture();
+    init_derived_graph(dir.path()).await;
+    let state_dir = dir.path().join(CLUSTER_STATE_DIR);
+    fs::create_dir_all(&state_dir).unwrap();
+    let graph_digest = historical_graph_digest("knowledge", None, &[]);
+    let ledger = serde_json::to_string(&json!({
+        "version": 1,
+        "state_revision": u64::MAX,
+        "applied_revision": {
+            "config_digest": "old",
+            "resources": { "graph.knowledge": { "digest": graph_digest } }
+        }
+    }))
+    .unwrap();
+    fs::write(state_dir.join("state.json"), &ledger).unwrap();
+
+    let out = refresh_config_dir(dir.path()).await;
+    assert!(!out.ok);
+    assert!(
+        out.diagnostics
+            .iter()
+            .any(|d| d.code == "state_revision_overflow"),
+        "{:?}",
+        out.diagnostics
+    );
+    assert_eq!(
+        fs::read_to_string(state_dir.join("state.json")).unwrap(),
+        ledger
+    );
+    assert!(!dir.path().join(CLUSTER_LOCK_FILE).exists());
+}

--- a/crates/omnigraph-cluster/src/types.rs
+++ b/crates/omnigraph-cluster/src/types.rs
@@ -217,6 +217,8 @@ pub struct ApprovalRequirement {
 #[derive(Debug, Clone, Serialize)]
 pub struct PlanOutput {
     pub ok: bool,
+    /// Whether this plan held the cluster lock or only observed the ledger.
+    pub authority: LedgerAuthority,
     pub config_dir: String,
     pub desired_revision: DesiredRevision,
     pub resource_digests: BTreeMap<String, String>,
@@ -244,12 +246,38 @@ pub struct StatusOutput {
 pub enum StateSyncOperation {
     Refresh,
     Import,
+    /// `refresh` without the lock, the sweep, or the write (RFC 0049).
+    Observe,
+}
+
+/// Under which authority a command read the ledger (RFC 0049).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum LedgerAuthority {
+    /// The command held `__cluster/lock.json`.
+    #[default]
+    Locked,
+    /// The bundle sets `state.lock: false`: the command wrote (or planned)
+    /// without the lock, as the `state_lock_disabled` warning says.
+    Unlocked,
+    /// The command took no lock and wrote nothing. Its findings are a
+    /// point-in-time observation; `state_cas` names the ledger it read.
+    Observed,
+}
+
+/// Options for [`crate::plan_config_dir_with_options`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PlanOptions {
+    /// Plan without the cluster lock and label the output `observed`.
+    pub observe: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct StateSyncOutput {
     pub ok: bool,
     pub operation: StateSyncOperation,
+    /// Whether this command held the cluster lock or only observed.
+    pub authority: LedgerAuthority,
     pub config_dir: String,
     pub state_observations: StateObservations,
     pub resource_digests: BTreeMap<String, String>,

--- a/docs/dev/control-plane.md
+++ b/docs/dev/control-plane.md
@@ -34,11 +34,12 @@ The cluster sidecars are separate from each graph's ordinary recovery-v9 sidecar
 | Operation | Mutation | Responsibility |
 |---|---|---|
 | `validate` | None | Parse the whole bundle, normalize references, type-check schemas and queries, validate policies and bindings, and report all diagnostics. |
-| `plan` | None | Compare desired resource digests with recorded/applied and observed state; compute dependencies and approval requirements. |
+| `plan` | None | Compare desired resource digests with recorded/applied and observed state; compute dependencies and approval requirements. `--observe` takes no lock and labels the output `authority: observed`. |
 | `approve` | Approval artifact | Bind one irreversible planned operation to exact before/after/config digests and an actor. |
 | `apply` | Resources and ledger | Re-plan under the lock, execute eligible changes in dependency order, recover interrupted changes, then CAS the applied ledger. |
 | `status` | None | Read the ledger, lock, recoveries, approvals, and current observations. |
 | `refresh` | Ledger observations | Reconcile recorded observations with live resources without changing the desired bundle. |
+| `observe` | None | `refresh` without the lock, the recovery sweep, or the write: report the statuses and observations `refresh` would record, labeled `authority: observed` with the exact `state_cas` read (RFC 0049). |
 | `import` | Initial ledger | Adopt declared existing resources after validation and observation. |
 | `force-unlock` | Lock only | Remove one exact stale lock ID after an operator proves no owner is alive. |
 
@@ -48,7 +49,7 @@ Destructive graph deletion requires a matching unconsumed approval. Any relevant
 
 ## Concurrency
 
-State-changing operations acquire `__cluster/lock.json` with storage-native create-if-absent semantics. Final ledger publication is also conditional on the state version observed under the operation. The lock coordinates operator processes; graph-level manifest gates and recovery still own data correctness.
+State-changing operations acquire `__cluster/lock.json` with storage-native create-if-absent semantics. Observe-only reads (`plan --observe`, `observe`) take no lock and write nothing; their output says so (`authority: observed`) and names the `state_cas` they read, and an existing lock is reported rather than refused. A bundle that sets `state.lock: false` gets `authority: unlocked` on every command that would otherwise have held the lock. Final ledger publication is also conditional on the state version observed under the operation. The lock coordinates operator processes; graph-level manifest gates and recovery still own data correctness.
 
 Do not bypass the cluster API with direct filesystem writes, edit `state.json`, or derive a second mutable inventory. Content digests and live observations are recomputed from the declared and durable authorities.
 

--- a/docs/releases/v0.11.0.md
+++ b/docs/releases/v0.11.0.md
@@ -107,3 +107,18 @@ Notes accumulate here until the release is cut.
   the setting that declared it. A bundle is one directory of files read
   exactly as declared. Absolute paths keep their old behavior: they are
   accepted as given and are not checked for either shape.
+
+## Cluster operations
+
+- **Observe without the lock.** `cluster observe` reports what `refresh`
+  would record (catalog payload findings and live graph observations)
+  without taking `__cluster/lock.json`, running the recovery sweep, or
+  writing the ledger, and `cluster plan --observe` plans the same way. Both
+  outputs carry `authority: "observed"` and the exact `state_cas` they read;
+  an existing lock is reported, not refused (RFC 0049).
+- **Honest authority and a bounded revision.** Every `plan`, `refresh`, and
+  `import` output now carries `authority`: `locked`, `observed`, or
+  `unlocked` when the bundle sets `state.lock: false`. `refresh` refuses with
+  `state_revision_overflow` instead of silently staying at `u64::MAX`, and
+  the human output distinguishes a lock this command acquired from one
+  another process holds (RFC 0049).

--- a/docs/rfcs/0049-control-plane-seams.md
+++ b/docs/rfcs/0049-control-plane-seams.md
@@ -3,7 +3,7 @@ rfc: "0049"
 title: "Control-plane seams: observe, readiness witness, bounded shutdown"
 track: maintainer
 status: accepted
-implementation: not-started
+implementation: partial
 authors:
   - OmniGraph maintainers
 created: 2026-09-03

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -174,4 +174,4 @@ This table is the human index for the canonical RFC corpus.
 | [0044](0044-edge-keys.md) | Edge keys: derived edge identity | maintainer | draft | in-progress |
 | [0045](0045-gq-logic-tests.md) | GQ logic tests | maintainer | draft | partial |
 | [0046](0046-index-status.md) | Read-only index status | maintainer | draft | not-started |
-| [0049](0049-control-plane-seams.md) | Control-plane seams: observe, readiness witness, bounded shutdown | maintainer | accepted | not-started |
+| [0049](0049-control-plane-seams.md) | Control-plane seams: observe, readiness witness, bounded shutdown | maintainer | accepted | partial |

--- a/docs/user/clusters/index.md
+++ b/docs/user/clusters/index.md
@@ -104,11 +104,15 @@ the delete is blocked again.
 
 ```bash
 omnigraph cluster status  --config ./company-brain
+omnigraph cluster observe --config ./company-brain
 omnigraph cluster refresh --config ./company-brain
 omnigraph cluster import  --config ./company-brain
 ```
 
 - `status` reads recorded state without changing resources.
+- `observe` reports what `refresh` would record, without taking the lock or
+  writing anything; the output is labeled `observed` and names the ledger
+  version it read. `plan --observe` does the same for a plan.
 - `refresh` updates observations for an existing state record.
 - `import` initializes state from declared resources when adopting an existing
   cluster.


### PR DESCRIPTION
## What & why

The cluster half of RFC 0049.

- `cluster plan --observe` (`plan_config_dir_with_options(dir, PlanOptions { observe: true })`) plans without taking the cluster lock: it reads the ledger once, reports an existing lock instead of refusing, and labels the output `authority: "observed"`.
- `cluster observe` (`observe_config_dir`) is `refresh` without the lock, the recovery sweep, or the write: catalog payload verification and the read-only graph observation run on an in-memory copy of the ledger, and the output reports the statuses and observations `refresh` would have recorded, with the `state_cas` and revision it read. Pending sidecars are the existing `cluster_recovery_pending` warning.
- `PlanOutput` and `StateSyncOutput` gain `authority: LedgerAuthority`: `locked`, `observed`, or `unlocked` when the bundle sets `state.lock: false`, so no output claims a lock it did not hold. `StateSyncOperation` gains `observe`.
- `refresh` refuses with `state_revision_overflow` instead of saturating at `u64::MAX`, and the human output distinguishes a lock this command acquired (`lock_acquired`) from one another process holds (`locked`).

The ledger restore that this PR first carried is withdrawn (see the RFC's decision log): its real use arrives with coherent restore points, and `import` plus `observe` rebuild a lost ledger today. No storage format, ledger schema, lock, or recovery change.

## Backing issue / RFC

- [ ] Fixes an **accepted** issue
- [x] Implements RFC 0049 (draft, #610): docs/rfcs/0049-control-plane-seams.md — kept as a draft PR until the RFC is accepted
- [ ] Trivial fast-lane

## Checklist

- [x] Change is focused (observe, the authority label, the overflow refusal, the CLI verb and flag, their docs)
- [x] Tests added: observe takes no lock and labels authority; observe reports drift without writing; a `state.lock: false` bundle is labeled `unlocked`; refresh refuses at `u64::MAX` and leaves the ledger untouched
- [x] Public docs updated: docs/dev/control-plane.md, docs/user/clusters/index.md, docs/releases/v0.11.0.md
- [x] Reviewed against docs/dev/invariants.md — 5 (observe never sweeps), 8 and 11 (typed refusals, bounded revision), 12 (no shadow ledger); no deny-list item. For Rust consumers the new variant and the new required field are breaking, as the RFC's compatibility section now says; every in-tree consumer is updated here.

## Local verification

- `cargo clippy -p omnigraph-cluster -p omnigraph-cli --all-targets --locked --features omnigraph-cluster/failpoints -- -D warnings -W clippy::dbg_macro` — clean
- `cargo test -p omnigraph-cluster --lib --locked --features failpoints` — 138 passed (134 existing + 4 new)
- `cargo test -p omnigraph-cli --locked` — every suite passes, `parity_matrix` included (21 passed) once `CARGO_BIN_EXE_omnigraph-server` points at the built server: with a redirected `CARGO_TARGET_DIR` the test support finds no `target/debug/omnigraph-server` in the workspace and falls back to `cargo run` inside the test, which times out; an earlier note here blamed the environment more vaguely
- `cargo fmt --all --check` — clean
- `python3 scripts/check-docs.py` — OK

## Notes for reviewers

`observe` reuses the `refresh`/`import` pipeline with three branches (no lock, no sweep, no write) rather than a parallel implementation, so the observation it reports is exactly what `refresh` would persist. The `saturating_add` in `apply`'s state write is pre-existing and untouched here. Release notes append a "Cluster operations" section that the server PR also appends near; expect a trivial conflict when the second lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cD8PEeUfrzpqYuU1jaZBq
