### PR TITLE
feat(server): readiness witness and bounded shutdown (RFC 0049)

### DIFF
--- a/crates/omnigraph-api-types/src/lib.rs
+++ b/crates/omnigraph-api-types/src/lib.rs
@@ -1065,6 +1065,33 @@ pub struct HealthOutput {
     pub source_version: Option<String>,
 }
 
+/// The readiness witness of one replica (`GET /readyz`, RFC 0048): whether
+/// it is serving or draining, the applied revision it booted from, and the
+/// graphs it does and does not serve.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ReadinessOutput {
+    /// False once shutdown has begun; the response is then 503.
+    pub ready: bool,
+    /// `serving` or `draining`.
+    pub status: String,
+    /// The `config_digest` of the applied revision this process booted from.
+    /// Fixed for the life of the process: the server never reloads.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub booted_serving_digest: Option<String>,
+    /// The ledger revision the process booted from.
+    pub state_revision: u64,
+    /// The ledger CAS (`sha256:<hex>`) the process booted from.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_cas: Option<String>,
+    /// Graphs this process serves, sorted.
+    pub served_graphs: Vec<String>,
+    /// Graphs the applied revision names that this process does not serve,
+    /// for any reason, sorted.
+    pub quarantined_graphs: Vec<String>,
+    /// The bound on graceful shutdown, after which the process exits 2.
+    pub shutdown_grace_seconds: u64,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ErrorCode {

--- a/crates/omnigraph-api-types/src/lib.rs
+++ b/crates/omnigraph-api-types/src/lib.rs
@@ -1065,9 +1065,10 @@ pub struct HealthOutput {
     pub source_version: Option<String>,
 }
 
-/// The readiness witness of one replica (`GET /readyz`, RFC 0048): whether
-/// it is serving or draining, the applied revision it booted from, and the
-/// graphs it does and does not serve.
+/// The readiness witness of one replica (`GET /readyz`, RFC 0049): whether
+/// it is serving or draining, the applied revision it booted from, and how
+/// many graphs it does and does not serve. Unauthenticated, so it carries
+/// no graph id: those stay behind `GET /graphs`.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ReadinessOutput {
     /// False once shutdown has begun; the response is then 503.
@@ -1083,11 +1084,11 @@ pub struct ReadinessOutput {
     /// The ledger CAS (`sha256:<hex>`) the process booted from.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub state_cas: Option<String>,
-    /// Graphs this process serves, sorted.
-    pub served_graphs: Vec<String>,
-    /// Graphs the applied revision names that this process does not serve,
-    /// for any reason, sorted.
-    pub quarantined_graphs: Vec<String>,
+    /// How many graphs this process serves.
+    pub served_graph_count: usize,
+    /// How many graphs the applied revision names that this process does
+    /// not serve, for any reason. `GET /graphs` names them.
+    pub quarantined_graph_count: usize,
     /// The bound on graceful shutdown, after which the process exits 2.
     pub shutdown_grace_seconds: u64,
 }
@@ -1638,6 +1639,11 @@ pub struct GraphInfo {
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct GraphListResponse {
     pub graphs: Vec<GraphInfo>,
+    /// Graphs the applied revision names that this process does not serve,
+    /// for any reason, sorted (RFC 0049). Empty when every applied graph is
+    /// served.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub quarantined: Vec<String>,
 }
 
 #[cfg(test)]

--- a/crates/omnigraph-cluster/src/serve.rs
+++ b/crates/omnigraph-cluster/src/serve.rs
@@ -42,13 +42,16 @@ pub struct ServingSnapshot {
     pub policies: Vec<ServingPolicy>,
     pub diagnostics: Vec<Diagnostic>,
     /// The applied revision's `config_digest`: what a server booted from
-    /// reports as its `booted_serving_digest` (RFC 0048).
+    /// reports as its `booted_serving_digest` (RFC 0049).
     pub config_digest: Option<String>,
     /// The ledger revision and CAS this snapshot was read from.
     pub state_revision: u64,
     pub state_cas: Option<String>,
-    /// Graphs the applied revision names that this snapshot does not serve
-    /// (pending recovery quarantined them), sorted.
+    /// Every graph the applied revision names, sorted.
+    pub applied_graphs: Vec<String>,
+    /// Applied graphs this snapshot does not serve because pending recovery
+    /// quarantined them, sorted. A sidecar for a graph the revision does not
+    /// name is not in this list.
     pub quarantined_graphs: Vec<String>,
 }
 
@@ -283,6 +286,7 @@ async fn read_snapshot_with_store(
     let boot_config_digest = state.applied_revision.config_digest.clone();
     let boot_state_revision = state.state_revision;
     let boot_state_cas = observations.state_cas.clone();
+    let boot_applied_graphs = applied_graph_ids(&state);
 
     let required_embedding_providers: BTreeSet<String> = state
         .applied_revision
@@ -472,7 +476,11 @@ async fn read_snapshot_with_store(
         config_digest: boot_config_digest,
         state_revision: boot_state_revision,
         state_cas: boot_state_cas,
-        quarantined_graphs: quarantined_graphs.into_iter().collect(),
+        quarantined_graphs: quarantined_graphs
+            .into_iter()
+            .filter(|graph_id| boot_applied_graphs.contains(graph_id))
+            .collect(),
+        applied_graphs: boot_applied_graphs,
     })
 }
 

--- a/crates/omnigraph-cluster/src/serve.rs
+++ b/crates/omnigraph-cluster/src/serve.rs
@@ -41,6 +41,15 @@ pub struct ServingSnapshot {
     pub queries: Vec<ServingQuery>,
     pub policies: Vec<ServingPolicy>,
     pub diagnostics: Vec<Diagnostic>,
+    /// The applied revision's `config_digest`: what a server booted from
+    /// reports as its `booted_serving_digest` (RFC 0048).
+    pub config_digest: Option<String>,
+    /// The ledger revision and CAS this snapshot was read from.
+    pub state_revision: u64,
+    pub state_cas: Option<String>,
+    /// Graphs the applied revision names that this snapshot does not serve
+    /// (pending recovery quarantined them), sorted.
+    pub quarantined_graphs: Vec<String>,
 }
 
 /// Read the applied revision as a serving snapshot — the read-only loader for
@@ -271,6 +280,9 @@ async fn read_snapshot_with_store(
         diagnostics.extend(startup_diagnostics);
         return Err(diagnostics);
     };
+    let boot_config_digest = state.applied_revision.config_digest.clone();
+    let boot_state_revision = state.state_revision;
+    let boot_state_cas = observations.state_cas.clone();
 
     let required_embedding_providers: BTreeSet<String> = state
         .applied_revision
@@ -457,6 +469,10 @@ async fn read_snapshot_with_store(
         queries,
         policies,
         diagnostics: startup_diagnostics,
+        config_digest: boot_config_digest,
+        state_revision: boot_state_revision,
+        state_cas: boot_state_cas,
+        quarantined_graphs: quarantined_graphs.into_iter().collect(),
     })
 }
 

--- a/crates/omnigraph-server/src/handlers.rs
+++ b/crates/omnigraph-server/src/handlers.rs
@@ -28,6 +28,61 @@ pub(crate) async fn server_health() -> Json<HealthOutput> {
     })
 }
 
+/// Readiness witness (RFC 0048).
+///
+/// Unauthenticated. Reports whether this replica is serving or draining,
+/// the applied `config_digest` it booted from, the ledger revision and CAS
+/// it read, and the graphs it serves and does not serve. Answers 503 once
+/// shutdown has begun; `/healthz` stays 200 while the process is alive.
+#[utoipa::path(
+    get,
+    path = "/readyz",
+    tag = "health",
+    operation_id = "readiness",
+    responses(
+        (status = 200, description = "Serving", body = ReadinessOutput),
+        (status = 503, description = "Draining", body = ReadinessOutput),
+    ),
+)]
+pub(crate) async fn server_ready(
+    State(state): State<AppState>,
+) -> (StatusCode, Json<ReadinessOutput>) {
+    let draining = state.draining.load(std::sync::atomic::Ordering::SeqCst);
+    let mut served: Vec<String> = state
+        .routing()
+        .registry
+        .list()
+        .iter()
+        .map(|handle| handle.key.graph_id.as_str().to_string())
+        .collect();
+    served.sort();
+    let mut quarantined: Vec<String> = state
+        .witness
+        .applied_graphs
+        .iter()
+        .filter(|graph_id| !served.contains(graph_id))
+        .cloned()
+        .collect();
+    quarantined.sort();
+    quarantined.dedup();
+    let output = ReadinessOutput {
+        ready: !draining,
+        status: if draining { "draining" } else { "serving" }.to_string(),
+        booted_serving_digest: state.witness.booted_serving_digest.clone(),
+        state_revision: state.witness.state_revision,
+        state_cas: state.witness.state_cas.clone(),
+        served_graphs: served,
+        quarantined_graphs: quarantined,
+        shutdown_grace_seconds: state.shutdown_grace.as_secs(),
+    };
+    let status = if draining {
+        StatusCode::SERVICE_UNAVAILABLE
+    } else {
+        StatusCode::OK
+    };
+    (status, Json(output))
+}
+
 #[utoipa::path(
     get,
     path = "/graphs",
@@ -114,7 +169,7 @@ const CLUSTER_OPERATION_ID_PREFIX: &str = "cluster_";
 /// always-flat endpoints. `/graphs` is the management enumeration —
 /// it lives at the root in both single mode (405) and multi mode, and
 /// must never be rewritten to `/graphs/{graph_id}/graphs`.
-const ALWAYS_FLAT_PATHS: &[&str] = &["/healthz", "/graphs"];
+const ALWAYS_FLAT_PATHS: &[&str] = &["/healthz", "/readyz", "/graphs"];
 
 /// In multi-mode `server_openapi`, every protected path-item is
 /// reattached under the cluster prefix. Operation IDs gain the

--- a/crates/omnigraph-server/src/handlers.rs
+++ b/crates/omnigraph-server/src/handlers.rs
@@ -28,12 +28,14 @@ pub(crate) async fn server_health() -> Json<HealthOutput> {
     })
 }
 
-/// Readiness witness (RFC 0048).
+/// Readiness witness (RFC 0049).
 ///
-/// Unauthenticated. Reports whether this replica is serving or draining,
-/// the applied `config_digest` it booted from, the ledger revision and CAS
-/// it read, and the graphs it serves and does not serve. Answers 503 once
-/// shutdown has begun; `/healthz` stays 200 while the process is alive.
+/// Unauthenticated, and therefore minimal: it reports whether this replica
+/// is serving or draining, the applied `config_digest` it booted from, the
+/// ledger revision and CAS it read, and how many graphs it serves and does
+/// not serve. Graph ids are topology and stay behind `GET /graphs`. Answers
+/// 503 once shutdown has begun; `/healthz` stays 200 while the process is
+/// alive.
 #[utoipa::path(
     get,
     path = "/readyz",
@@ -48,31 +50,16 @@ pub(crate) async fn server_ready(
     State(state): State<AppState>,
 ) -> (StatusCode, Json<ReadinessOutput>) {
     let draining = state.draining.load(std::sync::atomic::Ordering::SeqCst);
-    let mut served: Vec<String> = state
-        .routing()
-        .registry
-        .list()
-        .iter()
-        .map(|handle| handle.key.graph_id.as_str().to_string())
-        .collect();
-    served.sort();
-    let mut quarantined: Vec<String> = state
-        .witness
-        .applied_graphs
-        .iter()
-        .filter(|graph_id| !served.contains(graph_id))
-        .cloned()
-        .collect();
-    quarantined.sort();
-    quarantined.dedup();
+    let served_graph_count = state.routing().registry.list().len();
+    let quarantined_graph_count = state.quarantined_graphs().len();
     let output = ReadinessOutput {
         ready: !draining,
         status: if draining { "draining" } else { "serving" }.to_string(),
         booted_serving_digest: state.witness.booted_serving_digest.clone(),
         state_revision: state.witness.state_revision,
         state_cas: state.witness.state_cas.clone(),
-        served_graphs: served,
-        quarantined_graphs: quarantined,
+        served_graph_count,
+        quarantined_graph_count,
         shutdown_grace_seconds: state.shutdown_grace.as_secs(),
     };
     let status = if draining {
@@ -136,7 +123,10 @@ pub(crate) async fn server_graphs_list(
         })
         .collect();
     graphs.sort_by(|a, b| a.graph_id.cmp(&b.graph_id));
-    Ok(Json(GraphListResponse { graphs }))
+    Ok(Json(GraphListResponse {
+        graphs,
+        quarantined: state.quarantined_graphs(),
+    }))
 }
 
 pub(crate) async fn server_openapi(

--- a/crates/omnigraph-server/src/lib.rs
+++ b/crates/omnigraph-server/src/lib.rs
@@ -189,21 +189,54 @@ pub struct ServerConfig {
     /// startup failures quarantine that graph and healthy graphs still serve.
     /// When true, any quarantined or failed graph aborts startup.
     pub require_all_graphs: bool,
-    /// What `GET /readyz` reports about the revision this process booted
-    /// from (RFC 0048).
+    /// What `GET /readyz` and `GET /graphs` report about the revision this
+    /// process booted from (RFC 0049).
     pub witness: BootWitness,
     /// The bound on graceful shutdown: readiness turns off at the signal,
     /// in-flight requests drain, and at this deadline the process exits 2
-    /// (RFC 0048). `--shutdown-grace-seconds` or
-    /// `OMNIGRAPH_SHUTDOWN_GRACE_SECONDS`; default 25.
+    /// (RFC 0049). Resolved by [`resolve_shutdown_grace`]; default 25 s.
     pub shutdown_grace: std::time::Duration,
 }
 
 /// The default bound on graceful shutdown.
 pub const DEFAULT_SHUTDOWN_GRACE: std::time::Duration = std::time::Duration::from_secs(25);
 
-/// The boot facts `GET /readyz` reports (RFC 0048), fixed for the life of
-/// the process.
+/// The environment variable [`resolve_shutdown_grace`] reads when the flag
+/// is absent.
+pub const SHUTDOWN_GRACE_ENV: &str = "OMNIGRAPH_SHUTDOWN_GRACE_SECONDS";
+
+/// The shutdown grace: the `--shutdown-grace-seconds` flag when given, else
+/// `OMNIGRAPH_SHUTDOWN_GRACE_SECONDS`, else 25 seconds (RFC 0049). A
+/// malformed environment value is an error only when the flag is absent.
+pub fn resolve_shutdown_grace(flag_seconds: Option<u64>) -> Result<std::time::Duration> {
+    resolve_shutdown_grace_from(
+        flag_seconds,
+        std::env::var(SHUTDOWN_GRACE_ENV).ok().as_deref(),
+    )
+}
+
+fn resolve_shutdown_grace_from(
+    flag_seconds: Option<u64>,
+    env_value: Option<&str>,
+) -> Result<std::time::Duration> {
+    if let Some(seconds) = flag_seconds {
+        return Ok(std::time::Duration::from_secs(seconds));
+    }
+    match env_value {
+        Some(value) => {
+            let seconds: u64 = value.trim().parse().map_err(|err| {
+                eyre!(
+                    "{SHUTDOWN_GRACE_ENV} must be a whole number of seconds, got `{value}`: {err}"
+                )
+            })?;
+            Ok(std::time::Duration::from_secs(seconds))
+        }
+        None => Ok(DEFAULT_SHUTDOWN_GRACE),
+    }
+}
+
+/// The boot facts `GET /readyz` and `GET /graphs` report (RFC 0049), fixed
+/// for the life of the process.
 #[derive(Debug, Clone, Default)]
 pub struct BootWitness {
     /// The applied revision's `config_digest`.
@@ -211,8 +244,8 @@ pub struct BootWitness {
     /// The ledger revision and CAS the snapshot was read from.
     pub state_revision: u64,
     pub state_cas: Option<String>,
-    /// Every graph the applied revision names, sorted. `/readyz` reports the
-    /// ones not in the registry as quarantined.
+    /// Every graph the applied revision names, sorted. The ones not in the
+    /// registry are quarantined.
     pub applied_graphs: Vec<String>,
 }
 
@@ -311,7 +344,7 @@ pub struct AppState {
     /// Bounded process-wide ownership for queued served-export bytes. The
     /// response body and detached producer jointly retain each reservation.
     export_transport: export_transport::ExportTransport,
-    /// What `/readyz` reports about the boot (RFC 0048).
+    /// What `/readyz` and `/graphs` report about the boot (RFC 0049).
     witness: Arc<BootWitness>,
     /// Set at the shutdown signal; `/readyz` answers 503 from then on.
     draining: Arc<std::sync::atomic::AtomicBool>,
@@ -637,7 +670,7 @@ impl AppState {
     }
 
     /// Attach the boot witness `/readyz` reports and the flag shutdown sets
-    /// (RFC 0048). `serve` calls this; a test may build its own.
+    /// (RFC 0049). `serve` calls this; a test may build its own.
     #[must_use]
     pub fn with_boot_witness(
         mut self,
@@ -649,6 +682,28 @@ impl AppState {
         self.draining = draining;
         self.shutdown_grace = shutdown_grace;
         self
+    }
+
+    /// The applied graphs this process does not serve, sorted: the boot
+    /// witness's applied set minus the registry.
+    pub(crate) fn quarantined_graphs(&self) -> Vec<String> {
+        let served: std::collections::BTreeSet<String> = self
+            .routing
+            .registry
+            .list()
+            .iter()
+            .map(|handle| handle.key.graph_id.as_str().to_string())
+            .collect();
+        let mut quarantined: Vec<String> = self
+            .witness
+            .applied_graphs
+            .iter()
+            .filter(|graph_id| !served.contains(*graph_id))
+            .cloned()
+            .collect();
+        quarantined.sort();
+        quarantined.dedup();
+        quarantined
     }
 
     /// Runtime routing accessor. Handlers don't typically inspect this —
@@ -1887,6 +1942,22 @@ pub fn build_app(state: AppState) -> Router {
 }
 
 pub async fn serve(config: ServerConfig) -> Result<()> {
+    // RFC 0049: the signal listener is installed before anything else, so
+    // the shutdown bound covers startup. On the signal it sets `draining`,
+    // arms the watchdog thread, and releases the graceful shutdown.
+    let draining = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let shutdown_grace = config.shutdown_grace;
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    {
+        let draining = Arc::clone(&draining);
+        tokio::spawn(async move {
+            shutdown_signal().await;
+            draining.store(true, std::sync::atomic::Ordering::SeqCst);
+            arm_shutdown_watchdog(shutdown_grace);
+            let _ = shutdown_tx.send(true);
+        });
+    }
+
     let token_source = resolve_token_source().await?;
     info!(source = token_source.name(), "loaded bearer token source");
     let tokens = token_source.load().await?;
@@ -1956,22 +2027,20 @@ pub async fn serve(config: ServerConfig) -> Result<()> {
         stdout.flush()?;
     }
 
-    // RFC 0048: the boot witness `/readyz` reports, the flag shutdown sets,
-    // and one deadline on the drain.
-    let draining = Arc::new(std::sync::atomic::AtomicBool::new(false));
-    let shutdown_grace = config.shutdown_grace;
     let state = state.with_boot_witness(
         config.witness.clone(),
         Arc::clone(&draining),
         shutdown_grace,
     );
     let registry = Arc::clone(&state.routing.registry);
-    let draining_at_signal = Arc::clone(&draining);
+    let mut shutdown_rx = shutdown_rx;
     let served = axum::serve(listener, build_app(state))
         .with_graceful_shutdown(async move {
-            shutdown_signal().await;
-            draining_at_signal.store(true, std::sync::atomic::Ordering::SeqCst);
-            arm_shutdown_watchdog(shutdown_grace);
+            while !*shutdown_rx.borrow() {
+                if shutdown_rx.changed().await.is_err() {
+                    break;
+                }
+            }
         })
         .await;
     // The drain finishes in-flight requests, but branch_delete's fork
@@ -2171,24 +2240,29 @@ async fn shutdown_signal() {
     info!("shutdown signal received");
 }
 
-/// One absolute deadline on graceful shutdown (RFC 0048): in-flight work
+/// One absolute deadline on graceful shutdown (RFC 0049): in-flight work
 /// may finish until `grace` after the signal; then the process exits 2
-/// without claiming success. A zero grace is an immediate cutoff. The exit
-/// is crash-equivalent for the work it interrupts, and the engine's
-/// durability and next-open recovery remain the authority for it.
+/// without claiming success. A zero grace is an immediate cutoff. The
+/// watchdog is an operating-system thread, not a task: a blocked executor,
+/// a stalled teardown, or a runtime that never polls again cannot postpone
+/// it. The exit is crash-equivalent for the work it interrupts, and the
+/// engine's durability and next-open recovery remain the authority for it.
 fn arm_shutdown_watchdog(grace: std::time::Duration) {
     if grace.is_zero() {
         error!("shutdown grace is zero; exiting immediately with unfinished work");
         std::process::exit(2);
     }
-    tokio::spawn(async move {
-        tokio::time::sleep(grace).await;
-        error!(
-            grace_seconds = grace.as_secs(),
-            "shutdown deadline reached with unfinished work; exiting 2"
-        );
-        std::process::exit(2);
-    });
+    std::thread::Builder::new()
+        .name("shutdown-watchdog".to_string())
+        .spawn(move || {
+            std::thread::sleep(grace);
+            error!(
+                grace_seconds = grace.as_secs(),
+                "shutdown deadline reached with unfinished work; exiting 2"
+            );
+            std::process::exit(2);
+        })
+        .expect("the shutdown watchdog thread spawns");
 }
 
 #[cfg(all(test, unix))]
@@ -2266,8 +2340,26 @@ mod shutdown_signal_tests {
             return;
         }
         arm_shutdown_watchdog(Duration::from_millis(500));
-        // Work that never drains: the deadline, not this sleep, ends the process.
-        tokio::time::sleep(Duration::from_secs(60)).await;
+        // Non-cooperative work: block the only runtime thread so no task,
+        // timer, or teardown can run. Only a thread watchdog ends this.
+        std::thread::sleep(Duration::from_secs(60));
+    }
+
+    #[test]
+    fn the_flag_wins_and_the_environment_is_read_only_without_it() {
+        assert_eq!(
+            resolve_shutdown_grace_from(Some(10), Some("bogus")).unwrap(),
+            Duration::from_secs(10)
+        );
+        assert_eq!(
+            resolve_shutdown_grace_from(None, Some(" 7 ")).unwrap(),
+            Duration::from_secs(7)
+        );
+        assert_eq!(
+            resolve_shutdown_grace_from(None, None).unwrap(),
+            DEFAULT_SHUTDOWN_GRACE
+        );
+        assert!(resolve_shutdown_grace_from(None, Some("bogus")).is_err());
     }
 
     #[test]

--- a/crates/omnigraph-server/src/lib.rs
+++ b/crates/omnigraph-server/src/lib.rs
@@ -31,9 +31,9 @@ use api::{
     CommitListQuery, ErrorCode, ErrorOutput, ExportRequest, GraphBatchLoadOutput,
     GraphBatchLoadQuery, GraphInfo, GraphListResponse, HealthOutput, IngestOutput, IngestRequest,
     InvokeStoredQueryRequest, InvokeStoredQueryResponse, LegacyReadOutput, QueriesCatalogOutput,
-    QueryRequest, ReadOutput, ReadRequest, SchemaApplyOutput, SchemaApplyRequest, SchemaOutput,
-    SnapshotQuery, graph_batch_load_receipt_output, ingest_receipt_output, schema_apply_output,
-    snapshot_payload,
+    QueryRequest, ReadOutput, ReadRequest, ReadinessOutput, SchemaApplyOutput, SchemaApplyRequest,
+    SchemaOutput, SnapshotQuery, graph_batch_load_receipt_output, ingest_receipt_output,
+    schema_apply_output, snapshot_payload,
 };
 pub use auth::{AWS_SECRET_ENV, EnvOrFileTokenSource, TokenSource, resolve_token_source};
 use axum::body::{Body, Bytes};
@@ -94,6 +94,7 @@ fn hash_bearer_token(token: &str) -> BearerTokenHash {
     ),
     paths(
         handlers::server_health,
+        handlers::server_ready,
         handlers::server_graphs_list,
         handlers::server_snapshot,
         handlers::server_blob_get,
@@ -188,6 +189,31 @@ pub struct ServerConfig {
     /// startup failures quarantine that graph and healthy graphs still serve.
     /// When true, any quarantined or failed graph aborts startup.
     pub require_all_graphs: bool,
+    /// What `GET /readyz` reports about the revision this process booted
+    /// from (RFC 0048).
+    pub witness: BootWitness,
+    /// The bound on graceful shutdown: readiness turns off at the signal,
+    /// in-flight requests drain, and at this deadline the process exits 2
+    /// (RFC 0048). `--shutdown-grace-seconds` or
+    /// `OMNIGRAPH_SHUTDOWN_GRACE_SECONDS`; default 25.
+    pub shutdown_grace: std::time::Duration,
+}
+
+/// The default bound on graceful shutdown.
+pub const DEFAULT_SHUTDOWN_GRACE: std::time::Duration = std::time::Duration::from_secs(25);
+
+/// The boot facts `GET /readyz` reports (RFC 0048), fixed for the life of
+/// the process.
+#[derive(Debug, Clone, Default)]
+pub struct BootWitness {
+    /// The applied revision's `config_digest`.
+    pub booted_serving_digest: Option<String>,
+    /// The ledger revision and CAS the snapshot was read from.
+    pub state_revision: u64,
+    pub state_cas: Option<String>,
+    /// Every graph the applied revision names, sorted. `/readyz` reports the
+    /// ones not in the registry as quarantined.
+    pub applied_graphs: Vec<String>,
 }
 
 /// What `load_server_settings` produces. RFC-011 cluster-only: the
@@ -285,6 +311,13 @@ pub struct AppState {
     /// Bounded process-wide ownership for queued served-export bytes. The
     /// response body and detached producer jointly retain each reservation.
     export_transport: export_transport::ExportTransport,
+    /// What `/readyz` reports about the boot (RFC 0048).
+    witness: Arc<BootWitness>,
+    /// Set at the shutdown signal; `/readyz` answers 503 from then on.
+    draining: Arc<std::sync::atomic::AtomicBool>,
+    /// Reported by `/readyz` so an orchestrator can check its own grace
+    /// exceeds the server's.
+    shutdown_grace: std::time::Duration,
 }
 
 struct OpenedGraph {
@@ -567,6 +600,9 @@ impl AppState {
             bearer_tokens,
             server_policy: None,
             export_transport: export_transport::ExportTransport::with_defaults(),
+            witness: Arc::new(BootWitness::default()),
+            draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            shutdown_grace: DEFAULT_SHUTDOWN_GRACE,
         }
     }
 
@@ -594,7 +630,25 @@ impl AppState {
             bearer_tokens,
             server_policy: server_policy.map(Arc::new),
             export_transport: export_transport::ExportTransport::with_defaults(),
+            witness: Arc::new(BootWitness::default()),
+            draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            shutdown_grace: DEFAULT_SHUTDOWN_GRACE,
         })
+    }
+
+    /// Attach the boot witness `/readyz` reports and the flag shutdown sets
+    /// (RFC 0048). `serve` calls this; a test may build its own.
+    #[must_use]
+    pub fn with_boot_witness(
+        mut self,
+        witness: BootWitness,
+        draining: Arc<std::sync::atomic::AtomicBool>,
+        shutdown_grace: std::time::Duration,
+    ) -> Self {
+        self.witness = Arc::new(witness);
+        self.draining = draining;
+        self.shutdown_grace = shutdown_grace;
+        self
     }
 
     /// Runtime routing accessor. Handlers don't typically inspect this —
@@ -1824,6 +1878,7 @@ pub fn build_app(state: AppState) -> Router {
 
     Router::new()
         .route("/healthz", get(server_health))
+        .route("/readyz", get(server_ready))
         .route("/openapi.json", get(server_openapi))
         .merge(protected)
         .layer(DefaultBodyLimit::max(DEFAULT_REQUEST_BODY_LIMIT_BYTES))
@@ -1901,9 +1956,23 @@ pub async fn serve(config: ServerConfig) -> Result<()> {
         stdout.flush()?;
     }
 
+    // RFC 0048: the boot witness `/readyz` reports, the flag shutdown sets,
+    // and one deadline on the drain.
+    let draining = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let shutdown_grace = config.shutdown_grace;
+    let state = state.with_boot_witness(
+        config.witness.clone(),
+        Arc::clone(&draining),
+        shutdown_grace,
+    );
     let registry = Arc::clone(&state.routing.registry);
+    let draining_at_signal = Arc::clone(&draining);
     let served = axum::serve(listener, build_app(state))
-        .with_graceful_shutdown(shutdown_signal())
+        .with_graceful_shutdown(async move {
+            shutdown_signal().await;
+            draining_at_signal.store(true, std::sync::atomic::Ordering::SeqCst);
+            arm_shutdown_watchdog(shutdown_grace);
+        })
         .await;
     // The drain finishes in-flight requests, but branch_delete's fork
     // reclaims run as detached tasks; join them on both exit paths so
@@ -2102,6 +2171,26 @@ async fn shutdown_signal() {
     info!("shutdown signal received");
 }
 
+/// One absolute deadline on graceful shutdown (RFC 0048): in-flight work
+/// may finish until `grace` after the signal; then the process exits 2
+/// without claiming success. A zero grace is an immediate cutoff. The exit
+/// is crash-equivalent for the work it interrupts, and the engine's
+/// durability and next-open recovery remain the authority for it.
+fn arm_shutdown_watchdog(grace: std::time::Duration) {
+    if grace.is_zero() {
+        error!("shutdown grace is zero; exiting immediately with unfinished work");
+        std::process::exit(2);
+    }
+    tokio::spawn(async move {
+        tokio::time::sleep(grace).await;
+        error!(
+            grace_seconds = grace.as_secs(),
+            "shutdown deadline reached with unfinished work; exiting 2"
+        );
+        std::process::exit(2);
+    });
+}
+
 #[cfg(all(test, unix))]
 mod shutdown_signal_tests {
     use std::process::Command;
@@ -2166,5 +2255,41 @@ mod shutdown_signal_tests {
 
         let status = child.wait().unwrap();
         assert!(status.success(), "SIGTERM helper failed with {status}");
+    }
+
+    const WATCHDOG_CHILD_ENV: &str = "OMNIGRAPH_SERVER_WATCHDOG_TEST_CHILD";
+
+    #[tokio::test(flavor = "current_thread")]
+    #[ignore = "subprocess helper; exercised by the_shutdown_watchdog_exits_nonzero_at_the_deadline"]
+    async fn watchdog_child_outlives_its_deadline() {
+        if std::env::var_os(WATCHDOG_CHILD_ENV).is_none() {
+            return;
+        }
+        arm_shutdown_watchdog(Duration::from_millis(500));
+        // Work that never drains: the deadline, not this sleep, ends the process.
+        tokio::time::sleep(Duration::from_secs(60)).await;
+    }
+
+    #[test]
+    fn the_shutdown_watchdog_exits_nonzero_at_the_deadline() {
+        let started = std::time::Instant::now();
+        let status = Command::new(std::env::current_exe().unwrap())
+            .arg("--exact")
+            .arg("shutdown_signal_tests::watchdog_child_outlives_its_deadline")
+            .arg("--ignored")
+            .arg("--nocapture")
+            .env(WATCHDOG_CHILD_ENV, "1")
+            .status()
+            .unwrap();
+        assert_eq!(
+            status.code(),
+            Some(2),
+            "the watchdog must exit 2 at the deadline, got {status}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(30),
+            "the watchdog did not bound the process: {:?}",
+            started.elapsed()
+        );
     }
 }

--- a/crates/omnigraph-server/src/main.rs
+++ b/crates/omnigraph-server/src/main.rs
@@ -2,7 +2,9 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use color_eyre::eyre::Result;
-use omnigraph_server::{ServerConfig, init_tracing, load_server_settings, serve};
+use omnigraph_server::{
+    ServerConfig, init_tracing, load_server_settings, resolve_shutdown_grace, serve,
+};
 
 #[derive(Debug, Parser)]
 #[command(name = "omnigraph-server")]
@@ -32,7 +34,7 @@ struct Cli {
     /// serve. Equivalent to setting `OMNIGRAPH_REQUIRE_ALL_GRAPHS=1`.
     #[arg(long)]
     require_all_graphs: bool,
-    /// Bound on graceful shutdown, in seconds (RFC 0048): readiness turns off
+    /// Bound on graceful shutdown, in seconds (RFC 0049): readiness turns off
     /// at the signal, in-flight requests drain, and at the deadline the
     /// process exits 2. Zero cuts off immediately. Equivalent to
     /// `OMNIGRAPH_SHUTDOWN_GRACE_SECONDS`; default 25. The orchestrator's own
@@ -54,8 +56,6 @@ async fn main() -> Result<()> {
         cli.require_all_graphs,
     )
     .await?;
-    if let Some(seconds) = cli.shutdown_grace_seconds {
-        settings.shutdown_grace = std::time::Duration::from_secs(seconds);
-    }
+    settings.shutdown_grace = resolve_shutdown_grace(cli.shutdown_grace_seconds)?;
     serve(settings).await
 }

--- a/crates/omnigraph-server/src/main.rs
+++ b/crates/omnigraph-server/src/main.rs
@@ -32,6 +32,13 @@ struct Cli {
     /// serve. Equivalent to setting `OMNIGRAPH_REQUIRE_ALL_GRAPHS=1`.
     #[arg(long)]
     require_all_graphs: bool,
+    /// Bound on graceful shutdown, in seconds (RFC 0048): readiness turns off
+    /// at the signal, in-flight requests drain, and at the deadline the
+    /// process exits 2. Zero cuts off immediately. Equivalent to
+    /// `OMNIGRAPH_SHUTDOWN_GRACE_SECONDS`; default 25. The orchestrator's own
+    /// termination grace must be longer.
+    #[arg(long)]
+    shutdown_grace_seconds: Option<u64>,
 }
 
 #[tokio::main]
@@ -40,12 +47,15 @@ async fn main() -> Result<()> {
     init_tracing();
 
     let cli = Cli::parse();
-    let settings: ServerConfig = load_server_settings(
+    let mut settings: ServerConfig = load_server_settings(
         cli.cluster.as_ref(),
         cli.bind,
         cli.unauthenticated,
         cli.require_all_graphs,
     )
     .await?;
+    if let Some(seconds) = cli.shutdown_grace_seconds {
+        settings.shutdown_grace = std::time::Duration::from_secs(seconds);
+    }
     serve(settings).await
 }

--- a/crates/omnigraph-server/src/settings.rs
+++ b/crates/omnigraph-server/src/settings.rs
@@ -53,23 +53,14 @@ pub(crate) async fn load_cluster_settings(
     }
     let env_require_all_graphs = env_flag("OMNIGRAPH_REQUIRE_ALL_GRAPHS");
     let require_all_graphs = cli_require_all_graphs || env_require_all_graphs;
-    // RFC 0048: what `/readyz` will report. Every graph the applied revision
-    // names, whether or not this process ends up serving it.
-    let mut applied_graphs: Vec<String> = snapshot
-        .graphs
-        .iter()
-        .map(|graph| graph.graph_id.clone())
-        .chain(snapshot.quarantined_graphs.iter().cloned())
-        .collect();
-    applied_graphs.sort();
-    applied_graphs.dedup();
+    // RFC 0049: what `/readyz` and `GET /graphs` report. Every graph the
+    // applied revision names, whether or not this process ends up serving it.
     let witness = BootWitness {
         booted_serving_digest: snapshot.config_digest.clone(),
         state_revision: snapshot.state_revision,
         state_cas: snapshot.state_cas.clone(),
-        applied_graphs,
+        applied_graphs: snapshot.applied_graphs.clone(),
     };
-    let shutdown_grace = shutdown_grace_from_env()?;
     if require_all_graphs && !snapshot.diagnostics.is_empty() {
         let details = snapshot
             .diagnostics
@@ -219,22 +210,10 @@ pub(crate) async fn load_cluster_settings(
         allow_unauthenticated: cli_allow_unauthenticated || env_unauth,
         require_all_graphs,
         witness,
-        shutdown_grace,
+        // The binary resolves the flag, then the environment, then the default
+        // (`resolve_shutdown_grace`); settings carry the default.
+        shutdown_grace: DEFAULT_SHUTDOWN_GRACE,
     })
-}
-
-/// `OMNIGRAPH_SHUTDOWN_GRACE_SECONDS`, or the default (RFC 0048). The CLI
-/// flag, when given, replaces this after loading.
-fn shutdown_grace_from_env() -> Result<std::time::Duration> {
-    match std::env::var("OMNIGRAPH_SHUTDOWN_GRACE_SECONDS") {
-        Ok(value) => {
-            let seconds: u64 = value.trim().parse().map_err(|err| {
-                eyre!("OMNIGRAPH_SHUTDOWN_GRACE_SECONDS must be a whole number of seconds, got `{value}`: {err}")
-            })?;
-            Ok(std::time::Duration::from_secs(seconds))
-        }
-        Err(_) => Ok(DEFAULT_SHUTDOWN_GRACE),
-    }
 }
 
 /// RFC-011 cluster-only boot: the server serves exclusively from a

--- a/crates/omnigraph-server/src/settings.rs
+++ b/crates/omnigraph-server/src/settings.rs
@@ -53,6 +53,23 @@ pub(crate) async fn load_cluster_settings(
     }
     let env_require_all_graphs = env_flag("OMNIGRAPH_REQUIRE_ALL_GRAPHS");
     let require_all_graphs = cli_require_all_graphs || env_require_all_graphs;
+    // RFC 0048: what `/readyz` will report. Every graph the applied revision
+    // names, whether or not this process ends up serving it.
+    let mut applied_graphs: Vec<String> = snapshot
+        .graphs
+        .iter()
+        .map(|graph| graph.graph_id.clone())
+        .chain(snapshot.quarantined_graphs.iter().cloned())
+        .collect();
+    applied_graphs.sort();
+    applied_graphs.dedup();
+    let witness = BootWitness {
+        booted_serving_digest: snapshot.config_digest.clone(),
+        state_revision: snapshot.state_revision,
+        state_cas: snapshot.state_cas.clone(),
+        applied_graphs,
+    };
+    let shutdown_grace = shutdown_grace_from_env()?;
     if require_all_graphs && !snapshot.diagnostics.is_empty() {
         let details = snapshot
             .diagnostics
@@ -201,7 +218,23 @@ pub(crate) async fn load_cluster_settings(
         bind: cli_bind.unwrap_or_else(|| "127.0.0.1:8080".to_string()),
         allow_unauthenticated: cli_allow_unauthenticated || env_unauth,
         require_all_graphs,
+        witness,
+        shutdown_grace,
     })
+}
+
+/// `OMNIGRAPH_SHUTDOWN_GRACE_SECONDS`, or the default (RFC 0048). The CLI
+/// flag, when given, replaces this after loading.
+fn shutdown_grace_from_env() -> Result<std::time::Duration> {
+    match std::env::var("OMNIGRAPH_SHUTDOWN_GRACE_SECONDS") {
+        Ok(value) => {
+            let seconds: u64 = value.trim().parse().map_err(|err| {
+                eyre!("OMNIGRAPH_SHUTDOWN_GRACE_SECONDS must be a whole number of seconds, got `{value}`: {err}")
+            })?;
+            Ok(std::time::Duration::from_secs(seconds))
+        }
+        Err(_) => Ok(DEFAULT_SHUTDOWN_GRACE),
+    }
 }
 
 /// RFC-011 cluster-only boot: the server serves exclusively from a
@@ -667,6 +700,8 @@ mod tests {
             bind: "127.0.0.1:0".to_string(),
             allow_unauthenticated: false,
             require_all_graphs: false,
+            witness: crate::BootWitness::default(),
+            shutdown_grace: crate::DEFAULT_SHUTDOWN_GRACE,
         };
         let result = serve(config).await;
         let err = result
@@ -721,6 +756,8 @@ mod tests {
             bind: "127.0.0.1:0".to_string(),
             allow_unauthenticated: false,
             require_all_graphs: false,
+            witness: crate::BootWitness::default(),
+            shutdown_grace: crate::DEFAULT_SHUTDOWN_GRACE,
         };
         let result = serve(config).await;
         let err =

--- a/crates/omnigraph-server/tests/boot_settings.rs
+++ b/crates/omnigraph-server/tests/boot_settings.rs
@@ -556,3 +556,66 @@ rules:
         );
     }
 }
+
+mod readiness_witness {
+    use super::*;
+    use omnigraph::storage::normalize_root_uri;
+    use omnigraph_server::{BootWitness, GraphHandle, GraphId, GraphKey};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// `/readyz` reports the boot witness, the served and quarantined graphs,
+    /// and turns off while draining; `/healthz` stays 200 (RFC 0048).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn readyz_reports_the_boot_witness_and_turns_off_while_draining() {
+        let dir = tempfile::tempdir().unwrap();
+        let graph_uri = dir.path().join("alpha").to_str().unwrap().to_string();
+        let schema = fs::read_to_string(fixture("test.pg")).unwrap();
+        let engine = Omnigraph::init(&graph_uri, &schema).await.unwrap();
+        let handle = Arc::new(GraphHandle {
+            key: GraphKey::cluster(GraphId::try_from("alpha").unwrap()),
+            uri: normalize_root_uri(&graph_uri).unwrap(),
+            engine: Arc::new(engine),
+            policy: None,
+            queries: None,
+        });
+        let workload = omnigraph_server::workload::WorkloadController::from_env();
+        let draining = Arc::new(AtomicBool::new(false));
+        let state = AppState::new_multi(vec![handle], Vec::new(), None, workload, None)
+            .unwrap()
+            .with_boot_witness(
+                BootWitness {
+                    booted_serving_digest: Some("digest-1".to_string()),
+                    state_revision: 42,
+                    state_cas: Some("sha256:abc".to_string()),
+                    applied_graphs: vec!["alpha".to_string(), "beta".to_string()],
+                },
+                Arc::clone(&draining),
+                std::time::Duration::from_secs(7),
+            );
+        let app = build_app(state);
+
+        let (status, body) = json_response(&app, get_request("/readyz", "")).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["ready"], true);
+        assert_eq!(body["status"], "serving");
+        assert_eq!(body["booted_serving_digest"], "digest-1");
+        assert_eq!(body["state_revision"], 42);
+        assert_eq!(body["state_cas"], "sha256:abc");
+        assert_eq!(body["served_graphs"], serde_json::json!(["alpha"]));
+        assert_eq!(body["quarantined_graphs"], serde_json::json!(["beta"]));
+        assert_eq!(body["shutdown_grace_seconds"], 7);
+
+        draining.store(true, Ordering::SeqCst);
+        let (status, body) = json_response(&app, get_request("/readyz", "")).await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body["ready"], false);
+        assert_eq!(body["status"], "draining");
+        let (status, _) = json_response(&app, get_request("/healthz", "")).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "liveness is unchanged while draining"
+        );
+    }
+}

--- a/crates/omnigraph-server/tests/boot_settings.rs
+++ b/crates/omnigraph-server/tests/boot_settings.rs
@@ -564,10 +564,12 @@ mod readiness_witness {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
 
-    /// `/readyz` reports the boot witness, the served and quarantined graphs,
-    /// and turns off while draining; `/healthz` stays 200 (RFC 0048).
+    /// `/readyz` reports the boot witness and counts only, turns off while
+    /// draining, and leaves `/healthz` alone; the quarantined ids are on the
+    /// gated `GET /graphs`, derived from the applied set minus the registry
+    /// (RFC 0049).
     #[tokio::test(flavor = "multi_thread")]
-    async fn readyz_reports_the_boot_witness_and_turns_off_while_draining() {
+    async fn readyz_reports_counts_and_graphs_names_the_quarantined() {
         let dir = tempfile::tempdir().unwrap();
         let graph_uri = dir.path().join("alpha").to_str().unwrap().to_string();
         let schema = fs::read_to_string(fixture("test.pg")).unwrap();
@@ -579,9 +581,28 @@ mod readiness_witness {
             policy: None,
             queries: None,
         });
+        // The inventory is gated: a bearer token and a server policy that
+        // permits `graph_list` for it. Readiness needs neither.
+        let policy_path = dir.path().join("server-policy.yaml");
+        fs::write(
+            &policy_path,
+            r#"
+version: 1
+groups:
+  operators: [act-test]
+rules:
+  - id: operators-list-graphs
+    allow:
+      actors: { group: operators }
+      actions: [graph_list]
+"#,
+        )
+        .unwrap();
+        let server_policy = omnigraph_policy::PolicyEngine::load_server(&policy_path).unwrap();
+        let tokens = vec![("act-test".to_string(), "secret".to_string())];
         let workload = omnigraph_server::workload::WorkloadController::from_env();
         let draining = Arc::new(AtomicBool::new(false));
-        let state = AppState::new_multi(vec![handle], Vec::new(), None, workload, None)
+        let state = AppState::new_multi(vec![handle], tokens, Some(server_policy), workload, None)
             .unwrap()
             .with_boot_witness(
                 BootWitness {
@@ -602,9 +623,22 @@ mod readiness_witness {
         assert_eq!(body["booted_serving_digest"], "digest-1");
         assert_eq!(body["state_revision"], 42);
         assert_eq!(body["state_cas"], "sha256:abc");
-        assert_eq!(body["served_graphs"], serde_json::json!(["alpha"]));
-        assert_eq!(body["quarantined_graphs"], serde_json::json!(["beta"]));
+        assert_eq!(body["served_graph_count"], 1);
+        assert_eq!(body["quarantined_graph_count"], 1);
         assert_eq!(body["shutdown_grace_seconds"], 7);
+        assert!(
+            body.get("served_graphs").is_none() && body.get("quarantined_graphs").is_none(),
+            "public readiness carries no graph id: {body}"
+        );
+
+        // The ids live on the gated inventory: refused without the token,
+        // listed with it.
+        let (status, _) = json_response(&app, get_request("/graphs", "wrong")).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        let (status, body) = json_response(&app, get_request("/graphs", "secret")).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["graphs"][0]["graph_id"], "alpha");
+        assert_eq!(body["quarantined"], serde_json::json!(["beta"]));
 
         draining.store(true, Ordering::SeqCst);
         let (status, body) = json_response(&app, get_request("/readyz", "")).await;

--- a/crates/omnigraph-server/tests/openapi.rs
+++ b/crates/omnigraph-server/tests/openapi.rs
@@ -180,10 +180,11 @@ fn openapi_info_contains_version() {
 // Path coverage tests
 // ---------------------------------------------------------------------------
 
-// The canonical served spec keeps `/healthz` and `/graphs` flat; every
+// The canonical served spec keeps `/healthz`, `/readyz`, and `/graphs` flat; every
 // protected route nests under `/graphs/{graph_id}/…`.
 const EXPECTED_PATHS: &[&str] = &[
     "/healthz",
+    "/readyz",
     "/graphs",
     "/graphs/{graph_id}/snapshot",
     "/graphs/{graph_id}/blob",
@@ -2189,12 +2190,12 @@ async fn multi_mode_openapi_prefixes_operation_ids_with_cluster() {
         .unwrap();
     let (_, json) = json_response(&app, request).await;
     // Every cluster path operation must have a `cluster_` operation_id.
-    // Flat-mounted paths (healthz, management /graphs) keep their
+    // Flat-mounted paths (healthz, readyz, management /graphs) keep their
     // original operation_ids — they're not per-graph.
     let paths = json["paths"].as_object().unwrap();
     let mut checked = 0;
     for (path, item) in paths {
-        if path == "/healthz" || path == "/graphs" {
+        if path == "/healthz" || path == "/readyz" || path == "/graphs" {
             continue;
         }
         for method in ["get", "head", "post", "put", "delete", "patch"] {

--- a/docs/dev/control-plane.md
+++ b/docs/dev/control-plane.md
@@ -71,6 +71,13 @@ Servers do not hot-reload. Apply the new revision and restart every server that 
 
 Bearer authentication is a server concern. Cedar mutation enforcement also lives in the engine's `_as` APIs so embedded and CLI writers cannot bypass it. Cluster policy application publishes the bundles and bindings; it does not replace either enforcement layer.
 
+A replica reports what it booted from on `GET /readyz` (RFC 0048): the
+applied `config_digest` as `booted_serving_digest`, the ledger revision and
+CAS, and its served and quarantined graphs; it answers 503 from the shutdown
+signal on. Graceful shutdown is bounded by one deadline
+(`--shutdown-grace-seconds`, default 25) after which the process exits 2
+without claiming success.
+
 ## Azure boundary
 
 `az://container/prefix` uses the same control-object and graph-root model as

--- a/docs/dev/control-plane.md
+++ b/docs/dev/control-plane.md
@@ -71,11 +71,13 @@ Servers do not hot-reload. Apply the new revision and restart every server that 
 
 Bearer authentication is a server concern. Cedar mutation enforcement also lives in the engine's `_as` APIs so embedded and CLI writers cannot bypass it. Cluster policy application publishes the bundles and bindings; it does not replace either enforcement layer.
 
-A replica reports what it booted from on `GET /readyz` (RFC 0048): the
+A replica reports what it booted from on `GET /readyz` (RFC 0049): the
 applied `config_digest` as `booted_serving_digest`, the ledger revision and
-CAS, and its served and quarantined graphs; it answers 503 from the shutdown
-signal on. Graceful shutdown is bounded by one deadline
-(`--shutdown-grace-seconds`, default 25) after which the process exits 2
+CAS, and how many applied graphs it serves and does not; it answers 503 from
+the shutdown signal on. Graph ids stay on the authenticated `GET /graphs`,
+which also lists the quarantined ones. Graceful shutdown is bounded by one
+deadline (`--shutdown-grace-seconds`, default 25), kept by a thread and armed
+by a listener installed before graphs open, after which the process exits 2
 without claiming success.
 
 ## Azure boundary

--- a/docs/releases/v0.11.0.md
+++ b/docs/releases/v0.11.0.md
@@ -127,12 +127,16 @@ Notes accumulate here until the release is cut.
 
 - **Readiness witness.** `GET /readyz` reports whether a replica is serving
   or draining, the applied `config_digest` it booted from
-  (`booted_serving_digest`), the ledger revision and CAS it read, and its
-  served and quarantined graphs; it answers 503 once shutdown has begun.
-  `/healthz` is unchanged (RFC 0048).
-- **Bounded shutdown.** `--shutdown-grace-seconds` (or
-  `OMNIGRAPH_SHUTDOWN_GRACE_SECONDS`, default 25) puts one deadline on
-  graceful shutdown: readiness turns off at the signal, in-flight requests
-  drain, and at the deadline the process exits 2 with the unfinished work
-  logged instead of waiting forever. A clean drain still exits 0. Set the
-  orchestrator's termination grace longer than this value (RFC 0048).
+  (`booted_serving_digest`), the ledger revision and CAS it read, and how
+  many applied graphs it serves and does not serve; it answers 503 once
+  shutdown has begun. It is unauthenticated and names no graph: the
+  authenticated `GET /graphs` gains `quarantined`, the applied graphs this
+  process does not serve. `/healthz` is unchanged (RFC 0049).
+- **Bounded shutdown.** `--shutdown-grace-seconds` (else
+  `OMNIGRAPH_SHUTDOWN_GRACE_SECONDS`, else 25) puts one deadline on graceful
+  shutdown: readiness turns off at the signal, in-flight requests drain, and
+  at the deadline a watchdog thread exits the process with status 2 and the
+  unfinished work logged, whether or not the async runtime is still making
+  progress. The signal is handled from process start, so the bound covers
+  startup. A clean drain still exits 0. Set the orchestrator's termination
+  grace longer than this value (RFC 0049).

--- a/docs/releases/v0.11.0.md
+++ b/docs/releases/v0.11.0.md
@@ -122,3 +122,17 @@ Notes accumulate here until the release is cut.
   `state_revision_overflow` instead of silently staying at `u64::MAX`, and
   the human output distinguishes a lock this command acquired from one
   another process holds (RFC 0049).
+
+## Server
+
+- **Readiness witness.** `GET /readyz` reports whether a replica is serving
+  or draining, the applied `config_digest` it booted from
+  (`booted_serving_digest`), the ledger revision and CAS it read, and its
+  served and quarantined graphs; it answers 503 once shutdown has begun.
+  `/healthz` is unchanged (RFC 0048).
+- **Bounded shutdown.** `--shutdown-grace-seconds` (or
+  `OMNIGRAPH_SHUTDOWN_GRACE_SECONDS`, default 25) puts one deadline on
+  graceful shutdown: readiness turns off at the signal, in-flight requests
+  drain, and at the deadline the process exits 2 with the unfinished work
+  logged instead of waiting forever. A clean drain still exits 0. Set the
+  orchestrator's termination grace longer than this value (RFC 0048).

--- a/docs/rfcs/0049-control-plane-seams.md
+++ b/docs/rfcs/0049-control-plane-seams.md
@@ -3,7 +3,7 @@ rfc: "0049"
 title: "Control-plane seams: observe, readiness witness, bounded shutdown"
 track: maintainer
 status: accepted
-implementation: partial
+implementation: complete
 authors:
   - OmniGraph maintainers
 created: 2026-09-03

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -174,4 +174,4 @@ This table is the human index for the canonical RFC corpus.
 | [0044](0044-edge-keys.md) | Edge keys: derived edge identity | maintainer | draft | in-progress |
 | [0045](0045-gq-logic-tests.md) | GQ logic tests | maintainer | draft | partial |
 | [0046](0046-index-status.md) | Read-only index status | maintainer | draft | not-started |
-| [0049](0049-control-plane-seams.md) | Control-plane seams: observe, readiness witness, bounded shutdown | maintainer | accepted | partial |
+| [0049](0049-control-plane-seams.md) | Control-plane seams: observe, readiness witness, bounded shutdown | maintainer | accepted | complete |

--- a/docs/user/deployment.md
+++ b/docs/user/deployment.md
@@ -30,14 +30,18 @@ OMNIGRAPH_SERVER_BEARER_TOKENS_JSON='{"act-service":"secret"}' \
 Use `GET /healthz` for process health and `GET /readyz` for readiness:
 `/readyz` reports whether the replica is serving or draining, the applied
 `config_digest` it booted from (`booted_serving_digest`), the ledger revision
-it read, and its served and quarantined graphs, and answers 503 once shutdown
-has begun. Add `--require-all-graphs` when a quarantined graph should make the
-whole process fail startup.
+it read, and how many graphs it serves and does not serve, and answers 503
+once shutdown has begun. It is unauthenticated and therefore names no graph:
+the authenticated `GET /graphs` lists the served graphs and, as `quarantined`,
+the applied graphs this process does not serve. Add `--require-all-graphs`
+when a quarantined graph should make the whole process fail startup.
 
 Shutdown is bounded: at SIGTERM the server stops accepting connections and
-drains in-flight requests for at most `--shutdown-grace-seconds` (or
-`OMNIGRAPH_SHUTDOWN_GRACE_SECONDS`; default 25), then exits 2 with the
-unfinished work logged. A clean drain exits 0. Set the orchestrator's own
+drains in-flight requests for at most `--shutdown-grace-seconds` (else
+`OMNIGRAPH_SHUTDOWN_GRACE_SECONDS`, else 25), then exits 2 with the unfinished
+work logged. The deadline is kept by a thread, so a stalled request or a
+blocked runtime cannot extend it, and the signal is handled from process start,
+so it covers startup too. A clean drain exits 0. Set the orchestrator's own
 termination grace longer than this value; a cutoff is crash-equivalent for the
 work it interrupts, and the next open recovers it as after any crash.
 

--- a/docs/user/deployment.md
+++ b/docs/user/deployment.md
@@ -27,8 +27,19 @@ OMNIGRAPH_SERVER_BEARER_TOKENS_JSON='{"act-service":"secret"}' \
     --bind 0.0.0.0:8080
 ```
 
-Use `GET /healthz` for process health. Add `--require-all-graphs` when a
-quarantined graph should make the whole process fail startup.
+Use `GET /healthz` for process health and `GET /readyz` for readiness:
+`/readyz` reports whether the replica is serving or draining, the applied
+`config_digest` it booted from (`booted_serving_digest`), the ledger revision
+it read, and its served and quarantined graphs, and answers 503 once shutdown
+has begun. Add `--require-all-graphs` when a quarantined graph should make the
+whole process fail startup.
+
+Shutdown is bounded: at SIGTERM the server stops accepting connections and
+drains in-flight requests for at most `--shutdown-grace-seconds` (or
+`OMNIGRAPH_SHUTDOWN_GRACE_SECONDS`; default 25), then exits 2 with the
+unfinished work logged. A clean drain exits 0. Set the orchestrator's own
+termination grace longer than this value; a cutoff is crash-equivalent for the
+work it interrupts, and the next open recovers it as after any crash.
 
 ## Container
 

--- a/openapi.json
+++ b/openapi.json
@@ -3525,6 +3525,38 @@
           }
         }
       }
+    },
+    "/readyz": {
+      "get": {
+        "tags": [
+          "health"
+        ],
+        "summary": "Readiness witness (RFC 0048).",
+        "description": "Unauthenticated. Reports whether this replica is serving or draining,\nthe applied `config_digest` it booted from, the ledger revision and CAS\nit read, and the graphs it serves and does not serve. Answers 503 once\nshutdown has begun; `/healthz` stays 200 while the process is alive.",
+        "operationId": "readiness",
+        "responses": {
+          "200": {
+            "description": "Serving",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadinessOutput"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Draining",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadinessOutput"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -5171,6 +5203,68 @@
               "string",
               "null"
             ]
+          }
+        }
+      },
+      "ReadinessOutput": {
+        "type": "object",
+        "description": "The readiness witness of one replica (`GET /readyz`, RFC 0048): whether\nit is serving or draining, the applied revision it booted from, and the\ngraphs it does and does not serve.",
+        "required": [
+          "ready",
+          "status",
+          "state_revision",
+          "served_graphs",
+          "quarantined_graphs",
+          "shutdown_grace_seconds"
+        ],
+        "properties": {
+          "booted_serving_digest": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The `config_digest` of the applied revision this process booted from.\nFixed for the life of the process: the server never reloads."
+          },
+          "quarantined_graphs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Graphs the applied revision names that this process does not serve,\nfor any reason, sorted."
+          },
+          "ready": {
+            "type": "boolean",
+            "description": "False once shutdown has begun; the response is then 503."
+          },
+          "served_graphs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Graphs this process serves, sorted."
+          },
+          "shutdown_grace_seconds": {
+            "type": "integer",
+            "format": "int64",
+            "description": "The bound on graceful shutdown, after which the process exits 2.",
+            "minimum": 0
+          },
+          "state_cas": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The ledger CAS (`sha256:<hex>`) the process booted from."
+          },
+          "state_revision": {
+            "type": "integer",
+            "format": "int64",
+            "description": "The ledger revision the process booted from.",
+            "minimum": 0
+          },
+          "status": {
+            "type": "string",
+            "description": "`serving` or `draining`."
           }
         }
       },

--- a/openapi.json
+++ b/openapi.json
@@ -3531,8 +3531,8 @@
         "tags": [
           "health"
         ],
-        "summary": "Readiness witness (RFC 0048).",
-        "description": "Unauthenticated. Reports whether this replica is serving or draining,\nthe applied `config_digest` it booted from, the ledger revision and CAS\nit read, and the graphs it serves and does not serve. Answers 503 once\nshutdown has begun; `/healthz` stays 200 while the process is alive.",
+        "summary": "Readiness witness (RFC 0049).",
+        "description": "Unauthenticated, and therefore minimal: it reports whether this replica\nis serving or draining, the applied `config_digest` it booted from, the\nledger revision and CAS it read, and how many graphs it serves and does\nnot serve. Graph ids are topology and stay behind `GET /graphs`. Answers\n503 once shutdown has begun; `/healthz` stays 200 while the process is\nalive.",
         "operationId": "readiness",
         "responses": {
           "200": {
@@ -4617,6 +4617,13 @@
             "items": {
               "$ref": "#/components/schemas/GraphInfo"
             }
+          },
+          "quarantined": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Graphs the applied revision names that this process does not serve,\nfor any reason, sorted (RFC 0049). Empty when every applied graph is\nserved."
           }
         }
       },
@@ -5208,13 +5215,13 @@
       },
       "ReadinessOutput": {
         "type": "object",
-        "description": "The readiness witness of one replica (`GET /readyz`, RFC 0048): whether\nit is serving or draining, the applied revision it booted from, and the\ngraphs it does and does not serve.",
+        "description": "The readiness witness of one replica (`GET /readyz`, RFC 0049): whether\nit is serving or draining, the applied revision it booted from, and how\nmany graphs it does and does not serve. Unauthenticated, so it carries\nno graph id: those stay behind `GET /graphs`.",
         "required": [
           "ready",
           "status",
           "state_revision",
-          "served_graphs",
-          "quarantined_graphs",
+          "served_graph_count",
+          "quarantined_graph_count",
           "shutdown_grace_seconds"
         ],
         "properties": {
@@ -5225,23 +5232,19 @@
             ],
             "description": "The `config_digest` of the applied revision this process booted from.\nFixed for the life of the process: the server never reloads."
           },
-          "quarantined_graphs": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Graphs the applied revision names that this process does not serve,\nfor any reason, sorted."
+          "quarantined_graph_count": {
+            "type": "integer",
+            "description": "How many graphs the applied revision names that this process does\nnot serve, for any reason. `GET /graphs` names them.",
+            "minimum": 0
           },
           "ready": {
             "type": "boolean",
             "description": "False once shutdown has begun; the response is then 503."
           },
-          "served_graphs": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Graphs this process serves, sorted."
+          "served_graph_count": {
+            "type": "integer",
+            "description": "How many graphs this process serves.",
+            "minimum": 0
           },
           "shutdown_grace_seconds": {
             "type": "integer",


### PR DESCRIPTION
## What & why

The server half of RFC 0049.

- **`GET /readyz`**, unauthenticated like `/healthz` and therefore minimal: `ready`, `status` (`serving` | `draining`), `booted_serving_digest` (the applied revision's `config_digest` the process booted from, fixed for its life), `state_revision`, `state_cas`, `served_graph_count`, `quarantined_graph_count`, and `shutdown_grace_seconds`. 503 once shutdown has begun. Graph ids are topology and stay behind the bearer and Cedar `graph_list` gate: the authenticated `GET /graphs` gains `quarantined`, the applied graphs this process does not serve, computed as the ledger's applied graphs minus the registry. `/healthz` is unchanged.
- **Bounded shutdown**: `--shutdown-grace-seconds`, else `OMNIGRAPH_SHUTDOWN_GRACE_SECONDS`, else 25; a malformed environment value is an error only when the flag is absent. The signal listener is spawned at the start of `serve`, before any graph opens, so the bound covers startup. At the signal the server sets draining, starts a `std::thread` watchdog, and releases the graceful shutdown; a clean drain still exits 0; at the deadline the thread logs the unfinished work and exits 2 whether or not the async runtime is making progress. Zero is an immediate cutoff. This is the deadline half of RFC 0035 §8 without its admission cells.

Plumbing: `ServingSnapshot` gains `config_digest`, `state_revision`, `state_cas`, `applied_graphs` (the ledger's `graph.*` addresses), and `quarantined_graphs` (sidecar graphs intersected with the applied set, so a sidecar for a graph the revision does not name is never a phantom); `ServerConfig` gains `witness: BootWitness` and `shutdown_grace`; `AppState::with_boot_witness`; `ReadinessOutput` and `GraphListResponse.quarantined` in `omnigraph-api-types`; `/readyz` joins the always-flat paths; `openapi.json` regenerated.

## Backing issue / RFC

- [ ] Fixes an **accepted** issue
- [x] Implements RFC 0049 (draft, #610): docs/rfcs/0049-control-plane-seams.md — kept as a draft PR until the RFC is accepted
- [ ] Trivial fast-lane

## Checklist

- [x] Change is focused (one logical change: the witness and the bound it reports)
- [x] Tests added: `boot_settings::readiness_witness` (counts, no ids on the public route, quarantined ids on `/graphs`, 503 while draining, `/healthz` unchanged); `shutdown_signal_tests::the_shutdown_watchdog_exits_nonzero_at_the_deadline` (subprocess whose only runtime thread is blocked; exit code 2 within the bound); `the_flag_wins_and_the_environment_is_read_only_without_it`; OpenAPI expectations extended
- [x] Public docs updated: docs/user/deployment.md, docs/dev/control-plane.md, docs/releases/v0.11.0.md
- [x] Reviewed against docs/dev/invariants.md — 8 and 11 (bounded shutdown the runtime cannot postpone; cutoff never claims success), 10 (public readiness discloses no graph id), 12 (the witness reports what was booted); no deny-list item. For Rust consumers the new required fields on `ServingSnapshot`, `ServerConfig`, and `GraphListResponse` are breaking, as the RFC says; every in-tree consumer is updated here.

## Local verification

- `cargo clippy -p omnigraph-server -p omnigraph-cluster -p omnigraph-api-types --all-targets --locked --features omnigraph-cluster/failpoints -- -D warnings -W clippy::dbg_macro` — clean
- `OMNIGRAPH_UPDATE_OPENAPI=1 cargo test -p omnigraph-server --locked --test openapi openapi_spec_is_up_to_date` — regenerated; `cargo test -p omnigraph-server --locked` — every suite passes
- `env CARGO_BIN_EXE_omnigraph-server=<built server> cargo test -p omnigraph-cli --locked --test parity_matrix` — 21 passed against this server binary (the CLI's end-to-end suite starts the server, so it exercises the early listener and the shutdown path as a black box)
- `cargo fmt --all --check` — clean
- `python3 scripts/check-docs.py` — OK

## Notes for reviewers

The watchdog thread and the early listener are the two changes from the first cut, both from review: a Tokio task could not fire under a blocked executor or during runtime teardown, and a listener created inside `with_graceful_shutdown` left startup unbounded. A startup-time signal is covered by construction (the listener task is the first thing `serve` spawns); there is no subprocess test for a stalled graph open because the server test support has no fixture whose open hangs. Release notes append a "Server" section near the cluster PR's; expect a trivial conflict when the second lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cD8PEeUfrzpqYuU1jaZBq
