### PR TITLE
test(gq): add the Kuzu-derived `.gqt` case corpus

### DIFF
--- a/crates/omnigraph-gqt/README.md
+++ b/crates/omnigraph-gqt/README.md
@@ -11,6 +11,61 @@ or `--workspace` reaches it.
   (`docs/rfcs/0045-gq-logic-tests.md`). A regression for a merged fix is
   `issue_NNN_<short_name>.gqt`; `scripts/check-fix-regression.py` looks for it
   here.
+- `cases/kuzu_*.gqt`: cases derived from the [Kuzu](https://github.com/kuzudb/kuzu)
+  e2e test corpus (`test/test_files/`), named `kuzu_<area>_<file>[_<case>]`,
+  one file per Kuzu `-CASE`, or per `-LOG` block or statement when a case
+  was split (`__<log>` / `__stmt_N` suffix; merged scenarios carry both
+  numbers, `scenario3_4`). They are `# issue: none` feature cases; the fix
+  regression gate never looks at them. Each Cypher statement is translated
+  to GQ. The header names the source file and case, and its `# notes:`
+  lines record every spelling substitution the translation needed and which
+  of these rules the expectation follows:
+  - Where the engines agree, the expectation is Kuzu's, translated to GQ;
+    the attribution line in every header ("the expected rows are Kuzu's
+    unless a line above says they were rewritten") says so. Numbers
+    render at scale 12 (Compatibility), so a six-decimal Kuzu AVG is
+    written at twelve.
+  - Where the engines disagree on semantics, the statement is split into
+    its own file, the header names Kuzu's value and the reading taken, and
+    the expectation follows that reading: a bounded traversal as
+    shortest-path distance per endpoint pair, an undirected self-loop as
+    one row per matched node.
+  - Where Kuzu asserts only `ok`, the expected rows are derived from the
+    seed.
+  - A translation may add an order key so a `limit` cut is deterministic,
+    or split one statement into typed reads when an untyped edge has no GQ
+    spelling; the header records each such change.
+  - A case pinning a refusal or fix the engine does not have yet may be
+    red on its pull-request branch; its header names what it waits on, and
+    the PR merges only after that lands, so the corpus on `main` is never
+    red.
+
+  Statements Kuzu can express and GQ cannot (arithmetic, `WITH`, path
+  variables, functions, multi-label patterns, and so on) are simply absent.
+  The `kuzu_` prefix is a convention, not a harness distinction.
+
+  Copyright (c) 2022-2025 Kùzu Inc., MIT License
+  ([Kuzu's LICENSE](https://github.com/kuzudb/kuzu/blob/master/LICENSE)).
+  This directory holds only `.gqt` files, so the permission notice is
+  reproduced here:
+
+  > Permission is hereby granted, free of charge, to any person obtaining a copy
+  > of this software and associated documentation files (the "Software"), to deal
+  > in the Software without restriction, including without limitation the rights
+  > to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  > copies of the Software, and to permit persons to whom the Software is
+  > furnished to do so, subject to the following conditions:
+  >
+  > The above copyright notice and this permission notice shall be included in all
+  > copies or substantial portions of the Software.
+  >
+  > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  > IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  > FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  > AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  > LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  > SOFTWARE.
 - `src/lib.rs`: the runner (case parsing, execution against a fresh
   temporary store, row comparison, bless). Format self-tests and the corpus
   layout check are its unit tests (`src/tests.rs`).

--- a/crates/omnigraph-gqt/cases/kuzu_agg_hash.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_agg_hash.gqt
@@ -1,0 +1,269 @@
+# issue: none
+# notes: kuzu test/test_files/agg/hash.test, -CASE AggHash, tinysnb seed. One query step
+# notes: per convertible Kuzu -STATEMENT, in file order. `CALL threads=N` knobs dropped.
+# notes: OPTIONAL MATCH, DISTINCT, collect, whole-entity returns, arithmetic around an
+# notes: aggregate, `or`, and the dropped columns (movies, hugedata) are absent here and
+# notes: not translated. Kuzu `a.ID` is `pk`; grouping is implicit on the non-aggregate
+# notes: return columns.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query single_node_agg_test() {
+    match {
+        $a: Person
+    }
+    return { $a.age, min($a.pk) as min_pk, avg($a.eyeSight) as avg_eye_sight, count($a) as n }
+}
+
+--- expect unordered
+{"a.age": 20, "min_pk": 5, "avg_eye_sight": 4.75, "n": 2}
+{"a.age": 25, "min_pk": 8, "avg_eye_sight": 4.5, "n": 1}
+{"a.age": 30, "min_pk": 2, "avg_eye_sight": 5.1, "n": 1}
+{"a.age": 35, "min_pk": 0, "avg_eye_sight": 5.0, "n": 1}
+{"a.age": 40, "min_pk": 9, "avg_eye_sight": 4.9, "n": 1}
+{"a.age": 45, "min_pk": 3, "avg_eye_sight": 5.0, "n": 1}
+{"a.age": 83, "min_pk": 10, "avg_eye_sight": 4.9, "n": 1}
+
+--- query
+query in_mem_overflow_buffer_test() {
+    match {
+        $a: Person
+    }
+    return { $a.fName as name, count($a) as n }
+    order { name desc }
+}
+
+--- expect unordered
+{"name": "Hubert Blaine Wolfeschlegelsteinhausenbergerdorff", "n": 1}
+{"name": "Greg", "n": 1}
+{"name": "Farooq", "n": 1}
+{"name": "Elizabeth", "n": 1}
+{"name": "Dan", "n": 1}
+{"name": "Carol", "n": 1}
+{"name": "Bob", "n": 1}
+{"name": "Alice", "n": 1}
+
+--- query
+query one_hop_agg_test() {
+    match {
+        $a: Person
+        $b: Person
+        $a knows $b
+    }
+    return { $a.age, $a.gender, count($a) as n }
+}
+
+--- expect unordered
+{"a.age": 20, "a.gender": 1, "n": 2}
+{"a.age": 20, "a.gender": 2, "n": 3}
+{"a.age": 30, "a.gender": 2, "n": 3}
+{"a.age": 35, "a.gender": 1, "n": 3}
+{"a.age": 45, "a.gender": 1, "n": 3}
+
+--- query
+query one_hop_agg_flat_unflat_vec_test() {
+    match {
+        $a: Person
+        $b: Person
+        $a knows $b
+    }
+    return { $a.pk, $b.gender, sum($b.age) as s }
+}
+
+--- expect unordered
+{"a.pk": 0, "b.gender": 1, "s": 45}
+{"a.pk": 0, "b.gender": 2, "s": 50}
+{"a.pk": 2, "b.gender": 1, "s": 80}
+{"a.pk": 2, "b.gender": 2, "s": 20}
+{"a.pk": 3, "b.gender": 1, "s": 35}
+{"a.pk": 3, "b.gender": 2, "s": 50}
+{"a.pk": 5, "b.gender": 1, "s": 80}
+{"a.pk": 5, "b.gender": 2, "s": 30}
+{"a.pk": 7, "b.gender": 2, "s": 65}
+
+--- query
+query one_hop_agg_flat_unflat_vec_with_non_hash_key_test() {
+    match {
+        $a: Person
+        $b: Person
+        $a knows $b
+    }
+    return { $a.pk, $a.gender, $b.gender, sum($b.age) as s }
+}
+
+--- expect unordered
+{"a.pk": 0, "a.gender": 1, "b.gender": 1, "s": 45}
+{"a.pk": 0, "a.gender": 1, "b.gender": 2, "s": 50}
+{"a.pk": 2, "a.gender": 2, "b.gender": 1, "s": 80}
+{"a.pk": 2, "a.gender": 2, "b.gender": 2, "s": 20}
+{"a.pk": 3, "a.gender": 1, "b.gender": 1, "s": 35}
+{"a.pk": 3, "a.gender": 1, "b.gender": 2, "s": 50}
+{"a.pk": 5, "a.gender": 2, "b.gender": 1, "s": 80}
+{"a.pk": 5, "a.gender": 2, "b.gender": 2, "s": 30}
+{"a.pk": 7, "a.gender": 1, "b.gender": 2, "s": 65}
+
+--- query
+query hash_agg_count_int8() {
+    match {
+        $p: Person
+        $o: Organisation
+        $p $s:studyAt $o
+    }
+    return { $s.year, count($s.level) as n }
+}
+
+--- expect unordered
+{"s.year": 2020, "n": 2}
+{"s.year": 2021, "n": 1}
+
+--- query
+query hash_agg_int8_key() {
+    match {
+        $p: Person
+        $o: Organisation
+        $p $s:studyAt $o
+    }
+    return { $s.level, count($s.year) as n }
+}
+
+--- expect unordered
+{"s.level": 2, "n": 1}
+{"s.level": 5, "n": 1}
+{"s.level": 120, "n": 1}
+
+--- query
+query hash_agg_uint8_key() {
+    match {
+        $p: Person
+        $o: Organisation
+        $p $s:studyAt $o
+    }
+    return { $s.ulevel, count($s.year) as n }
+}
+
+--- expect unordered
+{"s.ulevel": 12, "n": 1}
+{"s.ulevel": 220, "n": 1}
+{"s.ulevel": 250, "n": 1}
+
+--- query
+query hash_agg_uint16_key() {
+    match {
+        $p: Person
+        $o: Organisation
+        $p $s:studyAt $o
+    }
+    return { $s.ulength, count($s.year) as n }
+}
+
+--- expect unordered
+{"s.ulength": 33768, "n": 1}
+{"s.ulength": 90, "n": 1}
+{"s.ulength": 180, "n": 1}
+
+--- query
+query hash_agg_uint32_key() {
+    match {
+        $p: Person
+        $o: Organisation
+        $p $s:studyAt $o
+    }
+    return { $s.temperature, count($s.year) as n }
+}
+
+--- expect unordered
+{"s.temperature": 32800, "n": 1}
+{"s.temperature": 1, "n": 1}
+{"s.temperature": 20, "n": 1}
+
+--- query
+query hash_agg_uint64_key() {
+    match {
+        $p: Person
+        $o: Organisation
+        $p $s:studyAt $o
+    }
+    return { $s.code, count($s.year) as n }
+}
+
+--- expect unordered
+{"s.code": 23, "n": 1}
+{"s.code": 9223372036854775808, "n": 1}
+{"s.code": 6689, "n": 1}

--- a/crates/omnigraph-gqt/cases/kuzu_agg_simple.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_agg_simple.gqt
@@ -1,0 +1,320 @@
+# issue: none
+# notes: kuzu test/test_files/agg/simple.test, -CASE AggSimple, tinysnb seed. One query
+# notes: step per convertible Kuzu -STATEMENT, in file order. `CALL threads=N` knobs
+# notes: dropped. Statements with arithmetic on or around an aggregate,
+# notes: collect/DISTINCT/CAST/ABS, WITH, or a dropped column (grades, movies, hugedata,
+# notes: u, registerTime, lastJobDuration, courseScoresPerTerm) are absent here and not
+# notes: translated. Kuzu `a.ID` is `pk`; -CHECK_ORDER on an aggregate stays
+# notes: `unordered`.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query simple_avg_test_1() {
+    match {
+        $a: Person
+    }
+    return { avg($a.age) as avg_age, avg($a.eyeSight) as avg_eye_sight }
+}
+
+--- expect unordered
+{"avg_age": 37.25, "avg_eye_sight": 4.8625}
+
+--- query
+query simple_sum_test() {
+    match {
+        $a: Person
+    }
+    return { sum($a.age) as s_age, sum($a.eyeSight) as s_eye_sight }
+}
+
+--- expect unordered
+{"s_age": 298, "s_eye_sight": 38.9}
+
+--- query
+query simple_avg_test_2() {
+    match {
+        $a: Person
+    }
+    return { avg($a.age) as avg_age, avg($a.eyeSight) as avg_eye_sight }
+}
+
+--- expect unordered
+{"avg_age": 37.25, "avg_eye_sight": 4.8625}
+
+--- query
+query int8_key_test() {
+    match {
+        $p: Person
+        $o: Organisation
+        $p $s:studyAt $o
+        $s.level = 5
+    }
+    return { $p.pk, $o.pk }
+}
+
+--- expect unordered
+{"p.pk": 0, "o.pk": 1}
+
+--- query
+query uint8_key_test() {
+    match {
+        $p: Person
+        $o: Organisation
+        $p $s:studyAt $o
+        $s.ulevel = 220
+    }
+    return { $p.pk, $o.pk }
+}
+
+--- expect unordered
+{"p.pk": 2, "o.pk": 1}
+
+--- query
+query uint16_key_test() {
+    match {
+        $p: Person
+        $o: Organisation
+        $p $s:studyAt $o
+        $s.ulength = 90
+    }
+    return { $p.pk, $o.pk }
+}
+
+--- expect unordered
+{"p.pk": 2, "o.pk": 1}
+
+--- query
+query uint32_key_test() {
+    match {
+        $p: Person
+        $o: Organisation
+        $p $s:studyAt $o
+        $s.temperature = 1
+    }
+    return { $p.pk, $o.pk }
+}
+
+--- expect unordered
+{"p.pk": 2, "o.pk": 1}
+
+--- query
+query uint64_key_test() {
+    match {
+        $p: Person
+        $o: Organisation
+        $p $s:studyAt $o
+        $s.code = 6689
+    }
+    return { $p.pk, $o.pk }
+}
+
+--- expect unordered
+{"p.pk": 2, "o.pk": 1}
+
+--- query
+query simple_agg_max_int16_test() {
+    match {
+        $p: Person
+        $o: Organisation
+        $p $s:studyAt $o
+    }
+    return { max($s.length) as max_length }
+}
+
+--- expect unordered
+{"max_length": 55}
+
+--- query
+query simple_agg_max_int8_test() {
+    match {
+        $p: Person
+        $o: Organisation
+        $p $s:studyAt $o
+    }
+    return { max($s.level) as max_level }
+}
+
+--- expect unordered
+{"max_level": 120}
+
+--- query
+query simple_agg_sum_int8_test() {
+    match {
+        $p: Person
+        $o: Organisation
+        $p $s:studyAt $o
+    }
+    return { sum($s.level) as sum_level }
+}
+
+--- expect unordered
+{"sum_level": 127}
+
+--- query
+query simple_agg_max_uint64_test() {
+    match {
+        $p: Person
+        $o: Organisation
+        $p $s:studyAt $o
+    }
+    return { max($s.code) as max_code }
+}
+
+--- expect unordered
+{"max_code": 9223372036854775808}
+
+--- query
+query simple_agg_max_uint32_test() {
+    match {
+        $p: Person
+        $o: Organisation
+        $p $s:studyAt $o
+    }
+    return { max($s.temperature) as max_temperature }
+}
+
+--- expect unordered
+{"max_temperature": 32800}
+
+--- query
+query simple_agg_sum_uint32_test() {
+    match {
+        $p: Person
+        $o: Organisation
+        $p $s:studyAt $o
+    }
+    return { sum($s.temperature) as sum_temperature }
+}
+
+--- expect unordered
+{"sum_temperature": 32821}
+
+--- query
+query simple_agg_max_uint16_test() {
+    match {
+        $p: Person
+        $o: Organisation
+        $p $s:studyAt $o
+    }
+    return { max($s.ulength) as max_ulength }
+}
+
+--- expect unordered
+{"max_ulength": 33768}
+
+--- query
+query simple_agg_sum_uint16_test() {
+    match {
+        $p: Person
+        $o: Organisation
+        $p $s:studyAt $o
+    }
+    return { sum($s.ulength) as sum_ulength }
+}
+
+--- expect unordered
+{"sum_ulength": 34038}
+
+--- query
+query simple_agg_max_uint8_test() {
+    match {
+        $p: Person
+        $o: Organisation
+        $p $s:studyAt $o
+    }
+    return { max($s.ulevel) as max_ulevel }
+}
+
+--- expect unordered
+{"max_ulevel": 250}
+
+--- query
+query simple_agg_sum_uint8_test() {
+    match {
+        $p: Person
+        $o: Organisation
+        $p $s:studyAt $o
+        $s.year = 2020
+    }
+    return { sum($s.ulevel) as sum_ulevel }
+}
+
+--- expect unordered
+{"sum_ulevel": 232}

--- a/crates/omnigraph-gqt/cases/kuzu_agg_simple__simple_agg_max_float_test.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_agg_simple__simple_agg_max_float_test.gqt
@@ -1,0 +1,99 @@
+# issue: none
+# notes: kuzu test/test_files/agg/simple.test, -CASE AggSimple, -LOG
+# notes: SimpleAggMaxFloatTest, tinysnb seed. Split out of kuzu_agg_simple because the
+# notes: step diverges in rendering: WorkAt.rating is F32 and the seeded 9.2 comes back
+# notes: as 9.199999809265 (the f32 widened to f64 before the scale-12 normalization),
+# notes: where Kuzu prints 9.200000. Distinct from the AVG six-decimal truncation.
+# notes: Red on purpose: the engine renders the f64 widening of the stored F32;
+# notes: pending a fix of F32 rendering (the stored decimal, not its f64 widening).
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query simple_agg_max_float_test() {
+    match {
+        $p: Person
+        $o: Organisation
+        $p $w:workAt $o
+    }
+    return { max($w.rating) as max_rating }
+}
+
+--- expect unordered
+{"max_rating": 9.2}

--- a/crates/omnigraph-gqt/cases/kuzu_agg_simple__simple_agg_min_date_test.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_agg_simple__simple_agg_min_date_test.gqt
@@ -1,0 +1,95 @@
+# issue: none
+# notes: kuzu test/test_files/agg/simple.test, -CASE AggSimple, -LOG
+# notes: SimpleAggMinDateTest, tinysnb seed. Split out of kuzu_agg_simple.
+# notes: Red on purpose: the compiler refuses min over a Date column (T8: min requires
+# notes: numeric or string type, got Date?); pending support for min/max over Date and
+# notes: Bool.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query simple_agg_min_date_test() {
+    match {
+        $a: Person
+    }
+    return { min($a.birthdate) as min_birthdate }
+}
+
+--- expect unordered
+{"min_birthdate": "1900-01-01"}

--- a/crates/omnigraph-gqt/cases/kuzu_agg_simple__simple_agg_sum_uint64_test.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_agg_simple__simple_agg_sum_uint64_test.gqt
@@ -1,0 +1,97 @@
+# issue: none
+# notes: kuzu test/test_files/agg/simple.test, -CASE AggSimple, -LOG
+# notes: SimpleAggSumUInt64Test, tinysnb seed. Split out of kuzu_agg_simple.
+# notes: Red on purpose: sum over a U64 column accumulates in f64, so
+# notes: 9223372036854775808 + 6689 + 23 comes back as 9223372036854781952 instead of
+# notes: 9223372036854782520; pending a fix for sum over U64 accumulating in f64.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query simple_agg_sum_uint64_test() {
+    match {
+        $p: Person
+        $o: Organisation
+        $p $s:studyAt $o
+    }
+    return { sum($s.code) as sum_code }
+}
+
+--- expect unordered
+{"sum_code": 9223372036854782520}

--- a/crates/omnigraph-gqt/cases/kuzu_agg_simple__simple_avg_test2.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_agg_simple__simple_avg_test2.gqt
@@ -1,0 +1,96 @@
+# issue: none
+# notes: kuzu test/test_files/agg/simple.test, -CASE AggSimple, -LOG SimpleAvgTest2,
+# notes: tinysnb seed. Split out of kuzu_agg_simple because its AVG rendering diverges
+# notes: from Kuzu's six-decimal print: Kuzu truncates AVG to six decimals (28.333333),
+# notes: the engine keeps 28.333333333333. Expectation rewritten to the engine's
+# notes: twelve-decimal precision; Kuzu prints 28.333333.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query simple_avg_test2() {
+    match {
+        $a: Person
+        $a.birthdate = date("1980-10-26")
+    }
+    return { avg($a.age) as avg_age, avg($a.eyeSight) as avg_eye_sight }
+}
+
+--- expect unordered
+{"avg_age": 28.333333333333, "avg_eye_sight": 4.7}

--- a/crates/omnigraph-gqt/cases/kuzu_agg_simple__simple_count_test2.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_agg_simple__simple_count_test2.gqt
@@ -1,0 +1,99 @@
+# issue: none
+# notes: kuzu test/test_files/agg/simple.test, -CASE AggSimple, -LOG SimpleCountTest2,
+# notes: tinysnb seed. Split out of kuzu_agg_simple. `RETURN COUNT(e1)` is spelled
+# notes: `count($e1) as n`. An edge binding may be projected or filtered by its
+# notes: properties and bound to keep per-edge multiplicity, but a bare edge binding
+# notes: cannot be an aggregate argument.
+# notes: Red on purpose: the compiler refuses a bare edge binding as an aggregate
+# notes: argument (T23); pending support for count over an edge binding.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query simple_count_test2() {
+    match {
+        $a: Person
+        $b: Person
+        $a $e1:knows $b
+    }
+    return { count($e1) as n }
+}
+
+--- expect unordered
+{"n": 14}

--- a/crates/omnigraph-gqt/cases/kuzu_agg_simple__simple_min_max_test.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_agg_simple__simple_min_max_test.gqt
@@ -1,0 +1,96 @@
+# issue: none
+# notes: kuzu test/test_files/agg/simple.test, -CASE AggSimple, -LOG SimpleMinMaxTest,
+# notes: tinysnb seed. Split out of kuzu_agg_simple.
+# notes: Red on purpose: the compiler refuses min/max over a Bool column (T8: min
+# notes: requires numeric or string type, got Bool?), and the same restriction covers
+# notes: the Date columns in the same return; pending support for min/max over Date
+# notes: and Bool.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query simple_min_max_test() {
+    match {
+        $a: Person
+    }
+    return { min($a.age) as min_age, max($a.age) as max_age, min($a.isStudent) as min_is_student, max($a.isStudent) as max_is_student, min($a.eyeSight) as min_eye_sight, max($a.eyeSight) as max_eye_sight, min($a.birthdate) as min_birthdate, max($a.birthdate) as max_birthdate }
+}
+
+--- expect unordered
+{"min_age": 20, "max_age": 83, "min_is_student": false, "max_is_student": true, "min_eye_sight": 4.5, "max_eye_sight": 5.1, "min_birthdate": "1900-01-01", "max_birthdate": "1990-11-27"}

--- a/crates/omnigraph-gqt/cases/kuzu_agg_simple__two_hop_test.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_agg_simple__two_hop_test.gqt
@@ -1,0 +1,97 @@
+# issue: none
+# notes: kuzu test/test_files/agg/simple.test, -CASE AggSimple, -LOG TwoHopTest, tinysnb
+# notes: seed. Split out of kuzu_agg_simple because its AVG rendering diverges from
+# notes: Kuzu's six-decimal print: Kuzu truncates AVG to six decimals (4.935714), the
+# notes: engine keeps 4.935714285714. Expectation rewritten to the engine's
+# notes: twelve-decimal precision; Kuzu prints 4.935714.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query two_hop_test() {
+    match {
+        $a: Person
+        $b: Person
+        $a knows $b
+    }
+    return { sum($b.age) as s_age, min($b.pk) as min_pk, avg($b.eyeSight) as avg_eye_sight }
+}
+
+--- expect unordered
+{"s_age": 455, "min_pk": 0, "avg_eye_sight": 4.935714285714}

--- a/crates/omnigraph-gqt/cases/kuzu_cyclic_single_label.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_cyclic_single_label.gqt
@@ -1,0 +1,397 @@
+# issue: none
+# notes: kuzu test/test_files/cyclic/single_label.test, -CASE CyclicSingleLabel, tinysnb
+# notes: seed. Cycles become traversal clauses over the same variables ($a knows $b + $b
+# notes: knows $a); every variable is bound once. a.ID -> $a.pk; DATE('...') ->
+# notes: date("..."); timestamp('...') -> datetime("...Z"). Statements with arithmetic
+# notes: are not translated. -TEST_FWD_ONLY_REL is a runner knob.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query two_node_cycle_test_1() {
+    match {
+        $a: Person
+        $b: Person
+        $a knows $b
+        $b knows $a
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 12}
+
+--- query
+query two_node_cycle_test_2() {
+    match {
+        $a: Person
+        $b: Person
+        $a knows $b
+        $b knows $a
+        $a knows $b
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 12}
+
+--- query
+query two_node_cycle_with_projection_test() {
+    match {
+        $a: Person
+        $b: Person
+        $a knows $b
+        $b knows $a
+    }
+    return { $a.fName, $b.fName }
+}
+
+--- expect unordered
+{"a.fName": "Alice", "b.fName": "Bob"}
+{"a.fName": "Alice", "b.fName": "Carol"}
+{"a.fName": "Alice", "b.fName": "Dan"}
+{"a.fName": "Bob", "b.fName": "Alice"}
+{"a.fName": "Bob", "b.fName": "Carol"}
+{"a.fName": "Bob", "b.fName": "Dan"}
+{"a.fName": "Carol", "b.fName": "Alice"}
+{"a.fName": "Carol", "b.fName": "Bob"}
+{"a.fName": "Carol", "b.fName": "Dan"}
+{"a.fName": "Dan", "b.fName": "Alice"}
+{"a.fName": "Dan", "b.fName": "Bob"}
+{"a.fName": "Dan", "b.fName": "Carol"}
+
+--- query
+query triangle_test() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $a knows $b
+        $b knows $c
+        $a knows $c
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 24}
+
+--- query
+query triangle_test_with_edge_filter() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $a $e1:knows $b
+        $b $e2:knows $c
+        $a $e3:knows $c
+        $e1.date = date("1950-05-14")
+    }
+    return { $a.fName, $e1.date, $b.fName, $e2.date, $c.fName, $e3.date }
+}
+
+--- expect unordered
+{"a.fName": "Bob", "e1.date": "1950-05-14", "b.fName": "Carol", "e2.date": "2021-06-30", "c.fName": "Alice", "e3.date": "2021-06-30"}
+{"a.fName": "Bob", "e1.date": "1950-05-14", "b.fName": "Carol", "e2.date": "2000-01-01", "c.fName": "Dan", "e3.date": "1950-05-14"}
+{"a.fName": "Bob", "e1.date": "1950-05-14", "b.fName": "Dan", "e2.date": "2021-06-30", "c.fName": "Alice", "e3.date": "2021-06-30"}
+{"a.fName": "Bob", "e1.date": "1950-05-14", "b.fName": "Dan", "e2.date": "2000-01-01", "c.fName": "Carol", "e3.date": "1950-05-14"}
+{"a.fName": "Carol", "e1.date": "1950-05-14", "b.fName": "Bob", "e2.date": "2021-06-30", "c.fName": "Alice", "e3.date": "2021-06-30"}
+{"a.fName": "Carol", "e1.date": "1950-05-14", "b.fName": "Bob", "e2.date": "1950-05-14", "c.fName": "Dan", "e3.date": "2000-01-01"}
+{"a.fName": "Dan", "e1.date": "1950-05-14", "b.fName": "Bob", "e2.date": "2021-06-30", "c.fName": "Alice", "e3.date": "2021-06-30"}
+{"a.fName": "Dan", "e1.date": "1950-05-14", "b.fName": "Bob", "e2.date": "1950-05-14", "c.fName": "Carol", "e3.date": "2000-01-01"}
+
+--- query
+query triangle_test3() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Organisation
+        $a knows $b
+        $b studyAt $c
+        $a studyAt $c
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 2}
+
+--- query
+query triangle_test5() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $a $e1:knows $b
+        $b $e2:knows $c
+        $a $e3:knows $c
+        $e1.date = $e2.date
+        $e2.date = $e3.date
+    }
+    return { $a.pk, $b.pk, $c.pk }
+}
+
+--- expect unordered
+
+--- query
+query triangle_test6() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $a $e1:knows $b
+        $b $e2:knows $c
+        $a $e3:knows $c
+        $a.fName = "Alice"
+        $e1.meetTime = datetime("1986-10-21T21:08:31.521Z")
+    }
+    return { $b.fName, $c.fName }
+}
+
+--- expect unordered
+{"b.fName": "Bob", "c.fName": "Carol"}
+{"b.fName": "Bob", "c.fName": "Dan"}
+
+--- query
+query triangle_with_projection_test() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Organisation
+        $a $e1:knows $b
+        $b $e2:studyAt $c
+        $a $e3:studyAt $c
+    }
+    return { $a.fName, $e1.date, $b.fName, $e2.year, $c.name, $e3.year }
+}
+
+--- expect unordered
+{"a.fName": "Alice", "e1.date": "2021-06-30", "b.fName": "Bob", "e2.year": 2020, "c.name": "ABFsUni", "e3.year": 2021}
+{"a.fName": "Bob", "e1.date": "2021-06-30", "b.fName": "Alice", "e2.year": 2021, "c.name": "ABFsUni", "e3.year": 2020}
+
+--- query
+query triangle_filter_test2() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Organisation
+        $a knows $b
+        $b studyAt $c
+        $a studyAt $c
+        $a.fName = "Alice"
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 1}
+
+--- query
+query triangle_filter_with_projection_test() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $a knows $b
+        $b knows $c
+        $a knows $c
+        $a.pk < $b.pk
+        $b.pk < $c.pk
+    }
+    return { $a.fName, $b.fName, $c.fName }
+}
+
+--- expect unordered
+{"a.fName": "Alice", "b.fName": "Bob", "c.fName": "Carol"}
+{"a.fName": "Alice", "b.fName": "Bob", "c.fName": "Dan"}
+{"a.fName": "Alice", "b.fName": "Carol", "c.fName": "Dan"}
+{"a.fName": "Bob", "b.fName": "Carol", "c.fName": "Dan"}
+
+--- query
+query triangle_filter_with_projection_test2() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Organisation
+        $a $e1:knows $b
+        $b $e2:studyAt $c
+        $a $e3:studyAt $c
+        $a.fName = "Bob"
+    }
+    return { $a.fName, $e1.date, $b.fName, $e2.year, $c.name, $e3.year }
+}
+
+--- expect unordered
+{"a.fName": "Bob", "e1.date": "2021-06-30", "b.fName": "Alice", "e2.year": 2021, "c.name": "ABFsUni", "e3.year": 2020}
+
+--- query
+query square_test() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $d: Person
+        $a knows $b
+        $b knows $c
+        $c knows $d
+        $a knows $d
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 84}
+
+--- query
+query square_test2() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $d: Organisation
+        $b knows $a
+        $b knows $c
+        $c studyAt $d
+        $a studyAt $d
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 11}
+
+--- query
+query square_filter_with_projection_test() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $d: Organisation
+        $b knows $a
+        $b knows $c
+        $c studyAt $d
+        $a studyAt $d
+        $a.fName = "Bob"
+    }
+    return { $a.fName, $b.fName, $c.fName, $d.name }
+}
+
+--- expect unordered
+{"a.fName": "Bob", "b.fName": "Alice", "c.fName": "Bob", "d.name": "ABFsUni"}
+{"a.fName": "Bob", "b.fName": "Carol", "c.fName": "Alice", "d.name": "ABFsUni"}
+{"a.fName": "Bob", "b.fName": "Carol", "c.fName": "Bob", "d.name": "ABFsUni"}
+{"a.fName": "Bob", "b.fName": "Dan", "c.fName": "Alice", "d.name": "ABFsUni"}
+{"a.fName": "Bob", "b.fName": "Dan", "c.fName": "Bob", "d.name": "ABFsUni"}
+
+--- query
+query square_filter_test2() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $d: Organisation
+        $b knows $a
+        $b knows $c
+        $c studyAt $d
+        $a studyAt $d
+        $b.fName = "Elizabeth"
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 1}
+
+--- query
+query cross_product_after_wcoj() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $d: Person
+        $a knows $b
+        $b knows $c
+        $a knows $c
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 192}

--- a/crates/omnigraph-gqt/cases/kuzu_filter_four_five_hop_five.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_filter_four_five_hop_five.gqt
@@ -1,0 +1,105 @@
+# issue: none
+# notes: kuzu test/test_files/filter/four_five_hop.test, -CASE FiveHopFilter, tinysnb
+# notes: seed. The sibling -CASE FourHopFilter uses OR and is not translated. f.age =
+# notes: a.age is a cross-variable filter clause.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query five_hop_knows_filter() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $d: Person
+        $e: Person
+        $f: Person
+        $a knows $b
+        $b knows $c
+        $c knows $d
+        $d knows $e
+        $e knows $f
+        $a.age = 35
+        $f.age = $a.age
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 60}

--- a/crates/omnigraph-gqt/cases/kuzu_filter_multi_label.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_filter_multi_label.gqt
@@ -1,0 +1,99 @@
+# issue: none
+# notes: kuzu test/test_files/filter/multi_label.test, -CASE FilterMultiLabel, tinysnb
+# notes: seed. Three of the four statements use the multi-label rel pattern knows|:meets
+# notes: (or knows|:marries) and are not translated; meets and marries are also absent
+# notes: from the seed. The Zonemap statement's unlabelled destination (b) is spelled
+# notes: $b: Organisation because the StudyAt edge is declared Person -> Organisation,
+# notes: so the label is forced.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query zonemap() {
+    match {
+        $a: Person
+        $b: Organisation
+        $a $e:studyAt $b
+        $e.year < 1
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 0}

--- a/crates/omnigraph-gqt/cases/kuzu_filter_multi_label_zonemap_updates.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_filter_multi_label_zonemap_updates.gqt
@@ -1,0 +1,91 @@
+# issue: none
+# notes: kuzu test/test_files/filter/multi_label.test, -CASE ZonemapWithUpdates, tinysnb
+# notes: seed. Every read and the SET in this case use the multi-label rel pattern
+# notes: knows|:meets and are not translated (meets is also absent from the seed), so
+# notes: only the single-label CREATE edge statement is converted here; no read in the
+# notes: case can observe it without multi-label.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- mutate
+query stmt_5() {
+    insert Knows { from: "3", to: "9", meetTime: datetime("2026-02-01T11:22:33.530Z") }
+}
+
+--- expect affected: nodes=0 edges=1

--- a/crates/omnigraph-gqt/cases/kuzu_filter_node.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_filter_node.gqt
@@ -1,0 +1,288 @@
+# issue: none
+# notes: kuzu test/test_files/filter/node.test, -CASE FilterNode, tinysnb seed.
+# notes: Statements with arithmetic, OR/XOR, IS [NOT] NULL, or a null literal have no GQ
+# notes: spelling and are not translated; `WHERE a.isStudent` is spelled `= true`, `NOT
+# notes: a.isWorker` as `= false` (equivalent while the column holds no nulls).
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query age_le_25() {
+    match {
+        $a: Person
+        $a.age <= 25
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 3}
+
+--- query
+query age_lt_25() {
+    match {
+        $a: Person
+        $a.age < 25
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 2}
+
+--- query
+query age_ge_25() {
+    match {
+        $a: Person
+        $a.age >= 25
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 6}
+
+--- query
+query age_gt_25() {
+    match {
+        $a: Person
+        $a.age > 25
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 5}
+
+--- query
+query age_inline_25() {
+    match {
+        $a: Person { age: 25 }
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 1}
+
+--- query
+query age_ne_25() {
+    match {
+        $a: Person
+        $a.age != 25
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 7}
+
+--- query
+query is_student_true() {
+    match {
+        $a: Person
+        $a.isStudent = true
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 3}
+
+--- query
+query is_worker_inline_true() {
+    match {
+        $a: Person { isWorker: true }
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 4}
+
+--- query
+query is_worker_and_is_student() {
+    match {
+        $a: Person
+        $a.isWorker = true
+        $a.isStudent = true
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 0}
+
+--- query
+query not_is_worker() {
+    match {
+        $a: Person
+        $a.isWorker = false
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 4}
+
+--- query
+query organisation_mark_ge() {
+    match {
+        $a: Organisation
+        $a.mark >= 3.7
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 3}
+
+--- query
+query fname_eq() {
+    match {
+        $a: Person
+        $a.fName = "Farooq"
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 1}
+
+--- query
+query fname_ne() {
+    match {
+        $a: Person
+        $a.fName != "Farooq"
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 7}
+
+--- query
+query fname_lt() {
+    match {
+        $a: Person
+        $a.fName < "Carom"
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 3}
+
+--- query
+query fname_ge() {
+    match {
+        $a: Person
+        $a.fName >= "Eliz"
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 4}
+
+--- query
+query node_cross_product_same_id() {
+    match {
+        $a: Person
+        $b: Person
+        $b.pk = $a.pk
+        $a.pk < 4
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 3}
+
+--- query
+query node_cross_product_missing_id() {
+    match {
+        $a: Person { pk:1000 }
+        $b: Person
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 0}

--- a/crates/omnigraph-gqt/cases/kuzu_filter_one_hop.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_filter_one_hop.gqt
@@ -1,0 +1,248 @@
+# issue: none
+# notes: kuzu test/test_files/filter/one_hop.test, -CASE FilterOneHop, tinysnb seed.
+# notes: id(a) </> id(b) spelled as $a.pk </> $b.pk (internal ids follow load order = pk
+# notes: order). RETURN e1 (whole edge) spelled as the edge's kept scalar props.
+# notes: Statements with arithmetic on gender or the dropped validInterval column are
+# notes: not translated.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query two_hop_knows_id_less_than() {
+    match {
+        $a: Person
+        $b: Person
+        $a knows $b
+        $a.pk < $b.pk
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 8}
+
+--- query
+query one_hop_knows_filtered() {
+    match {
+        $a: Person { gender: 1 }
+        $b: Person { gender: 2 }
+        $a knows $b
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 6}
+
+--- query
+query one_hop_knows_filtered_2() {
+    match {
+        $a: Person
+        $b: Person
+        $a knows $b
+        $a.age > 22
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 9}
+
+--- query
+query one_hop_org_code_filter() {
+    match {
+        $a: Person
+        $b: Organisation
+        $a studyAt $b
+        $b.orgCode > 100
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 3}
+
+--- query
+query one_hop_knows_id_greater_than() {
+    match {
+        $a: Person
+        $b: Person
+        $a knows $b
+        $a.pk > $b.pk
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 6}
+
+--- query
+query one_hop_cross_product() {
+    match {
+        $a: Person { age: 30 }
+        $c: Person
+        $d: Person { fName: "Greg" }
+        $c knows $d
+    }
+    return { $a.pk, $c.pk }
+}
+
+--- expect unordered
+{"a.pk": 2, "c.pk": 7}
+
+--- query
+query edge_filter() {
+    match {
+        $a: Person
+        $b: Person
+        $a $e1:knows $b
+        $e1.date = date("1905-12-12")
+    }
+    return { $a.pk, $b.pk }
+}
+
+--- expect unordered
+{"a.pk": 7, "b.pk": 8}
+{"a.pk": 7, "b.pk": 9}
+
+--- query
+query zonemap_1() {
+    match {
+        $a: Person
+        $b: Person
+        $a $e1:knows $b
+        $e1.date > date("2024-01-01")
+    }
+    return { $e1.date, $e1.meetTime }
+}
+
+--- expect unordered
+
+--- query
+query zonemap_2() {
+    match {
+        $a: Person
+        $b: Person
+        $a $e1:knows $b
+        $e1.date < date("1900-01-01")
+    }
+    return { $e1.date, $e1.meetTime }
+}
+
+--- expect unordered
+
+--- query
+query zonemap_3() {
+    match {
+        $a: Person
+        $b: Person
+        $a $e1:knows $b
+        $e1.meetTime < datetime("1900-08-25T19:07:22Z")
+    }
+    return { $e1.date, $e1.meetTime }
+}
+
+--- expect unordered
+
+--- query
+query zonemap_4() {
+    match {
+        $a: Person
+        $b: Person
+        $a $e1:knows $b
+        $e1.meetTime > datetime("2024-01-01T19:07:22Z")
+    }
+    return { $e1.meetTime }
+}
+
+--- expect unordered
+{"e1.meetTime": "2025-01-01T11:22:33.520Z"}
+
+--- query
+query zonemap_5() {
+    match {
+        $a: Person
+        $b: Person
+        $a $e1:knows $b
+        $e1.meetTime > datetime("2025-01-01T11:22:33.530Z")
+    }
+    return { $e1.date, $e1.meetTime }
+}
+
+--- expect unordered

--- a/crates/omnigraph-gqt/cases/kuzu_filter_one_hop_zonemap_updates.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_filter_one_hop_zonemap_updates.gqt
@@ -1,0 +1,122 @@
+# issue: none
+# notes: kuzu test/test_files/filter/one_hop.test, -CASE ZonemapWithUpdatesNoCheckpoint,
+# notes: tinysnb seed. GQ's update_stmt takes ONE where-predicate, so the case's opening
+# notes: `SET e1.meetTime` (matched on a.ID=0 AND b.ID=2) has no spelling and is not
+# notes: translated, and the one read that observes it is dropped with it. The two reads
+# notes: kept below filter a.pk = 2 and meetTime > 2026-01-01, which the dropped SET
+# notes: (2025-02-01 on the 0->2 edge) does not reach, so their expectations are
+# notes: unchanged by the drop.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query stmt_3() {
+    match {
+        $a: Person
+        $b: Person
+        $a $e1:knows $b
+        $e1.meetTime > datetime("2026-01-01T11:22:33.530Z")
+        $a.pk = 2
+    }
+    return { $a.pk, $b.pk, $e1.meetTime }
+}
+
+--- expect unordered
+
+--- mutate
+query stmt_4() {
+    insert Knows { from: "2", to: "7", meetTime: datetime("2026-02-01T11:22:33.530Z") }
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- query
+query stmt_5() {
+    match {
+        $a: Person
+        $b: Person
+        $a $e1:knows $b
+        $e1.meetTime > datetime("2026-01-01T11:22:33.530Z")
+        $a.pk = 2
+    }
+    return { $a.pk, $b.pk, $e1.meetTime }
+}
+
+--- expect unordered
+{"a.pk": 2, "b.pk": 7, "e1.meetTime": "2026-02-01T11:22:33.530Z"}

--- a/crates/omnigraph-gqt/cases/kuzu_filter_two_hop.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_filter_two_hop.gqt
@@ -1,0 +1,231 @@
+# issue: none
+# notes: kuzu test/test_files/filter/two_hop.test, -CASE FilterTwoHop, tinysnb seed.
+# notes: id(a) vs id(c) spelled as $a.pk vs $c.pk (internal ids follow load order = pk
+# notes: order). ID(r1) <> ID(r2) on the shared-source pattern (a)<-[r1]-(b)-[r2]->(c)
+# notes: reduces to $a.pk != $c.pk because knows carries no parallel edges, so an edge
+# notes: is identified by its endpoint pair; likewise ID(r1) = ID(r2) becomes $a.pk =
+# notes: $c.pk.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query two_hop_knows_id_not_equal() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $a knows $b
+        $b knows $c
+        $a.pk != $c.pk
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 24}
+
+--- query
+query two_hop_knows_id_greater_than_equals() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $a knows $b
+        $b knows $c
+        $a.pk >= $c.pk
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 24}
+
+--- query
+query two_hop_knows_id_less_than_equals() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $a knows $b
+        $b knows $c
+        $a.pk <= $c.pk
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 24}
+
+--- query
+query rel_id_comparison_2() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $b knows $a
+        $b knows $c
+        $a.pk != $c.pk
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 26}
+
+--- query
+query two_hop_knows_filtered() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $a knows $b
+        $b knows $c
+        $c.age = $a.age
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 12}
+
+--- query
+query two_hop_knows_id_equal() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $a knows $b
+        $b knows $c
+        $a.pk = $c.pk
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 12}
+
+--- query
+query two_hop_knows_filtered_2() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $a $e1:knows $b
+        $a $e2:knows $c
+        $e1.date = $e2.date
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 24}
+
+--- query
+query symmetric_two_hop() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $b $e1:knows $a
+        $b $e2:knows $c
+        $b.fName = "Bob"
+        $e1.date = $e2.date
+        $a.pk != $c.pk
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 2}
+
+--- query
+query rel_id_comparison_1() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $b knows $a
+        $b knows $c
+        $a.pk = $c.pk
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 14}

--- a/crates/omnigraph-gqt/cases/kuzu_issue_issue2_3055.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_issue_issue2_3055.gqt
@@ -1,0 +1,281 @@
+# issue: none
+# notes: kuzu test/test_files/issue/issue2.test, -CASE 3055 (kuzudb/kuzu issue 3055),
+# notes: -DATASET CSV empty; the case builds its own schema and rows. Tables `test` /
+# notes: `res` become types Test / Res and the rel table `etable` becomes edge type
+# notes: Etable (GQ type names start uppercase); the string primary key `id` becomes
+# notes: `pk` (engine system field). MERGE has no GQ spelling: each MERGE is not
+# notes: translated and its values are carried into the seed. The two tables Kuzu
+# notes: creates mid-case are hoisted into the single schema section; their DDL
+# notes: statements stay unexpressible. Kuzu asserts only `ok` on the six node reads;
+# notes: the expected rows there are read off the seed the MERGEs build. `RETURN n` is
+# notes: spelled as the property list. The two `COUNT(*)` reads (stmt_34, stmt_52) are
+# notes: the only rows Kuzu asserts: their unlabeled endpoints are pinned by the typed
+# notes: edge etable, and the count is over the bound edge's target node. Two
+# notes: MATCH+CREATE statements target a non-existent test key, where Kuzu creates
+# notes: nothing and a GQ insert has no conditional form.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Test {
+    pk: String @key
+    prop1: String?
+    prop2: I64?
+    prop3: String?
+    prop4: String?
+}
+node Res {
+    name: String @key
+}
+edge Etable: Res -> Test {
+    eprop1: String?
+    eprop2: String?
+    eprop3: String?
+}
+
+--- seed
+{"type":"Test","data":{"pk":"ewm8ewnn@l23:","prop1":"model","prop2":6,"prop3":"trips_2","prop4":"0bbhfwnenwafnw88989382932wwewej332938293jiwojewie923892389283923"}}
+{"type":"Test","data":{"pk":"ewm8ewnn ewweklnbgeireg@l23:ewe","prop1":"model","prop2":16,"prop3":"normalize_data","prop4":"1bbhfwnenwafnw88989234342wwewej332938293jiwojewie923892389283923"}}
+{"type":"Test","data":{"pk":"ewm8ewnn ewweklnbgew888g@lew3:ewe","prop1":"model","prop2":74,"prop3":"zones","prop4":"2bbhfwnenaafnw88989234342wwewej332938293jiwojewie923192389283923"}}
+{"type":"Test","data":{"pk":"ewm8ew43lnbgew888g@lew3:ewe","prop1":"expectation","prop2":27,"prop3":"test_trips_1","prop4":"3bbhfwnenaafnw88989234342wwewej332938213jiwojewie923192389283923"}}
+{"type":"Test","data":{"pk":"ewm8ew43ffbgew888g@lew3:ewe","prop1":"expectation","prop2":37,"prop3":"test_trips_2","prop4":"4bbhfwnenaafnw88989234312wwewej332938213jiwojewie923192389283923"}}
+{"type":"Test","data":{"pk":"ewm8ew43ffrrr88g@lew3:ewe","prop1":"expectation","prop2":47,"prop3":"test_norm_data_1","prop4":"5bbhfwnenaafnw88989234312wwewej332938213jiwojewie923192389283923"}}
+{"type":"Test","data":{"pk":"fwfwfe8g@lew3:ewe","prop1":"model","prop4":"6bbhfwnenaafnw88989234312wwewej332938213jiwojewie923192389283923"}}
+{"type":"Test","data":{"pk":"nfewnfwn+wnfw"}}
+{"type":"Test","data":{"pk":"nfewn32n+wnfw"}}
+{"type":"Res","data":{"name":"nfewnnfw"}}
+{"type":"Res","data":{"name":"fwfsiewmk"}}
+{"type":"Res","data":{"name":"pdanwewer"}}
+{"type":"Res","data":{"name":"another_dep"}}
+{"type":"Res","data":{"name":"numpy"}}
+
+--- query
+query stmt_10() {
+    match {
+        $n: Test
+        $n.pk = "ewm8ewnn ewweklnbgew888g@lew3:ewe"
+        $n.prop1 = "model"
+        $n.prop2 = 74
+        $n.prop3 = "zones"
+    }
+    return { $n.pk, $n.prop1, $n.prop2, $n.prop3, $n.prop4 }
+}
+
+--- expect unordered
+{"n.pk": "ewm8ewnn ewweklnbgew888g@lew3:ewe", "n.prop1": "model", "n.prop2": 74, "n.prop3": "zones", "n.prop4": "2bbhfwnenaafnw88989234342wwewej332938293jiwojewie923192389283923"}
+
+--- query
+query stmt_11() {
+    match {
+        $n: Test
+        $n.pk = "ewm8ewnn@l23:"
+        $n.prop1 = "model"
+        $n.prop2 = 6
+        $n.prop3 = "trips_2"
+    }
+    return { $n.pk, $n.prop1, $n.prop2, $n.prop3, $n.prop4 }
+}
+
+--- expect unordered
+{"n.pk": "ewm8ewnn@l23:", "n.prop1": "model", "n.prop2": 6, "n.prop3": "trips_2", "n.prop4": "0bbhfwnenwafnw88989382932wwewej332938293jiwojewie923892389283923"}
+
+--- query
+query stmt_12() {
+    match {
+        $n: Test
+        $n.pk = "ewm8ewnn ewweklnbgeireg@l23:ewe"
+        $n.prop1 = "model"
+        $n.prop2 = 16
+        $n.prop3 = "normalize_data"
+    }
+    return { $n.pk, $n.prop1, $n.prop2, $n.prop3, $n.prop4 }
+}
+
+--- expect unordered
+{"n.pk": "ewm8ewnn ewweklnbgeireg@l23:ewe", "n.prop1": "model", "n.prop2": 16, "n.prop3": "normalize_data", "n.prop4": "1bbhfwnenwafnw88989234342wwewej332938293jiwojewie923892389283923"}
+
+--- query
+query stmt_13() {
+    match {
+        $n: Test
+        $n.pk = "ewm8ew43lnbgew888g@lew3:ewe"
+        $n.prop1 = "expectation"
+        $n.prop2 = 27
+        $n.prop3 = "test_trips_1"
+    }
+    return { $n.pk, $n.prop1, $n.prop2, $n.prop3, $n.prop4 }
+}
+
+--- expect unordered
+{"n.pk": "ewm8ew43lnbgew888g@lew3:ewe", "n.prop1": "expectation", "n.prop2": 27, "n.prop3": "test_trips_1", "n.prop4": "3bbhfwnenaafnw88989234342wwewej332938213jiwojewie923192389283923"}
+
+--- query
+query stmt_14() {
+    match {
+        $n: Test
+        $n.pk = "ewm8ew43ffbgew888g@lew3:ewe"
+        $n.prop1 = "expectation"
+        $n.prop2 = 37
+        $n.prop3 = "test_trips_2"
+    }
+    return { $n.pk, $n.prop1, $n.prop2, $n.prop3, $n.prop4 }
+}
+
+--- expect unordered
+{"n.pk": "ewm8ew43ffbgew888g@lew3:ewe", "n.prop1": "expectation", "n.prop2": 37, "n.prop3": "test_trips_2", "n.prop4": "4bbhfwnenaafnw88989234312wwewej332938213jiwojewie923192389283923"}
+
+--- query
+query stmt_15() {
+    match {
+        $n: Test
+        $n.pk = "ewm8ew43ffrrr88g@lew3:ewe"
+        $n.prop1 = "expectation"
+        $n.prop2 = 47
+        $n.prop3 = "test_norm_data_1"
+    }
+    return { $n.pk, $n.prop1, $n.prop2, $n.prop3, $n.prop4 }
+}
+
+--- expect unordered
+{"n.pk": "ewm8ew43ffrrr88g@lew3:ewe", "n.prop1": "expectation", "n.prop2": 47, "n.prop3": "test_norm_data_1", "n.prop4": "5bbhfwnenaafnw88989234312wwewej332938213jiwojewie923192389283923"}
+
+--- mutate
+query stmt_21() {
+    insert Etable { from: "nfewnnfw", to: "nfewnfwn+wnfw", eprop1: "1.1.1", eprop3: "nfewj932-ew2b-5f33-nfew" }
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- mutate
+query stmt_23() {
+    insert Etable { from: "fwfsiewmk", to: "nfewnfwn+wnfw", eprop1: "0.0.0", eprop3: "nfewj932-ew2b-5f33-nfew" }
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- mutate
+query stmt_25() {
+    insert Etable { from: "nfewnnfw", to: "nfewn32n+wnfw", eprop1: "1.1.1", eprop3: "mdewj932-ew2b-5f44-nfew" }
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- mutate
+query stmt_28() {
+    insert Etable { from: "fwfsiewmk", to: "nfewn32n+wnfw", eprop1: "0.0.0", eprop3: "mdewj932-ew2b-5f44-nfew" }
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- mutate
+query stmt_31() {
+    insert Etable { from: "nfewnnfw", to: "ewm8ewnn ewweklnbgew888g@lew3:ewe", eprop1: "1.1.1", eprop3: "qqewj932-ew2b-5f88-nfew" }
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- mutate
+query stmt_32() {
+    insert Etable { from: "nfewnnfw", to: "ewm8ewnn@l23:", eprop1: "1.1.1", eprop3: "qqewj932-ew2b-5f88-nfew" }
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- mutate
+query stmt_33() {
+    insert Etable { from: "nfewnnfw", to: "ewm8ew43ffrrr88g@lew3:ewe", eprop1: "1.1.1", eprop3: "qqewj932-ew2b-5f88-nfew" }
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- query
+query stmt_34() {
+    match {
+        $f: Res
+        $t: Test
+        $f $r:etable $t
+        $t.pk = "ewm8ewnn@l23:"
+        $r.eprop3 = "qqewj932-ew2b-5f88-nfew"
+    }
+    return { count($t) as n }
+}
+
+--- expect unordered
+{"n": 1}
+
+--- mutate
+query stmt_35() {
+    insert Etable { from: "nfewnnfw", to: "ewm8ew43ffbgew888g@lew3:ewe", eprop1: "1.1.1", eprop3: "ooewj932-ew2b-5f19-nfew" }
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- mutate
+query stmt_37() {
+    insert Etable { from: "pdanwewer", to: "ewm8ew43ffbgew888g@lew3:ewe", eprop1: "1.2.4", eprop3: "ooewj932-ew2b-5f19-nfew" }
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- mutate
+query stmt_39() {
+    insert Etable { from: "another_dep", to: "ewm8ew43ffbgew888g@lew3:ewe", eprop1: "9.9.9", eprop3: "ooewj932-ew2b-5f19-nfew" }
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- mutate
+query stmt_41() {
+    insert Etable { from: "nfewnnfw", to: "ewm8ewnn ewweklnbgeireg@l23:ewe", eprop1: "1.1.1", eprop3: "rrewj932-ew2b-5f92-nfew" }
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- mutate
+query stmt_43() {
+    insert Etable { from: "pdanwewer", to: "ewm8ewnn ewweklnbgeireg@l23:ewe", eprop1: "1.1.1", eprop3: "rrewj932-ew2b-5f92-nfew" }
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- mutate
+query stmt_45() {
+    insert Etable { from: "numpy", to: "ewm8ewnn ewweklnbgeireg@l23:ewe", eprop1: "2.2.2", eprop3: "rrewj932-ew2b-5f92-nfew" }
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- mutate
+query stmt_47() {
+    insert Etable { from: "nfewnnfw", to: "fwfwfe8g@lew3:ewe", eprop1: "1.1.1", eprop3: "mmewj932-ew2b-5f00-nfew" }
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- mutate
+query stmt_49() {
+    insert Etable { from: "nfewnnfw", to: "ewm8ew43lnbgew888g@lew3:ewe", eprop1: "1.1.1", eprop3: "piewj932-ew2b-5f00-nfrr" }
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- mutate
+query stmt_51() {
+    insert Etable { from: "pdanwewer", to: "ewm8ew43lnbgew888g@lew3:ewe", eprop1: "1.2.3", eprop3: "piewj932-ew2b-5f00-nfrr" }
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- query
+query stmt_52() {
+    match {
+        $f: Res
+        $t: Test
+        $f $r:etable $t
+        $t.pk = "ewm8ewnn@l23:"
+        $r.eprop3 = "qqewj932-ew2b-5f88-nfew"
+    }
+    return { count($t) as n }
+}
+
+--- expect unordered
+{"n": 1}

--- a/crates/omnigraph-gqt/cases/kuzu_issue_issue3_bug.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_issue_issue3_bug.gqt
@@ -1,0 +1,63 @@
+# issue: none
+# notes: kuzu test/test_files/issue/issue3.test, -CASE BUG, -DATASET CSV EMPTY; the case
+# notes: builds its own schema and rows. Tables `n` and `f` become types N and F (GQ
+# notes: type names start uppercase); their string primary key `id` becomes `pk` (engine
+# notes: system field). MERGE has no GQ spelling: each MERGE is not translated and its
+# notes: values are carried into the seed, so the four MATCH+CREATE edge inserts see the
+# notes: same rows.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node N {
+    pk: String @key
+    name: String?
+}
+node F {
+    pk: String @key
+    prop1: String?
+    prop2: String?
+    prop3: I64?
+    prop4: String?
+    prop5: String?
+}
+edge E: N -> F {
+    prop: Bool?
+}
+
+--- seed
+{"type":"F","data":{"pk":"fewnjw32i3o#new","prop1":"wen3","prop2":"ewfw23","prop5":"d6112fewnfw2323ir203092323f78r2r"}}
+{"type":"F","data":{"pk":"nj2r2br2&323h^w8","prop1":"wen3","prop2":"wpy","prop3":6,"prop4":"tpi32","prop5":"s12"}}
+{"type":"N","data":{"pk":"wfw24sd","name":"fs23"}}
+{"type":"N","data":{"pk":"fwfw232few","name":"fw3dds"}}
+{"type":"N","data":{"pk":"7fnfjwe*33","name":"89njfew23"}}
+{"type":"N","data":{"pk":"8nfw*","name":"fs23"}}
+{"type":"N","data":{"pk":"wefn&323","name":"89njfew23"}}
+{"type":"N","data":{"pk":"njwf&33bnjkfw*f","name":"cs"}}
+
+--- mutate
+query stmt_6() {
+    insert E { from: "wfw24sd", to: "fewnjw32i3o#new", prop: true }
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- mutate
+query stmt_8() {
+    insert E { from: "fwfw232few", to: "fewnjw32i3o#new", prop: true }
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- mutate
+query stmt_10() {
+    insert E { from: "7fnfjwe*33", to: "fewnjw32i3o#new", prop: true }
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- mutate
+query stmt_15() {
+    insert E { from: "njwf&33bnjkfw*f", to: "nj2r2br2&323h^w8", prop: false }
+}
+
+--- expect affected: nodes=0 edges=1

--- a/crates/omnigraph-gqt/cases/kuzu_issue_issue4_3083.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_issue_issue4_3083.gqt
@@ -1,0 +1,37 @@
+# issue: none
+# notes: kuzu test/test_files/issue/issue4.test, -CASE 3083 (kuzudb/kuzu issue 3083),
+# notes: -DATASET CSV empty; the case builds its own schema and rows. MERGE has no GQ
+# notes: spelling: each MERGE is not translated and its values are carried into the
+# notes: seed, so the closing read sees the same rows Kuzu does. Table `test` becomes
+# notes: type `Test` (GQ type names start uppercase). One key is merged twice and seeded
+# notes: once.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Test {
+    prop0: String?
+    prop1: [String]?
+    prop2: String?
+    prop3: I64?
+    prop4: String @key
+}
+
+--- seed
+{"type":"Test","data":{"prop4":"efwb2143d10ccfw","prop0":"efwoj23","prop1":["eee","wefwhiihifwe23343","dmkwlenfwef232323"],"prop2":"NOT eee IS NULL AND dmkwlenfwef232323 <'2023-01-10T00:00:00-05:00' AND dmkwlenfwef232323 >='2022-01-01T00:00:00-05:00'","prop3":5}}
+{"type":"Test","data":{"prop4":"sdnweh2382933228","prop0":"efwoj23","prop1":["customer_name","wefwhiihifwe23343","dmkwlenfwef232323"],"prop2":"NOT customer_name IS NULL AND NOT dmkwlenfwef232323 IS NULL"}}
+{"type":"Test","data":{"prop4":"sdnjb232*23ksfew","prop0":"fw","prop1":["wefwhiihifwe23343","dmkwlenfwef232323"],"prop2":"wefwhiihifwe23343 > 5"}}
+{"type":"Test","data":{"prop4":"dsnfjwne*&232","prop0":"tweee"}}
+{"type":"Test","data":{"prop4":"nsdwew*232njfds^","prop0":"fw"}}
+{"type":"Test","data":{"prop4":"fwsdmwfnw&","prop0":"sds"}}
+
+--- query
+query stmt_9() {
+    match {
+        $n: Test
+        $n.prop4 = "efwb2143d10ccfw"
+    }
+    return { $n.prop1 }
+}
+
+--- expect unordered
+{"n.prop1": ["eee", "wefwhiihifwe23343", "dmkwlenfwef232323"]}

--- a/crates/omnigraph-gqt/cases/kuzu_issue_issue6_issue3576.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_issue_issue6_issue3576.gqt
@@ -1,0 +1,40 @@
+# issue: none
+# notes: kuzu test/test_files/issue/issue6.test, -CASE issue3576 (kuzudb/kuzu issue
+# notes: 3576), -DATASET CSV empty; the case builds its own schema and rows. SERIAL
+# notes: primary key `uid` becomes `pk`, assigned 0 per table in creation order. BEGIN
+# notes: TRANSACTION / COMMIT have no GQ spelling and are not translated; the two bare
+# notes: CREATEs are the seed.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node MyNode {
+    pk: I64 @key
+}
+node MyOtherNode {
+    pk: I64 @key
+}
+edge MyRel: MyNode -> MyOtherNode
+
+--- seed
+{"type":"MyNode","data":{"pk":0}}
+{"type":"MyOtherNode","data":{"pk":0}}
+
+--- mutate
+query stmt_7() {
+    insert MyRel { from: "0", to: "0" }
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- query
+query stmt_9() {
+    match {
+        $n: MyNode
+        $m: MyOtherNode
+        $n myRel $m
+    }
+    return { $n.pk, $m.pk }
+}
+
+--- expect unordered
+{"n.pk": 0, "m.pk": 0}

--- a/crates/omnigraph-gqt/cases/kuzu_issue_issue8_nodeswith300props.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_issue_issue8_nodeswith300props.gqt
@@ -1,0 +1,630 @@
+# issue: none
+# notes: kuzu test/test_files/issue/issue8.test, -CASE NodesWith300Props, -DATASET CSV
+# notes: empty; the case builds its own schema and rows. Table `person` becomes type
+# notes: Person; the primary key is the STRING column prop1, and Kuzu's `create
+# notes: (p:person {prop1: 5})` implicitly casts 5 to the string "5". Even-numbered
+# notes: props are INT64, odd-numbered are STRING. `RETURN p` is spelled as the
+# notes: 300-property list; Kuzu prints only the set property, GQ prints every projected
+# notes: column with an explicit null. The 300 properties are generated
+# notes: (even-numbered INT64, odd-numbered STRING); regenerate by script if a column
+# notes: changes.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    prop0: I64?
+    prop1: String @key
+    prop2: I64?
+    prop3: String?
+    prop4: I64?
+    prop5: String?
+    prop6: I64?
+    prop7: String?
+    prop8: I64?
+    prop9: String?
+    prop10: I64?
+    prop11: String?
+    prop12: I64?
+    prop13: String?
+    prop14: I64?
+    prop15: String?
+    prop16: I64?
+    prop17: String?
+    prop18: I64?
+    prop19: String?
+    prop20: I64?
+    prop21: String?
+    prop22: I64?
+    prop23: String?
+    prop24: I64?
+    prop25: String?
+    prop26: I64?
+    prop27: String?
+    prop28: I64?
+    prop29: String?
+    prop30: I64?
+    prop31: String?
+    prop32: I64?
+    prop33: String?
+    prop34: I64?
+    prop35: String?
+    prop36: I64?
+    prop37: String?
+    prop38: I64?
+    prop39: String?
+    prop40: I64?
+    prop41: String?
+    prop42: I64?
+    prop43: String?
+    prop44: I64?
+    prop45: String?
+    prop46: I64?
+    prop47: String?
+    prop48: I64?
+    prop49: String?
+    prop50: I64?
+    prop51: String?
+    prop52: I64?
+    prop53: String?
+    prop54: I64?
+    prop55: String?
+    prop56: I64?
+    prop57: String?
+    prop58: I64?
+    prop59: String?
+    prop60: I64?
+    prop61: String?
+    prop62: I64?
+    prop63: String?
+    prop64: I64?
+    prop65: String?
+    prop66: I64?
+    prop67: String?
+    prop68: I64?
+    prop69: String?
+    prop70: I64?
+    prop71: String?
+    prop72: I64?
+    prop73: String?
+    prop74: I64?
+    prop75: String?
+    prop76: I64?
+    prop77: String?
+    prop78: I64?
+    prop79: String?
+    prop80: I64?
+    prop81: String?
+    prop82: I64?
+    prop83: String?
+    prop84: I64?
+    prop85: String?
+    prop86: I64?
+    prop87: String?
+    prop88: I64?
+    prop89: String?
+    prop90: I64?
+    prop91: String?
+    prop92: I64?
+    prop93: String?
+    prop94: I64?
+    prop95: String?
+    prop96: I64?
+    prop97: String?
+    prop98: I64?
+    prop99: String?
+    prop100: I64?
+    prop101: String?
+    prop102: I64?
+    prop103: String?
+    prop104: I64?
+    prop105: String?
+    prop106: I64?
+    prop107: String?
+    prop108: I64?
+    prop109: String?
+    prop110: I64?
+    prop111: String?
+    prop112: I64?
+    prop113: String?
+    prop114: I64?
+    prop115: String?
+    prop116: I64?
+    prop117: String?
+    prop118: I64?
+    prop119: String?
+    prop120: I64?
+    prop121: String?
+    prop122: I64?
+    prop123: String?
+    prop124: I64?
+    prop125: String?
+    prop126: I64?
+    prop127: String?
+    prop128: I64?
+    prop129: String?
+    prop130: I64?
+    prop131: String?
+    prop132: I64?
+    prop133: String?
+    prop134: I64?
+    prop135: String?
+    prop136: I64?
+    prop137: String?
+    prop138: I64?
+    prop139: String?
+    prop140: I64?
+    prop141: String?
+    prop142: I64?
+    prop143: String?
+    prop144: I64?
+    prop145: String?
+    prop146: I64?
+    prop147: String?
+    prop148: I64?
+    prop149: String?
+    prop150: I64?
+    prop151: String?
+    prop152: I64?
+    prop153: String?
+    prop154: I64?
+    prop155: String?
+    prop156: I64?
+    prop157: String?
+    prop158: I64?
+    prop159: String?
+    prop160: I64?
+    prop161: String?
+    prop162: I64?
+    prop163: String?
+    prop164: I64?
+    prop165: String?
+    prop166: I64?
+    prop167: String?
+    prop168: I64?
+    prop169: String?
+    prop170: I64?
+    prop171: String?
+    prop172: I64?
+    prop173: String?
+    prop174: I64?
+    prop175: String?
+    prop176: I64?
+    prop177: String?
+    prop178: I64?
+    prop179: String?
+    prop180: I64?
+    prop181: String?
+    prop182: I64?
+    prop183: String?
+    prop184: I64?
+    prop185: String?
+    prop186: I64?
+    prop187: String?
+    prop188: I64?
+    prop189: String?
+    prop190: I64?
+    prop191: String?
+    prop192: I64?
+    prop193: String?
+    prop194: I64?
+    prop195: String?
+    prop196: I64?
+    prop197: String?
+    prop198: I64?
+    prop199: String?
+    prop200: I64?
+    prop201: String?
+    prop202: I64?
+    prop203: String?
+    prop204: I64?
+    prop205: String?
+    prop206: I64?
+    prop207: String?
+    prop208: I64?
+    prop209: String?
+    prop210: I64?
+    prop211: String?
+    prop212: I64?
+    prop213: String?
+    prop214: I64?
+    prop215: String?
+    prop216: I64?
+    prop217: String?
+    prop218: I64?
+    prop219: String?
+    prop220: I64?
+    prop221: String?
+    prop222: I64?
+    prop223: String?
+    prop224: I64?
+    prop225: String?
+    prop226: I64?
+    prop227: String?
+    prop228: I64?
+    prop229: String?
+    prop230: I64?
+    prop231: String?
+    prop232: I64?
+    prop233: String?
+    prop234: I64?
+    prop235: String?
+    prop236: I64?
+    prop237: String?
+    prop238: I64?
+    prop239: String?
+    prop240: I64?
+    prop241: String?
+    prop242: I64?
+    prop243: String?
+    prop244: I64?
+    prop245: String?
+    prop246: I64?
+    prop247: String?
+    prop248: I64?
+    prop249: String?
+    prop250: I64?
+    prop251: String?
+    prop252: I64?
+    prop253: String?
+    prop254: I64?
+    prop255: String?
+    prop256: I64?
+    prop257: String?
+    prop258: I64?
+    prop259: String?
+    prop260: I64?
+    prop261: String?
+    prop262: I64?
+    prop263: String?
+    prop264: I64?
+    prop265: String?
+    prop266: I64?
+    prop267: String?
+    prop268: I64?
+    prop269: String?
+    prop270: I64?
+    prop271: String?
+    prop272: I64?
+    prop273: String?
+    prop274: I64?
+    prop275: String?
+    prop276: I64?
+    prop277: String?
+    prop278: I64?
+    prop279: String?
+    prop280: I64?
+    prop281: String?
+    prop282: I64?
+    prop283: String?
+    prop284: I64?
+    prop285: String?
+    prop286: I64?
+    prop287: String?
+    prop288: I64?
+    prop289: String?
+    prop290: I64?
+    prop291: String?
+    prop292: I64?
+    prop293: String?
+    prop294: I64?
+    prop295: String?
+    prop296: I64?
+    prop297: String?
+    prop298: I64?
+    prop299: String?
+}
+
+--- seed
+{"type":"Person","data":{"prop1":"5"}}
+
+--- query
+query stmt_3() {
+    match {
+        $p: Person
+    }
+    return {
+        $p.prop0,
+        $p.prop1,
+        $p.prop2,
+        $p.prop3,
+        $p.prop4,
+        $p.prop5,
+        $p.prop6,
+        $p.prop7,
+        $p.prop8,
+        $p.prop9,
+        $p.prop10,
+        $p.prop11,
+        $p.prop12,
+        $p.prop13,
+        $p.prop14,
+        $p.prop15,
+        $p.prop16,
+        $p.prop17,
+        $p.prop18,
+        $p.prop19,
+        $p.prop20,
+        $p.prop21,
+        $p.prop22,
+        $p.prop23,
+        $p.prop24,
+        $p.prop25,
+        $p.prop26,
+        $p.prop27,
+        $p.prop28,
+        $p.prop29,
+        $p.prop30,
+        $p.prop31,
+        $p.prop32,
+        $p.prop33,
+        $p.prop34,
+        $p.prop35,
+        $p.prop36,
+        $p.prop37,
+        $p.prop38,
+        $p.prop39,
+        $p.prop40,
+        $p.prop41,
+        $p.prop42,
+        $p.prop43,
+        $p.prop44,
+        $p.prop45,
+        $p.prop46,
+        $p.prop47,
+        $p.prop48,
+        $p.prop49,
+        $p.prop50,
+        $p.prop51,
+        $p.prop52,
+        $p.prop53,
+        $p.prop54,
+        $p.prop55,
+        $p.prop56,
+        $p.prop57,
+        $p.prop58,
+        $p.prop59,
+        $p.prop60,
+        $p.prop61,
+        $p.prop62,
+        $p.prop63,
+        $p.prop64,
+        $p.prop65,
+        $p.prop66,
+        $p.prop67,
+        $p.prop68,
+        $p.prop69,
+        $p.prop70,
+        $p.prop71,
+        $p.prop72,
+        $p.prop73,
+        $p.prop74,
+        $p.prop75,
+        $p.prop76,
+        $p.prop77,
+        $p.prop78,
+        $p.prop79,
+        $p.prop80,
+        $p.prop81,
+        $p.prop82,
+        $p.prop83,
+        $p.prop84,
+        $p.prop85,
+        $p.prop86,
+        $p.prop87,
+        $p.prop88,
+        $p.prop89,
+        $p.prop90,
+        $p.prop91,
+        $p.prop92,
+        $p.prop93,
+        $p.prop94,
+        $p.prop95,
+        $p.prop96,
+        $p.prop97,
+        $p.prop98,
+        $p.prop99,
+        $p.prop100,
+        $p.prop101,
+        $p.prop102,
+        $p.prop103,
+        $p.prop104,
+        $p.prop105,
+        $p.prop106,
+        $p.prop107,
+        $p.prop108,
+        $p.prop109,
+        $p.prop110,
+        $p.prop111,
+        $p.prop112,
+        $p.prop113,
+        $p.prop114,
+        $p.prop115,
+        $p.prop116,
+        $p.prop117,
+        $p.prop118,
+        $p.prop119,
+        $p.prop120,
+        $p.prop121,
+        $p.prop122,
+        $p.prop123,
+        $p.prop124,
+        $p.prop125,
+        $p.prop126,
+        $p.prop127,
+        $p.prop128,
+        $p.prop129,
+        $p.prop130,
+        $p.prop131,
+        $p.prop132,
+        $p.prop133,
+        $p.prop134,
+        $p.prop135,
+        $p.prop136,
+        $p.prop137,
+        $p.prop138,
+        $p.prop139,
+        $p.prop140,
+        $p.prop141,
+        $p.prop142,
+        $p.prop143,
+        $p.prop144,
+        $p.prop145,
+        $p.prop146,
+        $p.prop147,
+        $p.prop148,
+        $p.prop149,
+        $p.prop150,
+        $p.prop151,
+        $p.prop152,
+        $p.prop153,
+        $p.prop154,
+        $p.prop155,
+        $p.prop156,
+        $p.prop157,
+        $p.prop158,
+        $p.prop159,
+        $p.prop160,
+        $p.prop161,
+        $p.prop162,
+        $p.prop163,
+        $p.prop164,
+        $p.prop165,
+        $p.prop166,
+        $p.prop167,
+        $p.prop168,
+        $p.prop169,
+        $p.prop170,
+        $p.prop171,
+        $p.prop172,
+        $p.prop173,
+        $p.prop174,
+        $p.prop175,
+        $p.prop176,
+        $p.prop177,
+        $p.prop178,
+        $p.prop179,
+        $p.prop180,
+        $p.prop181,
+        $p.prop182,
+        $p.prop183,
+        $p.prop184,
+        $p.prop185,
+        $p.prop186,
+        $p.prop187,
+        $p.prop188,
+        $p.prop189,
+        $p.prop190,
+        $p.prop191,
+        $p.prop192,
+        $p.prop193,
+        $p.prop194,
+        $p.prop195,
+        $p.prop196,
+        $p.prop197,
+        $p.prop198,
+        $p.prop199,
+        $p.prop200,
+        $p.prop201,
+        $p.prop202,
+        $p.prop203,
+        $p.prop204,
+        $p.prop205,
+        $p.prop206,
+        $p.prop207,
+        $p.prop208,
+        $p.prop209,
+        $p.prop210,
+        $p.prop211,
+        $p.prop212,
+        $p.prop213,
+        $p.prop214,
+        $p.prop215,
+        $p.prop216,
+        $p.prop217,
+        $p.prop218,
+        $p.prop219,
+        $p.prop220,
+        $p.prop221,
+        $p.prop222,
+        $p.prop223,
+        $p.prop224,
+        $p.prop225,
+        $p.prop226,
+        $p.prop227,
+        $p.prop228,
+        $p.prop229,
+        $p.prop230,
+        $p.prop231,
+        $p.prop232,
+        $p.prop233,
+        $p.prop234,
+        $p.prop235,
+        $p.prop236,
+        $p.prop237,
+        $p.prop238,
+        $p.prop239,
+        $p.prop240,
+        $p.prop241,
+        $p.prop242,
+        $p.prop243,
+        $p.prop244,
+        $p.prop245,
+        $p.prop246,
+        $p.prop247,
+        $p.prop248,
+        $p.prop249,
+        $p.prop250,
+        $p.prop251,
+        $p.prop252,
+        $p.prop253,
+        $p.prop254,
+        $p.prop255,
+        $p.prop256,
+        $p.prop257,
+        $p.prop258,
+        $p.prop259,
+        $p.prop260,
+        $p.prop261,
+        $p.prop262,
+        $p.prop263,
+        $p.prop264,
+        $p.prop265,
+        $p.prop266,
+        $p.prop267,
+        $p.prop268,
+        $p.prop269,
+        $p.prop270,
+        $p.prop271,
+        $p.prop272,
+        $p.prop273,
+        $p.prop274,
+        $p.prop275,
+        $p.prop276,
+        $p.prop277,
+        $p.prop278,
+        $p.prop279,
+        $p.prop280,
+        $p.prop281,
+        $p.prop282,
+        $p.prop283,
+        $p.prop284,
+        $p.prop285,
+        $p.prop286,
+        $p.prop287,
+        $p.prop288,
+        $p.prop289,
+        $p.prop290,
+        $p.prop291,
+        $p.prop292,
+        $p.prop293,
+        $p.prop294,
+        $p.prop295,
+        $p.prop296,
+        $p.prop297,
+        $p.prop298,
+        $p.prop299,
+    }
+}
+
+--- expect unordered
+{"p.prop0": null, "p.prop1": "5", "p.prop2": null, "p.prop3": null, "p.prop4": null, "p.prop5": null, "p.prop6": null, "p.prop7": null, "p.prop8": null, "p.prop9": null, "p.prop10": null, "p.prop11": null, "p.prop12": null, "p.prop13": null, "p.prop14": null, "p.prop15": null, "p.prop16": null, "p.prop17": null, "p.prop18": null, "p.prop19": null, "p.prop20": null, "p.prop21": null, "p.prop22": null, "p.prop23": null, "p.prop24": null, "p.prop25": null, "p.prop26": null, "p.prop27": null, "p.prop28": null, "p.prop29": null, "p.prop30": null, "p.prop31": null, "p.prop32": null, "p.prop33": null, "p.prop34": null, "p.prop35": null, "p.prop36": null, "p.prop37": null, "p.prop38": null, "p.prop39": null, "p.prop40": null, "p.prop41": null, "p.prop42": null, "p.prop43": null, "p.prop44": null, "p.prop45": null, "p.prop46": null, "p.prop47": null, "p.prop48": null, "p.prop49": null, "p.prop50": null, "p.prop51": null, "p.prop52": null, "p.prop53": null, "p.prop54": null, "p.prop55": null, "p.prop56": null, "p.prop57": null, "p.prop58": null, "p.prop59": null, "p.prop60": null, "p.prop61": null, "p.prop62": null, "p.prop63": null, "p.prop64": null, "p.prop65": null, "p.prop66": null, "p.prop67": null, "p.prop68": null, "p.prop69": null, "p.prop70": null, "p.prop71": null, "p.prop72": null, "p.prop73": null, "p.prop74": null, "p.prop75": null, "p.prop76": null, "p.prop77": null, "p.prop78": null, "p.prop79": null, "p.prop80": null, "p.prop81": null, "p.prop82": null, "p.prop83": null, "p.prop84": null, "p.prop85": null, "p.prop86": null, "p.prop87": null, "p.prop88": null, "p.prop89": null, "p.prop90": null, "p.prop91": null, "p.prop92": null, "p.prop93": null, "p.prop94": null, "p.prop95": null, "p.prop96": null, "p.prop97": null, "p.prop98": null, "p.prop99": null, "p.prop100": null, "p.prop101": null, "p.prop102": null, "p.prop103": null, "p.prop104": null, "p.prop105": null, "p.prop106": null, "p.prop107": null, "p.prop108": null, "p.prop109": null, "p.prop110": null, "p.prop111": null, "p.prop112": null, "p.prop113": null, "p.prop114": null, "p.prop115": null, "p.prop116": null, "p.prop117": null, "p.prop118": null, "p.prop119": null, "p.prop120": null, "p.prop121": null, "p.prop122": null, "p.prop123": null, "p.prop124": null, "p.prop125": null, "p.prop126": null, "p.prop127": null, "p.prop128": null, "p.prop129": null, "p.prop130": null, "p.prop131": null, "p.prop132": null, "p.prop133": null, "p.prop134": null, "p.prop135": null, "p.prop136": null, "p.prop137": null, "p.prop138": null, "p.prop139": null, "p.prop140": null, "p.prop141": null, "p.prop142": null, "p.prop143": null, "p.prop144": null, "p.prop145": null, "p.prop146": null, "p.prop147": null, "p.prop148": null, "p.prop149": null, "p.prop150": null, "p.prop151": null, "p.prop152": null, "p.prop153": null, "p.prop154": null, "p.prop155": null, "p.prop156": null, "p.prop157": null, "p.prop158": null, "p.prop159": null, "p.prop160": null, "p.prop161": null, "p.prop162": null, "p.prop163": null, "p.prop164": null, "p.prop165": null, "p.prop166": null, "p.prop167": null, "p.prop168": null, "p.prop169": null, "p.prop170": null, "p.prop171": null, "p.prop172": null, "p.prop173": null, "p.prop174": null, "p.prop175": null, "p.prop176": null, "p.prop177": null, "p.prop178": null, "p.prop179": null, "p.prop180": null, "p.prop181": null, "p.prop182": null, "p.prop183": null, "p.prop184": null, "p.prop185": null, "p.prop186": null, "p.prop187": null, "p.prop188": null, "p.prop189": null, "p.prop190": null, "p.prop191": null, "p.prop192": null, "p.prop193": null, "p.prop194": null, "p.prop195": null, "p.prop196": null, "p.prop197": null, "p.prop198": null, "p.prop199": null, "p.prop200": null, "p.prop201": null, "p.prop202": null, "p.prop203": null, "p.prop204": null, "p.prop205": null, "p.prop206": null, "p.prop207": null, "p.prop208": null, "p.prop209": null, "p.prop210": null, "p.prop211": null, "p.prop212": null, "p.prop213": null, "p.prop214": null, "p.prop215": null, "p.prop216": null, "p.prop217": null, "p.prop218": null, "p.prop219": null, "p.prop220": null, "p.prop221": null, "p.prop222": null, "p.prop223": null, "p.prop224": null, "p.prop225": null, "p.prop226": null, "p.prop227": null, "p.prop228": null, "p.prop229": null, "p.prop230": null, "p.prop231": null, "p.prop232": null, "p.prop233": null, "p.prop234": null, "p.prop235": null, "p.prop236": null, "p.prop237": null, "p.prop238": null, "p.prop239": null, "p.prop240": null, "p.prop241": null, "p.prop242": null, "p.prop243": null, "p.prop244": null, "p.prop245": null, "p.prop246": null, "p.prop247": null, "p.prop248": null, "p.prop249": null, "p.prop250": null, "p.prop251": null, "p.prop252": null, "p.prop253": null, "p.prop254": null, "p.prop255": null, "p.prop256": null, "p.prop257": null, "p.prop258": null, "p.prop259": null, "p.prop260": null, "p.prop261": null, "p.prop262": null, "p.prop263": null, "p.prop264": null, "p.prop265": null, "p.prop266": null, "p.prop267": null, "p.prop268": null, "p.prop269": null, "p.prop270": null, "p.prop271": null, "p.prop272": null, "p.prop273": null, "p.prop274": null, "p.prop275": null, "p.prop276": null, "p.prop277": null, "p.prop278": null, "p.prop279": null, "p.prop280": null, "p.prop281": null, "p.prop282": null, "p.prop283": null, "p.prop284": null, "p.prop285": null, "p.prop286": null, "p.prop287": null, "p.prop288": null, "p.prop289": null, "p.prop290": null, "p.prop291": null, "p.prop292": null, "p.prop293": null, "p.prop294": null, "p.prop295": null, "p.prop296": null, "p.prop297": null, "p.prop298": null, "p.prop299": null}

--- a/crates/omnigraph-gqt/cases/kuzu_issue_issue_2167.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_issue_issue_2167.gqt
@@ -1,0 +1,27 @@
+# issue: none
+# notes: kuzu test/test_files/issue/issue.test, -CASE 2167 (kuzudb/kuzu issue 2167),
+# notes: -DATASET CSV empty; the case builds its own schema and rows. SERIAL primary key
+# notes: `id` becomes `pk` assigned 0 in creation order. Kuzu returns the whole node;
+# notes: the step projects its kept scalar properties instead
+# notes: (whole_entity_spelled_as_props).
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Test {
+    pk: I64 @key
+    content: String?
+}
+
+--- seed
+{"type":"Test","data":{"pk":0,"content":"mycontent"}}
+
+--- query
+query stmt_3() {
+    match {
+        $t: Test
+    }
+    return { $t.pk, $t.content }
+}
+
+--- expect unordered
+{"t.pk": 0, "t.content": "mycontent"}

--- a/crates/omnigraph-gqt/cases/kuzu_issue_issue_2587.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_issue_issue_2587.gqt
@@ -1,0 +1,35 @@
+# issue: none
+# notes: kuzu test/test_files/issue/issue.test, -CASE 2587 (kuzudb/kuzu issue 2587),
+# notes: -DATASET CSV empty; the case builds its own schema and rows. String primary key
+# notes: `id` becomes `pk` (engine system field). `RETURN t.*` is spelled as the
+# notes: explicit property list; four of the five rows leave `descr` unset, so the cell
+# notes: is null.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node T {
+    pk: String @key
+    descr: String?
+}
+
+--- seed
+{"type":"T","data":{"pk":"foo"}}
+{"type":"T","data":{"pk":"123456789012"}}
+{"type":"T","data":{"pk":"bar","descr":"fe38f9dc-f761-4184-8b8b-ec9a1b5ffb83"}}
+{"type":"T","data":{"pk":"ge38f9dc-f751-4174-8b8b-ec9a1b6gab83"}}
+{"type":"T","data":{"pk":"1234567890123"}}
+
+--- query
+query stmt_7() {
+    match {
+        $t: T
+    }
+    return { $t.pk, $t.descr }
+}
+
+--- expect unordered
+{"t.pk": "foo", "t.descr": null}
+{"t.pk": "123456789012", "t.descr": null}
+{"t.pk": "bar", "t.descr": "fe38f9dc-f761-4184-8b8b-ec9a1b5ffb83"}
+{"t.pk": "ge38f9dc-f751-4174-8b8b-ec9a1b6gab83", "t.descr": null}
+{"t.pk": "1234567890123", "t.descr": null}

--- a/crates/omnigraph-gqt/cases/kuzu_issue_issue_2701.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_issue_issue_2701.gqt
@@ -1,0 +1,41 @@
+# issue: none
+# notes: kuzu test/test_files/issue/issue.test, -CASE 2701 (kuzudb/kuzu issue 2701),
+# notes: -DATASET CSV empty; the case builds its own schema and rows. Property `id`
+# notes: becomes `pk`; the unlabeled nodes of the seeding CREATE resolve to T, the
+# notes: schema's only node table. The MATCH + CREATE self-loop is a mutate step. The
+# notes: closing read's untyped edges bind R, the schema's only rel table, so it is
+# notes: expressible: it is the read that pins the self-loop the Kuzu issue is about.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node T {
+    pk: I64 @key
+}
+edge R: T -> T
+
+--- seed
+{"type":"T","data":{"pk":1}}
+{"type":"T","data":{"pk":2}}
+{"edge":"R","from":"1","to":"2","data":{}}
+
+--- mutate
+query stmt_4() {
+    insert R { from: "1", to: "1" }
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- query
+query stmt_5() {
+    match {
+        $n1: T
+        $n2: T
+        $n2 r $n2
+        $n2 r $n1
+    }
+    return { $n1.pk, $n2.pk }
+}
+
+--- expect unordered
+{"n1.pk": 1, "n2.pk": 1}
+{"n1.pk": 2, "n2.pk": 1}

--- a/crates/omnigraph-gqt/cases/kuzu_issue_issue_2890.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_issue_issue_2890.gqt
@@ -1,0 +1,36 @@
+# issue: none
+# notes: kuzu test/test_files/issue/issue.test, -CASE 2890 (kuzudb/kuzu issue 2890),
+# notes: -DATASET CSV empty; the case builds its own schema and rows. BEGIN TRANSACTION
+# notes: / COMMIT have no GQ spelling and are not translated; the two CREATEs inside the
+# notes: transaction are the seed, and the MATCH+CREATE that links them is the one
+# notes: mutate step.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node SpotTableNode {
+    model_key: String @key
+    technical_name: String?
+    name: String?
+    row_count: I64?
+}
+node SpotColumnNode {
+    model_key: String @key
+    technical_name: String?
+    name: String?
+    p_unique: F64?
+    p_distinct: F64?
+    p_missing: F64?
+    common_values: [String]?
+}
+edge SpotTableToCol: SpotTableNode -> SpotColumnNode
+
+--- seed
+{"type":"SpotTableNode","data":{"model_key":"tableSchema::tpcds_1.tpcds.store_returns","technical_name":"tpcds.store_returns","name":"Store Returns","row_count":288279}}
+{"type":"SpotColumnNode","data":{"model_key":"columnSchema::tpcds_1.tpcds.store_returns.sr_return_time_sk","technical_name":"sr_return_time_sk","name":"Return Time","p_unique":0.055061,"p_distinct":0.318826,"p_missing":0.0,"common_values":["33413","31810","54900","54638","45302"]}}
+
+--- mutate
+query stmt_7() {
+    insert SpotTableToCol { from: "tableSchema::tpcds_1.tpcds.store_returns", to: "columnSchema::tpcds_1.tpcds.store_returns.sr_return_time_sk" }
+}
+
+--- expect affected: nodes=0 edges=1

--- a/crates/omnigraph-gqt/cases/kuzu_issue_issue_5893.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_issue_issue_5893.gqt
@@ -1,0 +1,33 @@
+# issue: none
+# notes: kuzu test/test_files/issue/issue.test, -CASE 5893 (kuzudb/kuzu issue 5893),
+# notes: -DATASET CSV empty; the case builds its own schema and rows. SERIAL primary key
+# notes: `id` becomes `pk` assigned 0,1,2,3 in creation order. Two Account rows carry a
+# notes: null name; the cross-variable equality must not pair them, so only alice
+# notes: survives.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Account {
+    pk: I64 @key
+    service: String?
+    name: String?
+}
+
+--- seed
+{"type":"Account","data":{"pk":0,"service":"A","name":"alice"}}
+{"type":"Account","data":{"pk":1,"service":"A","name":null}}
+{"type":"Account","data":{"pk":2,"service":"B","name":null}}
+{"type":"Account","data":{"pk":3,"service":"B","name":"alice"}}
+
+--- query
+query stmt_6() {
+    match {
+        $a: Account { service: "A" }
+        $b: Account { service: "B" }
+        $a.name = $b.name
+    }
+    return { $a.name }
+}
+
+--- expect unordered
+{"a.name": "alice"}

--- a/crates/omnigraph-gqt/cases/kuzu_issue_issue_5954.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_issue_issue_5954.gqt
@@ -1,0 +1,83 @@
+# issue: none
+# notes: kuzu test/test_files/issue/issue.test, -CASE 5954 (github.com/kuzudb/kuzu issue
+# notes: 5954), -DATASET CSV empty; the case builds its own schema and rows. Node
+# notes: property `id` is spelled `pk` (engine system field). Rel tables REQUESTED_BY /
+# notes: TARGET become edge types RequestedBy / Target. The first CREATE is the seed;
+# notes: the MATCH+CREATE chain is one mutate step with four inserts. DETACH DELETE is
+# notes: spelled as a plain node delete; the engine cascades the incident edges and
+# notes: reports them in affected_edges, so `expect affected` is what pins the detach
+# notes: (`ok` would assert success only). Kuzu's two closing reads walk an untyped edge
+# notes: across both rel tables, which has no GQ spelling; they are split into two typed
+# notes: reads that assert the same facts: RequestedBy is empty and Target holds only R2
+# notes: -> D2, together equal to Kuzu's `COUNT(*) = 1` and `R2|D2`.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Device {
+    pk: String @key
+}
+node Execution {
+    pk: String @key
+}
+node Request {
+    pk: String @key
+}
+edge RequestedBy: Execution -> Request
+edge Target: Request -> Device
+
+--- seed
+{"type":"Execution","data":{"pk":"E1"}}
+{"type":"Request","data":{"pk":"R1"}}
+{"type":"Device","data":{"pk":"D1"}}
+{"edge":"RequestedBy","from":"E1","to":"R1","data":{}}
+{"edge":"Target","from":"R1","to":"D1","data":{}}
+
+--- mutate
+query stmt_7() {
+    insert Request { pk: "R2" }
+    insert Device { pk: "D2" }
+    insert RequestedBy { from: "E1", to: "R2" }
+    insert Target { from: "R2", to: "D2" }
+}
+
+--- expect affected: nodes=2 edges=2
+
+--- mutate
+query stmt_8() {
+    delete Request where pk = "R1"
+}
+
+--- expect affected: nodes=1 edges=2
+
+--- mutate
+query stmt_9() {
+    delete Execution where pk = "E1"
+}
+
+--- expect affected: nodes=1 edges=1
+
+--- query
+query stmt_10() {
+    match {
+        $e: Execution
+        $r: Request
+        $e requestedBy $r
+    }
+    return { count($r) as n }
+}
+
+--- expect unordered
+{"n": 0}
+
+--- query
+query stmt_11() {
+    match {
+        $r: Request
+        $d: Device
+        $r target $d
+    }
+    return { $r.pk, $d.pk }
+}
+
+--- expect unordered
+{"r.pk": "R2", "d.pk": "D2"}

--- a/crates/omnigraph-gqt/cases/kuzu_issue_issue_kindoffruit.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_issue_issue_kindoffruit.gqt
@@ -1,0 +1,44 @@
+# issue: none
+# notes: kuzu test/test_files/issue/issue.test, -CASE KindOfFruit, -DATASET CSV empty;
+# notes: the case builds its own schema and rows. Rel tables LIKES / KIND_OF become edge
+# notes: types Likes / KindOf. Only the middle statement is expressible: the other two
+# notes: use a recursive traversal, OR, and UNION. No T likes both Apple and Banana, so
+# notes: the result is empty.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node T {
+    name: String @key
+}
+node Fruit {
+    name: String @key
+}
+edge Likes: T -> Fruit
+edge KindOf: T -> T
+
+--- seed
+{"type":"T","data":{"name":"T1"}}
+{"type":"T","data":{"name":"T2"}}
+{"type":"T","data":{"name":"T3"}}
+{"type":"Fruit","data":{"name":"Banana"}}
+{"type":"Fruit","data":{"name":"Orange"}}
+{"type":"Fruit","data":{"name":"Apple"}}
+{"edge":"Likes","from":"T1","to":"Banana","data":{}}
+{"edge":"Likes","from":"T2","to":"Orange","data":{}}
+{"edge":"Likes","from":"T3","to":"Apple","data":{}}
+{"edge":"KindOf","from":"T1","to":"T2","data":{}}
+{"edge":"KindOf","from":"T2","to":"T3","data":{}}
+
+--- query
+query stmt_7() {
+    match {
+        $t: T
+        $f1: Fruit { name: "Apple" }
+        $f2: Fruit { name: "Banana" }
+        $t likes $f1
+        $t likes $f2
+    }
+    return { $t.name }
+}
+
+--- expect unordered

--- a/crates/omnigraph-gqt/cases/kuzu_match_four_hop.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_match_four_hop.gqt
@@ -1,0 +1,121 @@
+# issue: none
+# notes: kuzu test/test_files/match/four_hop.test, -CASE MatchFourHop, tinysnb seed.
+# notes: COUNT(*) is spelled count($a) as n; Kuzu edge variables are anonymous in GQ
+# notes: (never projected) and no edge type has parallel edges, so endpoint-pair
+# notes: semantics match Kuzu's counts.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query four_hop_knows_test() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $d: Person
+        $e: Person
+        $a knows $b
+        $b knows $c
+        $c knows $d
+        $d knows $e
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 324}
+
+--- query
+query four_hop_three_knows_one_study_at_test() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $d: Person
+        $e: Organisation
+        $a knows $b
+        $b knows $c
+        $c knows $d
+        $d studyAt $e
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 54}

--- a/crates/omnigraph-gqt/cases/kuzu_match_node.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_match_node.gqt
@@ -1,0 +1,104 @@
+# issue: none
+# notes: kuzu test/test_files/match/node.test, -CASE MatchNode, tinysnb seed. COUNT(*)
+# notes: is spelled count($a) as n. The unlabeled MATCH (a) over the whole schema has no
+# notes: GQ spelling and is absent here.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query node1() {
+    match {
+        $a: Person
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 8}
+
+--- query
+query node2() {
+    match {
+        $a: Organisation
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 3}

--- a/crates/omnigraph-gqt/cases/kuzu_match_one_hop.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_match_one_hop.gqt
@@ -1,0 +1,171 @@
+# issue: none
+# notes: kuzu test/test_files/match/one_hop.test, -CASE MatchOneHop, on the tinysnb
+# notes: seed. One query step per Kuzu -STATEMENT, in file order. Unbound traversals
+# notes: have set semantics on endpoint pairs in GQ; knows carries no parallel edges, so
+# notes: the counts agree with Kuzu. In one_hop_undirected_edge_projection: `RETURN e`
+# notes: is spelled as the edge's date and meetTime properties (a whole edge cannot be
+# notes: projected), the pass-through `WITH e` is dropped, and the unlabelled endpoints
+# notes: a and b are pinned to Person because knows is the only edge type that can bind
+# notes: them.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query one_hop_knows() {
+    match {
+        $a: Person
+        $b: Person
+        $a knows $b
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 14}
+
+--- query
+query one_hop_study_at() {
+    match {
+        $a: Person
+        $b: Organisation
+        $a studyAt $b
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 3}
+
+--- query
+query one_hop_work_at() {
+    match {
+        $a: Person
+        $b: Organisation
+        $a workAt $b
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 3}
+
+--- query
+query one_hop_cross_product() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $d: Person
+        $a knows $b
+        $c knows $d
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 196}
+
+--- query
+query one_hop_study_at_code() {
+    match {
+        $a: Person
+        $b: Organisation
+        $a $e1:studyAt $b
+    }
+    return { $e1.code }
+}
+
+--- expect unordered
+{"e1.code": 9223372036854775808}
+{"e1.code": 6689}
+{"e1.code": 23}
+
+--- query
+query one_hop_undirected_edge_projection() {
+    match {
+        $a: Person { pk:0 }
+        $b: Person { pk:2 }
+        $a $e:<knows> $b
+    }
+    return { $e.date, $e.meetTime }
+}
+
+--- expect unordered
+{"e.date": "2021-06-30", "e.meetTime": "1986-10-21T21:08:31.521Z"}
+{"e.date": "2021-06-30", "e.meetTime": "1946-08-25T19:07:22.000Z"}

--- a/crates/omnigraph-gqt/cases/kuzu_match_three_hop.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_match_three_hop.gqt
@@ -1,0 +1,169 @@
+# issue: none
+# notes: kuzu test/test_files/match/three_hop.test, -CASE MatchThreeHop, tinysnb seed.
+# notes: COUNT(*) is spelled count($a) as n; Kuzu edge variables are anonymous in GQ
+# notes: (never projected) and no edge type has parallel edges, so endpoint-pair
+# notes: semantics match Kuzu's counts. Left-pointing Kuzu arrows are written as
+# notes: reversed GQ clauses.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query three_hop_two_knows_one_work_at_test() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $d: Organisation
+        $a knows $b
+        $b knows $c
+        $c workAt $d
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 18}
+
+--- query
+query open_wedge_knows_test_3() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $d: Person
+        $a knows $b
+        $a knows $c
+        $a knows $d
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 116}
+
+--- query
+query three_hop_knows_test() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $d: Person
+        $a knows $b
+        $b knows $c
+        $c knows $d
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 108}
+
+--- query
+query three_hop_two_knows_one_study_at_test() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $d: Organisation
+        $a knows $b
+        $b knows $c
+        $c studyAt $d
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 18}
+
+--- query
+query open_wedge_knows_test_4() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $d: Person
+        $b knows $a
+        $c knows $a
+        $d knows $a
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 110}

--- a/crates/omnigraph-gqt/cases/kuzu_match_two_hop.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_match_two_hop.gqt
@@ -1,0 +1,234 @@
+# issue: none
+# notes: kuzu test/test_files/match/two_hop.test, -CASE MatchTwoHop, tinysnb seed.
+# notes: COUNT(*) is spelled count($a) as n; every Kuzu edge variable is anonymous in GQ
+# notes: because none is projected, and no edge type carries parallel edges, so
+# notes: endpoint-pair semantics match Kuzu's counts. A left-pointing Kuzu arrow is
+# notes: written as the reversed GQ clause.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query two_hop_knows_study_at_test() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Organisation
+        $a knows $b
+        $b studyAt $c
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 7}
+
+--- query
+query two_hop_knows_work_at_test() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Organisation
+        $a knows $b
+        $b workAt $c
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 6}
+
+--- query
+query open_wedge_knows_test_1() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $a knows $b
+        $a knows $c
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 40}
+
+--- query
+query open_wedge_work_at_test_1() {
+    match {
+        $a: Person
+        $b: Organisation
+        $c: Organisation
+        $a workAt $b
+        $a workAt $c
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 3}
+
+--- query
+query open_wedge_study_at_test() {
+    match {
+        $a: Person
+        $b: Organisation
+        $c: Organisation
+        $a studyAt $b
+        $a studyAt $c
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 3}
+
+--- query
+query two_hop_knows_test() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $a knows $b
+        $b knows $c
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 36}
+
+--- query
+query open_wedge_knows_study_at_test() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Organisation
+        $a knows $b
+        $a studyAt $c
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 6}
+
+--- query
+query open_wedge_knows_work_at_test() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Organisation
+        $a knows $b
+        $a workAt $c
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 8}
+
+--- query
+query open_wedge_knows_test_2() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $b knows $a
+        $c knows $a
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 38}
+
+--- query
+query open_wedge_work_at_test_2() {
+    match {
+        $a: Person
+        $b: Organisation
+        $c: Organisation
+        $a workAt $b
+        $a studyAt $c
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 0}

--- a/crates/omnigraph-gqt/cases/kuzu_match_undirected.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_match_undirected.gqt
@@ -1,0 +1,131 @@
+# issue: none
+# notes: kuzu test/test_files/match/undirected.test, -CASE MatchUndirected, tinysnb
+# notes: seed. Kuzu counts one row per incident edge even when the relationship is
+# notes: anonymous, so each undirected hop binds an edge variable ($e, $e1, $e2) to keep
+# notes: per-edge multiplicity instead of endpoint-pair set semantics. An edge binding
+# notes: may be projected or filtered by its properties and bound to keep per-edge
+# notes: multiplicity, but a bare edge binding cannot be an aggregate argument.
+# notes: Statements using struct_extract/id(), label disjunctions, untyped edges, or an
+# notes: undirected cross-type edge are absent here.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query undir_knows_1() {
+    match {
+        $a: Person
+        $b: Person
+        $a $e:<knows> $b
+        $b.fName = "Bob"
+    }
+    return { $a.fName }
+}
+
+--- expect unordered
+{"a.fName": "Alice"}
+{"a.fName": "Carol"}
+{"a.fName": "Dan"}
+{"a.fName": "Alice"}
+{"a.fName": "Carol"}
+{"a.fName": "Dan"}
+
+--- query
+query undir_knows_2() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $a $e1:<knows> $b
+        $b $e2:<knows> $c
+        $a.gender = 1
+        $b.gender = 2
+        $c.fName = "Bob"
+    }
+    return { $a.fName, $b.fName }
+}
+
+--- expect unordered
+{"a.fName": "Alice", "b.fName": "Dan"}
+{"a.fName": "Carol", "b.fName": "Dan"}
+{"a.fName": "Alice", "b.fName": "Dan"}
+{"a.fName": "Carol", "b.fName": "Dan"}
+{"a.fName": "Alice", "b.fName": "Dan"}
+{"a.fName": "Carol", "b.fName": "Dan"}
+{"a.fName": "Alice", "b.fName": "Dan"}
+{"a.fName": "Carol", "b.fName": "Dan"}

--- a/crates/omnigraph-gqt/cases/kuzu_order_by_single_label.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_order_by_single_label.gqt
@@ -1,0 +1,537 @@
+# issue: none
+# notes: kuzu test/test_files/order_by/single_label.test, -CASE OrderBySingleLabel,
+# notes: tinysnb seed. One query step per Kuzu -STATEMENT, in file order; `CALL
+# notes: threads=N` steps are runner knobs and are dropped. Statements over dropped
+# notes: columns (registerTime, lastJobDuration, hugedata, the movies node) or with
+# notes: arithmetic in ORDER BY are not translated. Anonymous Cypher endpoints get
+# notes: explicit bindings ($a/$b); `-CHECK_ORDER` plus an order clause and no aggregate
+# notes: → `--- expect ordered`.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query order_by_int16_test() {
+    match {
+        $a: Person
+        $b: Organisation
+        $a $e:studyAt $b
+    }
+    return { $e.length }
+    order { $e.length asc }
+}
+
+--- expect ordered
+{"e.length": 5}
+{"e.length": 22}
+{"e.length": 55}
+
+--- query
+query order_by_int8_test() {
+    match {
+        $a: Person
+        $b: Organisation
+        $a $e:studyAt $b
+    }
+    return { $e.level }
+    order { $e.level asc }
+}
+
+--- expect ordered
+{"e.level": 2}
+{"e.level": 5}
+{"e.level": 120}
+
+--- query
+query order_by_uint64_test() {
+    match {
+        $a: Person
+        $b: Organisation
+        $a $e:studyAt $b
+    }
+    return { $e.code }
+    order { $e.code asc }
+}
+
+--- expect ordered
+{"e.code": 23}
+{"e.code": 6689}
+{"e.code": 9223372036854775808}
+
+--- query
+query order_by_uint32_test() {
+    match {
+        $a: Person
+        $b: Organisation
+        $a $e:studyAt $b
+    }
+    return { $e.temperature }
+    order { $e.temperature asc }
+}
+
+--- expect ordered
+{"e.temperature": 1}
+{"e.temperature": 20}
+{"e.temperature": 32800}
+
+--- query
+query order_by_uint16_test() {
+    match {
+        $a: Person
+        $b: Organisation
+        $a $e:studyAt $b
+    }
+    return { $e.ulength }
+    order { $e.ulength asc }
+}
+
+--- expect ordered
+{"e.ulength": 90}
+{"e.ulength": 180}
+{"e.ulength": 33768}
+
+--- query
+query order_by_uint8_test() {
+    match {
+        $a: Person
+        $b: Organisation
+        $a $e:studyAt $b
+    }
+    return { $e.ulevel }
+    order { $e.ulevel asc }
+}
+
+--- expect ordered
+{"e.ulevel": 12}
+{"e.ulevel": 220}
+{"e.ulevel": 250}
+
+--- query
+query order_by_boolean_test() {
+    match {
+        $p: Person
+    }
+    return { $p.isStudent }
+    order { $p.isStudent desc }
+}
+
+--- expect ordered
+{"p.isStudent": true}
+{"p.isStudent": true}
+{"p.isStudent": true}
+{"p.isStudent": false}
+{"p.isStudent": false}
+{"p.isStudent": false}
+{"p.isStudent": false}
+{"p.isStudent": false}
+
+--- query
+query order_by_double_test() {
+    match {
+        $p: Person
+    }
+    return { $p.eyeSight }
+    order { $p.eyeSight asc }
+}
+
+--- expect ordered
+{"p.eyeSight": 4.5}
+{"p.eyeSight": 4.7}
+{"p.eyeSight": 4.8}
+{"p.eyeSight": 4.9}
+{"p.eyeSight": 4.9}
+{"p.eyeSight": 5.0}
+{"p.eyeSight": 5.0}
+{"p.eyeSight": 5.1}
+
+--- query
+query order_by_date_test() {
+    match {
+        $p: Person
+    }
+    return { $p.birthdate }
+    order { $p.birthdate desc }
+}
+
+--- expect ordered
+{"p.birthdate": "1990-11-27"}
+{"p.birthdate": "1980-10-26"}
+{"p.birthdate": "1980-10-26"}
+{"p.birthdate": "1980-10-26"}
+{"p.birthdate": "1950-07-23"}
+{"p.birthdate": "1940-06-22"}
+{"p.birthdate": "1900-01-01"}
+{"p.birthdate": "1900-01-01"}
+
+--- query
+query order_by_string_test() {
+    match {
+        $p: Person
+    }
+    return { $p.fName }
+    order { $p.fName desc }
+}
+
+--- expect ordered
+{"p.fName": "Hubert Blaine Wolfeschlegelsteinhausenbergerdorff"}
+{"p.fName": "Greg"}
+{"p.fName": "Farooq"}
+{"p.fName": "Elizabeth"}
+{"p.fName": "Dan"}
+{"p.fName": "Carol"}
+{"p.fName": "Bob"}
+{"p.fName": "Alice"}
+
+--- query
+query order_by_str_multiple_col_test() {
+    match {
+        $p: Person
+    }
+    return { $p.age, $p.eyeSight }
+    order { $p.isWorker desc, $p.age asc, $p.eyeSight desc }
+}
+
+--- expect ordered
+{"p.age": 20, "p.eyeSight": 4.8}
+{"p.age": 20, "p.eyeSight": 4.7}
+{"p.age": 45, "p.eyeSight": 5.0}
+{"p.age": 83, "p.eyeSight": 4.9}
+{"p.age": 25, "p.eyeSight": 4.5}
+{"p.age": 30, "p.eyeSight": 5.1}
+{"p.age": 35, "p.eyeSight": 5.0}
+{"p.age": 40, "p.eyeSight": 4.9}
+
+--- query
+query order_by_three_hop_test() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $d: Person
+        $a knows $b
+        $b knows $c
+        $c knows $d
+    }
+    return { $a.fName }
+    order { $d.age desc, $c.age asc, $b.age asc, $a.age desc }
+    limit 10
+}
+
+--- expect ordered
+{"a.fName": "Carol"}
+{"a.fName": "Alice"}
+{"a.fName": "Dan"}
+{"a.fName": "Carol"}
+{"a.fName": "Bob"}
+{"a.fName": "Dan"}
+{"a.fName": "Alice"}
+{"a.fName": "Bob"}
+{"a.fName": "Dan"}
+{"a.fName": "Carol"}
+
+--- query
+query order_by_scan_single_tuple_test() {
+    match {
+        $a: Person
+        $b: Person
+        $a knows $b
+    }
+    return { $a.fName }
+    order { $b.fName asc, $a.fName asc }
+}
+
+--- expect ordered
+{"a.fName": "Bob"}
+{"a.fName": "Carol"}
+{"a.fName": "Dan"}
+{"a.fName": "Alice"}
+{"a.fName": "Carol"}
+{"a.fName": "Dan"}
+{"a.fName": "Alice"}
+{"a.fName": "Bob"}
+{"a.fName": "Dan"}
+{"a.fName": "Alice"}
+{"a.fName": "Bob"}
+{"a.fName": "Carol"}
+{"a.fName": "Elizabeth"}
+{"a.fName": "Elizabeth"}
+
+--- query
+query order_by_empty_result() {
+    match {
+        $p: Person
+        $p.age > 100
+    }
+    return { $p.age }
+    order { $p.age asc }
+}
+
+--- expect unordered
+
+--- query
+query order_by_limit_empty_result() {
+    match {
+        $p: Person
+        $p.age > 100
+    }
+    return { $p.age }
+    order { $p.age asc }
+    limit 10
+}
+
+--- expect unordered
+
+--- query
+query order_by_aggregate_test1() {
+    match {
+        $a: Person
+        $b: Person
+        $a knows $b
+    }
+    return { $a.age, count($b) as c }
+    order { $a.age asc }
+}
+
+--- expect unordered
+{"a.age": 20, "c": 5}
+{"a.age": 30, "c": 3}
+{"a.age": 35, "c": 3}
+{"a.age": 45, "c": 3}
+
+--- query
+query order_by_flat_unflat() {
+    match {
+        $p: Person
+        $p1: Person
+        $p knows $p1
+    }
+    return { $p.pk, $p1.pk }
+    order { $p.pk asc, $p1.pk asc }
+    limit 13
+}
+
+--- expect ordered
+{"p.pk": 0, "p1.pk": 2}
+{"p.pk": 0, "p1.pk": 3}
+{"p.pk": 0, "p1.pk": 5}
+{"p.pk": 2, "p1.pk": 0}
+{"p.pk": 2, "p1.pk": 3}
+{"p.pk": 2, "p1.pk": 5}
+{"p.pk": 3, "p1.pk": 0}
+{"p.pk": 3, "p1.pk": 2}
+{"p.pk": 3, "p1.pk": 5}
+{"p.pk": 5, "p1.pk": 0}
+{"p.pk": 5, "p1.pk": 2}
+{"p.pk": 5, "p1.pk": 3}
+{"p.pk": 7, "p1.pk": 8}
+
+--- query
+query order_by_flat_unflat1() {
+    match {
+        $p: Person
+        $p1: Person
+        $p knows $p1
+    }
+    return { $p.pk, $p1.pk }
+    order { $p.pk asc, $p1.pk asc }
+}
+
+--- expect ordered
+{"p.pk": 0, "p1.pk": 2}
+{"p.pk": 0, "p1.pk": 3}
+{"p.pk": 0, "p1.pk": 5}
+{"p.pk": 2, "p1.pk": 0}
+{"p.pk": 2, "p1.pk": 3}
+{"p.pk": 2, "p1.pk": 5}
+{"p.pk": 3, "p1.pk": 0}
+{"p.pk": 3, "p1.pk": 2}
+{"p.pk": 3, "p1.pk": 5}
+{"p.pk": 5, "p1.pk": 0}
+{"p.pk": 5, "p1.pk": 2}
+{"p.pk": 5, "p1.pk": 3}
+{"p.pk": 7, "p1.pk": 8}
+{"p.pk": 7, "p1.pk": 9}
+
+--- query
+query top_k_int64_test() {
+    match {
+        $p: Person
+    }
+    return { $p.pk }
+    order { $p.pk desc }
+    limit 4
+}
+
+--- expect ordered
+{"p.pk": 10}
+{"p.pk": 9}
+{"p.pk": 8}
+{"p.pk": 7}
+
+--- query
+query top_k_int16_test() {
+    match {
+        $a: Person
+        $b: Organisation
+        $a $e:studyAt $b
+    }
+    return { $e.length }
+    order { $e.length asc }
+    limit 2
+}
+
+--- expect ordered
+{"e.length": 5}
+{"e.length": 22}
+
+--- query
+query top_k_int8_test() {
+    match {
+        $a: Person
+        $b: Organisation
+        $a $e:studyAt $b
+    }
+    return { $e.level }
+    order { $e.level asc }
+    limit 2
+}
+
+--- expect ordered
+{"e.level": 2}
+{"e.level": 5}
+
+--- query
+query top_k_uint64_test() {
+    match {
+        $a: Person
+        $b: Organisation
+        $a $e:studyAt $b
+    }
+    return { $e.code }
+    order { $e.code asc }
+    limit 1
+}
+
+--- expect ordered
+{"e.code": 23}
+
+--- query
+query top_k_uint32_test() {
+    match {
+        $a: Person
+        $b: Organisation
+        $a $e:studyAt $b
+    }
+    return { $e.temperature }
+    order { $e.temperature asc }
+    limit 1
+}
+
+--- expect ordered
+{"e.temperature": 1}
+
+--- query
+query top_k_uint16_test() {
+    match {
+        $a: Person
+        $b: Organisation
+        $a $e:studyAt $b
+    }
+    return { $e.ulength }
+    order { $e.ulength asc }
+    limit 1
+}
+
+--- expect ordered
+{"e.ulength": 90}
+
+--- query
+query top_k_uint8_test() {
+    match {
+        $a: Person
+        $b: Organisation
+        $a $e:studyAt $b
+    }
+    return { $e.ulevel }
+    order { $e.ulevel asc }
+    limit 2
+}
+
+--- expect ordered
+{"e.ulevel": 12}
+{"e.ulevel": 220}

--- a/crates/omnigraph-gqt/cases/kuzu_order_by_single_label__order_by_aggregate_test2.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_order_by_single_label__order_by_aggregate_test2.gqt
@@ -1,0 +1,101 @@
+# issue: none
+# notes: kuzu test/test_files/order_by/single_label.test, -CASE OrderBySingleLabel, -LOG
+# notes: OrderByAggregateTest2, tinysnb seed. Split out of
+# notes: kuzu_order_by_single_label.gqt because Kuzu's `ORDER BY COUNT(b)` has no direct
+# notes: spelling: the aggregate is aliased `n` in the return and the order clause names
+# notes: the alias. -CHECK_ORDER with an aggregate in the return uses `expect
+# notes: unordered`. The refusal of an aggregate written out inside `order { }` is
+# notes: pinned separately by order_clause_aggregate_refused.gqt.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query order_by_aggregate_test2() {
+    match {
+        $a: Person
+        $b: Person
+        $a knows $b
+    }
+    return { $a.gender, count($b) as n }
+    order { n desc }
+}
+
+--- expect unordered
+{"a.gender": 1, "n": 8}
+{"a.gender": 2, "n": 6}

--- a/crates/omnigraph-gqt/cases/kuzu_order_by_single_label__order_by_float_test.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_order_by_single_label__order_by_float_test.gqt
@@ -1,0 +1,103 @@
+# issue: none
+# notes: kuzu test/test_files/order_by/single_label.test, -CASE OrderBySingleLabel, -LOG
+# notes: OrderByFloatTest, tinysnb seed. Split out of kuzu_order_by_single_label.gqt.
+# notes: Red on purpose: F32 cells render as the scale-12 decimal expansion of the
+# notes: float32 (0.990000009537), so Kuzu's 0.990000 never matches; pending a fix of
+# notes: F32 rendering (the stored decimal, not its f64 widening).
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query order_by_float_test() {
+    match {
+        $p: Person
+    }
+    return { $p.height }
+    order { $p.height asc }
+}
+
+--- expect ordered
+{"p.height": 0.99}
+{"p.height": 1.0}
+{"p.height": 1.3}
+{"p.height": 1.323}
+{"p.height": 1.463}
+{"p.height": 1.51}
+{"p.height": 1.6}
+{"p.height": 1.731}

--- a/crates/omnigraph-gqt/cases/kuzu_projection_dupe_return_aliases.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_projection_dupe_return_aliases.gqt
@@ -1,0 +1,30 @@
+# issue: none
+# notes: kuzu test/test_files/projection/dupe_return.test, -CASE ReturnDupeAliases.
+# notes: -DATASET CSV empty, so the case carries its own schema+seed; SERIAL ID -> pk 0
+# notes: for the single CREATE. Kuzu returns two columns named `number` (`1|2`); a
+# notes: name-keyed row cannot carry `number` twice, so the expectation is the
+# notes: engine's refusal, not Kuzu's rows.
+# notes: Expectation rewritten to the engine's refusal by project decision
+# notes: (2026-09-04); Kuzu returns the rows 1|2 here.
+# notes: Red on purpose: waits on the duplicate-column refusal landing in the engine.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    pk: I64 @key
+    num1: I64?
+    num2: I64?
+}
+
+--- seed
+{"type":"A","data":{"pk":0,"num1":1,"num2":2}}
+
+--- query
+query return_dupe_aliases() {
+    match {
+        $a: A
+    }
+    return { $a.num1 as number, $a.num2 as number }
+}
+
+--- expect error: T25: result column `number` is produced by more than one projection

--- a/crates/omnigraph-gqt/cases/kuzu_projection_dupe_return_columns.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_projection_dupe_return_columns.gqt
@@ -1,0 +1,32 @@
+# issue: none
+# notes: kuzu test/test_files/projection/dupe_return.test, -CASE ReturnDupeColumnNames.
+# notes: -DATASET CSV empty, so the case carries its own schema+seed: CREATE NODE TABLE
+# notes: A(ID SERIAL, num INT64) -> node A { pk: I64 @key num: I64? } with SERIAL pk 0
+# notes: for the single CREATE. `MATCH (a)` over a one-table schema binds A. Kuzu
+# notes: returns two columns named `a.num`; a name-keyed row cannot carry `a.num`
+# notes: twice, so the expectation is the engine's refusal, not Kuzu's rows. Its
+# notes: sibling kuzu_projection_dupe_return_aliases is the aliased form of the same
+# notes: refusal.
+# notes: Expectation rewritten to the engine's refusal by project decision
+# notes: (2026-09-04); Kuzu returns the rows 1|1 here.
+# notes: Red on purpose: waits on the duplicate-column refusal landing in the engine.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    pk: I64 @key
+    num: I64?
+}
+
+--- seed
+{"type":"A","data":{"pk":0,"num":1}}
+
+--- query
+query return_dupe_column_names() {
+    match {
+        $a: A
+    }
+    return { $a.num, $a.num }
+}
+
+--- expect error: T25: result column `a.num` is produced by more than one projection

--- a/crates/omnigraph-gqt/cases/kuzu_projection_single_label.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_projection_single_label.gqt
@@ -1,0 +1,400 @@
+# issue: none
+# notes: kuzu test/test_files/projection/single_label.test, -CASE ProjectionSingleLabel,
+# notes: tinysnb seed. One query step per convertible Kuzu -STATEMENT, in file order.
+# notes: Statements with struct/map/uuid/union literals, arithmetic, a bare RETURN with
+# notes: no MATCH, star projections, internal ids, or a dropped column (registerTime,
+# notes: courseScoresPerTerm, grades, hugedata, the movies / meets / marries tables) are
+# notes: not translated. `COUNT(3)` over a matched row set is spelled `count($a)`;
+# notes: anonymous Cypher endpoints get explicit bindings.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query return_agg_on_const() {
+    match {
+        $a: Person
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 8}
+
+--- query
+query return_column_with_same_expression() {
+    match {
+        $a: Person
+        $a.fName = "Alice"
+    }
+    return { $a.age, $a.age as k }
+}
+
+--- expect unordered
+{"a.age": 35, "k": 35}
+
+--- query
+query person_nodes_test_string() {
+    match {
+        $a: Person
+    }
+    return { $a.fName }
+}
+
+--- expect unordered
+{"a.fName": "Alice"}
+{"a.fName": "Bob"}
+{"a.fName": "Carol"}
+{"a.fName": "Dan"}
+{"a.fName": "Elizabeth"}
+{"a.fName": "Farooq"}
+{"a.fName": "Greg"}
+{"a.fName": "Hubert Blaine Wolfeschlegelsteinhausenbergerdorff"}
+
+--- query
+query person_nodes_test_int() {
+    match {
+        $a: Person
+    }
+    return { $a.age }
+}
+
+--- expect unordered
+{"a.age": 35}
+{"a.age": 30}
+{"a.age": 45}
+{"a.age": 20}
+{"a.age": 20}
+{"a.age": 25}
+{"a.age": 40}
+{"a.age": 83}
+
+--- query
+query person_nodes_test_boolean() {
+    match {
+        $a: Person
+    }
+    return { $a.isStudent }
+}
+
+--- expect unordered
+{"a.isStudent": true}
+{"a.isStudent": true}
+{"a.isStudent": false}
+{"a.isStudent": false}
+{"a.isStudent": false}
+{"a.isStudent": true}
+{"a.isStudent": false}
+{"a.isStudent": false}
+
+--- query
+query person_nodes_test_double() {
+    match {
+        $a: Person
+    }
+    return { $a.eyeSight }
+}
+
+--- expect unordered
+{"a.eyeSight": 5.0}
+{"a.eyeSight": 5.1}
+{"a.eyeSight": 5.0}
+{"a.eyeSight": 4.8}
+{"a.eyeSight": 4.7}
+{"a.eyeSight": 4.5}
+{"a.eyeSight": 4.9}
+{"a.eyeSight": 4.9}
+
+--- query
+query person_nodes_test_date() {
+    match {
+        $a: Person
+    }
+    return { $a.birthdate }
+}
+
+--- expect unordered
+{"a.birthdate": "1900-01-01"}
+{"a.birthdate": "1900-01-01"}
+{"a.birthdate": "1940-06-22"}
+{"a.birthdate": "1950-07-23"}
+{"a.birthdate": "1980-10-26"}
+{"a.birthdate": "1980-10-26"}
+{"a.birthdate": "1980-10-26"}
+{"a.birthdate": "1990-11-27"}
+
+--- query
+query person_nodes_test_list() {
+    match {
+        $a: Person
+    }
+    return { $a.workedHours, $a.usedNames }
+}
+
+--- expect unordered
+{"a.workedHours": [10, 5], "a.usedNames": ["Aida"]}
+{"a.workedHours": [12, 8], "a.usedNames": ["Bobby"]}
+{"a.workedHours": [4, 5], "a.usedNames": ["Carmen", "Fred"]}
+{"a.workedHours": [1, 9], "a.usedNames": ["Wolfeschlegelstein", "Daniel"]}
+{"a.workedHours": [2], "a.usedNames": ["Ein"]}
+{"a.workedHours": [3, 4, 5, 6, 7], "a.usedNames": ["Fesdwe"]}
+{"a.workedHours": [1], "a.usedNames": ["Grad"]}
+{"a.workedHours": [10, 11, 12, 3, 4, 5, 6, 7], "a.usedNames": ["Ad", "De", "Hi", "Kye", "Orlan"]}
+
+--- query
+query knows_one_hop_test1() {
+    match {
+        $a: Person
+        $b: Person
+        $a knows $b
+        $b.age = 20
+    }
+    return { $b.age }
+}
+
+--- expect unordered
+{"b.age": 20}
+{"b.age": 20}
+{"b.age": 20}
+
+--- query
+query knows_two_hop_test1() {
+    match {
+        $a: Person
+        $m: Person
+        $b: Person
+        $a knows $m
+        $m knows $b
+        $b.age > 40
+    }
+    return { $b.age }
+}
+
+--- expect unordered
+{"b.age": 45}
+{"b.age": 45}
+{"b.age": 45}
+{"b.age": 45}
+{"b.age": 45}
+{"b.age": 45}
+{"b.age": 45}
+{"b.age": 45}
+{"b.age": 45}
+
+--- query
+query knows_rel_test_date() {
+    match {
+        $a: Person
+        $b: Person
+        $a $e:knows $b
+    }
+    return { $e.date }
+}
+
+--- expect unordered
+{"e.date": "2021-06-30"}
+{"e.date": "2021-06-30"}
+{"e.date": "2021-06-30"}
+{"e.date": "2021-06-30"}
+{"e.date": "1950-05-14"}
+{"e.date": "1950-05-14"}
+{"e.date": "2021-06-30"}
+{"e.date": "1950-05-14"}
+{"e.date": "2000-01-01"}
+{"e.date": "2021-06-30"}
+{"e.date": "1950-05-14"}
+{"e.date": "2000-01-01"}
+{"e.date": "1905-12-12"}
+{"e.date": "1905-12-12"}
+
+--- query
+query knows_one_hop_test3() {
+    match {
+        $a: Person
+        $b: Person
+        $a knows $b
+        $a.age > 20
+    }
+    return { $b.fName }
+}
+
+--- expect unordered
+{"b.fName": "Alice"}
+{"b.fName": "Alice"}
+{"b.fName": "Bob"}
+{"b.fName": "Bob"}
+{"b.fName": "Carol"}
+{"b.fName": "Carol"}
+{"b.fName": "Dan"}
+{"b.fName": "Dan"}
+{"b.fName": "Dan"}
+
+--- query
+query knows_two_hop_test4() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $a knows $b
+        $b knows $c
+    }
+    return { $a.fName, $b.fName }
+}
+
+--- expect unordered
+{"a.fName": "Alice", "b.fName": "Bob"}
+{"a.fName": "Alice", "b.fName": "Bob"}
+{"a.fName": "Alice", "b.fName": "Bob"}
+{"a.fName": "Alice", "b.fName": "Carol"}
+{"a.fName": "Alice", "b.fName": "Carol"}
+{"a.fName": "Alice", "b.fName": "Carol"}
+{"a.fName": "Alice", "b.fName": "Dan"}
+{"a.fName": "Alice", "b.fName": "Dan"}
+{"a.fName": "Alice", "b.fName": "Dan"}
+{"a.fName": "Bob", "b.fName": "Alice"}
+{"a.fName": "Bob", "b.fName": "Alice"}
+{"a.fName": "Bob", "b.fName": "Alice"}
+{"a.fName": "Bob", "b.fName": "Carol"}
+{"a.fName": "Bob", "b.fName": "Carol"}
+{"a.fName": "Bob", "b.fName": "Carol"}
+{"a.fName": "Bob", "b.fName": "Dan"}
+{"a.fName": "Bob", "b.fName": "Dan"}
+{"a.fName": "Bob", "b.fName": "Dan"}
+{"a.fName": "Carol", "b.fName": "Alice"}
+{"a.fName": "Carol", "b.fName": "Alice"}
+{"a.fName": "Carol", "b.fName": "Alice"}
+{"a.fName": "Carol", "b.fName": "Bob"}
+{"a.fName": "Carol", "b.fName": "Bob"}
+{"a.fName": "Carol", "b.fName": "Bob"}
+{"a.fName": "Carol", "b.fName": "Dan"}
+{"a.fName": "Carol", "b.fName": "Dan"}
+{"a.fName": "Carol", "b.fName": "Dan"}
+{"a.fName": "Dan", "b.fName": "Alice"}
+{"a.fName": "Dan", "b.fName": "Alice"}
+{"a.fName": "Dan", "b.fName": "Alice"}
+{"a.fName": "Dan", "b.fName": "Bob"}
+{"a.fName": "Dan", "b.fName": "Bob"}
+{"a.fName": "Dan", "b.fName": "Bob"}
+{"a.fName": "Dan", "b.fName": "Carol"}
+{"a.fName": "Dan", "b.fName": "Carol"}
+{"a.fName": "Dan", "b.fName": "Carol"}
+
+--- query
+query study_at_property_projection_test() {
+    match {
+        $a: Person
+        $b: Organisation
+        $a $e:studyAt $b
+    }
+    return { $e.year, $e.level, $e.code, $e.temperature, $e.ulength }
+}
+
+--- expect unordered
+{"e.year": 2020, "e.level": 120, "e.code": 6689, "e.temperature": 1, "e.ulength": 90}
+{"e.year": 2020, "e.level": 2, "e.code": 23, "e.temperature": 20, "e.ulength": 180}
+{"e.year": 2021, "e.level": 5, "e.code": 9223372036854775808, "e.temperature": 32800, "e.ulength": 33768}
+
+--- query
+query return_array_rel_prop() {
+    match {
+        $a: Person
+        $o: Organisation
+        $a $e:workAt $o
+    }
+    return { $e.grading }
+}
+
+--- expect unordered
+{"e.grading": [2.1, 4.4]}
+{"e.grading": [3.8, 2.5]}
+{"e.grading": [9.2, 3.1]}
+
+--- query
+query return_int16_node_prop() {
+    match {
+        $a: Person
+        $b: Organisation
+        $a $e:studyAt $b
+    }
+    return { $e.length }
+}
+
+--- expect unordered
+{"e.length": 5}
+{"e.length": 55}
+{"e.length": 22}

--- a/crates/omnigraph-gqt/cases/kuzu_projection_single_label__return_float_node_prop.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_projection_single_label__return_float_node_prop.gqt
@@ -1,0 +1,103 @@
+# issue: none
+# notes: kuzu test/test_files/projection/single_label.test, -CASE ProjectionSingleLabel,
+# notes: -LOG ReturnFloatNodeProp, tinysnb seed. Split out of
+# notes: kuzu_projection_single_label.gqt.
+# notes: Red on purpose: F32 cells render as the scale-12 decimal expansion of the
+# notes: float32 (0.990000009537), so Kuzu's 0.990000 never matches; pending a fix of
+# notes: F32 rendering (the stored decimal, not its f64 widening).
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query return_float_node_prop() {
+    match {
+        $a: Person
+    }
+    return { $a.height }
+}
+
+--- expect unordered
+{"a.height": 1.731}
+{"a.height": 0.99}
+{"a.height": 1.0}
+{"a.height": 1.3}
+{"a.height": 1.463}
+{"a.height": 1.51}
+{"a.height": 1.6}
+{"a.height": 1.323}

--- a/crates/omnigraph-gqt/cases/kuzu_projection_single_label__return_float_rel_prop.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_projection_single_label__return_float_rel_prop.gqt
@@ -1,0 +1,101 @@
+# issue: none
+# notes: kuzu test/test_files/projection/single_label.test, -CASE ProjectionSingleLabel,
+# notes: -LOG ReturnFloatRelProp, tinysnb seed. Split out of
+# notes: kuzu_projection_single_label.gqt.
+# notes: Red on purpose: the F32 edge column WorkAt.rating renders as the scale-12
+# notes: decimal expansion of the float32 (8.199999809265), so Kuzu's 8.200000 never
+# notes: matches; pending a fix of F32 rendering (the stored decimal, not its f64
+# notes: widening).
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query return_float_rel_prop() {
+    match {
+        $a: Person
+        $o: Organisation
+        $a $e:workAt $o
+    }
+    return { $e.rating }
+}
+
+--- expect unordered
+{"e.rating": 8.2}
+{"e.rating": 7.6}
+{"e.rating": 9.2}

--- a/crates/omnigraph-gqt/cases/kuzu_projection_skip_limit.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_projection_skip_limit.gqt
@@ -1,0 +1,157 @@
+# issue: none
+# notes: kuzu test/test_files/projection/skip_limit.test, -CASE ProjectionSkipLimit,
+# notes: tinysnb seed. Every SKIP / WITH / UNWIND / arithmetic-limit statement is not
+# notes: translated; only the plain LIMIT statements are converted. `ORDER BY k` over an
+# notes: alias is spelled as the underlying property; no -CHECK_ORDER means `--- expect
+# notes: unordered`. Kuzu's plain LIMIT statements carry no ORDER BY, so which rows
+# notes: survive the cut is scan order, not semantics. Each such step here adds an order
+# notes: clause whose first N rows are exactly Kuzu's rows, so the pin no longer depends
+# notes: on storage order: `order { $a.pk asc }` in basic_limit_test1 (pk 0 Alice, 2
+# notes: Bob) and in limit_array_rel_prop (WorkAt sources 3, 5, 7).
+# notes: knows_two_hop_limit_test keeps Kuzu's `ORDER BY k` and adds `$m.pk asc` to
+# notes: break the three-way tie on k = "Alice" at the limit boundary.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query basic_limit_test1() {
+    match {
+        $a: Person
+    }
+    return { $a.fName }
+    order { $a.pk asc }
+    limit 2
+}
+
+--- expect unordered
+{"a.fName": "Alice"}
+{"a.fName": "Bob"}
+
+--- query
+query basic_limit_test2() {
+    match {
+        $a: Person
+    }
+    return { $a.fName }
+    limit 10
+}
+
+--- expect unordered
+{"a.fName": "Alice"}
+{"a.fName": "Bob"}
+{"a.fName": "Carol"}
+{"a.fName": "Dan"}
+{"a.fName": "Elizabeth"}
+{"a.fName": "Farooq"}
+{"a.fName": "Greg"}
+{"a.fName": "Hubert Blaine Wolfeschlegelsteinhausenbergerdorff"}
+
+--- query
+query knows_two_hop_limit_test() {
+    match {
+        $a: Person
+        $m: Person
+        $b: Person
+        $a knows $m
+        $m knows $b
+        $a.age = 35
+    }
+    return { $b.fName as k }
+    order { $b.fName asc, $m.pk asc }
+    limit 1
+}
+
+--- expect unordered
+{"k": "Alice"}
+
+--- query
+query limit_array_rel_prop() {
+    match {
+        $a: Person
+        $o: Organisation
+        $a $e:workAt $o
+    }
+    return { $e.grading }
+    order { $a.pk asc }
+    limit 2
+}
+
+--- expect unordered
+{"e.grading": [2.1, 4.4]}
+{"e.grading": [3.8, 2.5]}

--- a/crates/omnigraph-gqt/cases/kuzu_recursive_join_n_n.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_recursive_join_n_n.gqt
@@ -1,0 +1,102 @@
+# issue: none
+# notes: kuzu test/test_files/recursive_join/n_n.test, -CASE VarLengthExtendNNTests,
+# notes: tinysnb seed. -[:knows*m..n]-> becomes $a knows{m,n} $b. Kuzu counts WALKS; GQ
+# notes: bounds are shortest-path distance per endpoint pair (set semantics). The
+# notes: statements that diverged were split into their own files and, by project
+# notes: decision (2026-09-04), now pin GQ's distance semantics; each such header names
+# notes: the Kuzu value it replaced. Statements using path variables, rels(e)/nodes(e),
+# notes: recursive-rel property filters, lambdas, OPTIONAL MATCH or WITH are
+# notes: unexpressible.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query knows_one_to_two_hop_with_filter_test() {
+    match {
+        $a: Person
+        $b: Person
+        $a knows{1,2} $b
+        $a.pk = 7
+    }
+    return { $b.fName }
+}
+
+--- expect unordered
+{"b.fName": "Farooq"}
+{"b.fName": "Greg"}

--- a/crates/omnigraph-gqt/cases/kuzu_recursive_join_n_n__knows_knows2_to4_hop_test.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_recursive_join_n_n__knows_knows2_to4_hop_test.gqt
@@ -1,0 +1,101 @@
+# issue: none
+# notes: kuzu test/test_files/recursive_join/n_n.test, -CASE VarLengthExtendNNTests,
+# notes: -LOG KnowsKnows2To4HopTest, tinysnb seed. Split out of
+# notes: kuzu_recursive_join_n_n.gqt because GQ's answer diverges from Kuzu's walk
+# notes: semantics: Kuzu counts 1404 walks (one hop then 2..4 more), GQ's knows{2,4} is
+# notes: shortest-path distance per endpoint pair. Expectation rewritten to GQ's
+# notes: shortest-path-distance semantics by project decision (2026-09-04); Kuzu's walk
+# notes: semantics expect 1404 here.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query knows_knows2_to4_hop_test() {
+    match {
+        $a: Person
+        $b: Person
+        $c: Person
+        $a knows $b
+        $b knows{2,4} $c
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 0}

--- a/crates/omnigraph-gqt/cases/kuzu_recursive_join_n_n__knows_long_path_test.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_recursive_join_n_n__knows_long_path_test.gqt
@@ -1,0 +1,99 @@
+# issue: none
+# notes: kuzu test/test_files/recursive_join/n_n.test, -CASE VarLengthExtendNNTests,
+# notes: -LOG KnowsLongPathTest, tinysnb seed. Split out of kuzu_recursive_join_n_n.gqt
+# notes: because GQ's answer diverges from Kuzu's walk semantics: Kuzu counts 1049760
+# notes: walks of length 8..11, GQ's knows{8,11} is shortest-path distance per endpoint
+# notes: pair and no pair is 8 hops apart. Expectation rewritten to GQ's
+# notes: shortest-path-distance semantics by project decision (2026-09-04); Kuzu's walk
+# notes: semantics expect 1049760 here.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query knows_long_path_test() {
+    match {
+        $a: Person
+        $b: Person
+        $a knows{8,11} $b
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 0}

--- a/crates/omnigraph-gqt/cases/kuzu_recursive_join_n_n__knows_three_hop_min_len_equals_max_len.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_recursive_join_n_n__knows_three_hop_min_len_equals_max_len.gqt
@@ -1,0 +1,99 @@
+# issue: none
+# notes: kuzu test/test_files/recursive_join/n_n.test, -CASE VarLengthExtendNNTests,
+# notes: -LOG KnowsThreeHopMinLenEqualsMaxLen, tinysnb seed. Split out of
+# notes: kuzu_recursive_join_n_n.gqt because GQ's answer diverges from Kuzu's walk
+# notes: semantics: Kuzu counts 108 walks of length exactly 3, GQ's knows{3,3} is
+# notes: shortest-path distance per endpoint pair. Expectation rewritten to GQ's
+# notes: shortest-path-distance semantics by project decision (2026-09-04); Kuzu's walk
+# notes: semantics expect 108 here.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query knows_three_hop_min_len_equals_max_len() {
+    match {
+        $a: Person
+        $b: Person
+        $a knows{3,3} $b
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 0}

--- a/crates/omnigraph-gqt/cases/kuzu_recursive_join_n_n__self_loop_1.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_recursive_join_n_n__self_loop_1.gqt
@@ -1,0 +1,99 @@
+# issue: none
+# notes: kuzu test/test_files/recursive_join/n_n.test, -CASE VarLengthExtendNNTests,
+# notes: -LOG SelfLoop statement 1, tinysnb seed. Split out of
+# notes: kuzu_recursive_join_n_n.gqt because GQ's answer diverges from Kuzu's walk
+# notes: semantics: Kuzu counts 9 walks that leave Alice and return within 1..3 hops;
+# notes: GQ's knows{1,3} with the same variable at both ends yields nothing. Expectation
+# notes: rewritten to GQ's shortest-path-distance semantics by project decision
+# notes: (2026-09-04); Kuzu's walk semantics expect 9 here.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query self_loop_1() {
+    match {
+        $a: Person
+        $a knows{1,3} $a
+        $a.fName = "Alice"
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 0}

--- a/crates/omnigraph-gqt/cases/kuzu_recursive_join_range_literal_single_upper_bound.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_recursive_join_range_literal_single_upper_bound.gqt
@@ -1,0 +1,102 @@
+# issue: none
+# notes: kuzu test/test_files/recursive_join/range_literal.test, -CASE SingleUpperBound,
+# notes: tinysnb seed. Kuzu *..n means 1..n, so knows*..2 -> knows{1,2} and knows*..1 ->
+# notes: knows{1,1}. Kuzu counts WALKS while GQ bounds are shortest-path distance per
+# notes: endpoint pair; the one statement that diverged was split out and, by project
+# notes: decision (2026-09-04), now pins GQ's distance semantics. Every other statement
+# notes: in the case walks the `meets` edge, which the tinysnb seed drops, or uses an
+# notes: open upper bound.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query stmt_2() {
+    match {
+        $a: Person
+        $b: Person
+        $a knows{1,1} $b
+        $a.fName = "Alice"
+    }
+    return { $b.fName }
+}
+
+--- expect unordered
+{"b.fName": "Bob"}
+{"b.fName": "Carol"}
+{"b.fName": "Dan"}

--- a/crates/omnigraph-gqt/cases/kuzu_recursive_join_range_literal_single_upper_bound__stmt_1.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_recursive_join_range_literal_single_upper_bound__stmt_1.gqt
@@ -1,0 +1,100 @@
+# issue: none
+# notes: kuzu test/test_files/recursive_join/range_literal.test, -CASE SingleUpperBound,
+# notes: statement 1, tinysnb seed. Split out of
+# notes: kuzu_recursive_join_range_literal_single_upper_bound.gqt because GQ's answer
+# notes: diverges from Kuzu's walk semantics: Kuzu counts 12 walks of length 1..2 out of
+# notes: Alice, GQ's knows{1,2} is shortest-path distance per endpoint pair. Expectation
+# notes: rewritten to GQ's shortest-path-distance semantics by project decision
+# notes: (2026-09-04); Kuzu's walk semantics expect 12 here.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query stmt_1() {
+    match {
+        $a: Person
+        $b: Person
+        $a knows{1,2} $b
+        $a.fName = "Alice"
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 3}

--- a/crates/omnigraph-gqt/cases/kuzu_recursive_join_semantic_empty_three_cycle.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_recursive_join_semantic_empty_three_cycle.gqt
@@ -1,0 +1,66 @@
+# issue: none
+# notes: kuzu test/test_files/recursive_join/semantic_empty.test, -CASE ThreeCycle.
+# notes: -DATASET CSV EMPTY plus in-case DDL, so the schema and rows are inline: node N
+# notes: with pk 0,1,2 in creation order, edge R: N -> N, and CREATE
+# notes: (a)-[]->(b),(b)-[]->(c),(c)-[]->(a) -> the three edge rows. a.ID -> $a.pk.
+# notes: Statements 6, 8 and 9 live in __stmt_6, __stmt_8 and __stmt_9, split into their
+# notes: own files because their expectation diverges from Kuzu's walk semantics (Kuzu
+# notes: counts walks, GQ bounds are shortest-path distance). The TRAIL and ACYCLIC
+# notes: statements have no GQ spelling.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node N {
+    pk: I64 @key
+}
+edge R: N -> N
+
+--- seed
+{"type":"N","data":{"pk":0}}
+{"type":"N","data":{"pk":1}}
+{"type":"N","data":{"pk":2}}
+{"edge":"R","from":"0","to":"1"}
+{"edge":"R","from":"1","to":"2"}
+{"edge":"R","from":"2","to":"0"}
+
+--- query
+query stmt_4() {
+    match {
+        $a: N
+        $b: N
+        $a r{1,1} $b
+        $a.pk = 0
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 1}
+
+--- query
+query stmt_5() {
+    match {
+        $a: N
+        $b: N
+        $a r{1,2} $b
+        $a.pk = 0
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 2}
+
+--- query
+query stmt_7() {
+    match {
+        $a: N
+        $b: N
+        $a r{2,2} $b
+        $a.pk = 0
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 1}

--- a/crates/omnigraph-gqt/cases/kuzu_recursive_join_semantic_empty_three_cycle__stmt_6.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_recursive_join_semantic_empty_three_cycle__stmt_6.gqt
@@ -1,0 +1,37 @@
+# issue: none
+# notes: kuzu recursive_join/semantic_empty.test, -CASE ThreeCycle, statement 6. Split
+# notes: out of kuzu_recursive_join_semantic_empty_three_cycle.gqt because GQ's answer
+# notes: diverges from Kuzu's walk semantics: Kuzu counts 3 walks of length 1..3 out of
+# notes: node 0, the third closing the cycle back to node 0; GQ's r{1,3} is
+# notes: shortest-path distance per endpoint pair and does not return the source.
+# notes: expectation rewritten to GQ's shortest-path-distance semantics by project
+# notes: decision (2026-09-04); Kuzu's walk semantics expect 3 here.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node N {
+    pk: I64 @key
+}
+edge R: N -> N
+
+--- seed
+{"type":"N","data":{"pk":0}}
+{"type":"N","data":{"pk":1}}
+{"type":"N","data":{"pk":2}}
+{"edge":"R","from":"0","to":"1"}
+{"edge":"R","from":"1","to":"2"}
+{"edge":"R","from":"2","to":"0"}
+
+--- query
+query stmt_6() {
+    match {
+        $a: N
+        $b: N
+        $a r{1,3} $b
+        $a.pk = 0
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 2}

--- a/crates/omnigraph-gqt/cases/kuzu_recursive_join_semantic_empty_three_cycle__stmt_8.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_recursive_join_semantic_empty_three_cycle__stmt_8.gqt
@@ -1,0 +1,37 @@
+# issue: none
+# notes: kuzu recursive_join/semantic_empty.test, -CASE ThreeCycle, statement 8. Split
+# notes: out of kuzu_recursive_join_semantic_empty_three_cycle.gqt because GQ's answer
+# notes: diverges from Kuzu's walk semantics: Kuzu counts 2 walks of length 2..3 out of
+# notes: node 0, the longer one closing the cycle; GQ's r{2,3} is shortest-path distance
+# notes: per endpoint pair and does not return the source. Expectation rewritten to GQ's
+# notes: shortest-path-distance semantics by project decision (2026-09-04); Kuzu's walk
+# notes: semantics expect 2 here.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node N {
+    pk: I64 @key
+}
+edge R: N -> N
+
+--- seed
+{"type":"N","data":{"pk":0}}
+{"type":"N","data":{"pk":1}}
+{"type":"N","data":{"pk":2}}
+{"edge":"R","from":"0","to":"1"}
+{"edge":"R","from":"1","to":"2"}
+{"edge":"R","from":"2","to":"0"}
+
+--- query
+query stmt_8() {
+    match {
+        $a: N
+        $b: N
+        $a r{2,3} $b
+        $a.pk = 0
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 1}

--- a/crates/omnigraph-gqt/cases/kuzu_recursive_join_semantic_empty_three_cycle__stmt_9.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_recursive_join_semantic_empty_three_cycle__stmt_9.gqt
@@ -1,0 +1,37 @@
+# issue: none
+# notes: kuzu recursive_join/semantic_empty.test, -CASE ThreeCycle, statement 9. Split
+# notes: out of kuzu_recursive_join_semantic_empty_three_cycle.gqt because GQ's answer
+# notes: diverges from Kuzu's walk semantics: Kuzu counts the one walk 0 -> 1 -> 2 -> 0;
+# notes: GQ's r{3,3} asks for a pair whose shortest distance is exactly 3 and the source
+# notes: is not a destination of itself. Expectation rewritten to GQ's
+# notes: shortest-path-distance semantics by project decision (2026-09-04); Kuzu's walk
+# notes: semantics expect 1 here.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node N {
+    pk: I64 @key
+}
+edge R: N -> N
+
+--- seed
+{"type":"N","data":{"pk":0}}
+{"type":"N","data":{"pk":1}}
+{"type":"N","data":{"pk":2}}
+{"edge":"R","from":"0","to":"1"}
+{"edge":"R","from":"1","to":"2"}
+{"edge":"R","from":"2","to":"0"}
+
+--- query
+query stmt_9() {
+    match {
+        $a: N
+        $b: N
+        $a r{3,3} $b
+        $a.pk = 0
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 0}

--- a/crates/omnigraph-gqt/cases/kuzu_recursive_join_semantic_empty_two_cycle.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_recursive_join_semantic_empty_two_cycle.gqt
@@ -1,0 +1,37 @@
+# issue: none
+# notes: kuzu test/test_files/recursive_join/semantic_empty.test, -CASE TwoCycle.
+# notes: -DATASET CSV EMPTY plus in-case DDL, so the schema and rows are inline: CREATE
+# notes: NODE TABLE N(id SERIAL, PRIMARY KEY(id)) -> node N with pk assigned 0,1 in
+# notes: creation order, CREATE REL TABLE R(FROM N TO N) -> edge R, and CREATE
+# notes: (a)-[e]->(b),(b)-[]->(a) -> the two edge rows. a.ID -> $a.pk. Statements 5-9
+# notes: live in __stmt_5 .. __stmt_9, split into their own files because their
+# notes: expectation diverges from Kuzu's walk semantics (Kuzu counts walks, GQ bounds
+# notes: are shortest-path distance). The TRAIL and ACYCLIC statements have no GQ
+# notes: spelling.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node N {
+    pk: I64 @key
+}
+edge R: N -> N
+
+--- seed
+{"type":"N","data":{"pk":0}}
+{"type":"N","data":{"pk":1}}
+{"edge":"R","from":"0","to":"1"}
+{"edge":"R","from":"1","to":"0"}
+
+--- query
+query stmt_4() {
+    match {
+        $a: N
+        $b: N
+        $a r{1,1} $b
+        $a.pk = 0
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 1}

--- a/crates/omnigraph-gqt/cases/kuzu_recursive_join_semantic_empty_two_cycle__stmt_5.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_recursive_join_semantic_empty_two_cycle__stmt_5.gqt
@@ -1,0 +1,35 @@
+# issue: none
+# notes: kuzu recursive_join/semantic_empty.test, -CASE TwoCycle, statement 5. Split out
+# notes: of kuzu_recursive_join_semantic_empty_two_cycle.gqt because GQ's answer
+# notes: diverges from Kuzu's walk semantics: Kuzu counts 2 walks of length 1..2 out of
+# notes: node 0 (the second returns to node 0), GQ's r{1,2} is shortest-path distance
+# notes: per endpoint pair and does not return the source. Expectation rewritten to GQ's
+# notes: shortest-path-distance semantics by project decision (2026-09-04); Kuzu's walk
+# notes: semantics expect 2 here.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node N {
+    pk: I64 @key
+}
+edge R: N -> N
+
+--- seed
+{"type":"N","data":{"pk":0}}
+{"type":"N","data":{"pk":1}}
+{"edge":"R","from":"0","to":"1"}
+{"edge":"R","from":"1","to":"0"}
+
+--- query
+query stmt_5() {
+    match {
+        $a: N
+        $b: N
+        $a r{1,2} $b
+        $a.pk = 0
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 1}

--- a/crates/omnigraph-gqt/cases/kuzu_recursive_join_semantic_empty_two_cycle__stmt_6.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_recursive_join_semantic_empty_two_cycle__stmt_6.gqt
@@ -1,0 +1,34 @@
+# issue: none
+# notes: kuzu recursive_join/semantic_empty.test, -CASE TwoCycle, statement 6. Split out
+# notes: of kuzu_recursive_join_semantic_empty_two_cycle.gqt because GQ's answer
+# notes: diverges from Kuzu's walk semantics: Kuzu counts 3 walks of length 1..3 out of
+# notes: node 0 on a two-node cycle, GQ's r{1,3} is shortest-path distance per endpoint
+# notes: pair. Expectation rewritten to GQ's shortest-path-distance semantics by project
+# notes: decision (2026-09-04); Kuzu's walk semantics expect 3 here.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node N {
+    pk: I64 @key
+}
+edge R: N -> N
+
+--- seed
+{"type":"N","data":{"pk":0}}
+{"type":"N","data":{"pk":1}}
+{"edge":"R","from":"0","to":"1"}
+{"edge":"R","from":"1","to":"0"}
+
+--- query
+query stmt_6() {
+    match {
+        $a: N
+        $b: N
+        $a r{1,3} $b
+        $a.pk = 0
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 1}

--- a/crates/omnigraph-gqt/cases/kuzu_recursive_join_semantic_empty_two_cycle__stmt_7.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_recursive_join_semantic_empty_two_cycle__stmt_7.gqt
@@ -1,0 +1,35 @@
+# issue: none
+# notes: kuzu recursive_join/semantic_empty.test, -CASE TwoCycle, statement 7. Split out
+# notes: of kuzu_recursive_join_semantic_empty_two_cycle.gqt because GQ's answer
+# notes: diverges from Kuzu's walk semantics: Kuzu counts the one walk 0 -> 1 -> 0, GQ's
+# notes: r{2,2} asks for a pair whose shortest distance is exactly 2 and the source is
+# notes: not a destination of itself. Expectation rewritten to GQ's
+# notes: shortest-path-distance semantics by project decision (2026-09-04); Kuzu's walk
+# notes: semantics expect 1 here.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node N {
+    pk: I64 @key
+}
+edge R: N -> N
+
+--- seed
+{"type":"N","data":{"pk":0}}
+{"type":"N","data":{"pk":1}}
+{"edge":"R","from":"0","to":"1"}
+{"edge":"R","from":"1","to":"0"}
+
+--- query
+query stmt_7() {
+    match {
+        $a: N
+        $b: N
+        $a r{2,2} $b
+        $a.pk = 0
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 0}

--- a/crates/omnigraph-gqt/cases/kuzu_recursive_join_semantic_empty_two_cycle__stmt_8.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_recursive_join_semantic_empty_two_cycle__stmt_8.gqt
@@ -1,0 +1,34 @@
+# issue: none
+# notes: kuzu recursive_join/semantic_empty.test, -CASE TwoCycle, statement 8. Split out
+# notes: of kuzu_recursive_join_semantic_empty_two_cycle.gqt because GQ's answer
+# notes: diverges from Kuzu's walk semantics: Kuzu counts 2 walks of length 2..3 out of
+# notes: node 0 on a two-node cycle, GQ's r{2,3} is shortest-path distance per endpoint
+# notes: pair. Expectation rewritten to GQ's shortest-path-distance semantics by project
+# notes: decision (2026-09-04); Kuzu's walk semantics expect 2 here.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node N {
+    pk: I64 @key
+}
+edge R: N -> N
+
+--- seed
+{"type":"N","data":{"pk":0}}
+{"type":"N","data":{"pk":1}}
+{"edge":"R","from":"0","to":"1"}
+{"edge":"R","from":"1","to":"0"}
+
+--- query
+query stmt_8() {
+    match {
+        $a: N
+        $b: N
+        $a r{2,3} $b
+        $a.pk = 0
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 0}

--- a/crates/omnigraph-gqt/cases/kuzu_recursive_join_semantic_empty_two_cycle__stmt_9.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_recursive_join_semantic_empty_two_cycle__stmt_9.gqt
@@ -1,0 +1,34 @@
+# issue: none
+# notes: kuzu recursive_join/semantic_empty.test, -CASE TwoCycle, statement 9. Split out
+# notes: of kuzu_recursive_join_semantic_empty_two_cycle.gqt because GQ's answer
+# notes: diverges from Kuzu's walk semantics: Kuzu counts the one walk 0 -> 1 -> 0 -> 1,
+# notes: GQ's r{3,3} asks for a pair whose shortest distance is exactly 3. Expectation
+# notes: rewritten to GQ's shortest-path-distance semantics by project decision
+# notes: (2026-09-04); Kuzu's walk semantics expect 1 here.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node N {
+    pk: I64 @key
+}
+edge R: N -> N
+
+--- seed
+{"type":"N","data":{"pk":0}}
+{"type":"N","data":{"pk":1}}
+{"edge":"R","from":"0","to":"1"}
+{"edge":"R","from":"1","to":"0"}
+
+--- query
+query stmt_9() {
+    match {
+        $a: N
+        $b: N
+        $a r{3,3} $b
+        $a.pk = 0
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 0}

--- a/crates/omnigraph-gqt/cases/kuzu_subquery_exists.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_subquery_exists.gqt
@@ -1,0 +1,95 @@
+# issue: none
+# notes: kuzu test/test_files/subquery/exists.test, -CASE ExistsSubquery, tinysnb seed.
+# notes: Only the NEGATED subquery has a GQ spelling: NOT EXISTS { MATCH
+# notes: (a)-[:knows]->(b:person) } -> not { $a knows $_ }. Every positive
+# notes: EXISTS/pattern predicate, OPTIONAL MATCH and WITH statement is not translated.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    fName: String?
+    gender: I64?
+    isStudent: Bool?
+    isWorker: Bool?
+    age: I64?
+    eyeSight: F64?
+    birthdate: Date?
+    workedHours: [I64]?
+    usedNames: [String]?
+    height: F32?
+}
+node Organisation {
+    pk: I64 @key
+    name: String?
+    orgCode: I64?
+    mark: F64?
+    score: I64?
+    history: String?
+    rating: F64?
+}
+edge Knows: Person -> Person {
+    date: Date?
+    meetTime: DateTime?
+    comments: [String]?
+}
+edge StudyAt: Person -> Organisation {
+    year: I64?
+    places: [String]?
+    length: I64?
+    level: I64?
+    code: U64?
+    temperature: U32?
+    ulength: U32?
+    ulevel: U32?
+}
+edge WorkAt: Person -> Organisation {
+    year: I64?
+    grading: [F64]?
+    rating: F32?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"fName":"Alice","gender":1,"isStudent":true,"isWorker":false,"age":35,"eyeSight":5.0,"birthdate":"1900-01-01","workedHours":[10,5],"usedNames":["Aida"],"height":1.731}}
+{"type":"Person","data":{"pk":2,"fName":"Bob","gender":2,"isStudent":true,"isWorker":false,"age":30,"eyeSight":5.1,"birthdate":"1900-01-01","workedHours":[12,8],"usedNames":["Bobby"],"height":0.99}}
+{"type":"Person","data":{"pk":3,"fName":"Carol","gender":1,"isStudent":false,"isWorker":true,"age":45,"eyeSight":5.0,"birthdate":"1940-06-22","workedHours":[4,5],"usedNames":["Carmen","Fred"],"height":1.0}}
+{"type":"Person","data":{"pk":5,"fName":"Dan","gender":2,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.8,"birthdate":"1950-07-23","workedHours":[1,9],"usedNames":["Wolfeschlegelstein","Daniel"],"height":1.3}}
+{"type":"Person","data":{"pk":7,"fName":"Elizabeth","gender":1,"isStudent":false,"isWorker":true,"age":20,"eyeSight":4.7,"birthdate":"1980-10-26","workedHours":[2],"usedNames":["Ein"],"height":1.463}}
+{"type":"Person","data":{"pk":8,"fName":"Farooq","gender":2,"isStudent":true,"isWorker":false,"age":25,"eyeSight":4.5,"birthdate":"1980-10-26","workedHours":[3,4,5,6,7],"usedNames":["Fesdwe"],"height":1.51}}
+{"type":"Person","data":{"pk":9,"fName":"Greg","gender":2,"isStudent":false,"isWorker":false,"age":40,"eyeSight":4.9,"birthdate":"1980-10-26","workedHours":[1],"usedNames":["Grad"],"height":1.6}}
+{"type":"Person","data":{"pk":10,"fName":"Hubert Blaine Wolfeschlegelsteinhausenbergerdorff","gender":2,"isStudent":false,"isWorker":true,"age":83,"eyeSight":4.9,"birthdate":"1990-11-27","workedHours":[10,11,12,3,4,5,6,7],"usedNames":["Ad","De","Hi","Kye","Orlan"],"height":1.323}}
+{"type":"Organisation","data":{"pk":1,"name":"ABFsUni","orgCode":325,"mark":3.7,"score":-2,"history":"10 years 5 months 13 hours 24 us","rating":1.0}}
+{"type":"Organisation","data":{"pk":4,"name":"CsWork","orgCode":934,"mark":4.1,"score":-100,"history":"2 years 4 days 10 hours","rating":0.78}}
+{"type":"Organisation","data":{"pk":6,"name":"DEsWork","orgCode":824,"mark":4.1,"score":7,"history":"2 years 4 hours 22 us 34 minutes","rating":0.52}}
+{"edge":"Knows","from":"0","to":"2","data":{"date":"2021-06-30","meetTime":"1986-10-21T21:08:31.521Z","comments":["rnme","m8sihsdnf2990nfiwf"]}}
+{"edge":"Knows","from":"0","to":"3","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["njnojppo9u0jkmf","fjiojioh9h9h89hph"]}}
+{"edge":"Knows","from":"0","to":"5","data":{"date":"2021-06-30","meetTime":"2012-12-11T20:07:22Z","comments":["ioji232","jifhe8w99u43434"]}}
+{"edge":"Knows","from":"2","to":"0","data":{"date":"2021-06-30","meetTime":"1946-08-25T19:07:22Z","comments":["2huh9y89fsfw23","23nsihufhw723"]}}
+{"edge":"Knows","from":"2","to":"3","data":{"date":"1950-05-14","meetTime":"1946-08-25T19:07:22Z","comments":["fwehu9h9832wewew","23u9h989sdfsss"]}}
+{"edge":"Knows","from":"2","to":"5","data":{"date":"1950-05-14","meetTime":"2012-12-11T20:07:22Z","comments":["fwh9y81232uisuiehuf","ewnuihxy8dyf232"]}}
+{"edge":"Knows","from":"3","to":"0","data":{"date":"2021-06-30","meetTime":"2002-07-31T11:42:53.12342Z","comments":["fnioh8323aeweae34d","osd89e2ejshuih12"]}}
+{"edge":"Knows","from":"3","to":"2","data":{"date":"1950-05-14","meetTime":"2007-02-12T12:11:42.123Z","comments":["fwh983-sdjisdfji","ioh89y32r2huir"]}}
+{"edge":"Knows","from":"3","to":"5","data":{"date":"2000-01-01","meetTime":"1998-10-02T13:09:22.423Z","comments":["psh989823oaaioe","nuiuah1nosndfisf"]}}
+{"edge":"Knows","from":"5","to":"0","data":{"date":"2021-06-30","meetTime":"1936-11-02T11:02:01Z","comments":["fwewe"]}}
+{"edge":"Knows","from":"5","to":"2","data":{"date":"1950-05-14","meetTime":"1982-11-11T13:12:05.123Z","comments":["fewh9182912e3","h9y8y89soidfsf","nuhudf78w78efw","hioshe0f9023sdsd"]}}
+{"edge":"Knows","from":"5","to":"3","data":{"date":"2000-01-01","meetTime":"1999-04-21T15:12:11.42Z","comments":["23h9sdslnfowhu2932","shuhf98922323sf"]}}
+{"edge":"Knows","from":"7","to":"8","data":{"date":"1905-12-12","meetTime":"2025-01-01T11:22:33.52Z","comments":["ahu2333333333333","12weeeeeeeeeeeeeeeeee"]}}
+{"edge":"Knows","from":"7","to":"9","data":{"date":"1905-12-12","meetTime":"2020-03-01T12:11:41.6552Z","comments":["peweeeeeeeeeeeeeeeee","kowje9w0eweeeeeeeee"]}}
+{"edge":"StudyAt","from":"0","to":"1","data":{"year":2021,"places":["wwAewsdndweusd","wek"],"length":5,"level":5,"code":9223372036854775808,"temperature":32800,"ulength":33768,"ulevel":250}}
+{"edge":"StudyAt","from":"2","to":"1","data":{"year":2020,"places":["anew","jsdnwusklklklwewsd"],"length":55,"level":120,"code":6689,"temperature":1,"ulength":90,"ulevel":220}}
+{"edge":"StudyAt","from":"8","to":"1","data":{"year":2020,"places":["awndsnjwejwen","isuhuwennjnuhuhuwewe"],"length":22,"level":2,"code":23,"temperature":20,"ulength":180,"ulevel":12}}
+{"edge":"WorkAt","from":"3","to":"4","data":{"year":2015,"grading":[3.8,2.5],"rating":8.2}}
+{"edge":"WorkAt","from":"5","to":"6","data":{"year":2010,"grading":[2.1,4.4],"rating":7.6}}
+{"edge":"WorkAt","from":"7","to":"6","data":{"year":2015,"grading":[9.2,3.1],"rating":9.2}}
+
+--- query
+query not_exist_subquery_test() {
+    match {
+        $a: Person
+        not { $a knows $_ }
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 3}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_match1_scenario4.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_match1_scenario4.gqt
@@ -1,0 +1,29 @@
+# issue: none
+# notes: kuzu test/test_files/tck/match/match1.test, -CASE Scenario4, -DATASET CSV tck
+# notes: (empty schema; the case builds its own). SERIAL ID -> pk with 0,1,2 in creation
+# notes: order. Unlabeled (n) binds A, the schema's only node table. RETURN n is spelled
+# notes: as the node's declared scalar properties (whole_entity_spelled_as_props).
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    pk: I64 @key
+    name: String?
+    firstName: String?
+}
+
+--- seed
+{"type":"A","data":{"pk":0,"name":"bar"}}
+{"type":"A","data":{"pk":1,"name":"monkey"}}
+{"type":"A","data":{"pk":2,"firstName":"bar"}}
+
+--- query
+query stmt_3() {
+    match {
+        $n: A { name: "bar" }
+    }
+    return { $n.pk, $n.name, $n.firstName }
+}
+
+--- expect unordered
+{"n.pk": 0, "n.name": "bar", "n.firstName": null}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_match1_scenario5.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_match1_scenario5.gqt
@@ -1,0 +1,37 @@
+# issue: none
+# notes: kuzu test/test_files/tck/match/match1.test, -CASE Scenario5, -DATASET CSV tck
+# notes: (empty schema; the case builds its own). A(num INT64 PRIMARY KEY) keeps the
+# notes: name num as the @key. MATCH (n), (m) is two bindings with no traversal
+# notes: (cartesian product); both unlabeled patterns bind A, the schema's only node
+# notes: table.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    num: I64 @key
+}
+
+--- seed
+{"type":"A","data":{"num":1}}
+{"type":"A","data":{"num":2}}
+{"type":"A","data":{"num":3}}
+
+--- query
+query stmt_3() {
+    match {
+        $n: A
+        $m: A
+    }
+    return { $n.num as n, $m.num as m }
+}
+
+--- expect unordered
+{"n": 1, "m": 1}
+{"n": 1, "m": 2}
+{"n": 1, "m": 3}
+{"n": 2, "m": 1}
+{"n": 2, "m": 2}
+{"n": 2, "m": 3}
+{"n": 3, "m": 1}
+{"n": 3, "m": 2}
+{"n": 3, "m": 3}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_match2_scenario3_4.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_match2_scenario3_4.gqt
@@ -1,0 +1,30 @@
+# issue: none
+# notes: kuzu test/test_files/tck/match/match2.test, -CASE Scenario3&4, -DATASET CSV tck
+# notes: (empty schema; the case builds its own). A(name STRING PRIMARY KEY) keeps name
+# notes: as the @key. RETURN a is spelled as a.name (whole_entity_spelled_as_props).
+# notes: Statement 4 (the undirected self-loop) lives in
+# notes: kuzu_tck_match2_scenario3_4__stmt_4.gqt, split into its own file because its
+# notes: expectation follows the openCypher TCK reading rather than Kuzu's.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    name: String @key
+}
+edge T: A -> A
+
+--- seed
+{"type":"A","data":{"name":"xx"}}
+{"edge":"T","from":"xx","to":"xx","data":{}}
+
+--- query
+query stmt_5() {
+    match {
+        $a: A
+        $a t $a
+    }
+    return { $a.name }
+}
+
+--- expect unordered
+{"a.name": "xx"}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_match2_scenario3_4__stmt_4.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_match2_scenario3_4__stmt_4.gqt
@@ -1,0 +1,31 @@
+# issue: none
+# notes: kuzu test/test_files/tck/match/match2.test, -CASE Scenario3&4, statement 4,
+# notes: split out because GQ's answer diverges from Kuzu. -DATASET CSV tck (empty
+# notes: schema; the case builds its own). Kuzu expects the undirected self-loop MATCH
+# notes: (a)-[:T]-(a) to yield the node TWICE (once per adjacency direction); GQ's $a
+# notes: <t> $a has set semantics on the endpoint pair and yields it once. Expectation
+# notes: rewritten to the openCypher TCK reading, one row per matched node by project
+# notes: decision (2026-09-04); Kuzu expects the row twice.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    name: String @key
+}
+edge T: A -> A
+
+--- seed
+{"type":"A","data":{"name":"xx"}}
+{"edge":"T","from":"xx","to":"xx","data":{}}
+
+--- query
+query stmt_4() {
+    match {
+        $a: A
+        $a <t> $a
+    }
+    return { $a.name }
+}
+
+--- expect unordered
+{"a.name": "xx"}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_match2_scenario5.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_match2_scenario5.gqt
@@ -1,0 +1,36 @@
+# issue: none
+# notes: kuzu test/test_files/tck/match/match2.test, -CASE Scenario5, -DATASET CSV tck
+# notes: (empty schema; the case builds its own). A(ID INT64 PRIMARY KEY) -> pk (id is
+# notes: the engine system field). The inline edge predicate [r:KNOWS {name: 'monkey'}]
+# notes: is spelled as a bound edge plus a filter clause on $r.name. RETURN a is spelled
+# notes: as a.pk.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    pk: I64 @key
+}
+edge KNOWS: A -> A {
+    name: String?
+}
+
+--- seed
+{"type":"A","data":{"pk":1}}
+{"type":"A","data":{"pk":3}}
+{"type":"A","data":{"pk":5}}
+{"edge":"KNOWS","from":"3","to":"1","data":{"name":"monkey"}}
+{"edge":"KNOWS","from":"3","to":"5","data":{"name":"woot"}}
+
+--- query
+query stmt_4() {
+    match {
+        $n: A
+        $a: A
+        $n $r:knows $a
+        $r.name = "monkey"
+    }
+    return { $a.pk }
+}
+
+--- expect unordered
+{"a.pk": 1}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_match2_scenario6.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_match2_scenario6.gqt
@@ -1,0 +1,40 @@
+# issue: none
+# notes: kuzu test/test_files/tck/match/match2.test, -CASE Scenario6, -DATASET CSV tck
+# notes: (empty schema; the case builds its own). Only the first query statement is
+# notes: expressible: MATCH (n) binds A, the schema's only node table. The other two
+# notes: statements use an untyped edge and an edge-type disjunction and are not
+# notes: translated.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    name: String @key
+}
+edge KNOWS: A -> A {
+    name: String?
+}
+edge HATES: A -> A {
+    name: String?
+}
+edge WONDERS: A -> A {
+    name: String?
+}
+
+--- seed
+{"type":"A","data":{"name":"A"}}
+{"type":"A","data":{"name":"B"}}
+{"type":"A","data":{"name":"C"}}
+{"edge":"KNOWS","from":"A","to":"B","data":{}}
+{"edge":"HATES","from":"A","to":"C","data":{}}
+{"edge":"WONDERS","from":"A","to":"C","data":{}}
+
+--- query
+query stmt_6() {
+    match {
+        $n: A
+    }
+    return { count($n) as n }
+}
+
+--- expect unordered
+{"n": 3}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_match3_scenario1.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_match3_scenario1.gqt
@@ -1,0 +1,34 @@
+# issue: none
+# notes: kuzu test/test_files/tck/match/match3.test, -CASE Scenario1, -DATASET CSV tck
+# notes: (empty schema; the case builds its own). n1/n2 are unlabeled in Cypher but the
+# notes: typed edge KNOWS(FROM A TO B) pins them to A and B, so each gets its binding
+# notes: line. RETURN n1, n2 is spelled as their declared scalar properties
+# notes: (whole_entity_spelled_as_props).
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    num: I64 @key
+}
+node B {
+    num: I64 @key
+}
+edge KNOWS: A -> B
+
+--- seed
+{"type":"A","data":{"num":1}}
+{"type":"B","data":{"num":2}}
+{"edge":"KNOWS","from":"1","to":"2","data":{}}
+
+--- query
+query stmt_5() {
+    match {
+        $n1: A
+        $n2: B
+        $n1 knows $n2
+    }
+    return { $n1.num, $n2.num }
+}
+
+--- expect unordered
+{"n1.num": 1, "n2.num": 2}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_match3_scenario10.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_match3_scenario10.gqt
@@ -1,0 +1,32 @@
+# issue: none
+# notes: kuzu test/test_files/tck/match/match3.test, -CASE Scenario10, -DATASET CSV tck
+# notes: (empty schema; the case builds its own). The anonymous arrows --> resolve to T,
+# notes: the schema's only rel table, and the unlabeled nodes to A, its only node table.
+# notes: Self-referencing (b)-->(b) has no match.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    pk: I64 @key
+}
+edge T: A -> A
+
+--- seed
+{"type":"A","data":{"pk":0}}
+{"type":"A","data":{"pk":1}}
+{"type":"A","data":{"pk":2}}
+{"edge":"T","from":"0","to":"1","data":{}}
+{"edge":"T","from":"1","to":"2","data":{}}
+
+--- query
+query stmt_4() {
+    match {
+        $a: A
+        $b: A
+        $a t $b
+        $b t $b
+    }
+    return { $b.pk }
+}
+
+--- expect unordered

--- a/crates/omnigraph-gqt/cases/kuzu_tck_match3_scenario17_18.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_match3_scenario17_18.gqt
@@ -1,0 +1,55 @@
+# issue: none
+# notes: kuzu test/test_files/tck/match/match3.test, -CASE Scenario17&18, -DATASET CSV
+# notes: tck (empty schema; the case builds its own). Node tables are named T1/T2 and
+# notes: rel tables A/B in Kuzu; kept verbatim. The anonymous middle node of statement 5
+# notes: gets a named binding ($b), which is the same pattern statement 6 writes out as
+# notes: two comma-joined parts.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node T1 {
+    pk: I64 @key
+    name: String?
+}
+node T2 {
+    pk: I64 @key
+    name: String?
+}
+edge A: T1 -> T2
+edge B: T2 -> T1
+
+--- seed
+{"type":"T1","data":{"pk":0,"name":"a"}}
+{"type":"T2","data":{"pk":0,"name":"a"}}
+{"type":"T1","data":{"pk":1,"name":"c"}}
+{"edge":"A","from":"0","to":"0","data":{}}
+{"edge":"B","from":"0","to":"0","data":{}}
+{"edge":"B","from":"0","to":"1","data":{}}
+
+--- query
+query stmt_6() {
+    match {
+        $a: T1
+        $b: T2
+        $a a $b
+        $b b $a
+    }
+    return { $a.name }
+}
+
+--- expect unordered
+{"a.name": "a"}
+
+--- query
+query stmt_7() {
+    match {
+        $a: T1
+        $b: T2
+        $a a $b
+        $b b $a
+    }
+    return { $a.name }
+}
+
+--- expect unordered
+{"a.name": "a"}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_match3_scenario19.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_match3_scenario19.gqt
@@ -1,0 +1,39 @@
+# issue: none
+# notes: kuzu test/test_files/tck/match/match3.test, -CASE Scenario19, -DATASET CSV tck
+# notes: (empty schema; the case builds its own). The anonymous arrows resolve to KNOWS,
+# notes: the schema's only rel table; the undirected leg (x)--(b) is $x <KNOWS> $b (both
+# notes: ends are A). The two MATCH clauses are one match block.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    pk: I64 @key
+    name: String?
+}
+edge KNOWS: A -> A
+
+--- seed
+{"type":"A","data":{"pk":0,"name":"A"}}
+{"type":"A","data":{"pk":1,"name":"x1"}}
+{"type":"A","data":{"pk":2,"name":"x2"}}
+{"type":"A","data":{"pk":3,"name":"B"}}
+{"edge":"KNOWS","from":"0","to":"1","data":{}}
+{"edge":"KNOWS","from":"0","to":"2","data":{}}
+{"edge":"KNOWS","from":"3","to":"1","data":{}}
+{"edge":"KNOWS","from":"3","to":"2","data":{}}
+
+--- query
+query stmt_4() {
+    match {
+        $a: A { name: "A" }
+        $b: A { name: "B" }
+        $x: A
+        $a knows $x
+        $x <knows> $b
+    }
+    return { $x.name }
+}
+
+--- expect unordered
+{"x.name": "x1"}
+{"x.name": "x2"}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_match3_scenario20.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_match3_scenario20.gqt
@@ -1,0 +1,43 @@
+# issue: none
+# notes: kuzu test/test_files/tck/match/match3.test, -CASE Scenario20, -DATASET CSV tck
+# notes: (empty schema; the case builds its own). The anonymous arrows resolve to KNOWS,
+# notes: the schema's only rel table; the two MATCH clauses are one match block.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    pk: I64 @key
+    name: String?
+}
+edge KNOWS: A -> A
+
+--- seed
+{"type":"A","data":{"pk":0,"name":"A"}}
+{"type":"A","data":{"pk":1,"name":"x1"}}
+{"type":"A","data":{"pk":2,"name":"x2"}}
+{"type":"A","data":{"pk":3,"name":"B"}}
+{"type":"A","data":{"pk":4,"name":"C"}}
+{"edge":"KNOWS","from":"0","to":"1","data":{}}
+{"edge":"KNOWS","from":"0","to":"2","data":{}}
+{"edge":"KNOWS","from":"3","to":"1","data":{}}
+{"edge":"KNOWS","from":"3","to":"2","data":{}}
+{"edge":"KNOWS","from":"4","to":"1","data":{}}
+{"edge":"KNOWS","from":"4","to":"2","data":{}}
+
+--- query
+query stmt_4() {
+    match {
+        $a: A { name: "A" }
+        $b: A { name: "B" }
+        $c: A { name: "C" }
+        $x: A
+        $a knows $x
+        $b knows $x
+        $c knows $x
+    }
+    return { $x.name }
+}
+
+--- expect unordered
+{"x.name": "x1"}
+{"x.name": "x2"}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_match3_scenario21.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_match3_scenario21.gqt
@@ -1,0 +1,59 @@
+# issue: none
+# notes: kuzu test/test_files/tck/match/match3.test, -CASE Scenario21, -DATASET CSV tck
+# notes: (empty schema; the case builds its own). Seed nodes a..k are unlabeled in the
+# notes: CREATE and bind A, the schema's only node table, with pk 0..10 in creation
+# notes: order. RETURN x is spelled as x.pk, x.name (whole_entity_spelled_as_props).
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    pk: I64 @key
+    name: String?
+}
+edge KNOWS: A -> A
+
+--- seed
+{"type":"A","data":{"pk":0,"name":"a"}}
+{"type":"A","data":{"pk":1,"name":"b"}}
+{"type":"A","data":{"pk":2,"name":"c"}}
+{"type":"A","data":{"pk":3,"name":"d"}}
+{"type":"A","data":{"pk":4,"name":"e"}}
+{"type":"A","data":{"pk":5,"name":"f"}}
+{"type":"A","data":{"pk":6,"name":"g"}}
+{"type":"A","data":{"pk":7,"name":"h"}}
+{"type":"A","data":{"pk":8,"name":"i"}}
+{"type":"A","data":{"pk":9,"name":"j"}}
+{"type":"A","data":{"pk":10,"name":"k"}}
+{"edge":"KNOWS","from":"0","to":"3","data":{}}
+{"edge":"KNOWS","from":"0","to":"4","data":{}}
+{"edge":"KNOWS","from":"0","to":"5","data":{}}
+{"edge":"KNOWS","from":"0","to":"6","data":{}}
+{"edge":"KNOWS","from":"0","to":"8","data":{}}
+{"edge":"KNOWS","from":"1","to":"3","data":{}}
+{"edge":"KNOWS","from":"1","to":"4","data":{}}
+{"edge":"KNOWS","from":"1","to":"5","data":{}}
+{"edge":"KNOWS","from":"1","to":"7","data":{}}
+{"edge":"KNOWS","from":"1","to":"10","data":{}}
+{"edge":"KNOWS","from":"2","to":"3","data":{}}
+{"edge":"KNOWS","from":"2","to":"4","data":{}}
+{"edge":"KNOWS","from":"2","to":"7","data":{}}
+{"edge":"KNOWS","from":"2","to":"6","data":{}}
+{"edge":"KNOWS","from":"2","to":"9","data":{}}
+
+--- query
+query stmt_4() {
+    match {
+        $a: A { name: "a" }
+        $b: A { name: "b" }
+        $c: A { name: "c" }
+        $x: A
+        $a knows $x
+        $b knows $x
+        $c knows $x
+    }
+    return { $x.pk, $x.name }
+}
+
+--- expect unordered
+{"x.pk": 3, "x.name": "d"}
+{"x.pk": 4, "x.name": "e"}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_match3_scenario22.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_match3_scenario22.gqt
@@ -1,0 +1,33 @@
+# issue: none
+# notes: kuzu test/test_files/tck/match/match3.test, -CASE Scenario22, -DATASET CSV tck
+# notes: (empty schema; the case builds its own). c is bound but not part of the
+# notes: traversal, so it is a binding line with no edge clause. RETURN a, b, c is
+# notes: spelled as their declared scalar properties (whole_entity_spelled_as_props).
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    pk: I64 @key
+    name: String?
+}
+edge KNOWS: A -> A
+
+--- seed
+{"type":"A","data":{"pk":0,"name":"A"}}
+{"type":"A","data":{"pk":1,"name":"B"}}
+{"type":"A","data":{"pk":2,"name":"C"}}
+{"edge":"KNOWS","from":"0","to":"1","data":{}}
+
+--- query
+query stmt_4() {
+    match {
+        $a: A { name: "A" }
+        $c: A { name: "C" }
+        $b: A
+        $a knows $b
+    }
+    return { $a.pk, $a.name, $b.pk, $b.name, $c.pk, $c.name }
+}
+
+--- expect unordered
+{"a.pk": 0, "a.name": "A", "b.pk": 1, "b.name": "B", "c.pk": 2, "c.name": "C"}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_match3_scenario6.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_match3_scenario6.gqt
@@ -1,0 +1,35 @@
+# issue: none
+# notes: kuzu test/test_files/tck/match/match3.test, -CASE Scenario6, -DATASET CSV tck
+# notes: (empty schema; the case builds its own). The seed CREATE leaves its nodes
+# notes: unlabeled; T(FROM A TO Foo) pins a to A and b1/b2 to Foo, so the rows are A pk
+# notes: 0 and Foo pk 0, 1. COUNT(*) -> count($a) as n.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    pk: I64 @key
+}
+node Foo {
+    pk: I64 @key
+}
+edge T: A -> Foo
+
+--- seed
+{"type":"A","data":{"pk":0}}
+{"type":"Foo","data":{"pk":0}}
+{"type":"Foo","data":{"pk":1}}
+{"edge":"T","from":"0","to":"0","data":{}}
+{"edge":"T","from":"0","to":"1","data":{}}
+
+--- query
+query stmt_5() {
+    match {
+        $a: A
+        $b: Foo
+        $a t $b
+    }
+    return { count($a) as n }
+}
+
+--- expect unordered
+{"n": 2}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_match_where1_scenario15.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_match_where1_scenario15.gqt
@@ -1,0 +1,24 @@
+# issue: none
+# notes: kuzu test/test_files/tck/match_where/match_where1.test, -CASE Scenario15. Kuzu
+# notes: refuses an aggregate in WHERE; GQ has both aggregates and filters, so the
+# notes: refusal is the same reason and stays an error step. The pinned substring is
+# notes: GQ's own message, not Kuzu's.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    pk: I64 @key
+}
+
+--- seed
+
+--- query
+query stmt_2() {
+    match {
+        $a: A
+        count($a) > 10
+    }
+    return { $a.pk }
+}
+
+--- expect error: T7: filter comparisons require scalar operands, got aggregate

--- a/crates/omnigraph-gqt/cases/kuzu_tck_match_where1_scenario4.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_match_where1_scenario4.gqt
@@ -1,0 +1,39 @@
+# issue: none
+# notes: kuzu test/test_files/tck/match_where/match_where1.test, -CASE Scenario4. tck
+# notes: dataset: the case builds its own schema and rows, so --- schema / --- seed are
+# notes: inline. SERIAL ID -> pk with 0,1,... in creation order per table. `-->`
+# notes: resolves to the single rel table T. RETURN n is spelled as n's declared scalar
+# notes: props.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    name: String?
+}
+node A {
+    pk: I64 @key
+}
+
+edge T: Person -> A
+
+--- seed
+{"type":"Person","data":{"pk":0,"name":"Alice"}}
+{"type":"Person","data":{"pk":1,"name":"Bob"}}
+{"type":"A","data":{"pk":0}}
+{"type":"A","data":{"pk":1}}
+{"edge":"T","from":"0","to":"0","data":{}}
+{"edge":"T","from":"1","to":"1","data":{}}
+
+--- query
+query stmt_5() {
+    match {
+        $n: Person
+        $n t $_
+        $n.name = "Bob"
+    }
+    return { $n.pk, $n.name }
+}
+
+--- expect unordered
+{"n.pk": 1, "n.name": "Bob"}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_match_where3_scenario2.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_match_where3_scenario2.gqt
@@ -1,0 +1,33 @@
+# issue: none
+# notes: kuzu test/test_files/tck/match_where/match_where3.test, -CASE Scenario2. tck
+# notes: dataset, inline schema/seed. Kuzu property `id` (the declared primary key)
+# notes: becomes `pk`. RETURN a, b is spelled as each node's declared scalar props,
+# notes: which for A and B is pk alone.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    pk: I64 @key
+}
+node B {
+    pk: I64 @key
+}
+
+--- seed
+{"type":"A","data":{"pk":1}}
+{"type":"A","data":{"pk":2}}
+{"type":"B","data":{"pk":2}}
+{"type":"B","data":{"pk":3}}
+
+--- query
+query stmt_4() {
+    match {
+        $a: A
+        $b: B
+        $a.pk = $b.pk
+    }
+    return { $a.pk, $b.pk }
+}
+
+--- expect unordered
+{"a.pk": 2, "b.pk": 2}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_return1_scenario1.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_return1_scenario1.gqt
@@ -1,0 +1,26 @@
+# issue: none
+# notes: kuzu test/test_files/tck/return/return1.test, -CASE Scenario1. tck dataset,
+# notes: inline schema/seed. One node table, so the unlabeled (n) binds A. RETURN n is
+# notes: spelled as A's declared scalar props (pk, numbers); Kuzu's _ID/_LABEL cells
+# notes: have no GQ spelling.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    pk: I64 @key
+    numbers: [I64]?
+}
+
+--- seed
+{"type":"A","data":{"pk":0,"numbers":[1,2,3]}}
+
+--- query
+query stmt_3() {
+    match {
+        $n: A
+    }
+    return { $n.pk, $n.numbers }
+}
+
+--- expect unordered
+{"n.pk": 0, "n.numbers": [1, 2, 3]}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_return1_scenario2.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_return1_scenario2.gqt
@@ -1,0 +1,23 @@
+# issue: none
+# notes: kuzu test/test_files/tck/return/return1.test, -CASE Scenario2. Kuzu refuses
+# notes: `RETURN foo` because foo is not in scope; GQ has the same notion of a bound
+# notes: variable, so the refusal is the same reason. Kuzu's MATCH () becomes an
+# notes: explicit binding of the one table.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    pk: I64 @key
+}
+
+--- seed
+
+--- query
+query stmt_2() {
+    match {
+        $a: A
+    }
+    return { $foo }
+}
+
+--- expect error: variable `$foo` is not bound

--- a/crates/omnigraph-gqt/cases/kuzu_tck_return2_scenario11.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_return2_scenario11.gqt
@@ -1,0 +1,25 @@
+# issue: none
+# notes: kuzu test/test_files/tck/return/return2.test, -CASE Scenario11. tck dataset,
+# notes: inline schema/seed. Kuzu property `id` (the declared primary key) becomes `pk`;
+# notes: the point of the case is that the large I64 value survives the round trip
+# notes: exactly.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node TheLabel {
+    pk: I64 @key
+}
+
+--- seed
+{"type":"TheLabel","data":{"pk":4611686018427387905}}
+
+--- query
+query stmt_3() {
+    match {
+        $p: TheLabel
+    }
+    return { $p.pk }
+}
+
+--- expect unordered
+{"p.pk": 4611686018427387905}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_return2_scenario2.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_return2_scenario2.gqt
@@ -1,0 +1,24 @@
+# issue: none
+# notes: kuzu test/test_files/tck/return/return2.test, -CASE Scenario2. tck dataset,
+# notes: inline schema/seed. One node table, so the unlabeled (a) binds A.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    pk: I64 @key
+    num: I64?
+}
+
+--- seed
+{"type":"A","data":{"pk":0,"num":1}}
+
+--- query
+query stmt_3() {
+    match {
+        $a: A
+    }
+    return { $a.num }
+}
+
+--- expect unordered
+{"a.num": 1}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_return2_scenario4.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_return2_scenario4.gqt
@@ -1,0 +1,33 @@
+# issue: none
+# notes: kuzu test/test_files/tck/return/return2.test, -CASE Scenario4. tck dataset,
+# notes: inline schema/seed. The untyped `-[r]->` resolves to the single rel table T;
+# notes: the anonymous endpoints are bound explicitly because GQ names both ends of a
+# notes: traversal.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    pk: I64 @key
+}
+
+edge T: A -> A {
+    num: I64?
+}
+
+--- seed
+{"type":"A","data":{"pk":0}}
+{"type":"A","data":{"pk":1}}
+{"edge":"T","from":"0","to":"1","data":{"num":1}}
+
+--- query
+query stmt_4() {
+    match {
+        $a: A
+        $b: A
+        $a $r:t $b
+    }
+    return { $r.num }
+}
+
+--- expect unordered
+{"r.num": 1}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_return3_scenario2.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_return3_scenario2.gqt
@@ -1,0 +1,26 @@
+# issue: none
+# notes: kuzu test/test_files/tck/return/return3.test, -CASE Scenario2. tck dataset,
+# notes: inline schema/seed. One node table, so the unlabeled (a) binds A.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    pk: I64 @key
+    name: String?
+    age: I64?
+    seasons: [I64]?
+}
+
+--- seed
+{"type":"A","data":{"pk":0,"name":"Philip J. Fry","age":2046,"seasons":[1,2,3,4,5,6,7]}}
+
+--- query
+query stmt_3() {
+    match {
+        $a: A
+    }
+    return { $a.name, $a.age, $a.seasons }
+}
+
+--- expect unordered
+{"a.name": "Philip J. Fry", "a.age": 2046, "a.seasons": [1, 2, 3, 4, 5, 6, 7]}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_return6_scenario1.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_return6_scenario1.gqt
@@ -1,0 +1,25 @@
+# issue: none
+# notes: kuzu test/test_files/tck/return/return6.test, -CASE Scenario1. tck dataset,
+# notes: inline schema/seed. One node table, so the unlabeled (n) binds A. Both
+# notes: projections carry an alias, so the expect keys are the bare aliases.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    pk: I64 @key
+    num: I64?
+}
+
+--- seed
+{"type":"A","data":{"pk":0,"num":42}}
+
+--- query
+query stmt_3() {
+    match {
+        $n: A
+    }
+    return { $n.num as n, count($n) as count }
+}
+
+--- expect unordered
+{"n": 42, "count": 1}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_return6_scenario12.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_return6_scenario12.gqt
@@ -1,0 +1,36 @@
+# issue: none
+# notes: kuzu test/test_files/tck/return/return6.test, -CASE Scenario12. tck dataset,
+# notes: inline schema/seed. The rel table is named A and the node tables L and B; the
+# notes: traversal spells the edge lowercase. RETURN a is spelled as L's only declared
+# notes: scalar prop, pk; count(*) is count($a) aliased.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node L {
+    pk: I64 @key
+}
+node B {
+    pk: I64 @key
+}
+
+edge A: L -> B
+
+--- seed
+{"type":"L","data":{"pk":0}}
+{"type":"B","data":{"pk":0}}
+{"type":"B","data":{"pk":1}}
+{"edge":"A","from":"0","to":"0","data":{}}
+{"edge":"A","from":"0","to":"1","data":{}}
+
+--- query
+query stmt_5() {
+    match {
+        $a: L
+        $b: B
+        $a $rel:a $b
+    }
+    return { $a.pk, count($a) as cnt }
+}
+
+--- expect unordered
+{"a.pk": 0, "cnt": 2}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_return6_scenario7.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_return6_scenario7.gqt
@@ -1,0 +1,29 @@
+# issue: none
+# notes: kuzu test/test_files/tck/return/return6.test, -CASE Scenario7. tck dataset,
+# notes: inline schema/seed. One node table, so the unlabeled (n) binds A. count(*) is
+# notes: spelled count($n) and aliased; grouping is implicit on the non-aggregate column
+# notes: n.num.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    pk: I64 @key
+    num: I64?
+}
+
+--- seed
+{"type":"A","data":{"pk":0,"num":33}}
+{"type":"A","data":{"pk":1,"num":33}}
+{"type":"A","data":{"pk":2,"num":42}}
+
+--- query
+query stmt_3() {
+    match {
+        $n: A
+    }
+    return { $n.num, count($n) as cnt }
+}
+
+--- expect unordered
+{"n.num": 42, "cnt": 1}
+{"n.num": 33, "cnt": 2}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_return_orderby2_scenario1.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_return_orderby2_scenario1.gqt
@@ -1,0 +1,32 @@
+# issue: none
+# notes: kuzu test/test_files/tck/return_orderby/return_orderby2.test, -CASE Scenario1.
+# notes: -DATASET CSV tck is empty, so the case's own CREATE NODE TABLE becomes ---
+# notes: schema and its CREATE rows become --- seed; ID SERIAL -> pk assigned 0,1,2 in
+# notes: creation order. MATCH (n) is unlabeled over a one-table schema, so it binds as
+# notes: $n: A. -CHECK_ORDER + order clause + no aggregate -> expect ordered.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    pk: I64 @key
+    num: I64?
+}
+
+--- seed
+{"type":"A","data":{"pk":0,"num":1}}
+{"type":"A","data":{"pk":1,"num":3}}
+{"type":"A","data":{"pk":2,"num":-5}}
+
+--- query
+query stmt_3() {
+    match {
+        $n: A
+    }
+    return { $n.num as prop }
+    order { $n.num asc }
+}
+
+--- expect ordered
+{"prop": -5}
+{"prop": 1}
+{"prop": 3}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_return_orderby2_scenario2.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_return_orderby2_scenario2.gqt
@@ -1,0 +1,30 @@
+# issue: none
+# notes: kuzu test/test_files/tck/return_orderby/return_orderby2.test, -CASE Scenario2.
+# notes: Same seed as Scenario1, ORDER BY ... DESC. ID SERIAL -> pk 0,1,2 in creation
+# notes: order; MATCH (n) binds as $n: A.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    pk: I64 @key
+    num: I64?
+}
+
+--- seed
+{"type":"A","data":{"pk":0,"num":1}}
+{"type":"A","data":{"pk":1,"num":3}}
+{"type":"A","data":{"pk":2,"num":-5}}
+
+--- query
+query stmt_3() {
+    match {
+        $n: A
+    }
+    return { $n.num as prop }
+    order { $n.num desc }
+}
+
+--- expect ordered
+{"prop": 3}
+{"prop": 1}
+{"prop": -5}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_return_orderby2_scenario3.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_return_orderby2_scenario3.gqt
@@ -1,0 +1,33 @@
+# issue: none
+# notes: kuzu test/test_files/tck/return_orderby/return_orderby2.test, -CASE Scenario3
+# notes: "Sort on aggregated function". Kuzu's unaliased max(n.age) is aliased `m`
+# notes: (aggregates are always aliased); ORDER BY max(n.age) becomes order over that
+# notes: alias. -CHECK_ORDER but the return carries an aggregate, so expect unordered.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    pk: I64 @key
+    division: String?
+    age: I64?
+}
+
+--- seed
+{"type":"A","data":{"pk":0,"division":"A","age":22}}
+{"type":"A","data":{"pk":1,"division":"B","age":33}}
+{"type":"A","data":{"pk":2,"division":"B","age":44}}
+{"type":"A","data":{"pk":3,"division":"C","age":55}}
+
+--- query
+query stmt_3() {
+    match {
+        $n: A
+    }
+    return { $n.division, max($n.age) as m }
+    order { m asc }
+}
+
+--- expect unordered
+{"n.division": "A", "m": 22}
+{"n.division": "B", "m": 44}
+{"n.division": "C", "m": 55}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_return_orderby2_scenario7.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_return_orderby2_scenario7.gqt
@@ -1,0 +1,27 @@
+# issue: none
+# notes: kuzu test/test_files/tck/return_orderby/return_orderby2.test, -CASE Scenario7
+# notes: "Ordering with aggregation". count(*) -> count($n) as foo. -CHECK_ORDER but the
+# notes: return carries an aggregate, so the harness refuses `ordered`: expect
+# notes: unordered.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    pk: I64 @key
+    name: String?
+}
+
+--- seed
+{"type":"A","data":{"pk":0,"name":"nisse"}}
+
+--- query
+query stmt_3() {
+    match {
+        $n: A
+    }
+    return { $n.name, count($n) as foo }
+    order { $n.name asc }
+}
+
+--- expect unordered
+{"n.name": "nisse", "foo": 1}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_return_skip_limit2_scenario2.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_return_skip_limit2_scenario2.gqt
@@ -1,0 +1,35 @@
+# issue: none
+# notes: kuzu test/test_files/tck/return_skip_limit/return_skip_limit2.test, -CASE
+# notes: Scenario2 "Limit to two hits with explicit order". -DATASET CSV tck is empty,
+# notes: so the case's CREATE NODE TABLE becomes --- schema and its CREATE rows ---
+# notes: seed; ID SERIAL -> pk 0..4 in creation order. RETURN n is spelled as the node's
+# notes: scalar properties (whole_entity_spelled_as_props). -CHECK_ORDER + order + no
+# notes: aggregate -> expect ordered.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    pk: I64 @key
+    name: String?
+}
+
+--- seed
+{"type":"A","data":{"pk":0,"name":"A"}}
+{"type":"A","data":{"pk":1,"name":"B"}}
+{"type":"A","data":{"pk":2,"name":"C"}}
+{"type":"A","data":{"pk":3,"name":"D"}}
+{"type":"A","data":{"pk":4,"name":"E"}}
+
+--- query
+query stmt_3() {
+    match {
+        $n: A
+    }
+    return { $n.pk, $n.name }
+    order { $n.name asc }
+    limit 2
+}
+
+--- expect ordered
+{"n.pk": 0, "n.name": "A"}
+{"n.pk": 1, "n.name": "B"}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_return_skip_limit2_scenario3.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_return_skip_limit2_scenario3.gqt
@@ -1,0 +1,30 @@
+# issue: none
+# notes: kuzu test/test_files/tck/return_skip_limit/return_skip_limit2.test, -CASE
+# notes: Scenario3 "LIMIT 0 should return an empty result". Table A carries only the
+# notes: SERIAL key, so RETURN n is spelled as $n.pk (whole_entity_spelled_as_props). No
+# notes: -CHECK_ORDER -> expect unordered, empty body. Kuzu's statement has no ORDER BY;
+# notes: an order clause is added for uniformity with the other limit steps; with limit
+# notes: 0 the result is empty under any order.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    pk: I64 @key
+}
+
+--- seed
+{"type":"A","data":{"pk":0}}
+{"type":"A","data":{"pk":1}}
+{"type":"A","data":{"pk":2}}
+
+--- query
+query stmt_3() {
+    match {
+        $n: A
+    }
+    return { $n.pk }
+    order { $n.pk asc }
+    limit 0
+}
+
+--- expect unordered

--- a/crates/omnigraph-gqt/cases/kuzu_tck_return_skip_limit2_scenario4.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_return_skip_limit2_scenario4.gqt
@@ -1,0 +1,28 @@
+# issue: none
+# notes: kuzu test/test_files/tck/return_skip_limit/return_skip_limit2.test, -CASE
+# notes: Scenario4 "Handle ORDER BY with LIMIT 1". ID SERIAL -> pk 0,1 in creation
+# notes: order. -CHECK_ORDER + order + no aggregate -> ordered.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    name: String?
+}
+
+--- seed
+{"type":"Person","data":{"pk":0,"name":"Steven"}}
+{"type":"Person","data":{"pk":1,"name":"Craig"}}
+
+--- query
+query stmt_3() {
+    match {
+        $p: Person
+    }
+    return { $p.name as name }
+    order { $p.name asc }
+    limit 1
+}
+
+--- expect ordered
+{"name": "Craig"}

--- a/crates/omnigraph-gqt/cases/kuzu_tck_return_skip_limit2_scenario5.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_return_skip_limit2_scenario5.gqt
@@ -1,0 +1,26 @@
+# issue: none
+# notes: kuzu test/test_files/tck/return_skip_limit/return_skip_limit2.test, -CASE
+# notes: Scenario5 "ORDER BY with LIMIT 0 should not generate errors". The case creates
+# notes: the table and no rows, so --- seed is empty. -CHECK_ORDER + order + no
+# notes: aggregate -> ordered, empty body.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node Person {
+    pk: I64 @key
+    name: String?
+}
+
+--- seed
+
+--- query
+query stmt_2() {
+    match {
+        $p: Person
+    }
+    return { $p.name as name }
+    order { $p.name asc }
+    limit 0
+}
+
+--- expect ordered

--- a/crates/omnigraph-gqt/cases/kuzu_tck_return_skip_limit2_scenario7.gqt
+++ b/crates/omnigraph-gqt/cases/kuzu_tck_return_skip_limit2_scenario7.gqt
@@ -1,0 +1,32 @@
+# issue: none
+# notes: kuzu test/test_files/tck/return_skip_limit/return_skip_limit2.test, -CASE
+# notes: Scenario7 "Limit to more rows than actual results 1". ORDER BY x refers to the
+# notes: projection alias, which GQ takes bare. -CHECK_ORDER + order + no aggregate ->
+# notes: ordered.
+# notes: derived from kuzudb/kuzu test/test_files (MIT License, see crates/omnigraph-gqt/README.md); the query is translated to GQ and the expected rows are Kuzu's unless a line above says they were rewritten.
+
+--- schema
+node A {
+    pk: I64 @key
+    num: I64?
+}
+
+--- seed
+{"type":"A","data":{"pk":0,"num":1}}
+{"type":"A","data":{"pk":1,"num":3}}
+{"type":"A","data":{"pk":2,"num":2}}
+
+--- query
+query stmt_3() {
+    match {
+        $foo: A
+    }
+    return { $foo.num as x }
+    order { x desc }
+    limit 4
+}
+
+--- expect ordered
+{"x": 3}
+{"x": 2}
+{"x": 1}

--- a/docs/rfcs/0045-gq-logic-tests.md
+++ b/docs/rfcs/0045-gq-logic-tests.md
@@ -7,7 +7,7 @@ implementation: partial
 authors:
   - azimafroozeh
 created: 2026-08-29
-updated: 2026-09-03
+updated: 2026-09-04
 discussion: https://github.com/ModernRelay/omnigraph/pull/584
 supersedes: []
 superseded_by: []
@@ -1097,3 +1097,39 @@ listed in Compatibility and reversibility.
     per-case budget, panic capture, and corpus layout (no foreign entry,
     never empty) each keep one test; the traversal-override and
     foreign-entry tests stay.
+- 2026-09-04, amendment from the PR that added the Kuzu-derived cases
+  (new, supersedes nothing). This entry extends the feature-case sentence
+  of User and operational behavior ("a case written for new or existing
+  behavior with no failure to witness") and File format's "A feature case
+  writes `# issue: none` and drops the prefix" with a third origin, derived
+  cases, translated from another engine's test corpus; it adds nothing to
+  the harness. The body says nothing about where a feature case's
+  expectation comes from, so no body sentence differs from this entry.
+  Derived cases live in the same directory under a source prefix
+  (`kuzu_*.gqt` for kuzudb/kuzu `test/test_files/`, MIT), as
+  `# issue: none` feature cases, with the source file and case named in the
+  header and the License attribution in `crates/omnigraph-gqt/README.md`.
+  Unchanged: File format's naming rule (`<short_name>.gqt` over
+  `[a-z0-9_]`) and its "there are deliberately no external-file references,
+  or single files decay back into directories", and the `corpus_layout`
+  unit test in Runner mechanics; the prefix is a convention, not a harness
+  distinction. The expectation of a derived case follows one of these
+  rules, and the header's `# notes:` lines say which:
+  - Where the engines agree, the expectation is the source engine's,
+    translated to GQ; the attribution line says so. Numbers render at
+    scale 12 (Compatibility), so a six-decimal Kuzu AVG is written at
+    twelve.
+  - Where the engines disagree on semantics, the statement is split into
+    its own file, the header names the source engine's value and the
+    reading taken, and the expectation follows that reading (a bounded
+    traversal as shortest-path distance per endpoint pair; an undirected
+    self-loop as one row per matched node).
+  - Where the source engine asserts only `ok`, the rows are derived from
+    the seed.
+  - A translation may add an order key so a `limit` cut is deterministic,
+    or split one statement into typed reads when an untyped edge has no GQ
+    spelling; the header records each such change.
+  - A case pinning a refusal or fix the engine does not have yet may be
+    red on its pull-request branch; its header names what it waits on, and
+    the PR merges only after that lands, so the corpus on `main` is never
+    red.


### PR DESCRIPTION
## What & why

97 `kuzu_*.gqt` feature cases (275 steps) translated from the [Kuzu](https://github.com/kuzudb/kuzu) e2e tests (`test/test_files/`, MIT): regression coverage for match patterns, `where`, `not { }`, bounded traversal, return, order, limit, and the aggregates. Follow-up to #607. No harness change.

- Coverage: every statement in Kuzu's GQ-shaped areas that GQ can express. Of 1,690 statements, 1,132 have no GQ spelling (arithmetic, `WITH`, path variables, functions, multi-label patterns) and 278 were skipped (large datasets, Kuzu `-SKIP`); they are absent, not red.
- Where the engines disagree by design, the case pins GQ's reading and the header names Kuzu's value: `{m,n}` is shortest-path distance per endpoint pair, an undirected self-loop is one row, `AVG` at scale 12.
- 10 cases pin behavior the engine does not have yet and are red on this branch (listed below); the PR is a draft until they go green.
- `crates/omnigraph-gqt/README.md` gains the derived-case rules and the MIT notice; RFC 0045's Decision log records the source-prefix convention. The fix-regression gate keys on the `issue_` prefix and never reads these files.

## Backing issue / RFC

- [x] RFC 0045, GQ logic tests (`docs/rfcs/0045-gq-logic-tests.md`, draft): Decision log amended with the derived-case rules; nothing here differs from its design.

## Checklist

- [x] Change is focused (one derived corpus, two doc paragraphs)
- [x] Tests added/updated for behavior changes (the PR is tests; each case is its own test)
- [x] Public docs updated if user-facing surface changed (none; crate README and RFC log updated)
- [x] Reviewed against [docs/dev/invariants.md](../blob/main/docs/dev/invariants.md) — data-only diff, no invariant touched

## Local verification

- `cargo test -p omnigraph-gqt`: 94 unit tests green; corpus 96 passed / 10 failed (the red-on-purpose set); slowest case 0.72 s.
- Every expectation checked against three oracles independent of the engine and of Kuzu: hand derivation from the seed with the Cypher re-read for fidelity; a SQL translation run on SQLite (268 of 270 steps agree, the 2 left are an oracle gap in delete-cascade counting; seeded faults: 86 of 86 values and 6 of 6 orderings caught); a Python evaluator of the documented semantics (234 of 247 agree, the rest being the hop-range cases where it let a path return to its start, which the self-loop fix's release note rules out). The pass found and fixed one wrong expectation, four `limit` steps that were green only by scan order, and five dropped reads.
- `python3 scripts/check-docs.py`: ok. Vocabulary guard, fmt, clippy: not run, no Rust or guarded surface in the diff.

## Notes for reviewers

- Red on purpose, 10 files, each with a `# notes: Red on purpose:` line naming what it waits on. `GQ Logic Tests` is a required check, so this stays a draft; each fix PR carries its own minimal `issue_N_` case and these remain as full-seed coverage:
  - `sum` over an integer column accumulates in `f64` (1 file)
  - duplicate result column name, `T25` refusal not yet in the compiler (2 files)
  - `F32` cells render as the `f64` widening, `0.99` as `0.990000009537` (4 files)
  - `min`/`max` over `Bool` and `Date` refused, `T8` (2 files)
  - `count($e)` over an edge binding refused, `T23` (1 file)
- 38 files inline the same seed: RFC 0045 keeps seeds inline by design; they are generated from one source, so a seed fix is one edit and a regenerate.