### PR TITLE
docs(release): drop the stray `; m` prefix from the v0.11.0 highlights bullet

### DIFF
--- a/docs/releases/v0.11.0.md
+++ b/docs/releases/v0.11.0.md
@@ -4,7 +4,7 @@ Notes accumulate here until the release is cut.
 
 ## Highlights
 
-; m- **Two projections producing one result column name are refused at
+- **Two projections producing one result column name are refused at
   compile time (`T25`).** `return { $a.num1 as number, $a.num2 as number }`
   used to run and emit two columns both named `number`; every reader that
   keys a row by column name (the JSON rows of the HTTP API, the CLI, and the


### PR DESCRIPTION
## What & why

The first Highlights bullet in `docs/releases/v0.11.0.md` begins with `; m- **Two projections …` (a stray keystroke that landed with #621), so Markdown renders it as a paragraph starting with `; m-` instead of a list item. This PR drops the three-character prefix; nothing else changes.

## Backing issue / RFC

- [x] **Trivial fast-lane** (one-line docs typo): no issue/RFC required

## Checklist

- [x] Change is focused (one line in one release-notes file)
- [x] Tests added/updated for behavior changes (N/A: docs only)
- [x] Public docs updated if user-facing surface changed (this is the docs edit)
- [x] Reviewed against docs/dev/invariants.md — no Hard Invariant weakened, no deny-list item hit (no code touched)

## Local verification

- `git diff --stat` — one file, one line changed
- `bash scripts/check-agents-md.sh` — passes; it links `docs/releases/` as a directory, so it confirms the index only, not the bullet's Markdown

## Notes for reviewers

- The fixed line is the opening of the #621 highlight; the bullet's remaining lines were already correct.