### PR TITLE
test(gq): add a mandatory `--- expect shape` section and a result-schema check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,7 @@ Set `OMNIGRAPH_UPDATE_OPENAPI=1` only when the drift is intentional.
   process environment, concurrency).
 - Every issue fix lands a regression test at the cheapest tier that catches
   the defect: a `.gqt` logic test when the defect is visible in rows, counts,
-  or errors, a `_issue_NNN` Rust test when it needs mechanism or scale
+  result column types, or errors, a `_issue_NNN` Rust test when it needs mechanism or scale
   assertions; when the reported symptom additionally needs scale to
   manifest, a second `#[ignore]`d test in a `tests/repro_issue_*.rs` target
   guards it, and the two cross-reference each other in comments.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5301,6 +5301,8 @@ dependencies = [
 name = "omnigraph-gqt"
 version = "0.10.0"
 dependencies = [
+ "arrow-array",
+ "arrow-schema",
  "datatest-stable",
  "futures",
  "omnigraph-compiler",

--- a/crates/omnigraph-compiler/src/query/typecheck.rs
+++ b/crates/omnigraph-compiler/src/query/typecheck.rs
@@ -1691,7 +1691,7 @@ fn infer_projection_field(
 /// spelling and names an unaliased property by the property alone; the two
 /// spellings drift for unaliased projections today, and this function
 /// follows the executor because T25 guards the batch the executor builds.
-fn executed_column_name(expr: &Expr, alias: Option<&str>) -> String {
+pub fn executed_column_name(expr: &Expr, alias: Option<&str>) -> String {
     if let Some(alias) = alias {
         return alias.to_string();
     }

--- a/crates/omnigraph-compiler/src/types.rs
+++ b/crates/omnigraph-compiler/src/types.rs
@@ -69,6 +69,32 @@ impl ScalarType {
         }
     }
 
+    /// The inverse of [`Self::to_arrow`] over its image; `None` for an Arrow
+    /// type no scalar maps to.
+    pub fn from_arrow(data_type: &DataType) -> Option<Self> {
+        Some(match data_type {
+            DataType::Utf8 => Self::String,
+            DataType::Boolean => Self::Bool,
+            DataType::Int32 => Self::I32,
+            DataType::Int64 => Self::I64,
+            DataType::UInt32 => Self::U32,
+            DataType::UInt64 => Self::U64,
+            DataType::Float32 => Self::F32,
+            DataType::Float64 => Self::F64,
+            DataType::Date32 => Self::Date,
+            DataType::Date64 => Self::DateTime,
+            DataType::LargeBinary => Self::Blob,
+            DataType::FixedSizeList(item, dim)
+                if item.name() == "item"
+                    && item.is_nullable()
+                    && *item.data_type() == DataType::Float32 =>
+            {
+                Self::Vector(u32::try_from(*dim).ok()?)
+            }
+            _ => return None,
+        })
+    }
+
     pub fn is_numeric(&self) -> bool {
         matches!(
             self,
@@ -163,6 +189,21 @@ impl PropType {
         }
     }
 
+    /// The inverse of [`Self::to_arrow`] over its image, non-nullable and
+    /// enum-free (both are erased by `to_arrow`); `None` outside the image.
+    pub fn from_arrow(data_type: &DataType) -> Option<Self> {
+        if let DataType::List(item) = data_type {
+            if item.name() != "item" || !item.is_nullable() {
+                return None;
+            }
+            return Some(Self::list_of(
+                ScalarType::from_arrow(item.data_type())?,
+                false,
+            ));
+        }
+        Some(Self::scalar(ScalarType::from_arrow(data_type)?, false))
+    }
+
     pub fn display_name(&self) -> String {
         let base = if let Some(values) = &self.enum_values {
             format!("enum({})", values.join(", "))
@@ -213,6 +254,77 @@ mod tests {
         assert_eq!(
             ScalarType::from_str_name("Vector(2147483647)"),
             Some(ScalarType::Vector(2147483647))
+        );
+    }
+
+    const EVERY_SCALAR: [ScalarType; 12] = [
+        ScalarType::String,
+        ScalarType::Bool,
+        ScalarType::I32,
+        ScalarType::I64,
+        ScalarType::U32,
+        ScalarType::U64,
+        ScalarType::F32,
+        ScalarType::F64,
+        ScalarType::Date,
+        ScalarType::DateTime,
+        ScalarType::Vector(3),
+        ScalarType::Blob,
+    ];
+
+    #[test]
+    fn from_arrow_inverts_to_arrow_over_every_scalar_list_and_nullability() {
+        for scalar in EVERY_SCALAR {
+            assert_eq!(ScalarType::from_arrow(&scalar.to_arrow()), Some(scalar));
+            for list in [false, true] {
+                for nullable in [false, true] {
+                    let prop = if list {
+                        PropType::list_of(scalar, nullable)
+                    } else {
+                        PropType::scalar(scalar, nullable)
+                    };
+                    let mut expected = prop.clone();
+                    expected.nullable = false;
+                    assert_eq!(
+                        PropType::from_arrow(&prop.to_arrow()),
+                        Some(expected),
+                        "{prop:?}"
+                    );
+                }
+            }
+        }
+        assert_eq!(
+            PropType::from_arrow(&PropType::enum_type(vec!["a".into()], true).to_arrow()),
+            Some(PropType::scalar(ScalarType::String, false))
+        );
+        assert_eq!(
+            ScalarType::from_arrow(&DataType::Struct(Default::default())),
+            None
+        );
+        assert_eq!(ScalarType::from_arrow(&DataType::Int8), None);
+    }
+
+    #[test]
+    fn to_arrow_image_table_is_pinned() {
+        let table: [(ScalarType, DataType); 11] = [
+            (ScalarType::String, DataType::Utf8),
+            (ScalarType::Bool, DataType::Boolean),
+            (ScalarType::I32, DataType::Int32),
+            (ScalarType::I64, DataType::Int64),
+            (ScalarType::U32, DataType::UInt32),
+            (ScalarType::U64, DataType::UInt64),
+            (ScalarType::F32, DataType::Float32),
+            (ScalarType::F64, DataType::Float64),
+            (ScalarType::Date, DataType::Date32),
+            (ScalarType::DateTime, DataType::Date64),
+            (ScalarType::Blob, DataType::LargeBinary),
+        ];
+        for (scalar, data_type) in table {
+            assert_eq!(scalar.to_arrow(), data_type, "{scalar:?}");
+        }
+        assert_eq!(
+            PropType::list_of(ScalarType::I32, true).to_arrow(),
+            DataType::List(Arc::new(Field::new("item", DataType::Int32, true)))
         );
     }
 

--- a/crates/omnigraph-gqt/Cargo.toml
+++ b/crates/omnigraph-gqt/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 doctest = false
 
 [dependencies]
+arrow-schema = { workspace = true }
 futures = { workspace = true }
 omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.10.0" }
 omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.10.0" }
@@ -21,6 +22,7 @@ tempfile = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
+arrow-array = { workspace = true }
 datatest-stable = "0.3"
 
 # One libtest test per `cases/*.gqt`; mechanism and flags: tests/gq_logic_tests.rs.

--- a/crates/omnigraph-gqt/README.md
+++ b/crates/omnigraph-gqt/README.md
@@ -12,8 +12,11 @@ or `--workspace` reaches it.
   `issue_NNN_<short_name>.gqt`; `scripts/check-fix-regression.py` looks for it
   here.
 - `src/lib.rs`: the runner (case parsing, execution against a fresh
-  temporary store, row comparison, bless). Format self-tests and the corpus
-  layout check are its unit tests (`src/tests.rs`).
+  temporary store, the `--- expect shape` check of each rows step's result
+  columns, the result-schema check against the compiler's inferred schema,
+  row comparison, bless); `src/shape.rs` parses and compares the shape
+  section. Format self-tests and the corpus layout check are its unit
+  tests (`src/tests.rs`).
 - `tests/gq_logic_tests.rs`: one libtest test per case, named
   `case::<file>.gqt`, registered at run time by `datatest-stable`
   (`harness = false`). A new case file is picked up without any Rust change.

--- a/crates/omnigraph-gqt/cases/issue_563_aggregate_uncapped.gqt
+++ b/crates/omnigraph-gqt/cases/issue_563_aggregate_uncapped.gqt
@@ -63,3 +63,6 @@ query recall_count($q: String) {
 
 --- expect unordered
 {"total": 20}
+
+--- expect shape
+total: I64

--- a/crates/omnigraph-gqt/cases/issue_563_underfill_retry.gqt
+++ b/crates/omnigraph-gqt/cases/issue_563_underfill_retry.gqt
@@ -66,3 +66,7 @@ query recall($q: String) {
 --- expect ordered
 {"c.slug": "chunk-08", "a.slug": "art-0"}
 {"c.slug": "chunk-09", "a.slug": "art-0"}
+
+--- expect shape
+c.slug: String
+a.slug: String

--- a/crates/omnigraph-gqt/cases/issue_603_negation_string_predicate_outer_var.gqt
+++ b/crates/omnigraph-gqt/cases/issue_603_negation_string_predicate_outer_var.gqt
@@ -24,3 +24,6 @@ query not_prefixed() {
 
 --- expect unordered
 {"p.name": "bob"}
+
+--- expect shape
+p.name: String

--- a/crates/omnigraph-gqt/cases/issue_605_two_anonymous_destinations.gqt
+++ b/crates/omnigraph-gqt/cases/issue_605_two_anonymous_destinations.gqt
@@ -31,6 +31,9 @@ query knows_anyone_twice() {
 {"p.name": "alice"}
 {"p.name": "bob"}
 
+--- expect shape
+p.name: String
+
 --- query
 query bound_twice() {
     match {
@@ -42,6 +45,9 @@ query bound_twice() {
 
 --- expect unordered
 {"p.name": "bob"}
+
+--- expect shape
+p.name: String
 
 --- query
 query bound_twice_in_negation() {
@@ -55,6 +61,9 @@ query bound_twice_in_negation() {
 --- expect unordered
 {"p.name": "alice"}
 
+--- expect shape
+p.name: String
+
 --- query
 query self_loop_twice() {
     match {
@@ -67,6 +76,9 @@ query self_loop_twice() {
 
 --- expect unordered
 {"p.name": "bob"}
+
+--- expect shape
+p.name: String
 
 --- query
 query rebind_inside_negation_non_root() {
@@ -85,3 +97,6 @@ query rebind_inside_negation_non_root() {
 --- expect unordered
 {"p.name": "alice"}
 {"p.name": "bob"}
+
+--- expect shape
+p.name: String

--- a/crates/omnigraph-gqt/cases/issue_613_self_loop_pinned_hop_distance.gqt
+++ b/crates/omnigraph-gqt/cases/issue_613_self_loop_pinned_hop_distance.gqt
@@ -25,6 +25,10 @@ query exactly_two_hops() {
 
 --- expect unordered
 
+--- expect shape
+p.name: String
+f.name: String
+
 --- query
 query one_to_two_hops() {
     match {
@@ -37,3 +41,7 @@ query one_to_two_hops() {
 --- expect unordered
 {"p.name": "alice", "f.name": "bob"}
 {"p.name": "bob", "f.name": "bob"}
+
+--- expect shape
+p.name: String
+f.name: String

--- a/crates/omnigraph-gqt/cases/issue_618_json_f32_datetime_null_spelling.gqt
+++ b/crates/omnigraph-gqt/cases/issue_618_json_f32_datetime_null_spelling.gqt
@@ -29,3 +29,10 @@ query point_values() {
 --- expect unordered
 {"p.name": "p", "p.score": 0.99, "p.embedding": [0.1, 0.2, 0.3], "p.at": "2024-01-01T11:54:56.789"}
 {"p.name": "q", "p.score": 1, "p.embedding": [1, 2, 3], "p.at": "2024-01-01T00:00:00", "p.note": "kept"}
+
+--- expect shape
+p.name: String
+p.score: F32
+p.embedding: Vector(3)
+p.at: DateTime
+p.note: String?

--- a/crates/omnigraph-gqt/cases/issue_620_duplicate_projection_alias_refused.gqt
+++ b/crates/omnigraph-gqt/cases/issue_620_duplicate_projection_alias_refused.gqt
@@ -115,6 +115,10 @@ query distinct_aliases() {
 --- expect unordered
 {"who": "p", "how_many": 7}
 
+--- expect shape
+who: String
+how_many: I64
+
 --- query
 query property_and_aliased_aggregate() {
     match {
@@ -126,6 +130,10 @@ query property_and_aliased_aggregate() {
 --- expect unordered
 {"a.name": "p", "n": 1}
 
+--- expect shape
+a.name: String
+n: I64
+
 --- query
 query two_aliased_literals() {
     match {
@@ -136,3 +144,7 @@ query two_aliased_literals() {
 
 --- expect unordered
 {"one": 1, "two": 2}
+
+--- expect shape
+one: I64
+two: I64

--- a/crates/omnigraph-gqt/cases/ordered_two_key_sort.gqt
+++ b/crates/omnigraph-gqt/cases/ordered_two_key_sort.gqt
@@ -28,3 +28,7 @@ query ranked() {
 {"p.name": "dave", "p.rank": 1}
 {"p.name": "alice", "p.rank": 2}
 {"p.name": "carol", "p.rank": 2}
+
+--- expect shape
+p.name: String
+p.rank: I64

--- a/crates/omnigraph-gqt/cases/restart_survives_reopen.gqt
+++ b/crates/omnigraph-gqt/cases/restart_survives_reopen.gqt
@@ -37,3 +37,6 @@ query all_names() {
 {"p.name": "alice"}
 {"p.name": "bob"}
 {"p.name": "carol"}
+
+--- expect shape
+p.name: String

--- a/crates/omnigraph-gqt/src/lib.rs
+++ b/crates/omnigraph-gqt/src/lib.rs
@@ -27,16 +27,23 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
+use arrow_schema::{DataType, Schema};
 use futures::FutureExt as _;
 use omnigraph::db::{Omnigraph, ReadTarget};
 use omnigraph::instrumentation::{QueryIoProbes, with_query_io_probes, with_traversal_mode};
 use omnigraph::loader::{LoadMode, load_jsonl};
 use omnigraph_compiler::query::ast::{Clause, Expr, Literal, Param, QueryDecl};
 use omnigraph_compiler::query::parser::parse_query;
+use omnigraph_compiler::query::typecheck::{
+    executed_column_name, infer_query_result_schema, typecheck_query,
+};
 use omnigraph_compiler::schema::ast::{Annotation, PropDecl, SchemaDecl};
 use omnigraph_compiler::schema::parser::parse_schema;
-use omnigraph_compiler::{JsonParamMode, json_params_to_param_map};
+use omnigraph_compiler::{JsonParamMode, QueryResult, json_params_to_param_map};
 use serde_json::Value;
+
+mod shape;
+use shape::{ShapeExpect, bless_shape_lines, parse_shape_body, shape_mismatch};
 
 pub const CASE_TIMEOUT_ENV: &str = "OMNIGRAPH_GQ_CASE_TIMEOUT_SECS";
 pub const DEFAULT_CASE_TIMEOUT_SECS: u64 = 10;
@@ -80,7 +87,7 @@ struct QueryStep {
     ordinal: usize,
     source: String,
     name: String,
-    ast_params: Vec<Param>,
+    decl: Box<QueryDecl>,
     params_raw: Option<String>,
     expect: QueryExpect,
     /// The match clause carries an unbound traversal, so a successful run
@@ -104,6 +111,7 @@ enum QueryExpect {
         ordered: bool,
         body_raw: String,
         span: BodySpan,
+        shape: ShapeExpect,
     },
     Error {
         needle: String,
@@ -675,7 +683,7 @@ struct PendingStep {
     ordinal: usize,
     source: String,
     name: String,
-    ast_params: Vec<Param>,
+    decl: Box<QueryDecl>,
     ordered_refusal: Option<String>,
     expects_expand: bool,
     params_raw: Option<String>,
@@ -718,9 +726,22 @@ fn parse_case(stem: &str, text: &str) -> Result<Case, String> {
     let mut items: Vec<Item> = Vec::new();
     let mut open_loop: Option<(String, Vec<String>, Vec<Step>)> = None;
     let mut pending: Option<PendingStep> = None;
+    let mut awaiting_shape: Option<QueryStep> = None;
     let mut ordinal = 0usize;
     let mut qm_steps = 0usize;
     let mut substitutable_lines: HashSet<usize> = HashSet::new();
+
+    /// The refusal for a rows step whose `--- expect shape` did not arrive
+    /// next: any other section, or the end of the file, ends the case here.
+    fn missing_shape(step: &QueryStep) -> String {
+        let line = match &step.expect {
+            QueryExpect::Rows { span, .. } => span.start_line,
+            QueryExpect::Error { .. } => 0,
+        };
+        format!(
+            "line {line}: the rows expect needs an `--- expect shape` section directly after it; write it from the .pg schema, or fill it with OMNIGRAPH_GQ_BLESS=1 and review the diff"
+        )
+    }
 
     fn push_step(
         items: &mut Vec<Item>,
@@ -738,6 +759,11 @@ fn parse_case(stem: &str, text: &str) -> Result<Case, String> {
             Some((k, rest)) => (k, rest),
             None => (section.name.as_str(), ""),
         };
+        if let Some(waiting) = &awaiting_shape
+            && !(kind == "expect" && rest.trim().starts_with("shape"))
+        {
+            return Err(missing_shape(waiting));
+        }
         match kind {
             "schema" | "seed" => {
                 return Err(format!(
@@ -793,7 +819,7 @@ fn parse_case(stem: &str, text: &str) -> Result<Case, String> {
                     ordinal,
                     source: source.clone(),
                     name: decl.name.clone(),
-                    ast_params: decl.params.clone(),
+                    decl: Box::new(decl.clone()),
                     ordered_refusal: ordered_refusal(decl),
                     expects_expand: expects_expand(&decl.match_clause),
                     params_raw: None,
@@ -826,13 +852,41 @@ fn parse_case(stem: &str, text: &str) -> Result<Case, String> {
                 step.params_raw = Some(body);
             }
             "expect" => {
+                if rest.trim() == "shape" {
+                    let Some(mut step) = awaiting_shape.take() else {
+                        return Err(format!(
+                            "line {}: `--- expect shape` must directly follow a query step's unordered or ordered expect",
+                            section.header_line + 1
+                        ));
+                    };
+                    let lines = parse_shape_body(&section.body)?;
+                    match &mut step.expect {
+                        QueryExpect::Rows { shape, .. } => {
+                            *shape = ShapeExpect {
+                                lines,
+                                span: BodySpan {
+                                    start_line: section.header_line + 1,
+                                    len: section.body.len(),
+                                },
+                            };
+                        }
+                        QueryExpect::Error { .. } => {
+                            return Err(format!(
+                                "line {}: internal: the step awaiting a shape section carries no rows expect",
+                                section.header_line + 1
+                            ));
+                        }
+                    }
+                    push_step(&mut items, &mut open_loop, Step::Query(step));
+                    continue;
+                }
+                let mode = parse_expect_header(rest)?;
                 let Some(step) = pending.take() else {
                     return Err(format!(
                         "line {}: `--- expect` has no query or mutate step to bind to",
                         section.header_line + 1
                     ));
                 };
-                let mode = parse_expect_header(rest)?;
                 let completed = match (&mode, step.is_mutation) {
                     (ExpectHeader::Unordered | ExpectHeader::Ordered, true) => {
                         return Err(
@@ -866,7 +920,7 @@ fn parse_case(stem: &str, text: &str) -> Result<Case, String> {
                             ordinal: step.ordinal,
                             source: step.source,
                             name: step.name,
-                            ast_params: step.ast_params,
+                            decl: step.decl,
                             params_raw: step.params_raw,
                             expects_expand: step.expects_expand,
                             expect: QueryExpect::Rows {
@@ -875,6 +929,13 @@ fn parse_case(stem: &str, text: &str) -> Result<Case, String> {
                                 span: BodySpan {
                                     start_line: section.header_line + 1,
                                     len: section.body.len(),
+                                },
+                                shape: ShapeExpect {
+                                    lines: Vec::new(),
+                                    span: BodySpan {
+                                        start_line: 0,
+                                        len: 0,
+                                    },
                                 },
                             },
                         })
@@ -886,7 +947,7 @@ fn parse_case(stem: &str, text: &str) -> Result<Case, String> {
                                 ordinal: step.ordinal,
                                 source: step.source,
                                 name: step.name,
-                                ast_params: step.ast_params,
+                                ast_params: step.decl.params,
                                 params_raw: step.params_raw,
                                 expect: MutateExpect::Error {
                                     needle: needle.clone(),
@@ -897,7 +958,7 @@ fn parse_case(stem: &str, text: &str) -> Result<Case, String> {
                                 ordinal: step.ordinal,
                                 source: step.source,
                                 name: step.name,
-                                ast_params: step.ast_params,
+                                decl: step.decl,
                                 params_raw: step.params_raw,
                                 expects_expand: step.expects_expand,
                                 expect: QueryExpect::Error {
@@ -912,7 +973,7 @@ fn parse_case(stem: &str, text: &str) -> Result<Case, String> {
                             ordinal: step.ordinal,
                             source: step.source,
                             name: step.name,
-                            ast_params: step.ast_params,
+                            ast_params: step.decl.params,
                             params_raw: step.params_raw,
                             expect: MutateExpect::Ok,
                         })
@@ -923,7 +984,7 @@ fn parse_case(stem: &str, text: &str) -> Result<Case, String> {
                             ordinal: step.ordinal,
                             source: step.source,
                             name: step.name,
-                            ast_params: step.ast_params,
+                            ast_params: step.decl.params,
                             params_raw: step.params_raw,
                             expect: MutateExpect::Affected {
                                 nodes: *nodes,
@@ -932,7 +993,15 @@ fn parse_case(stem: &str, text: &str) -> Result<Case, String> {
                         })
                     }
                 };
-                push_step(&mut items, &mut open_loop, completed);
+                match completed {
+                    Step::Query(
+                        step @ QueryStep {
+                            expect: QueryExpect::Rows { .. },
+                            ..
+                        },
+                    ) => awaiting_shape = Some(step),
+                    other => push_step(&mut items, &mut open_loop, other),
+                }
             }
             "restart" => {
                 if !rest.is_empty() {
@@ -990,6 +1059,9 @@ fn parse_case(stem: &str, text: &str) -> Result<Case, String> {
     }
     if pending.is_some() {
         return Err("the final step is missing its `--- expect`".into());
+    }
+    if let Some(waiting) = &awaiting_shape {
+        return Err(missing_shape(waiting));
     }
     if open_loop.is_some() {
         return Err("a loop is not closed with `--- endloop`".into());
@@ -1138,7 +1210,7 @@ fn compare_rows(
 struct StepFail {
     label: String,
     message: String,
-    bless_rows: Option<(BodySpan, Vec<String>)>,
+    bless_lines: Option<(BodySpan, Vec<String>)>,
 }
 
 fn step_label(ordinal: usize, kind: &str, binding: Option<(&str, &str)>) -> String {
@@ -1263,6 +1335,51 @@ fn expects_expand(clauses: &[Clause]) -> bool {
     })
 }
 
+/// Why the executed result disagrees with the schema the compiler inferred
+/// for `decl`, if it does: the column count, then per position the executed
+/// name, the Arrow type, and nulls in a column the compiler inferred non-null.
+fn schema_drift(decl: &QueryDecl, inferred: &Schema, result: &QueryResult) -> Option<String> {
+    let executed = result.schema();
+    if executed.fields().len() != inferred.fields().len() {
+        return Some(format!(
+            "result schema mismatch: the compiler inferred {} column(s), the executor returned {}",
+            inferred.fields().len(),
+            executed.fields().len()
+        ));
+    }
+    for (i, (want, got)) in inferred.fields().iter().zip(executed.fields()).enumerate() {
+        let proj = &decl.return_clause[i];
+        let name = executed_column_name(&proj.expr, proj.alias.as_deref());
+        if got.name() != &name {
+            return Some(format!(
+                "result schema mismatch at column {i}: expected name `{name}`, the executor returned `{}`",
+                got.name()
+            ));
+        }
+        if got.data_type() != want.data_type() {
+            let hint = if matches!(want.data_type(), DataType::Struct(_)) {
+                "; a bare node projection executes as the id column today and has no green shape until the engine returns the node object"
+            } else {
+                "; the compiler and the executor disagree: an engine defect to file, not a case error"
+            };
+            return Some(format!(
+                "result schema mismatch at column {i} `{name}`: the compiler inferred {:?}, the executor returned {:?}{hint}",
+                want.data_type(),
+                got.data_type()
+            ));
+        }
+        if !want.is_nullable() {
+            let nulls = shape::null_cells(result, i);
+            if nulls > 0 {
+                return Some(format!(
+                    "result schema mismatch at column {i} `{name}`: the compiler inferred it non-nullable, the executor returned {nulls} null(s)"
+                ));
+            }
+        }
+    }
+    None
+}
+
 async fn run_query_step(
     db: &Omnigraph,
     mode: Option<&'static str>,
@@ -1273,11 +1390,11 @@ async fn run_query_step(
     let fail = |message: String| StepFail {
         label: label.clone(),
         message,
-        bless_rows: None,
+        bless_lines: None,
     };
     // A params refusal is one of the ways "the query must fail": route it
     // into an `error:` expectation instead of always failing the step.
-    let params = match build_params(step.params_raw.as_ref(), &step.ast_params, binding) {
+    let params = match build_params(step.params_raw.as_ref(), &step.decl.params, binding) {
         Ok(params) => params,
         Err(e) => {
             return match &step.expect {
@@ -1309,8 +1426,34 @@ async fn run_query_step(
             ordered,
             body_raw,
             span,
+            shape,
         } => {
             let result = outcome.map_err(|e| fail(format!("query failed: {e}")))?;
+            let catalog = db.catalog();
+            let inferred = typecheck_query(&catalog, &step.decl)
+                .and_then(|ctx| infer_query_result_schema(&catalog, &step.decl, &ctx))
+                .map_err(|e| fail(format!("result schema inference failed: {e}")))?;
+            let drift = schema_drift(&step.decl, &inferred, &result);
+            if let Some(mismatch) = shape_mismatch(&shape.lines, &result, &inferred) {
+                let (message, bless_lines) = match (&drift, bless_shape_lines(&result)) {
+                    (Some(drift), _) => (
+                        format!(
+                            "{mismatch}\nthe executor disagrees with the compiler's schema, so bless does not rewrite the shape: {drift}"
+                        ),
+                        None,
+                    ),
+                    (None, Ok(lines)) => (mismatch, Some((shape.span, lines))),
+                    (None, Err(unspellable)) => (format!("{mismatch}\n{unspellable}"), None),
+                };
+                return Err(StepFail {
+                    label: label.clone(),
+                    message,
+                    bless_lines,
+                });
+            }
+            if let Some(drift) = drift {
+                return Err(fail(drift));
+            }
             let rows = result
                 .to_rust_json()
                 .map_err(|e| fail(format!("query rows failed to render as JSON: {e}")))?;
@@ -1321,7 +1464,7 @@ async fn run_query_step(
             compare_rows(&expected, &actual, *ordered).map_err(|(message, rows)| StepFail {
                 label: label.clone(),
                 message,
-                bless_rows: Some((*span, rows)),
+                bless_lines: Some((*span, rows)),
             })
         }
         QueryExpect::Error { needle } => match outcome {
@@ -1350,7 +1493,7 @@ async fn run_mutate_step(
     let fail = |message: String| StepFail {
         label: label.clone(),
         message,
-        bless_rows: None,
+        bless_lines: None,
     };
     let params = match build_params(step.params_raw.as_ref(), &step.ast_params, binding) {
         Ok(params) => params,
@@ -1468,15 +1611,15 @@ async fn execute_case(case: &Case, path: &Path, bless: bool) -> Result<(), Strin
     };
     let mut detail = format!("{}: {}", fail.label, fail.message);
     if bless {
-        if let Some((span, rows)) = &fail.bless_rows {
+        if let Some((span, lines)) = &fail.bless_lines {
             if case.has_loops() {
                 detail.push_str("\nbless: refused, the case contains loops");
             } else {
-                bless_rewrite(path, *span, rows)?;
+                bless_rewrite(path, *span, lines)?;
                 let _ = write!(
                     detail,
-                    "\nbless: expect rewritten in place ({} rows), re-run to confirm",
-                    rows.len()
+                    "\nbless: expect rewritten in place ({} lines), re-run to confirm",
+                    lines.len()
                 );
             }
         }
@@ -1484,33 +1627,33 @@ async fn execute_case(case: &Case, path: &Path, bless: bool) -> Result<(), Strin
     Err(detail)
 }
 
-fn splice_lines(original: &str, span: BodySpan, rows: &[String]) -> String {
-    let lines: Vec<&str> = original.lines().collect();
-    let body = &lines[span.start_line..span.start_line + span.len];
+fn splice_lines(original: &str, span: BodySpan, lines: &[String]) -> String {
+    let original_lines: Vec<&str> = original.lines().collect();
+    let body = &original_lines[span.start_line..span.start_line + span.len];
     let trailing_blanks = body
         .iter()
         .rev()
         .take_while(|l| l.trim().is_empty())
         .count();
-    let mut out: Vec<&str> = lines[..span.start_line].to_vec();
-    out.extend(rows.iter().map(String::as_str));
+    let mut out: Vec<&str> = original_lines[..span.start_line].to_vec();
+    out.extend(lines.iter().map(String::as_str));
     out.extend(std::iter::repeat_n("", trailing_blanks));
-    out.extend(&lines[span.start_line + span.len..]);
+    out.extend(&original_lines[span.start_line + span.len..]);
     let mut joined = out.join("\n");
     joined.push('\n');
     joined
 }
 
-fn bless_rewrite(path: &Path, span: BodySpan, rows: &[String]) -> Result<(), String> {
+fn bless_rewrite(path: &Path, span: BodySpan, lines: &[String]) -> Result<(), String> {
     let original =
         std::fs::read_to_string(path).map_err(|e| format!("bless: cannot re-read case: {e}"))?;
-    std::fs::write(path, splice_lines(&original, span, rows))
+    std::fs::write(path, splice_lines(&original, span, lines))
         .map_err(|e| format!("bless: cannot write case: {e}"))
 }
 
 /// Parses and executes one case file; `bless` rewrites a failing step's
-/// `--- expect` rows in place and still reports the step (`expect
-/// rewritten`), so the run stays red until the re-run confirms.
+/// `--- expect` rows or shape lines in place and still reports the step
+/// (`expect rewritten`), so the run stays red until the re-run confirms.
 pub async fn run_case(path: PathBuf, bless: bool) -> Result<(), String> {
     let stem = stem_of(&path);
     let text = std::fs::read_to_string(&path).map_err(|e| format!("cannot read case file: {e}"))?;

--- a/crates/omnigraph-gqt/src/shape.rs
+++ b/crates/omnigraph-gqt/src/shape.rs
@@ -1,0 +1,219 @@
+//! The `--- expect shape` section: the author's statement of a rows step's
+//! result columns, one `<name>: <type>` line per column in `.pg` property
+//! syntax, held against the executed batch before the rows are compared.
+
+use arrow_schema::{DataType, Schema};
+use omnigraph_compiler::schema::ast::SchemaDecl;
+use omnigraph_compiler::schema::parser::parse_schema;
+use omnigraph_compiler::{PropType, QueryResult, ScalarType};
+
+use crate::BodySpan;
+
+#[derive(Debug, Clone)]
+pub(crate) struct ShapeLine {
+    pub(crate) name: String,
+    pub(crate) prop_type: PropType,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ShapeExpect {
+    pub(crate) lines: Vec<ShapeLine>,
+    pub(crate) span: BodySpan,
+}
+
+/// Parses a shape body. Blank lines are skipped; an empty body is the bless
+/// target and asserts zero columns.
+pub(crate) fn parse_shape_body(body: &[(usize, &str)]) -> Result<Vec<ShapeLine>, String> {
+    let mut lines = Vec::new();
+    for (idx, raw) in body {
+        let line_no = idx + 1;
+        let text = raw.trim();
+        if text.is_empty() {
+            continue;
+        }
+        if text.starts_with('#') || text.contains("//") || text.contains("/*") {
+            return Err(format!(
+                "line {line_no}: comments are refused inside the shape section; comments live in the header"
+            ));
+        }
+        if text.contains("${") {
+            return Err(format!(
+                "line {line_no}: `${{` is refused in a shape body; a column cannot depend on the iteration"
+            ));
+        }
+        let Some((name, type_text)) = text.split_once(':') else {
+            return Err(format!("line {line_no}: not a `<name>: <type>` shape line"));
+        };
+        let name = name.trim();
+        if !is_column_name(name) {
+            return Err(format!(
+                "line {line_no}: `{name}` is not a column name (`ident` or `ident.ident`)"
+            ));
+        }
+        let type_text = type_text.trim();
+        if type_text.contains('@') {
+            return Err(format!(
+                "line {line_no}: annotations and body constraints are not allowed in a shape line"
+            ));
+        }
+        let prop_type = parse_type(type_text)
+            .ok_or_else(|| format!("line {line_no}: unknown type `{type_text}`"))?;
+        if prop_type.enum_values.is_some() {
+            return Err(format!(
+                "line {line_no}: `enum(...)` is refused; the column's Arrow type is `Utf8`, write `String`"
+            ));
+        }
+        if prop_type.scalar == ScalarType::Blob {
+            return Err(format!(
+                "line {line_no}: `Blob` is refused; a Blob is not a read value (T24)"
+            ));
+        }
+        lines.push(ShapeLine {
+            name: name.to_string(),
+            prop_type,
+        });
+    }
+    Ok(lines)
+}
+
+fn is_ident(s: &str) -> bool {
+    let mut chars = s.chars();
+    chars
+        .next()
+        .is_some_and(|c| c.is_ascii_lowercase() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+fn is_column_name(name: &str) -> bool {
+    match name.split_once('.') {
+        Some((var, prop)) => is_ident(var) && is_ident(prop),
+        None => is_ident(name),
+    }
+}
+
+/// The `.pg` type of one shape line, through the product schema parser: the
+/// text is parsed as the one property of a `node Shape { }` declaration.
+fn parse_type(type_text: &str) -> Option<PropType> {
+    let file = parse_schema(&format!("node Shape {{\n    v: {type_text}\n}}\n")).ok()?;
+    let [SchemaDecl::Node(node)] = file.declarations.as_slice() else {
+        return None;
+    };
+    let [prop] = node.properties.as_slice() else {
+        return None;
+    };
+    Some(prop.prop_type.clone())
+}
+
+/// Why the executed result disagrees with the shape section, if it does:
+/// column count, then per position the name, the Arrow type, and a null cell
+/// in a column written without `?`. `inferred` is the compiler's schema for
+/// the step, consulted only to say when it sides with the shape line.
+pub(crate) fn shape_mismatch(
+    shape: &[ShapeLine],
+    result: &QueryResult,
+    inferred: &Schema,
+) -> Option<String> {
+    let executed = result.schema();
+    if executed.fields().len() != shape.len() {
+        let hint = if shape.is_empty() {
+            "; fill it with OMNIGRAPH_GQ_BLESS=1 and review the diff"
+        } else {
+            ""
+        };
+        return Some(format!(
+            "result shape mismatch: the shape section names {} column(s), the executor returned {}{hint}",
+            shape.len(),
+            executed.fields().len()
+        ));
+    }
+    for (i, (want, got)) in shape.iter().zip(executed.fields()).enumerate() {
+        if got.name() != &want.name {
+            return Some(format!(
+                "result shape mismatch at column {i}: expected name `{}`, the executor returned `{}`",
+                want.name,
+                got.name()
+            ));
+        }
+        let want_arrow = want.prop_type.to_arrow();
+        if got.data_type() != &want_arrow {
+            let expected = spell_pg(&want.prop_type.scalar, want.prop_type.list);
+            let verdict = if inferred
+                .fields()
+                .get(i)
+                .is_some_and(|f| f.data_type() == &want_arrow)
+            {
+                format!(
+                    "; the compiler infers {expected} too, so the executor is wrong, not the shape line"
+                )
+            } else {
+                String::new()
+            };
+            return Some(format!(
+                "result shape mismatch at column {i} `{}`: expected {expected}, the executor returned {}{verdict}",
+                want.name,
+                spell_arrow(got.data_type())
+            ));
+        }
+        if !want.prop_type.nullable {
+            let nulls = null_cells(result, i);
+            if nulls > 0 {
+                return Some(format!(
+                    "result shape mismatch at column {i} `{}`: written without `?`, the executor returned {nulls} null(s)",
+                    want.name
+                ));
+            }
+        }
+    }
+    None
+}
+
+pub(crate) fn null_cells(result: &QueryResult, column: usize) -> usize {
+    result
+        .batches()
+        .iter()
+        .map(|batch| batch.column(column).null_count())
+        .sum()
+}
+
+/// The shape lines bless writes for an executed result: the name as
+/// executed, the `.pg` spelling of the Arrow type, `?` exactly when the
+/// column holds a null cell. `Err` names a column the shape grammar cannot
+/// spell, so the section is not rewritten.
+pub(crate) fn bless_shape_lines(result: &QueryResult) -> Result<Vec<String>, String> {
+    let mut lines = Vec::with_capacity(result.schema().fields().len());
+    for (i, field) in result.schema().fields().iter().enumerate() {
+        if !is_column_name(field.name()) {
+            return Err(format!(
+                "column `{}` is not a column name the shape section can spell; the shape is not rewritten",
+                field.name()
+            ));
+        }
+        let Some(mut prop_type) = PropType::from_arrow(field.data_type()) else {
+            return Err(format!(
+                "column `{}` has Arrow type {} with no `.pg` spelling; the shape is not rewritten",
+                field.name(),
+                spell_arrow(field.data_type())
+            ));
+        };
+        prop_type.nullable = null_cells(result, i) > 0;
+        lines.push(format!("{}: {}", field.name(), prop_type.display_name()));
+    }
+    Ok(lines)
+}
+
+fn spell_pg(scalar: &ScalarType, list: bool) -> String {
+    if list {
+        format!("[{scalar}]")
+    } else {
+        scalar.to_string()
+    }
+}
+
+/// An executed Arrow type in `.pg` spelling when it has one, Arrow spelling
+/// otherwise.
+fn spell_arrow(data_type: &DataType) -> String {
+    match PropType::from_arrow(data_type) {
+        Some(prop_type) => spell_pg(&prop_type.scalar, prop_type.list),
+        None => format!("{data_type:?}"),
+    }
+}

--- a/crates/omnigraph-gqt/src/tests.rs
+++ b/crates/omnigraph-gqt/src/tests.rs
@@ -5,7 +5,9 @@ const SCHEMA: &str = "--- schema\nnode Person {\n    name: String @key\n}\n";
 const SEED: &str = "--- seed\n{\"type\":\"Person\",\"data\":{\"name\":\"alice\"}}\n";
 const QUERY: &str =
     "--- query\nquery all() {\n    match { $p: Person }\n    return { $p.name }\n}\n";
-const EXPECT: &str = "--- expect unordered\n{\"p.name\": \"alice\"}\n";
+const EXPECT: &str =
+    "--- expect unordered\n{\"p.name\": \"alice\"}\n--- expect shape\np.name: String\n";
+const SHAPE: &str = "--- expect shape\np.name: String\n";
 const MUTATE: &str = "--- mutate\nquery ins($n: String) {\n    insert Person { name: $n }\n}\n";
 const PARAMS: &str = "--- params\n{\"n\": \"bob\"}\n";
 const EXPECT_OK: &str = "--- expect ok\n";
@@ -431,7 +433,7 @@ fn refuses_nearest_over_a_string_param() {
 
 #[test]
 fn accepts_empty_expect_body_as_empty_result_assertion() {
-    let text = format!("{HDR}{SCHEMA}{SEED}{QUERY}--- expect unordered\n");
+    let text = format!("{HDR}{SCHEMA}{SEED}{QUERY}--- expect unordered\n{SHAPE}");
     parse_case("x", &text).unwrap();
 }
 
@@ -440,7 +442,7 @@ fn search_construct_sets_the_index_decision() {
     let schema = "--- schema\nnode Doc {\n    slug: String @key\n    text: String @index\n}\n";
     let query = "--- query\nquery q($q: String) {\n    match {\n        $d: Doc\n        search($d.text, $q)\n    }\n    return { $d.slug }\n}\n";
     let text = format!(
-        "{HDR}{schema}--- seed\n{query}--- params\n{{\"q\": \"needle\"}}\n--- expect unordered\n"
+        "{HDR}{schema}--- seed\n{query}--- params\n{{\"q\": \"needle\"}}\n--- expect unordered\n--- expect shape\nd.slug: String\n"
     );
     let case = parse_case("x", &text).unwrap();
     assert!(case.needs_indices);
@@ -500,10 +502,458 @@ fn ordered_comparison_is_positional() {
     compare_rows(&expected, &expected.clone(), true).unwrap();
 }
 
+mod schema_drift {
+    use arrow_array::{ArrayRef, Float64Array, Int32Array, Int64Array, RecordBatch, StringArray};
+    use arrow_schema::{DataType, Field};
+
+    use super::*;
+
+    const AGG_QUERY: &str =
+        "query q() {\n    match { $p: Person }\n    return { count($p) as n, min($p.age) as m }\n}";
+    const NAME_QUERY: &str = "query q() {\n    match { $p: Person }\n    return { $p.name }\n}";
+
+    fn decl(source: &str) -> QueryDecl {
+        parse_query(source).unwrap().queries.remove(0)
+    }
+
+    fn agg_inferred() -> Schema {
+        Schema::new(vec![
+            Field::new("n", DataType::Int64, true),
+            Field::new("m", DataType::Int32, true),
+        ])
+    }
+
+    fn result(fields: Vec<Field>, columns: Vec<ArrayRef>) -> QueryResult {
+        let schema = Arc::new(Schema::new(fields));
+        let batch = RecordBatch::try_new(Arc::clone(&schema), columns).unwrap();
+        QueryResult::new(schema, vec![batch])
+    }
+
+    #[test]
+    fn names_the_column_whose_type_differs_from_the_inferred_field() {
+        let executed = result(
+            vec![
+                Field::new("n", DataType::Int64, true),
+                Field::new("m", DataType::Float64, true),
+            ],
+            vec![
+                Arc::new(Int64Array::from(vec![0])),
+                Arc::new(Float64Array::from(vec![None::<f64>])),
+            ],
+        );
+        let msg = schema_drift(&decl(AGG_QUERY), &agg_inferred(), &executed).unwrap();
+        assert!(msg.contains("column 1 `m`"), "got: {msg}");
+        assert!(msg.contains("inferred Int32"), "got: {msg}");
+        assert!(msg.contains("returned Float64"), "got: {msg}");
+    }
+
+    #[test]
+    fn accepts_a_matching_schema_whatever_the_executor_declares_nullable() {
+        let executed = result(
+            vec![
+                Field::new("n", DataType::Int64, false),
+                Field::new("m", DataType::Int32, true),
+            ],
+            vec![
+                Arc::new(Int64Array::from(vec![2])),
+                Arc::new(Int32Array::from(vec![Some(7)])),
+            ],
+        );
+        assert_eq!(
+            schema_drift(&decl(AGG_QUERY), &agg_inferred(), &executed),
+            None
+        );
+    }
+
+    #[test]
+    fn reports_a_column_count_mismatch() {
+        let executed = result(
+            vec![Field::new("n", DataType::Int64, true)],
+            vec![Arc::new(Int64Array::from(vec![0]))],
+        );
+        let msg = schema_drift(&decl(AGG_QUERY), &agg_inferred(), &executed).unwrap();
+        assert!(msg.contains("inferred 2 column(s)"), "got: {msg}");
+        assert!(msg.contains("returned 1"), "got: {msg}");
+    }
+
+    #[test]
+    fn reports_an_executed_name_off_the_compiler_rule() {
+        let inferred = Schema::new(vec![Field::new("name", DataType::Utf8, false)]);
+        let executed = result(
+            vec![Field::new("name", DataType::Utf8, false)],
+            vec![Arc::new(StringArray::from(vec!["alice"]))],
+        );
+        let msg = schema_drift(&decl(NAME_QUERY), &inferred, &executed).unwrap();
+        assert!(msg.contains("expected name `p.name`"), "got: {msg}");
+        assert!(msg.contains("returned `name`"), "got: {msg}");
+    }
+
+    #[test]
+    fn reports_nulls_in_a_column_inferred_non_nullable() {
+        let inferred = Schema::new(vec![Field::new("name", DataType::Utf8, false)]);
+        let executed = result(
+            vec![Field::new("p.name", DataType::Utf8, true)],
+            vec![Arc::new(StringArray::from(vec![Some("alice"), None]))],
+        );
+        let msg = schema_drift(&decl(NAME_QUERY), &inferred, &executed).unwrap();
+        assert!(msg.contains("column 0 `p.name`"), "got: {msg}");
+        assert!(msg.contains("returned 1 null(s)"), "got: {msg}");
+    }
+}
+
+mod shape_section {
+    use arrow_array::{ArrayRef, Int32Array, RecordBatch, StringArray, StructArray};
+    use arrow_schema::{DataType, Field, Fields};
+
+    use super::*;
+    use crate::shape::{ShapeLine, bless_shape_lines, parse_shape_body, shape_mismatch};
+
+    fn mismatch(shape: &[ShapeLine], result: &QueryResult) -> Option<String> {
+        shape_mismatch(shape, result, &Schema::empty())
+    }
+
+    const AGE_SCHEMA: &str = "--- schema\nnode Person {\n    name: String @key\n    age: I32?\n}\n";
+    const AGE_SEED: &str = "--- seed\n{\"type\":\"Person\",\"data\":{\"name\":\"alice\",\"age\":30}}\n{\"type\":\"Person\",\"data\":{\"name\":\"bob\"}}\n";
+    const AGE_QUERY: &str =
+        "--- query\nquery all() {\n    match { $p: Person }\n    return { $p.name, $p.age }\n}\n";
+    const AGE_ROWS: &str =
+        "--- expect unordered\n{\"p.name\": \"alice\", \"p.age\": 30}\n{\"p.name\": \"bob\"}\n";
+
+    fn lines(body: &str) -> Vec<ShapeLine> {
+        let owned: Vec<(usize, &str)> = body.lines().enumerate().collect();
+        parse_shape_body(&owned).unwrap()
+    }
+
+    fn shape_refusal(body: &str) -> String {
+        let owned: Vec<(usize, &str)> = body.lines().enumerate().collect();
+        parse_shape_body(&owned).expect_err("expected the shape body to be refused")
+    }
+
+    fn result(fields: Vec<Field>, columns: Vec<ArrayRef>) -> QueryResult {
+        let schema = Arc::new(Schema::new(fields));
+        let batch = RecordBatch::try_new(Arc::clone(&schema), columns).unwrap();
+        QueryResult::new(schema, vec![batch])
+    }
+
+    #[test]
+    fn a_rows_expect_without_a_shape_section_is_refused() {
+        let text =
+            format!("{HDR}{SCHEMA}{SEED}{QUERY}--- expect unordered\n{{\"p.name\": \"alice\"}}\n");
+        let reason = refusal("x", &text);
+        assert!(
+            reason.contains("line 13: the rows expect needs an `--- expect shape` section"),
+            "{reason}"
+        );
+        assert!(reason.contains("OMNIGRAPH_GQ_BLESS=1"), "{reason}");
+        let text = format!(
+            "{HDR}{SCHEMA}{SEED}{QUERY}--- expect unordered\n{{\"p.name\": \"alice\"}}\n{QUERY}{EXPECT}"
+        );
+        assert!(
+            refusal("x", &text).contains("the rows expect needs an `--- expect shape` section")
+        );
+    }
+
+    #[test]
+    fn a_shape_section_must_directly_follow_a_rows_expect() {
+        let placement = "must directly follow a query step's unordered or ordered expect";
+        let text = format!("{HDR}{SCHEMA}{SEED}{SHAPE}{QUERY}{EXPECT}");
+        assert!(refusal("x", &text).contains(placement));
+        let text = format!("{HDR}{SCHEMA}{SEED}{MUTATE}{EXPECT_OK}{SHAPE}");
+        assert!(refusal("x", &text).contains(placement));
+        let text = format!("{HDR}{SCHEMA}{SEED}{QUERY}{SHAPE}");
+        assert!(refusal("x", &text).contains(placement));
+        let text = format!("{HDR}{SCHEMA}{SEED}{QUERY}{EXPECT}{SHAPE}");
+        assert!(refusal("x", &text).contains(placement));
+        let text = format!("{HDR}{SCHEMA}{SEED}{QUERY}--- expect error: T1\n{SHAPE}");
+        assert!(refusal("x", &text).contains(placement));
+    }
+
+    #[test]
+    fn shape_lines_accept_plain_and_dotted_names_and_every_pg_type_ref() {
+        let parsed = lines(
+            "p.name: String\ntotal: I64?\np.tags: [I32]?\np.emb: Vector(2)\n__nanograph_now: DateTime\n\n",
+        );
+        let spelled: Vec<String> = parsed
+            .iter()
+            .map(|l| format!("{}: {}", l.name, l.prop_type.display_name()))
+            .collect();
+        assert_eq!(
+            spelled,
+            [
+                "p.name: String",
+                "total: I64?",
+                "p.tags: [I32]?",
+                "p.emb: Vector(2)",
+                "__nanograph_now: DateTime",
+            ]
+        );
+        assert!(lines("").is_empty());
+    }
+
+    #[test]
+    fn shape_body_refusals_name_the_line() {
+        assert!(shape_refusal("# nope").contains("comments are refused"));
+        assert!(shape_refusal("// nope").contains("comments are refused"));
+        assert!(
+            shape_refusal("p.name String").contains("line 1: not a `<name>: <type>` shape line")
+        );
+        assert!(
+            shape_refusal("p.name: String\n1x: I64").contains("line 2: `1x` is not a column name")
+        );
+        assert!(shape_refusal("a.b.c: I64").contains("is not a column name"));
+        assert!(
+            shape_refusal("p.name: String @key")
+                .contains("annotations and body constraints are not allowed")
+        );
+        assert!(shape_refusal("p: Person").contains("line 1: unknown type `Person`"));
+        assert!(shape_refusal("Name: String").contains("`Name` is not a column name"));
+        assert!(shape_refusal("p.name: String // note").contains("comments are refused"));
+        assert!(shape_refusal("p.name: String /* note */").contains("comments are refused"));
+        assert!(shape_refusal("p.name: string").contains("unknown type `string`"));
+        assert!(shape_refusal("kind: enum(a, b)").contains("`enum(...)` is refused"));
+        assert!(shape_refusal("doc: Blob").contains("`Blob` is refused"));
+    }
+
+    #[test]
+    fn substitution_markers_are_refused_inside_a_shape_body() {
+        let text = format!(
+            "{HDR}{SCHEMA}{SEED}--- foreach $x a b\n{QUERY}--- expect unordered\n--- expect shape\np.${{x}}: String\n--- endloop\n"
+        );
+        assert!(refusal("x", &text).contains("`${` is refused in a shape body"));
+    }
+
+    #[test]
+    fn mismatch_names_the_column_and_spells_both_types_in_pg() {
+        let shape = lines("n: I64?\nm: I32?");
+        let executed = result(
+            vec![
+                Field::new("n", DataType::Int64, true),
+                Field::new("m", DataType::Float64, true),
+            ],
+            vec![
+                Arc::new(arrow_array::Int64Array::from(vec![0])),
+                Arc::new(arrow_array::Float64Array::from(vec![None::<f64>])),
+            ],
+        );
+        let msg = mismatch(&shape, &executed).unwrap();
+        assert_eq!(
+            msg,
+            "result shape mismatch at column 1 `m`: expected I32, the executor returned F64"
+        );
+        let msg = mismatch(&lines("n: I64?"), &executed).unwrap();
+        assert!(
+            msg.contains("names 1 column(s), the executor returned 2"),
+            "{msg}"
+        );
+        let msg = mismatch(&lines("n: I64?\nmm: I32?"), &executed).unwrap();
+        assert!(
+            msg.contains("expected name `mm`, the executor returned `m`"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn a_null_cell_fails_a_column_written_without_the_marker() {
+        let executed = result(
+            vec![Field::new("p.age", DataType::Int32, true)],
+            vec![Arc::new(Int32Array::from(vec![Some(30), None]))],
+        );
+        let msg = mismatch(&lines("p.age: I32"), &executed).unwrap();
+        assert!(
+            msg.contains("written without `?`, the executor returned 1 null(s)"),
+            "{msg}"
+        );
+        assert_eq!(mismatch(&lines("p.age: I32?"), &executed), None);
+        let no_nulls = result(
+            vec![Field::new("p.age", DataType::Int32, true)],
+            vec![Arc::new(Int32Array::from(vec![Some(30)]))],
+        );
+        assert_eq!(mismatch(&lines("p.age: I32"), &no_nulls), None);
+        assert_eq!(mismatch(&lines("p.age: I32?"), &no_nulls), None);
+    }
+
+    #[test]
+    fn bless_spells_the_executed_type_and_marks_only_columns_holding_a_null() {
+        let executed = result(
+            vec![
+                Field::new("p.name", DataType::Utf8, true),
+                Field::new("p.age", DataType::Int32, false),
+            ],
+            vec![
+                Arc::new(StringArray::from(vec![Some("alice"), None])),
+                Arc::new(Int32Array::from(vec![30, 31])),
+            ],
+        );
+        assert_eq!(
+            bless_shape_lines(&executed).unwrap(),
+            ["p.name: String?", "p.age: I32"]
+        );
+    }
+
+    #[test]
+    fn a_shape_header_with_arguments_is_an_unknown_mode() {
+        let text = format!(
+            "{HDR}{SCHEMA}{SEED}{QUERY}--- expect unordered\n{{\"p.name\": \"alice\"}}\n--- expect shape foo\np.name: String\n"
+        );
+        assert!(refusal("x", &text).contains("unknown expect mode `shape foo`"));
+    }
+
+    #[test]
+    fn an_empty_shape_count_mismatch_names_the_bless_route() {
+        let executed = result(
+            vec![Field::new("n", DataType::Int64, true)],
+            vec![Arc::new(arrow_array::Int64Array::from(vec![0]))],
+        );
+        let msg = mismatch(&lines(""), &executed).unwrap();
+        assert!(
+            msg.contains(
+                "names 0 column(s), the executor returned 1; fill it with OMNIGRAPH_GQ_BLESS=1"
+            ),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn a_type_mismatch_the_compiler_sides_with_names_the_executor_as_wrong() {
+        let executed = result(
+            vec![Field::new("m", DataType::Float64, true)],
+            vec![Arc::new(arrow_array::Float64Array::from(vec![None::<f64>]))],
+        );
+        let inferred = Schema::new(vec![Field::new("m", DataType::Int32, true)]);
+        let msg = shape_mismatch(&lines("m: I32?"), &executed, &inferred).unwrap();
+        assert!(msg.ends_with("expected I32, the executor returned F64; the compiler infers I32 too, so the executor is wrong, not the shape line"), "{msg}");
+        let disagreeing = Schema::new(vec![Field::new("m", DataType::Float64, true)]);
+        let msg = shape_mismatch(&lines("m: I32?"), &executed, &disagreeing).unwrap();
+        assert!(
+            msg.ends_with("expected I32, the executor returned F64"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn bless_refuses_a_column_name_the_shape_grammar_cannot_spell() {
+        let executed = result(
+            vec![Field::new("?", DataType::Int64, true)],
+            vec![Arc::new(arrow_array::Int64Array::from(vec![0]))],
+        );
+        let err = bless_shape_lines(&executed).unwrap_err();
+        assert!(
+            err.contains("column `?` is not a column name the shape section can spell"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn bless_refuses_an_arrow_type_with_no_pg_spelling() {
+        let inner = Fields::from(vec![Field::new("id", DataType::Utf8, false)]);
+        let column: ArrayRef = Arc::new(StructArray::new(
+            inner.clone(),
+            vec![Arc::new(StringArray::from(vec!["alice"])) as ArrayRef],
+            None,
+        ));
+        let executed = result(
+            vec![Field::new("p", DataType::Struct(inner), false)],
+            vec![column],
+        );
+        let err = bless_shape_lines(&executed).unwrap_err();
+        assert!(err.contains("column `p` has Arrow type Struct"), "{err}");
+        let msg = mismatch(&lines("p: String"), &executed).unwrap();
+        assert!(
+            msg.contains("expected String, the executor returned Struct"),
+            "{msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_shape_is_checked_before_the_rows() {
+        let text = format!(
+            "{HDR}{AGE_SCHEMA}{AGE_SEED}{AGE_QUERY}--- expect unordered\n{{\"p.name\": \"nobody\"}}\n--- expect shape\np.name: String\np.age: I64?\n"
+        );
+        let case = parse_case("x", &text).unwrap();
+        let err = execute_case(&case, Path::new("unused.gqt"), false)
+            .await
+            .unwrap_err();
+        assert!(err.contains("step 1 (query): result shape mismatch at column 1 `p.age`: expected I64, the executor returned I32"), "got: {err}");
+        assert!(!err.contains("row mismatch"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn a_nullable_property_without_a_null_cell_may_be_written_strict() {
+        let seed = "--- seed\n{\"type\":\"Person\",\"data\":{\"name\":\"alice\",\"age\":30}}\n";
+        let text = format!(
+            "{HDR}{AGE_SCHEMA}{seed}{AGE_QUERY}--- expect unordered\n{{\"p.name\": \"alice\", \"p.age\": 30}}\n--- expect shape\np.name: String\np.age: I32\n"
+        );
+        let case = parse_case("x", &text).unwrap();
+        execute_case(&case, Path::new("unused.gqt"), false)
+            .await
+            .unwrap();
+        let text = format!(
+            "{HDR}{AGE_SCHEMA}{AGE_SEED}{AGE_QUERY}{AGE_ROWS}--- expect shape\np.name: String\np.age: I32\n"
+        );
+        let case = parse_case("x", &text).unwrap();
+        let err = execute_case(&case, Path::new("unused.gqt"), false)
+            .await
+            .unwrap_err();
+        assert!(
+            err.contains("`p.age`: written without `?`, the executor returned 1 null(s)"),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn bless_fills_an_empty_shape_section_from_the_data_and_converges() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bless_shape.gqt");
+        let text = format!("{HDR}{AGE_SCHEMA}{AGE_SEED}{AGE_QUERY}{AGE_ROWS}--- expect shape\n");
+        std::fs::write(&path, &text).unwrap();
+        let case = parse_case("bless_shape", &text).unwrap();
+        let err = execute_case(&case, &path, true).await.unwrap_err();
+        assert!(
+            err.contains("names 0 column(s), the executor returned 2"),
+            "got: {err}"
+        );
+        assert!(
+            err.contains("expect rewritten in place (2 lines)"),
+            "got: {err}"
+        );
+
+        let blessed = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            blessed.ends_with("--- expect shape\np.name: String\np.age: I32?\n"),
+            "got: {blessed}"
+        );
+        let case = parse_case("bless_shape", &blessed).unwrap();
+        execute_case(&case, &path, false).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn bless_never_rewrites_a_shape_over_a_row_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bless_rows_only.gqt");
+        let text = format!(
+            "{HDR}{AGE_SCHEMA}{AGE_SEED}{AGE_QUERY}--- expect unordered\n{{\"p.name\": \"nobody\"}}\n--- expect shape\np.name: String\np.age: I32?\n"
+        );
+        std::fs::write(&path, &text).unwrap();
+        let case = parse_case("bless_rows_only", &text).unwrap();
+        let err = execute_case(&case, &path, true).await.unwrap_err();
+        assert!(err.contains("row mismatch"), "got: {err}");
+        let blessed = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            blessed.ends_with("--- expect shape\np.name: String\np.age: I32?\n"),
+            "got: {blessed}"
+        );
+        assert!(
+            blessed.contains("{\"p.age\":30,\"p.name\":\"alice\"}"),
+            "got: {blessed}"
+        );
+    }
+}
+
 #[tokio::test]
 async fn execution_reports_a_row_mismatch() {
-    let text =
-        format!("{HDR}{SCHEMA}{SEED}{QUERY}--- expect unordered\n{{\"p.name\": \"nobody\"}}\n");
+    let text = format!(
+        "{HDR}{SCHEMA}{SEED}{QUERY}--- expect unordered\n{{\"p.name\": \"nobody\"}}\n{SHAPE}"
+    );
     let case = parse_case("mismatch", &text).unwrap();
     let err = execute_case(&case, Path::new("unused.gqt"), false)
         .await
@@ -516,8 +966,9 @@ async fn execution_reports_a_row_mismatch() {
 async fn bless_rewrites_the_failing_expect_and_converges() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("bless_case.gqt");
-    let text =
-        format!("{HDR}{SCHEMA}{SEED}{QUERY}--- expect unordered\n{{\"p.name\": \"nobody\"}}\n");
+    let text = format!(
+        "{HDR}{SCHEMA}{SEED}{QUERY}--- expect unordered\n{{\"p.name\": \"nobody\"}}\n{SHAPE}"
+    );
     std::fs::write(&path, &text).unwrap();
     let case = parse_case("bless_case", &text).unwrap();
     let err = execute_case(&case, &path, true).await.unwrap_err();
@@ -678,7 +1129,8 @@ const TRAVERSAL_SEED: &str = "--- seed\n{\"type\":\"Person\",\"data\":{\"name\":
 const TRAVERSAL_QUERY: &str = "--- query\nquery friends($n: String) {\n    match {\n        $a: Person\n        \
                                $a.name = $n\n        $a knows $b\n    }\n    return { $b.name }\n}\n";
 const TRAVERSAL_PARAMS: &str = "--- params\n{\"n\": \"alice\"}\n";
-const TRAVERSAL_EXPECT: &str = "--- expect unordered\n{\"b.name\": \"bob\"}\n";
+const TRAVERSAL_EXPECT: &str =
+    "--- expect unordered\n{\"b.name\": \"bob\"}\n--- expect shape\nb.name: String\n";
 
 /// The pin reaches the executor on both paths: a pinned step runs its
 /// expands on the pinned path only, and the probes see them (a zero count
@@ -698,7 +1150,7 @@ async fn pinned_step_runs_only_its_pinned_path() {
         let Some(Item::Step(Step::Query(step))) = case.items.first() else {
             panic!("first item is the query step");
         };
-        let params = build_params(step.params_raw.as_ref(), &step.ast_params, None).unwrap();
+        let params = build_params(step.params_raw.as_ref(), &step.decl.params, None).unwrap();
         let (outcome, counts) = under_traversal(
             Some(mode),
             db.query(
@@ -736,7 +1188,7 @@ fn refuses_ordered_expect_on_an_rrf_led_order() {
     let text = format!("{HDR}{SCHEMA}{SEED}{query}--- expect ordered\n");
     let message = refusal("x", &text);
     assert!(message.contains("led by `rrf()`"), "{message}");
-    let text = format!("{HDR}{SCHEMA}{SEED}{query}--- expect unordered\n");
+    let text = format!("{HDR}{SCHEMA}{SEED}{query}--- expect unordered\n{SHAPE}");
     parse_case("x", &text).unwrap();
 }
 
@@ -746,7 +1198,8 @@ fn refuses_ordered_expect_with_an_aggregate_in_return() {
                  return { count($p) as total }\n    order { bm25($p.name, $t) }\n}\n";
     let text = format!("{HDR}{SCHEMA}{SEED}{query}--- expect ordered\n");
     assert!(refusal("x", &text).contains("aggregate in its `return` list"));
-    let text = format!("{HDR}{SCHEMA}{SEED}{query}--- expect unordered\n");
+    let text =
+        format!("{HDR}{SCHEMA}{SEED}{query}--- expect unordered\n--- expect shape\ntotal: I64?\n");
     parse_case("x", &text).unwrap();
 }
 
@@ -857,7 +1310,7 @@ async fn bless_refuses_cases_containing_loops() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("bless_loop_case.gqt");
     let text = format!(
-        "{HDR}{SCHEMA}{SEED}--- foreach $x a b\n{QUERY}--- expect unordered\n{{\"p.name\": \"nobody\"}}\n--- endloop\n"
+        "{HDR}{SCHEMA}{SEED}--- foreach $x a b\n{QUERY}--- expect unordered\n{{\"p.name\": \"nobody\"}}\n{SHAPE}--- endloop\n"
     );
     std::fs::write(&path, &text).unwrap();
     let case = parse_case("bless_loop_case", &text).unwrap();
@@ -871,7 +1324,9 @@ async fn bless_never_rewrites_on_a_kind_mismatch() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("bless_kind_case.gqt");
     let query = "--- query\nquery q() {\n    match { $p: Person }\n    return { $p.nope }\n}\n";
-    let text = format!("{HDR}{SCHEMA}{SEED}{query}--- expect unordered\n{{\"p.nope\": \"x\"}}\n");
+    let text = format!(
+        "{HDR}{SCHEMA}{SEED}{query}--- expect unordered\n{{\"p.nope\": \"x\"}}\n--- expect shape\np.nope: String\n"
+    );
     std::fs::write(&path, &text).unwrap();
     let case = parse_case("bless_kind_case", &text).unwrap();
     let err = execute_case(&case, &path, true).await.unwrap_err();

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -114,8 +114,13 @@ libtest-shaped output; no per-case gutter runnable exists, since no source
 item does). `--test-threads=<n>` bounds how many cases run
 concurrently (default: the machine's available parallelism); each case fails
 if it exceeds `OMNIGRAPH_GQ_CASE_TIMEOUT_SECS=<n>` seconds (default 10);
-`OMNIGRAPH_GQ_BLESS=1` rewrites the failing step's expect rows in place (local
-workflow only, never CI). Every `ok`/`FAIL` line carries the case's elapsed
+`OMNIGRAPH_GQ_BLESS=1` rewrites the failing step's expect rows, or its shape
+lines, in place (local workflow only, never CI). Every rows step carries a `--- expect shape`
+section, one `<name>: <type>` line per result column in `.pg` property syntax
+(`p.age: I32?`), checked against the executed result before the rows, and the
+executed schema is also checked against the compiler's inferred schema, so a
+wrongly typed column fails even when every cell is null (RFC 0045
+§Comparison semantics). Every `ok`/`FAIL` line carries the case's elapsed
 time, and a case over budget belongs in a `heavy-repro:` `#[ignore]`d test
 under `crates/omnigraph/tests/repro_issue_*.rs`, not the corpus. A name filter
 that matches no case is libtest's ordinary green zero-test run; read the

--- a/docs/rfcs/0045-gq-logic-tests.md
+++ b/docs/rfcs/0045-gq-logic-tests.md
@@ -7,7 +7,7 @@ implementation: partial
 authors:
   - azimafroozeh
 created: 2026-08-29
-updated: 2026-09-04
+updated: 2026-09-05
 discussion: https://github.com/ModernRelay/omnigraph/pull/584
 supersedes: []
 superseded_by: []
@@ -124,12 +124,25 @@ restricts the run to cases whose file name contains the argument, and
 expect-test drives with `UPDATE_EXPECT=1`): `OMNIGRAPH_GQ_BLESS=1`
 rewrites only the `--- expect` sections of the selected cases' failing
 steps, one step per case per run since a case stops at its first failure,
-so bless converges over reruns for row-body mismatches; a header-line
-mismatch stops its case until hand-edited. It rewrites row bodies only,
-in the comparison's normalized form (scale-12 decimals with trailing
-zeros trimmed, object keys sorted, null cells explicit, one row per
-line), in canonical sorted row order for `unordered` expects and the
-run's positional order for `ordered`. Header-line expectations (`error:`
+so bless converges over reruns for row-body and shape mismatches; a
+header-line mismatch stops its case until hand-edited. It rewrites the
+body the failing check owns: the shape body when the shape check failed
+(one line per executed column, the name as executed, the `.pg` spelling of
+the Arrow type, `?` exactly when the column holds a null cell; the
+executor's nullable flag is not read (Comparison semantics says why), so a
+hand-written line without `?` survives where the data holds no null; a
+column whose Arrow type has no `.pg` spelling fails bless with the type
+named), the rows body when the rows failed, and nothing when the computed
+check failed (that red is the executor disagreeing with the compiler, which
+no expectation should absorb), in
+the comparison's normalized form (scale-12 decimals with trailing zeros
+trimmed, object keys sorted, null cells omitted, one row per line), in
+canonical sorted row order for `unordered` expects and the run's
+positional order for `ordered`. Bless pins the executed schema as it
+stands, so a blessed shape can pin a wrong type, which the reviewed diff is
+the gate for: a shape rewrite outside a migration PR is a review flag, and
+the reviewer maps each rewritten line to the return clause's projection
+and its `.pg` declaration. Header-line expectations (`error:`
 substrings, `affected:` counts) stay hand-written, since pasting a full
 error message would defeat the stable-fragment rule in Comparison
 semantics. Bless never runs in CI; the diff of the logic test file is the
@@ -301,6 +314,9 @@ query recall_count($q: String) {
 
 --- expect unordered
 {"total": 2}
+
+--- expect shape
+total: I64
 ```
 
 A multi-step feature case, showing mutation steps, a restart, and a loop:
@@ -344,6 +360,9 @@ query all_names() {
 {"p.name": "alice"}
 {"p.name": "bob"}
 {"p.name": "carol"}
+
+--- expect shape
+p.name: String
 ```
 
 Grammar, fail-closed throughout: a section starts at a line beginning `--- `
@@ -380,7 +399,34 @@ included) is refused. A step is one of:
   by an optional `--- params` section (JSON object) and a mandatory
   `--- expect` section with mode word `unordered`, `ordered`, or
   `error: <substring>`, where the substring is the trimmed remainder of the
-  header line and the section body must be empty.
+  header line and the section body must be empty. A ***rows step*** (an
+  `unordered` or `ordered` expect) is followed by a mandatory
+  `--- expect shape` section, the ***shape section***: one
+  `<name>: <type>` line per result column in `return`-list order, in `.pg`
+  property syntax with `?` permitting a null cell (`p.age: I32?`); a `?` on
+  a `.pg`-nullable property is never wrong, and a line without `?` asserts
+  that no cell is null. The name is the executed column name: `p.name` for
+  an unaliased property or an aggregate over one, `p` for an aggregate over
+  a bare variable (`count($p)`), the alias for `expr as alias`, `literal`
+  for an unaliased literal, `x` for a bare `$x`, `__nanograph_now` for
+  `now()`. A bare node projection (`return { $p }`) has no green shape
+  today: the executor returns the node's id column while the compiler infers
+  the node object, so the computed check refuses the step whatever the shape
+  line says; no corpus case carries one until the engine returns the node
+  object. `x` for a bare `$x` therefore names a bare parameter. The type is
+  a `.pg` `type_ref` (`schema.pest`) parsed by the product schema parser as
+  the one property of a `node Shape { }` declaration the runner wraps around
+  it; annotations, body constraints, `enum(...)` (its Arrow type is `Utf8`,
+  write `String`), `Blob` (not a read value, T24), comment lines, and `${`
+  are refused, blank lines are ignored, and an empty body is accepted as the
+  bless target (it asserts zero columns and is never green). An aggregate's
+  type is `I64` for `count`, `F64` for `sum` and `avg`, and the argument's
+  type for `min` and `max`; a literal's is the compiler's literal inference
+  (`I64` for an integer, `F64` for a float, `String`, `Bool`, `Date`,
+  `DateTime`). A shape section anywhere but directly after a rows expect is
+  refused, and so is a rows expect without one; the latter refusal names the
+  two routes: write it from the `.pg` schema, or fill it with
+  `OMNIGRAPH_GQ_BLESS=1` and review the diff.
 - `--- mutate` holding exactly one GQ declaration with a mutation body,
   followed by an optional `--- params` and a mandatory `--- expect` with
   mode word `ok` (success, counts unasserted),
@@ -433,9 +479,10 @@ loop, or any other name, is refused); no escape syntax exists for a
 literal `${`.
 
 Null cells: a seed row sets a nullable property to null by writing JSON
-`null` for it. A result row always carries every projected column key, with
-null cells rendered as JSON `null` (never an absent key), and expected rows
-are written the same way.
+`null` for it. A result row omits a null cell's key (the Arrow JSON writer,
+RFC 0051), and expected rows are written the same way; the column's type
+and its `?` live in the step's shape section, which is why a rows body
+alone can never pin a type.
 
 File names are `issue_<N>_<short_name>.gqt`, `<short_name>` over `[a-z0-9_]`,
 and `<N>` must equal the `# issue:` header; the harness refuses
@@ -594,6 +641,40 @@ expect section is JSONL, one object per row, same keys.
   raw message fragment is the pin.
 - `expect affected: nodes=<N> edges=<M>`: exact equality on both counts.
   `expect ok` asserts success only.
+- The shape section of a rows step is checked first, against the executed
+  result (`QueryResult::schema()` and the batches), in order: the column
+  count equals the number of shape lines; per position the executed field
+  name equals the line's name; per position the executed `DataType` equals
+  the line's type through `PropType::to_arrow` (Arrow equality, child field
+  included); per position, when the line carries no `?`, no executed cell
+  in that column is null, summed over the batches. The executor's own
+  nullable flag is not compared: `project_return` derives it from the data
+  and the aggregate path declares every column nullable, so only the data
+  can be held to the author's statement, and a `.pg`-nullable property may
+  be written without `?` when the step's data holds no null. The first
+  failing check fails the step with the column position, the column name,
+  and both sides in `.pg` spelling where the executed type has one
+  (`expected Date, the executor returned F64`), Arrow spelling otherwise.
+  When the compiler infers the shape line's type too, the message says so
+  (`the compiler infers I32 too; the executor is wrong, not the shape
+  line`), and bless does not rewrite a shape whose executed schema the
+  compiler disputes: it reports the disagreement instead, since a blessed
+  line would pin an executor defect.
+- When the shape section passes, the executed schema is checked against
+  the schema the compiler infers for the step's declaration against the
+  case's catalog (`infer_query_result_schema`): count, executed-spelling
+  names (`executed_column_name`), `DataType`, and no null cell in a column
+  the compiler infers non-nullable. This costs the author nothing and is
+  the only check that ties `lint --json`'s promise to the executed result.
+  Only then are the rows compared; a schema failure of either kind never
+  reaches the rows comparison and bless never rewrites rows over it. The
+  two checks exist because a row comparison cannot see a type: the JSON
+  writer omits a null cell's key (RFC 0051), so a zero-row aggregate typed
+  `Float64` instead of the declared `Date32` renders as `{"n": 0}` either
+  way ([#623](https://github.com/ModernRelay/omnigraph/issues/623)); the
+  shape section is the author's statement of the columns, the way the rows
+  body is the author's statement of the values, and the computed check
+  proves the compiler and the executor agree.
 
 Ranking scores stay unprojected in logic tests (existing search-test
 practice): assert the resulting row order, never the score values.
@@ -1199,3 +1280,58 @@ listed in Compatibility and reversibility.
     crate still goes through the label); "docs-only fixes" as a reason the
     label exists, narrowed to a rustdoc-only change inside a crate; the
     quotable guarantee's two-way form.
+- 2026-09-05, amendment from the PR that added the result-schema check to
+  the runner. Trigger: the pending fix for #623 removes a zero-row
+  aggregate shortcut that typed every non-`count` column `Float64` against
+  the
+  declared type, and its `.gqt` case could not tell: the JSON writer omits
+  a null cell's key (RFC 0051), so `{"n": 0}` renders from the wrong type
+  and the right one alike. The check that a Rust test had to carry now
+  runs on every rows step.
+  - Comparison semantics: a `unordered`/`ordered` step compares the
+    executed `QueryResult::schema()` against the compiler's
+    `infer_query_result_schema` for the step's declaration before its rows
+    are compared: column count; per position the executed column name
+    (`executed_column_name`, the spelling the executor uses and T25 guards,
+    not `projection_name`'s, which names an unaliased property by the
+    property alone), the Arrow `DataType`, and no null cell in a column the
+    compiler infers non-nullable. The executor's own nullable flag is
+    outside the comparison (data-derived on the projection path, always
+    `true` on the aggregate path). A mismatch fails the step naming the
+    position, the column, and both types; bless does not run over it.
+  - Invariant added: a `.gqt` step that passes has an executed result
+    schema equal in count and Arrow types to the schema the compiler
+    infers for it, with the executed column names
+    (`executed_column_name`), and holds no null in a column inferred
+    non-nullable. A type-level regression in the executor therefore turns
+    a case red even when every affected cell is null.
+  - Runner mechanics: the runner keeps each query step's parsed declaration
+    and typechecks it against the open store's catalog after execution; the
+    typecheck cannot fail for a query that just executed, and a failure
+    there is reported as the step's failure.
+  - File format, the shape section: every rows step carries a mandatory
+    `--- expect shape` section, the author's statement of the result
+    columns in `.pg` property syntax, checked against the executed result
+    before the computed check and the rows (File format, Comparison
+    semantics, Bless mode). The computed check alone proves the executor
+    agrees with the compiler and cannot see a rule both share; its
+    expectation is produced by the code under test, while the rows body is
+    the author's, and the columns should be too (sqllogictest's per-query
+    type string, in the engine's own type vocabulary rather than three
+    letters). Names follow the executed spelling; the compiler's inferred
+    schema and `lint --json` still spell an unaliased property by the
+    property alone, and whether that spelling folds into the executed one
+    is a separate compiler decision. Landing order: until that fix lands, a
+    rows step whose zero-row result carries a non-`count` aggregate is red
+    by design (the executor types the column `Float64`; the `.pg` shape line
+    is right and the failure message says so), and no corpus case carries
+    one. Superseded: File format "a mandatory
+    `--- expect` section with mode word `unordered`, `ordered`, or
+    `error: <substring>`" as the whole of a query step's expectations;
+    File format "A result row always carries every projected column key,
+    with null cells rendered as JSON `null` (never an absent key)" (false
+    since RFC 0051 landed); Bless mode "rewrites row bodies only" and
+    "null cells explicit"; Motivation's "type strings" among the omitted
+    sqllogictest mistakes, for the three-letter form only; and this
+    entry's earlier "No new section, no opt-out", which described the
+    computed check alone.

--- a/scripts/check-fix-regression.py
+++ b/scripts/check-fix-regression.py
@@ -427,6 +427,9 @@ def failure_message(n: str, code_paths: list[str], hints: list[str]) -> str:
         "",
         "    --- expect unordered",
         '    {"p.name": "alice"}',
+        "",
+        "    --- expect shape",
+        "    p.name: String",
     ]
     return "\n".join(parts)
 


### PR DESCRIPTION
## What & why

This PR makes a `.gqt` rows step state and check its result columns, so a wrongly typed result column fails the case even when every affected cell is null. Follow-up to #596 and #607; motivated by the fix for #623, whose zero-row aggregate case could not go red: since #627 the JSON writer omits a null cell's key, so `{"n": 0}` renders from a `Float64` column and a `Date32` column alike, and the type assertion had to live in a Rust test.

- Every rows step (`--- expect unordered` / `--- expect ordered`) carries a mandatory `--- expect shape` section: one `<name>: <type>` line per result column in `.pg` property syntax, `?` permitting a null cell (`p.age: I32?`, `total: I64`, `p.embedding: Vector(3)`). A missing section is a parse refusal naming both routes (write it from the `.pg` schema, or fill it with `OMNIGRAPH_GQ_BLESS=1` and review the diff).
- The section is compared against the executed `QueryResult::schema()` before the rows: column count, executed column name (`executed_column_name`), Arrow `DataType` through `PropType::to_arrow`, and no null cell in a column written without `?`. Messages spell both sides in `.pg` where the executed type has a spelling (`expected I32, the executor returned F64`).
- A second, computed check compares the executed schema against the compiler's `infer_query_result_schema` for the step's declaration: count, name, `DataType`, and no null in a column the compiler infers non-nullable. It costs the author nothing and ties `lint`'s promise to the executed result; the shape section exists because this check cannot see a rule the compiler and the executor share.
- Bless fills an empty section or rewrites a mismatching one from the executed schema, writing `?` exactly when the column holds a null cell (the executor's own nullable flag is never read: `aggregate_return` sets every column nullable). Bless refuses to rewrite a shape whose executed type the compiler disputes, and refuses a type with no `.pg` spelling, naming it.
- `PropType::from_arrow` / `ScalarType::from_arrow` are added to the compiler as the inverse of `to_arrow` over its image, with a round-trip test over every scalar, list and nullable form; `executed_column_name` becomes `pub`.
- The 16 rows steps in the corpus gained their sections (9 cases); RFC 0045 is amended inline (File format, Comparison semantics, Bless mode, Execution semantics, Compatibility, Evidence, dated decision-log entry with a Superseded list); `docs/dev/testing.md`, the crate README, AGENTS.md's regression-tier sentence and the Fix Regression Gate's printed skeleton follow.

## Backing issue / RFC

- [x] Implements RFC 0045, GQ logic tests (`docs/rfcs/0045-gq-logic-tests.md`), amended in this PR with the shape section and the result-schema check; no separate issue.

## Checklist

- [x] Change is focused (the `.gqt` runner's result-schema checking: shape section, computed check, bless, and the docs and corpus that carry them)
- [x] Tests added/updated for behavior changes (116 runner self-tests, 22 of them new: section placement and refusals, mismatch messages, bless convergence and refusals, shape-before-rows ordering; compiler `from_arrow` round-trip; the 11 corpus cases run with their 16 shape sections; disabling the check turns three wiring pins red)
- [x] Public docs updated if user-facing surface changed (`docs/dev/testing.md`, `crates/omnigraph-gqt/README.md`, AGENTS.md, RFC 0045; no product surface changes)
- [x] Reviewed against docs/dev/invariants.md — no Hard Invariant weakened, no deny-list item hit (test harness and one compiler visibility change plus a pure type mapping; the product `.pg` grammar and the query surface are untouched)

## Local verification

- `cargo check --workspace --all-targets` — green
- `cargo test -p omnigraph-gqt` — green: 116 self-tests, 11 corpus cases
- `cargo test -p omnigraph-compiler types::` — green: 5 tests
- `cargo clippy -p omnigraph-gqt -p omnigraph-compiler --all-targets -- -D warnings -W clippy::dbg_macro` — green
- `cargo fmt --all --check` — green
- `python3 scripts/check-fix-regression.py --self-test` — ok
- `scripts/check-agents-md.sh` — green (45 links, 43 docs)
- `python3 scripts/check-docs.py` — green (125 files)
- `cargo run -p omnigraph-vocabulary-guard -- check --surface rust-string --base <merge base> ...` — not conclusive: the audit is disabled in CI (`VOCABULARY_AUDIT_ENABLED: "false"`) and the merge base itself reports unclassified occurrences
- `cargo test --workspace` — not run: the engine and server crates are not touched; the compiler change is a visibility keyword and a new type mapping covered by its own tests

## Notes for reviewers

- Landing order: a rows step whose zero-row result carries a non-`count` aggregate is red until the fix for #623 lands (the executor types the column `Float64`); the shape line written from the `.pg` schema is right, the message says so, and bless refuses to pin the executor's type. No corpus case carries one.
- Landing order: a bare node projection (`return { $p }`) is red under the computed check until the bare-node projection fix lands (the compiler infers the node object, the executor returns the id column); no corpus case carries one, and the failure message names the form.
- Open PRs whose cases have rows steps go red on rebase until their sections are added; bless fills them in one run per step, and the reviewed diff is where each blessed line is checked against its `.pg` declaration. #617 is the largest.
- Honest routes the docs give an author: write the section by hand from the `.pg` schema and the return clause; or run, hit the refusal, bless, review the diff. `p: Person` for a bare node is refused until the bare-node fix lands. A `.pg`-nullable property may be written without `?` when the step's data holds no null; that is the stronger assertion and is accepted.
- What the rule does not stop, accepted: blind bless of a wrong type (the reviewed diff is the stop; a shape rewrite outside a migration PR is a review flag); a hand-written `?` on a never-null column (nothing mechanical; bless never writes one the data does not justify, so it is visibly hand-made); aliasing every column to dodge the name spelling (legitimate, the types are still checked); a shape-only rebless in an `issue_N` case satisfying the Fix Regression Gate's added-body-line rule (a review flag).
- Column names follow the executed spelling (`p.name` for an unaliased property); the compiler's inferred schema and `lint --json` still spell it `name`, and whether that folds into the executed spelling is a separate compiler decision, out of scope here.
- Two comparators share one null-count walk rather than one comparator with two inputs: the shape check reports in `.pg` vocabulary against the author's lines, the computed check in Arrow vocabulary against the compiler's fields.
- Engine footprint: one `pub` on `executed_column_name`, `from_arrow` on `PropType` and `ScalarType`; `omnigraph-gqt` gains `arrow-schema` (dep) and `arrow-array` (dev-dep).