### PR TITLE
fix(traversal): do not count a self-loop as an extra hop

### DIFF
--- a/crates/omnigraph-gqt/cases/issue_613_self_loop_pinned_hop_distance.gqt
+++ b/crates/omnigraph-gqt/cases/issue_613_self_loop_pinned_hop_distance.gqt
@@ -1,0 +1,39 @@
+# issue: 613
+# red_on: 2026-09-03, pre-fix build: knows{2,2} from alice returned bob, one hop away, instead of no rows.
+
+--- schema
+node Person {
+    name: String @key
+}
+
+edge Knows: Person -> Person
+
+--- seed
+{"type":"Person","data":{"name":"alice"}}
+{"type":"Person","data":{"name":"bob"}}
+{"edge":"Knows","from":"alice","to":"bob"}
+{"edge":"Knows","from":"bob","to":"bob"}
+
+--- query
+query exactly_two_hops() {
+    match {
+        $p: Person
+        $p knows{2,2} $f
+    }
+    return { $p.name, $f.name }
+}
+
+--- expect unordered
+
+--- query
+query one_to_two_hops() {
+    match {
+        $p: Person
+        $p knows{1,2} $f
+    }
+    return { $p.name, $f.name }
+}
+
+--- expect unordered
+{"p.name": "alice", "f.name": "bob"}
+{"p.name": "bob", "f.name": "bob"}

--- a/crates/omnigraph/src/exec/query.rs
+++ b/crates/omnigraph/src/exec/query.rs
@@ -3315,13 +3315,11 @@ async fn execute_expand_bfs(
             }
         }
 
-        // Advance each source row's frontier independently (dense ids). The
-        // emission contract is identical across sources: a self-edge is a
-        // valid destination that reaches nothing new — emit it without
-        // entering the frontier, so the seeded-source `visited` pre-mark
-        // prunes only multi-hop cycle returns (same-type only: cross-type
-        // dense ids live in different namespaces, where node == neighbor is
-        // meaningless for Csr and collision-prone for Indexed).
+        // Advance each source row's frontier independently (dense ids). A
+        // self-edge is admitted only at hop 1, where the frontier is exactly
+        // the seed (seeded above): the seed's own loop, which the `visited`
+        // pre-mark would otherwise drop. Later it is a cycle return to a
+        // shorter distance. Same-type only: cross-type dense ids differ.
         for i in 0..n {
             let cur = std::mem::take(&mut frontiers[i]);
             let mut next: Vec<u32> = Vec::new();
@@ -3340,7 +3338,7 @@ async fn execute_expand_bfs(
                     ),
                 };
                 for &neighbor in fwd.iter().chain(rev) {
-                    let is_self = same_type && neighbor == node;
+                    let is_self = same_type && hop == 1 && neighbor == node;
                     if !is_self && same_type && !visited[i].insert(neighbor) {
                         continue;
                     }

--- a/crates/omnigraph/tests/traversal_indexed.rs
+++ b/crates/omnigraph/tests/traversal_indexed.rs
@@ -369,8 +369,9 @@ async fn variable_hops_terminate_and_dedup_on_cycle() {
     assert_eq!(got, vec!["b", "c"]);
 }
 
-// Self-loop a->a plus a->b: the self-edge is a genuine length-1 walk, so the
-// reach set is {a, b} (walk semantics); traversal must terminate. Cycle
+// Self-loop a->a plus a->b: the start node's own self-edge is a hop-1
+// destination, so the reach set is {a, b} (distance semantics; the start node
+// is never re-reached through a cycle); traversal must terminate. Cycle
 // pruning: see variable_hops_terminate_and_dedup_on_cycle.
 #[tokio::test]
 async fn variable_hops_handle_self_loop() {
@@ -388,9 +389,46 @@ async fn variable_hops_handle_self_loop() {
     assert_eq!(got, vec!["a", "b"]);
 }
 
+// Self-loop on a LATER node (b->b) under a range starting above 1: b is one
+// hop from a, so `{2,2}` returns only c. Before the fix the self-edge emitted
+// b again at hop 2. `{1,5}` is the control: a range starting at 1 already
+// deduped the re-emission through `seen_dst`, so its answer is unchanged.
+#[tokio::test]
+async fn pinned_range_does_not_re_reach_a_self_looped_node() {
+    const EXACTLY_2: &str = r#"
+query reach2($name: String) {
+    match {
+        $p: Person { name: $name }
+        $p knows{2,2} $f
+    }
+    return { $f.name }
+}
+"#;
+    let dir = tempfile::tempdir().unwrap();
+    let uri = dir.path().to_str().unwrap();
+    let data = r#"{"type":"Person","data":{"name":"a"}}
+{"type":"Person","data":{"name":"b"}}
+{"type":"Person","data":{"name":"c"}}
+{"edge":"Knows","from":"a","to":"b"}
+{"edge":"Knows","from":"b","to":"b"}
+{"edge":"Knows","from":"b","to":"c"}"#;
+    let mut db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+    load_jsonl(&db, data, LoadMode::Overwrite).await.unwrap();
+
+    let p = params(&[("$name", "a")]);
+    let exactly_two = both_modes(&mut db, EXACTLY_2, "reach2", &p).await;
+    assert_eq!(
+        exactly_two,
+        vec!["c"],
+        "b is one hop away; its self-loop must not re-reach it at hop 2"
+    );
+    let ranged = both_modes(&mut db, REACH_5, "reach", &p).await;
+    assert_eq!(ranged, vec!["b", "c"], "a range starting at 1 is unchanged");
+}
+
 // A stored self-loop must appear in every single-hop spelling — directed,
-// undirected (docs/user/queries/index.md: "a self-loop, appears once"), and
-// bound-edge — and all three must agree.
+// undirected (docs/user/queries/index.md: set semantics for endpoint pairs,
+// so the loop appears once), and bound-edge — and all three must agree.
 #[tokio::test]
 async fn single_hop_self_loop_is_emitted_by_all_spellings() {
     const QUERIES: &str = r#"

--- a/docs/releases/v0.11.0.md
+++ b/docs/releases/v0.11.0.md
@@ -4,6 +4,13 @@ Notes accumulate here until the release is cut.
 
 ## Highlights
 
+- **A self-loop no longer makes a hop range starting above 1 report a node
+  one hop late.** `$a knows{2,2} $b` on `a->b, b->b` returned b, which is one
+  hop from a, because a self-edge on a node already reached was emitted as a
+  destination one hop later. Hop counts are shortest-path distances: only
+  the start node's own self-loop counts, as one hop. Ranges starting at 1
+  are unchanged.
+
 - **Branch merges no longer fail on an unrelated wide row.** The ordered
   merge cursors (the general three-way walk, the adopt fallback, the
   lineage-candidate fetch, and the Blob-selection passes) now sort only the

--- a/docs/user/queries/index.md
+++ b/docs/user/queries/index.md
@@ -49,6 +49,11 @@ Inside `match { ... }`:
 | `$p.age >= 18` | Apply a filter expression. |
 | `not { $p Blocked $other }` | Keep rows for which the inner pattern has no match. |
 
+Hop counts are shortest-path distances from the start node: `{2,2}` returns the
+nodes exactly two hops away. A node is never re-reached through its own
+self-loop or through a cycle back to it. The start node is returned only
+through its own self-loop, which counts as one hop, never through a cycle.
+
 An unbound traversal has set semantics for endpoint pairs. Binding the edge
 returns one result per matching edge, so parallel edges remain distinct. Edge
 bindings are available only for a single hop.

--- a/skills/omnigraph/references/queries.md
+++ b/skills/omnigraph/references/queries.md
@@ -158,7 +158,10 @@ traversals keep set-of-pairs semantics). Rejected with `T23`: binding a
 
 Composes with hop bounds (`$a <knows>{1,3} $b`) and `not { }` ("no edge in
 either direction"). Asymmetric edges (e.g. `Comment -> Issue`) are rejected at
-typecheck (T22) — use the directional form there.
+typecheck (T22) — use the directional form there. Hop counts are shortest-path
+distances from the start node; a node is never re-reached through its own
+self-loop or a cycle, and the start node is returned only through its own
+self-loop, which counts as one hop.
 
 ### Negation
 


### PR DESCRIPTION
## What & why

Closes #613. A self-looped node reached at hop h was emitted again at hop h+1, so a hop range starting above 1 returned a node one hop away (`$a knows{2,2} $b` on `a->b, b->b` returned b). The self-edge bypass of `visited` now applies only at hop 1, the start node's own loop; a later self-edge is skipped like any cycle return. Hop counts are shortest-path distances, and the user doc now says so.

## Backing issue / RFC

- [x] Fixes an **accepted** issue: Closes #613

## Checklist

- [x] Change is focused: one condition in the bounded-hop BFS
- [x] Tests added: `issue_613_self_loop_pinned_hop_distance.gqt` (red on the untouched engine) and `pinned_range_does_not_re_reach_a_self_looped_node` under both traversal modes
- [x] Public docs updated: user doc paragraph, release note, skills reference
- [x] Reviewed against docs/dev/invariants.md: no invariant touched

## Local verification

- gqt corpus 8, traversal_indexed 14, traversal 28, proptest_equivalence 3, all passed
- clippy, fmt, check-docs, release vocabulary clean

## Notes for reviewers

- Ranges starting at 1 are unchanged: the ranged dedup already hid the re-emission. The `{1,5}` control pins it.
- Found by the GQ fuzzer prototype's bound-partition relation. Every traversal mode agreed, so the mode oracle could not see it.