### PR TITLE
fix(query): accept `Bool`, `Date`, and `DateTime` in `min` and `max`

### DIFF
--- a/crates/omnigraph-compiler/src/query/typecheck.rs
+++ b/crates/omnigraph-compiler/src/query/typecheck.rs
@@ -1586,7 +1586,6 @@ fn resolve_expr_type(
             let arg_type = resolve_expr_type(catalog, arg, ctx, params)?;
             reject_blob_read_value(&arg_type, arg)?;
 
-            // T8: sum/avg require numeric; min/max require numeric or string
             match func {
                 AggFunc::Sum | AggFunc::Avg => {
                     if let ResolvedType::Scalar(s) = &arg_type
@@ -1601,10 +1600,10 @@ fn resolve_expr_type(
                 }
                 AggFunc::Min | AggFunc::Max => {
                     if let ResolvedType::Scalar(s) = &arg_type
-                        && (s.list || (!s.scalar.is_numeric() && s.scalar != ScalarType::String))
+                        && (s.list || !s.scalar.is_orderable())
                     {
                         return Err(CompilerError::Type(format!(
-                            "T8: {} requires numeric or string type, got {}",
+                            "T8: {} requires a numeric, String, Bool, Date, or DateTime scalar, got {}",
                             func,
                             s.display_name()
                         )));

--- a/crates/omnigraph-compiler/src/types.rs
+++ b/crates/omnigraph-compiler/src/types.rs
@@ -101,6 +101,15 @@ impl ScalarType {
             Self::I32 | Self::I64 | Self::U32 | Self::U64 | Self::F32 | Self::F64
         )
     }
+
+    /// The scalar argument types `min` and `max` accept.
+    pub(crate) fn is_orderable(&self) -> bool {
+        self.is_numeric()
+            || matches!(
+                self,
+                Self::String | Self::Bool | Self::Date | Self::DateTime
+            )
+    }
 }
 
 impl std::fmt::Display for ScalarType {

--- a/crates/omnigraph-gqt/cases/issue_623_min_max_over_date_and_bool.gqt
+++ b/crates/omnigraph-gqt/cases/issue_623_min_max_over_date_and_bool.gqt
@@ -1,0 +1,112 @@
+# issue: 623
+# red_on: 2026-09-04, main @ 8ca9b12c: refused at typecheck (min requires numeric or string type, got Date?); the Bool and DateTime columns are refused by the same rule.
+
+--- schema
+node Person {
+    name: String @key
+    birthdate: Date?
+    isStudent: Bool?
+    registered: DateTime?
+    tags: [I32]?
+    emb: Vector(2)?
+    doc: Blob?
+}
+
+--- seed
+{"type":"Person","data":{"name":"alice","birthdate":"1900-01-01","isStudent":true,"registered":"2020-05-01T10:00:00.000Z"}}
+{"type":"Person","data":{"name":"bob","birthdate":"1940-06-22","isStudent":false,"registered":"2019-12-31T23:59:59.999Z"}}
+{"type":"Person","data":{"name":"carol"}}
+
+--- query
+query min_max_over_date_and_bool() {
+    match {
+        $p: Person
+    }
+    return { min($p.birthdate) as min_birthdate, max($p.birthdate) as max_birthdate, min($p.isStudent) as min_is_student, max($p.isStudent) as max_is_student, min($p.registered) as first_registered, max($p.registered) as last_registered }
+}
+
+--- expect unordered
+{"min_birthdate": "1900-01-01", "max_birthdate": "1940-06-22", "min_is_student": false, "max_is_student": true, "first_registered": "2019-12-31T23:59:59.999", "last_registered": "2020-05-01T10:00:00"}
+
+--- expect shape
+min_birthdate: Date
+max_birthdate: Date
+min_is_student: Bool
+max_is_student: Bool
+first_registered: DateTime
+last_registered: DateTime
+
+--- query
+query zero_rows_one_null_row() {
+    match {
+        $p: Person
+        $p.name = "nobody"
+    }
+    return { count($p) as n, min($p.birthdate) as min_birthdate, max($p.isStudent) as max_is_student, min($p.registered) as first_registered }
+}
+
+--- expect unordered
+{"n": 0}
+
+--- expect shape
+n: I64
+min_birthdate: Date?
+max_is_student: Bool?
+first_registered: DateTime?
+
+--- query
+query null_only_group_yields_null() {
+    match {
+        $p: Person
+        $p.name = "carol"
+    }
+    return { count($p) as n, max($p.isStudent) as max_is_student, min($p.birthdate) as min_birthdate }
+}
+
+--- expect unordered
+{"n": 1}
+
+--- expect shape
+n: I64
+max_is_student: Bool?
+min_birthdate: Date?
+
+--- query
+query min_over_list_refused() {
+    match {
+        $p: Person
+    }
+    return { min($p.tags) as t }
+}
+
+--- expect error: T8: min requires a numeric, String, Bool, Date, or DateTime scalar, got [I32]
+
+--- query
+query max_over_vector_refused() {
+    match {
+        $p: Person
+    }
+    return { max($p.emb) as e }
+}
+
+--- expect error: T8: max requires a numeric, String, Bool, Date, or DateTime scalar, got Vector(2)
+
+--- query
+query sum_over_date_refused() {
+    match {
+        $p: Person
+    }
+    return { sum($p.birthdate) as s }
+}
+
+--- expect error: T8: sum requires numeric type, got Date?
+
+--- query
+query min_over_blob_refused() {
+    match {
+        $p: Person
+    }
+    return { min($p.doc) as d }
+}
+
+--- expect error: T24: Blob property `$p.doc` is not available as a .gq read value

--- a/crates/omnigraph/src/exec/projection.rs
+++ b/crates/omnigraph/src/exec/projection.rs
@@ -566,11 +566,6 @@ fn aggregate_return(
         }
     }
 
-    // Handle empty input: return a single row with count=0, others=null
-    if num_rows == 0 && group_keys.is_empty() {
-        return build_empty_aggregate_result(projections);
-    }
-
     // Build group assignments
     let mut group_map: HashMap<String, usize> = HashMap::new();
     let mut group_indices: Vec<Vec<usize>> = Vec::new();
@@ -800,6 +795,9 @@ fn compute_min_max(
         DataType::UInt64 => minmax_typed!(UInt64Array, UInt64Builder, arg, is_min),
         DataType::Float32 => minmax_typed!(Float32Array, Float32Builder, arg, is_min),
         DataType::Float64 => minmax_typed!(Float64Array, Float64Builder, arg, is_min),
+        DataType::Boolean => minmax_typed!(BooleanArray, BooleanBuilder, arg, is_min),
+        DataType::Date32 => minmax_typed!(Date32Array, Date32Builder, arg, is_min),
+        DataType::Date64 => minmax_typed!(Date64Array, Date64Builder, arg, is_min),
         DataType::Utf8 => {
             let arr = arg.as_any().downcast_ref::<StringArray>().ok_or_else(|| {
                 OmniError::manifest(format!("min/max: expected Utf8, got {:?}", arg.data_type()))
@@ -834,34 +832,4 @@ fn compute_min_max(
             dt
         ))),
     }
-}
-
-/// Build a single-row result for an aggregate query with zero input rows and no group keys.
-fn build_empty_aggregate_result(projections: &[IRProjection]) -> Result<RecordBatch> {
-    let mut fields = Vec::with_capacity(projections.len());
-    let mut columns: Vec<ArrayRef> = Vec::with_capacity(projections.len());
-
-    for proj in projections {
-        let name = proj.alias.as_deref().unwrap_or("?");
-        match &proj.expr {
-            IRExpr::Aggregate { func, .. } => match func {
-                AggFunc::Count => {
-                    fields.push(Field::new(name, DataType::Int64, true));
-                    columns.push(Arc::new(Int64Array::from(vec![0i64])) as ArrayRef);
-                }
-                _ => {
-                    fields.push(Field::new(name, DataType::Float64, true));
-                    columns
-                        .push(Arc::new(Float64Array::from(vec![None as Option<f64>])) as ArrayRef);
-                }
-            },
-            _ => {
-                fields.push(Field::new(name, DataType::Utf8, true));
-                columns.push(Arc::new(StringArray::from(vec![None as Option<&str>])) as ArrayRef);
-            }
-        }
-    }
-
-    let schema = Arc::new(Schema::new(fields));
-    RecordBatch::try_new(schema, columns).map_err(OmniError::arrow_internal)
 }

--- a/docs/releases/v0.11.0.md
+++ b/docs/releases/v0.11.0.md
@@ -58,6 +58,17 @@ Notes accumulate here until the release is cut.
   spellings but KEEP an explicit `null` for a null cell, because an absent key
   there means the property was not in that commit's schema.
 
+- **`min` and `max` accept `Bool`, `Date`, and `DateTime` columns.**
+  `min($p.birthdate)` over a `Date` column was refused at compile time
+  (`T8: min requires numeric or string type, got Date?`), and `DateTime` and
+  `Bool` columns the same way. Both aggregates now take numeric, `String`,
+  `Bool` (`false` before `true`), `Date`, and `DateTime` (chronological)
+  columns and return the column's own type. Lists, vectors, and Blob values
+  stay refused. Over zero matched rows `min` and `max` now return a null in
+  the column's own type (it was a `Float64` null); `sum` and `avg` stay
+  `Float64` and `count` still returns 0. A JSON row omits the null cell's
+  key, so the type shows only in the Arrow IPC result schema.
+
 - **Two projections producing one result column name are refused at
   compile time (`T25`).** `return { $a.num1 as number, $a.num2 as number }`
   used to run and emit two columns both named `number`; every reader that

--- a/docs/user/queries/index.md
+++ b/docs/user/queries/index.md
@@ -94,7 +94,12 @@ limit 20
 
 Return expressions include variables, properties, literals, `now()`, earlier
 projection aliases, and the aggregates `count`, `sum`, `avg`, `min`, and `max`.
-'''''' Each projection produces one result column, named by its alias or, without
+`min` and `max` accept a numeric, `String`, `Bool`, `Date`, or `DateTime`
+column and return the column's own type; `Bool` orders `false` before `true`,
+dates and datetimes chronologically. When no row matches, a query whose
+projections are all aggregates returns one row: `count` is 0 and every other
+aggregate is null; a query that also projects a group value returns no rows.
+Each projection produces one result column, named by its alias or, without
 one, by its expression (`$p.name` gives `p.name`). Two projections that would
 produce the same column name are refused at compile time (`T25`); give each
 its own alias.


### PR DESCRIPTION
## What & why

Closes #623. `min($p.birthdate)` over a `Date` column was refused at typecheck (`T8: min requires numeric or string type, got Date?`), and `DateTime` and `Bool` columns the same way; only numeric and `String` columns passed, and the executor had arms for those alone. Found converting Kuzu's aggregate tests to `.gqt` cases.

- The `T8` rule for `min`/`max` keys on one predicate naming the accepted scalars (numeric, `String`, `Bool`, `Date`, `DateTime`) and its message lists them; lists, vectors, and Blob values stay refused.
- The executor gains `Boolean`, `Date32`, and `Date64` arms through the existing typed min/max path (`false` before `true`, dates chronological); the result keeps the column's own type, as before.
- The zero-row shortcut that typed every non-count aggregate as a `Float64` null is deleted: an all-aggregate query over zero matched rows now flows through grouping as one empty group, so `count` is 0 and `min`/`max` return a null of the column's own type; `sum` and `avg` still build `Float64`.
- Case `issue_623_min_max_over_date_and_bool.gqt`: one accept step over all three column types, a zero-row step and a null-only-row step whose `--- expect shape` blocks pin the result types through the schema check from #635, and four refusal steps (`min` over a list, `max` over a `Vector`, `sum` over a `Date`, `min` over a `Blob`).

## Backing issue / RFC

- [x] Fixes an **accepted** issue: Closes #623 (the diff carries `issue_623_min_max_over_date_and_bool.gqt`)

## Checklist

- [x] Change is focused (one typecheck predicate, three executor arms, and the zero-row builder that contradicted the declared type)
- [x] Tests added/updated for behavior changes (the `.gqt` case, 7 steps: accept, zero rows, null-only row, four refusals; result types via `--- expect shape`; no Rust test, nothing the format cannot express)
- [x] Public docs updated if user-facing surface changed (`docs/user/queries/index.md`: accepted types, ordering, zero-row shape; `docs/releases/v0.11.0.md`: Highlights bullet)
- [x] Reviewed against docs/dev/invariants.md — no Hard Invariant weakened, no deny-list item hit (typecheck and projection only; no storage, commit, or policy path touched)

## Local verification

- `cargo test -p omnigraph-gqt` — 116 unit + 12 cases green on `50f3a6bc` (the new case: 7 steps)
- `cargo test -p omnigraph-compiler` — 332 green
- `cargo test -p omnigraph-engine --test aggregation` — 8 green
- `cargo clippy --workspace --all-targets` — green
- `cargo fmt --all --check` — clean
- `python3 scripts/check-docs.py` — 126 files OK
- `cargo test --workspace` — run on the previous base `9570c7a7`: lib 403 passed / 1 failed (`external_blob_file_policy_rejects_special_files`, a known failure under the dev-machine sandbox), 45 integration binaries green; not rerun on `50f3a6bc`

## Notes for reviewers

- Behavior change beyond the accept set: over zero matched rows an all-aggregate query's `min`/`max` columns are now typed as the column, not `Float64`. A JSON row omits a null cell's key, so the difference shows only in the Arrow IPC result schema from #627.
- The deleted zero-row builder was a second producer of that row shape; the grouping path already builds it, and a no-match query that also projects a group value still returns zero rows (stated in the user doc).
- `Bool` in `min`/`max` follows Kuzu, Neo4j, DuckDB, and Memgraph; PostgreSQL refuses it and offers `bool_and`/`bool_or` instead.
- Pre-existing and out of scope: the `T8` rule consults the accept set only for scalar arguments, so `min($p)` over a node variable still typechecks and orders the id string.
- Drive-by in the same user-doc paragraph: the stray `''''''` left by #621 is removed.