### PR TITLE
fix(query): search ordering over a node type with a Blob property no longer fails

### DIFF
--- a/crates/omnigraph-gqt/cases/issue_634_blob_property_keeps_search_ranking.gqt
+++ b/crates/omnigraph-gqt/cases/issue_634_blob_property_keeps_search_ranking.gqt
@@ -1,0 +1,60 @@
+# issue: 634
+# red_on: 2026-09-05, main b570ebb2: query failed: search-ordered query produced rows without its 'c._score' ranking column
+# notes: a node type with a Blob property scans with an explicit non-Blob
+# notes: projection and rebuilds the batch afterwards; the rebuild must keep
+# notes: the ranking column the scan projects (`_score` for bm25, `_distance`
+# notes: for nearest) or the search-ordered read is refused. This case is the
+# notes: sole guard (no Rust twin). Seed rows have equal length so the bm25
+# notes: order rests on tf alone, not on length normalisation, and both
+# notes: expected orders are the reverse of the id tie-break order, so a
+# notes: present-but-constant ranking column fails the step.
+
+--- schema
+node Chunk {
+    slug: String @key
+    text: String @index
+    embedding: Vector(2)
+    payload: Blob?
+}
+
+--- seed
+{"type":"Chunk","data":{"slug":"chunk-00","text":"needle filler filler filler","embedding":[1.0,0.0]}}
+{"type":"Chunk","data":{"slug":"chunk-01","text":"needle needle needle filler","embedding":[0.0,1.0]}}
+
+--- query
+query ranked($q: String) {
+    match {
+        $c: Chunk
+        search($c.text, $q)
+    }
+    return { $c.slug }
+    order { bm25($c.text, $q) }
+}
+
+--- params
+{"q": "needle"}
+
+--- expect ordered
+{"c.slug": "chunk-01"}
+{"c.slug": "chunk-00"}
+
+--- expect shape
+c.slug: String
+
+--- query
+query closest($v: Vector(2)) {
+    match { $c: Chunk }
+    return { $c.slug }
+    order { nearest($c.embedding, $v) }
+    limit 2
+}
+
+--- params
+{"v": [0.0, 0.9]}
+
+--- expect ordered
+{"c.slug": "chunk-01"}
+{"c.slug": "chunk-00"}
+
+--- expect shape
+c.slug: String

--- a/crates/omnigraph/src/exec/query.rs
+++ b/crates/omnigraph/src/exec/query.rs
@@ -3838,20 +3838,40 @@ async fn execute_node_scan(
     // key, RRF fusion key, `apply_ordering` tie-break) and the type's key
     // columns (the row's declared identity, retained as cheap insurance).
     // `None` (unreferenced binding) and `All` (bare `$var`) fail open to the
-    // full non-blob projection; so do search scans, because Lance
-    // autoprojects `_distance`/`_score` onto explicit projections that omit
-    // them, with a deprecation warning. Only NodeScan bindings prune:
+    // full non-blob projection; so do search scans (a pruned search
+    // projection is untested, and the Blob-bearing search projection names
+    // its ranking column below). Only NodeScan bindings prune:
     // `hydrate_nodes` (Expand dst hydration) and edge-property attach keep
     // the full non-blob width.
-    let is_search_scan = search_mode
+    let nearest_here = search_mode
         .nearest
         .as_ref()
-        .is_some_and(|(var, ..)| var == variable)
-        || search_mode
-            .bm25
-            .as_ref()
-            .is_some_and(|(var, ..)| var == variable)
-        || filters.iter().any(is_search_filter);
+        .is_some_and(|(var, ..)| var == variable);
+    let bm25_here = search_mode
+        .bm25
+        .as_ref()
+        .is_some_and(|(var, ..)| var == variable);
+    // Search filters resolve once, here: the list decides the projection
+    // below and configures the scanner in the closure.
+    let fts_queries: Vec<lance_index::scalar::FullTextSearchQuery> = filters
+        .iter()
+        .filter(|filter| is_search_filter(filter))
+        .filter_map(|filter| build_fts_query(&filter.left, params))
+        .collect();
+    let is_search_scan = nearest_here || bm25_here || filters.iter().any(is_search_filter);
+    // A search scan behind an explicit projection (the Blob-bearing type's
+    // non-blob list) names its ranking column: Lance still autoprojects
+    // `_distance`/`_score` onto explicit projections that omit them, but
+    // labels that behavior deprecated and warns on every such scan, and the
+    // projection-free path never depended on it. `add_null_blob_columns`
+    // carries the column through the post-scan rebuild.
+    let mut blob_scan_cols: Vec<&str> = non_blob_cols.clone();
+    if has_blobs && nearest_here {
+        blob_scan_cols.push("_distance");
+    }
+    if has_blobs && (bm25_here || !fts_queries.is_empty()) {
+        blob_scan_cols.push("_score");
+    }
     let pruned_cols: Option<Vec<&str>> = match binding_columns {
         Some(NeededColumns::Columns(columns)) if !is_search_scan => Some(
             non_blob_cols
@@ -3871,7 +3891,7 @@ async fn execute_node_scan(
     };
     let projection = match &pruned_cols {
         Some(columns) => Some(columns.as_slice()),
-        None => has_blobs.then_some(non_blob_cols.as_slice()),
+        None => has_blobs.then_some(blob_scan_cols.as_slice()),
     };
     let batches = crate::table_store::TableStore::scan_stream_with(
         &ds,
@@ -3898,14 +3918,10 @@ async fn execute_node_scan(
             }
 
             // Apply FTS queries from hoisted search filters (search/fuzzy/match_text in match clause)
-            for filter in filters {
-                if is_search_filter(filter) {
-                    if let Some(fts_query) = build_fts_query(&filter.left, params) {
-                        scanner.full_text_search(fts_query).map_err(|error| {
-                            OmniError::storage_context("full_text_search filter", error)
-                        })?;
-                    }
-                }
+            for fts_query in fts_queries {
+                scanner.full_text_search(fts_query).map_err(|error| {
+                    OmniError::storage_context("full_text_search filter", error)
+                })?;
             }
 
             // Apply nearest vector search if this variable is the target
@@ -4019,11 +4035,16 @@ async fn execute_node_scan(
 /// Uses column_by_name (not positional) so it's order-independent, and
 /// silently skips non-blob fields absent from the batch — LOAD-BEARING for
 /// pruned scans (#564), which legitimately omit undemanded non-blob columns.
+/// Every column the scan produced beside the catalog's rides through after
+/// the catalog columns, as the no-blob path (batch passed through untouched)
+/// already delivers it: a search scan's `_distance`/`_score` must survive
+/// this rebuild because `search_score_orderings` ranks on it.
 fn add_null_blob_columns(
     batch: &RecordBatch,
     node_type: &omnigraph_compiler::catalog::NodeType,
 ) -> Result<RecordBatch> {
     let num_rows = batch.num_rows();
+    let batch_schema = batch.schema();
     let mut fields = Vec::with_capacity(node_type.arrow_schema.fields().len());
     let mut columns: Vec<ArrayRef> = Vec::with_capacity(node_type.arrow_schema.fields().len());
 
@@ -4032,7 +4053,6 @@ fn add_null_blob_columns(
             fields.push(Field::new(field.name(), DataType::Utf8, true));
             columns.push(Arc::new(StringArray::from(vec![None::<&str>; num_rows])));
         } else if let Some(col) = batch.column_by_name(field.name()) {
-            let batch_schema = batch.schema();
             let batch_field = batch_schema
                 .field_with_name(field.name())
                 .map_err(OmniError::arrow_internal)?;
@@ -4040,6 +4060,23 @@ fn add_null_blob_columns(
             columns.push(col.clone());
         }
     }
+    for (field, col) in batch_schema.fields().iter().zip(batch.columns()) {
+        if node_type.arrow_schema.fields().find(field.name()).is_none() {
+            fields.push(field.as_ref().clone());
+            columns.push(col.clone());
+        }
+    }
+    debug_assert_eq!(
+        columns.len(),
+        batch.num_columns()
+            + node_type
+                .arrow_schema
+                .fields()
+                .iter()
+                .filter(|field| node_type.blob_properties.contains(field.name()))
+                .count(),
+        "add_null_blob_columns dropped or replaced a scan column"
+    );
 
     RecordBatch::try_new(Arc::new(Schema::new(fields)), columns).map_err(OmniError::arrow_internal)
 }


### PR DESCRIPTION
## What & why

Closes #634. A `bm25()`- or `nearest()`-ordered query over a node type that declares a `Blob` property fails with `search-ordered query produced rows without its 'c._score' ranking column` (`'c._distance'` for `nearest`); the same query on the same type without the `Blob` property returns the ranked rows. Regression on `main` since #544, not in any release.

- Cause: a type with a `Blob` property scans behind an explicit non-Blob projection and rebuilds the batch afterwards; the rebuild copied only catalog properties, so Lance's `_score` / `_distance` (reserved names, never catalog properties) was dropped one step before `search_score_orderings` ranked on it. Before #544 nothing read the column and the rows came back in Lance's ranked scan order; #544 made it load-bearing without widening the rebuild.
- Fix, rebuild: the post-scan rebuild keeps every column the scan produced beside the catalog's, appended after the catalog-ordered ones. The rule is parity with the projection-free path, which hands Lance's batch through untouched; a `debug_assert_eq!` pins the column count.
- Fix, projection: the Blob-bearing search projection names its ranking column (`_distance` for `nearest`, `_score` for `bm25` or a resolvable `search()` filter) instead of relying on Lance's autoprojection, which Lance 11 labels deprecated and warns on. Search filters resolve once and feed both the projection and the scanner. Pruned projections (#564) never apply to search scans and are untouched.
- Test: `issue_634_blob_property_keeps_search_ranking.gqt`, schema `Chunk { slug @key, text @index, embedding: Vector(2), payload: Blob? }`, one `bm25` step and one `nearest` step, each expecting the reverse of the id tie-break so a present-but-constant ranking column fails the step, each with its `--- expect shape` (`c.slug: String`). Red on `b570ebb2`, green with the fix on `50f3a6bc`.

## Backing issue / RFC

- [x] Fixes an **accepted** issue: Closes #634 (the `issue_634_*.gqt` case is in the diff; `Fix Regression Gate` applies)

## Checklist

- [x] Change is focused (one logical change: the Blob-bearing scan path keeps the ranking column, rebuild and projection in `scan_node_type`)
- [x] Tests added/updated for behavior changes (the `.gqt` case with a `bm25` and a `nearest` step; it is the sole guard, no Rust twin)
- [x] Public docs updated if user-facing surface changed (N/A: `docs/user/blobs.md` never said search and `Blob` were exclusive; no release-note line because no release carried the refusal)
- [x] Reviewed against [docs/dev/invariants.md](../blob/main/docs/dev/invariants.md) — no Hard Invariant weakened, no deny-list item hit (nearest miss: the execution rule that rank and score survive downstream operations was the one broken on `main`; met after the diff)

## Local verification

- `cargo test -p omnigraph-gqt --test gq_logic_tests blob_property` — red on the untouched tree (`query failed: search-ordered query produced rows without its 'c._score' ranking column`), green with the fix, both steps
- `cargo test -p omnigraph-gqt` — green on the rebased tree (`50f3a6bc`), 116 self-tests + 12 cases, shape and executed-schema checks included
- `cargo test -p omnigraph-engine --test search --test ordering --test end_to_end --test aggregation --test traversal --test literal_filters --test lineage_projection` — green, 164 tests
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `python3 scripts/check-docs.py` — green, 125 files
- `cargo run -p omnigraph-vocabulary-guard -- check --surface rust-string --base b570ebb2 …` — no occurrence introduced by this diff (the 195 reported are all on the merge base; the audit is off in CI)
- `cargo test --workspace` — not run: the engine integration targets above and the corpus crate were run instead

## Notes for reviewers

- Regression on `main` only: `search_score_orderings` and the ranking-column guard arrived with #544 (`6126e683`, unreleased); at v0.10.0 the ordering block skipped search-ordered plans, so a Blob-bearing type's search query returned rows in Lance's ranked order. Hence no release-note line.
- The rebuild's pass-through admits any non-catalog column, not just the two ranking names: parity with the projection-free path is the invariant, and narrowing it to two names would reopen the divergence this PR closes. The count assert is debug-only.
- Adjacent, out of scope: no search or DST fixture declares a `Blob` property (why #544 landed green), and the empty-result arm derives the scan schema a second time without the ranking column (harmless behind the rows-present gate).