### PR TITLE
fix(loader): refuse wrong-typed JSON dates instead of coercing them to NULL

### DIFF
--- a/crates/omnigraph/src/loader/mod.rs
+++ b/crates/omnigraph/src/loader/mod.rs
@@ -2274,6 +2274,7 @@ fn build_column_from_json(
             let mut values = Vec::with_capacity(rows.len());
             for row in rows {
                 values.push(parse_date32_json_value(
+                    name,
                     row.get(name).unwrap_or(&JsonValue::Null),
                 )?);
             }
@@ -2283,6 +2284,7 @@ fn build_column_from_json(
             let mut values = Vec::with_capacity(rows.len());
             for row in rows {
                 values.push(parse_date64_json_value(
+                    name,
                     row.get(name).unwrap_or(&JsonValue::Null),
                 )?);
             }
@@ -2307,7 +2309,7 @@ fn build_column_from_json(
                     ))
                 })?;
                 for item in items {
-                    append_json_list_item(builder.values(), field.data_type(), item)?;
+                    append_json_list_item(name, builder.values(), field.data_type(), item)?;
                 }
                 builder.append(true);
             }
@@ -2512,6 +2514,7 @@ fn checked_json_f32(value: f64, context: &str) -> Result<f32> {
 }
 
 fn append_json_list_item(
+    property: &str,
     builder: &mut Box<dyn ArrayBuilder>,
     data_type: &DataType,
     value: &JsonValue,
@@ -2636,7 +2639,7 @@ fn append_json_list_item(
                 .as_any_mut()
                 .downcast_mut::<Date32Builder>()
                 .ok_or_else(|| OmniError::manifest("list Date32 builder downcast failed"))?;
-            if let Some(value) = parse_date32_json_value(value)? {
+            if let Some(value) = parse_date32_json_value(property, value)? {
                 builder.append_value(value);
             } else {
                 builder.append_null();
@@ -2647,7 +2650,7 @@ fn append_json_list_item(
                 .as_any_mut()
                 .downcast_mut::<Date64Builder>()
                 .ok_or_else(|| OmniError::manifest("list Date64 builder downcast failed"))?;
-            if let Some(value) = parse_date64_json_value(value)? {
+            if let Some(value) = parse_date64_json_value(property, value)? {
                 builder.append_value(value);
             } else {
                 builder.append_null();
@@ -2664,27 +2667,35 @@ fn append_json_list_item(
     Ok(())
 }
 
-fn parse_date32_json_value(value: &JsonValue) -> Result<Option<i32>> {
+fn parse_date32_json_value(property: &str, value: &JsonValue) -> Result<Option<i32>> {
     if value.is_null() {
         return Ok(None);
     }
     if let Some(days) = value.as_i64() {
-        let days = i32::try_from(days)
-            .map_err(|_| OmniError::manifest(format!("Date value out of range: {}", days)))?;
+        let days = i32::try_from(days).map_err(|_| {
+            OmniError::manifest(format!(
+                "Date value {days} for property '{property}' is outside the i32 day range"
+            ))
+        })?;
         return Ok(Some(checked_date32(days)?));
     }
     if let Some(days) = value.as_u64() {
-        let days = i32::try_from(days)
-            .map_err(|_| OmniError::manifest(format!("Date value out of range: {}", days)))?;
+        let days = i32::try_from(days).map_err(|_| {
+            OmniError::manifest(format!(
+                "Date value {days} for property '{property}' is outside the i32 day range"
+            ))
+        })?;
         return Ok(Some(checked_date32(days)?));
     }
     if let Some(value) = value.as_str() {
         return Ok(Some(parse_date32_literal(value)?));
     }
-    Ok(None)
+    Err(OmniError::manifest(format!(
+        "invalid Date value {value} for property '{property}': expected an integer day count or a date string"
+    )))
 }
 
-fn parse_date64_json_value(value: &JsonValue) -> Result<Option<i64>> {
+fn parse_date64_json_value(property: &str, value: &JsonValue) -> Result<Option<i64>> {
     if value.is_null() {
         return Ok(None);
     }
@@ -2692,14 +2703,19 @@ fn parse_date64_json_value(value: &JsonValue) -> Result<Option<i64>> {
         return Ok(Some(checked_date64(ms)?));
     }
     if let Some(ms) = value.as_u64() {
-        let ms = i64::try_from(ms)
-            .map_err(|_| OmniError::manifest(format!("DateTime value out of range: {}", ms)))?;
+        let ms = i64::try_from(ms).map_err(|_| {
+            OmniError::manifest(format!(
+                "DateTime value {ms} for property '{property}' is outside the i64 millisecond range"
+            ))
+        })?;
         return Ok(Some(checked_date64(ms)?));
     }
     if let Some(value) = value.as_str() {
         return Ok(Some(parse_date64_literal(value)?));
     }
-    Ok(None)
+    Err(OmniError::manifest(format!(
+        "invalid DateTime value {value} for property '{property}': expected an integer millisecond count or a datetime string"
+    )))
 }
 
 fn checked_date32(days: i32) -> Result<i32> {
@@ -3217,6 +3233,122 @@ edge WorksAt: Person -> Company
 {"edge": "WorksAt", "from": "Alice", "to": "Acme"}
 "#;
 
+    /// A wrong-typed JSON date is refused in both conversion modes, scalar and
+    /// list item, nullable or not, naming the property; integer counts, date
+    /// strings, and `null` still load with their values intact.
+    // FIXME(#628): Rust rather than `.gqt` because a `.gqt` seed failure is a
+    // harness error, not an expectable outcome. Once GQ has a `load`
+    // statement, this and `load_refuses_float_epoch_in_nullable_date_issue_628`
+    // become one `issue_628_*.gqt` case with an `--- expect error:` step.
+    #[test]
+    fn wrong_typed_date_values_are_refused_in_both_modes_issue_628() {
+        let modes = [JsonConversionMode::LoaderCompat, JsonConversionMode::Strict];
+        for (data_type, wrong, expected) in [
+            (
+                DataType::Date32,
+                serde_json::json!({"day": 19723.0}),
+                "invalid Date value 19723.0 for property 'day'",
+            ),
+            (
+                DataType::Date32,
+                serde_json::json!({"day": true}),
+                "invalid Date value true for property 'day'",
+            ),
+            (
+                DataType::Date32,
+                serde_json::json!({"day": {}}),
+                "invalid Date value {} for property 'day'",
+            ),
+            (
+                DataType::Date64,
+                serde_json::json!({"day": 1704067200000.0}),
+                "invalid DateTime value 1704067200000.0 for property 'day'",
+            ),
+            (
+                DataType::Date64,
+                serde_json::json!({"day": true}),
+                "invalid DateTime value true for property 'day'",
+            ),
+            (
+                DataType::Date64,
+                serde_json::json!({"day": {}}),
+                "invalid DateTime value {} for property 'day'",
+            ),
+        ] {
+            let rows = vec![wrong.clone()];
+            for mode in modes {
+                for nullable in [true, false] {
+                    let err = build_column_from_json("day", &data_type, nullable, &rows, mode)
+                        .expect_err("a wrong-typed date is refused, never stored as NULL");
+                    assert!(
+                        err.to_string().contains(expected),
+                        "{mode:?} {data_type:?} nullable={nullable} {wrong}: {err}"
+                    );
+                }
+            }
+            let list_type = DataType::List(Arc::new(arrow_schema::Field::new(
+                "item",
+                data_type.clone(),
+                true,
+            )));
+            let list_rows = vec![serde_json::json!({"days": [19723, wrong["day"].clone()]})];
+            let list_expected = expected.replace("'day'", "'days'");
+            for mode in modes {
+                let err = build_column_from_json("days", &list_type, true, &list_rows, mode)
+                    .expect_err("a wrong-typed date list item is refused, never stored as NULL");
+                assert!(
+                    err.to_string().contains(&list_expected),
+                    "{mode:?} {data_type:?}: {err}"
+                );
+            }
+        }
+        for (data_type, good, stored) in [
+            (
+                DataType::Date32,
+                serde_json::json!({"day": 19723}),
+                Some(19_723_i64),
+            ),
+            (
+                DataType::Date32,
+                serde_json::json!({"day": "2024-01-01"}),
+                Some(19_723),
+            ),
+            (DataType::Date32, serde_json::json!({"day": null}), None),
+            (
+                DataType::Date64,
+                serde_json::json!({"day": 1704067200000_i64}),
+                Some(1_704_067_200_000),
+            ),
+            (
+                DataType::Date64,
+                serde_json::json!({"day": "2024-01-01T00:00:00Z"}),
+                Some(1_704_067_200_000),
+            ),
+            (DataType::Date64, serde_json::json!({"day": null}), None),
+        ] {
+            let column = build_column_from_json(
+                "day",
+                &data_type,
+                true,
+                std::slice::from_ref(&good),
+                JsonConversionMode::LoaderCompat,
+            )
+            .expect("integer counts, date strings, and null still load");
+            let value = match data_type {
+                DataType::Date32 => column
+                    .as_any()
+                    .downcast_ref::<Date32Array>()
+                    .map(|a| (!a.is_null(0)).then(|| i64::from(a.value(0)))),
+                _ => column
+                    .as_any()
+                    .downcast_ref::<Date64Array>()
+                    .map(|a| (!a.is_null(0)).then(|| a.value(0))),
+            }
+            .expect("a date column of the declared type");
+            assert_eq!(value, stored, "{good}");
+        }
+    }
+
     #[test]
     fn signed_year_datetime_strings_read_back_as_the_writer_spells_them() {
         assert_eq!(
@@ -3242,15 +3374,15 @@ edge WorksAt: Person -> Company
     #[test]
     fn date_counts_outside_the_render_range_are_refused() {
         assert_eq!(
-            parse_date32_json_value(&serde_json::json!(19_723)).unwrap(),
+            parse_date32_json_value("day", &serde_json::json!(19_723)).unwrap(),
             Some(19_723)
         );
         assert_eq!(
-            parse_date64_json_value(&serde_json::json!(1_704_067_200_000_i64)).unwrap(),
+            parse_date64_json_value("day", &serde_json::json!(1_704_067_200_000_i64)).unwrap(),
             Some(1_704_067_200_000)
         );
         for days in [i32::MAX, i32::MIN] {
-            let err = parse_date32_json_value(&serde_json::json!(days)).unwrap_err();
+            let err = parse_date32_json_value("day", &serde_json::json!(days)).unwrap_err();
             assert!(
                 err.to_string().contains(&format!(
                     "Date value {days} is outside the range the JSON writer can format"
@@ -3259,7 +3391,7 @@ edge WorksAt: Person -> Company
             );
         }
         for ms in [i64::MAX, i64::MIN] {
-            let err = parse_date64_json_value(&serde_json::json!(ms)).unwrap_err();
+            let err = parse_date64_json_value("day", &serde_json::json!(ms)).unwrap_err();
             assert!(
                 err.to_string().contains(&format!(
                     "DateTime value {ms} is outside the range the JSON writer can format"
@@ -3725,6 +3857,38 @@ node Doc {
         let bad = r#"{"type": "FakeType", "data": {"name": "x"}}"#;
         let result = load_jsonl(&db, bad, LoadMode::Overwrite).await;
         assert!(result.is_err());
+    }
+
+    /// The compatibility load surface (`load_jsonl`, behind `omnigraph load`
+    /// and `POST /graphs/{id}/load`) refuses a float epoch in a nullable
+    /// `Date?` edge property and leaves the store version unchanged.
+    // FIXME(#628): same conversion as
+    // `wrong_typed_date_values_are_refused_in_both_modes_issue_628`.
+    #[tokio::test]
+    async fn load_refuses_float_epoch_in_nullable_date_issue_628() {
+        let dir = tempfile::tempdir().unwrap();
+        let uri = dir.path().to_str().unwrap();
+        let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+        let version_before = db.version().await;
+
+        let rows = r#"{"type": "Person", "data": {"name": "Alice"}}
+{"type": "Person", "data": {"name": "Bob"}}
+{"edge": "Knows", "from": "Alice", "to": "Bob", "data": {"since": 19723.0}}
+"#;
+        let err = load_jsonl(&db, rows, LoadMode::Overwrite)
+            .await
+            .expect_err("a float epoch in a Date? property fails the load");
+        assert!(
+            err.to_string().contains(
+                "invalid Date value 19723.0 for property 'since': expected an integer day count or a date string"
+            ),
+            "{err}"
+        );
+        assert_eq!(
+            db.version().await,
+            version_before,
+            "a refused load leaves no commit behind"
+        );
     }
 
     #[tokio::test]

--- a/docs/dev/ingestion.md
+++ b/docs/dev/ingestion.md
@@ -27,7 +27,7 @@ The HTTP handler authorizes both change and any requested branch creation before
 
 ### Compatibility loader
 
-`POST /graphs/{graph_id}/load` and the engine `load_as` accept a JSON envelope whose `data` field contains loader-compatible NDJSON. This preserves historical coercions and shapes that the strict graph-batch boundary intentionally refuses.
+`POST /graphs/{graph_id}/load` and the engine `load_as` accept a JSON envelope whose `data` field contains loader-compatible NDJSON. This preserves historical coercions and shapes that the strict graph-batch boundary intentionally refuses: a nullable scalar or list item of the wrong JSON type becomes NULL (a non-nullable property then refuses the load), and a list that is not a JSON array is refused. `Date` and `DateTime` are the exception on both paths: their string form already goes through a fallible parser, so a NULL for a wrong-typed value would be a lost error rather than a coercion, and such a value is refused with the property named.
 
 `POST /graphs/{graph_id}/ingest`, the CLI `ingest` command, and the engine `ingest*` methods are deprecated compatibility aliases over the same loader. They do not have a separate fast path or durability contract. New integrations use `load` or `/load/ndjson`.
 

--- a/docs/releases/v0.11.0.md
+++ b/docs/releases/v0.11.0.md
@@ -106,6 +106,17 @@ Notes accumulate here until the release is cut.
   the start node's own self-loop counts, as one hop. Ranges starting at 1
   are unchanged.
 
+- **A JSONL load refuses a `Date` or `DateTime` value of the wrong JSON
+  type.** `omnigraph load` and `POST /graphs/{id}/load` (and the deprecated
+  `ingest` aliases over the same loader) stored NULL for a nullable date
+  property whose value was a float (`19723.0`), a boolean, or an object, and
+  reported success; the same row through `POST /graphs/{id}/load/ndjson` was
+  refused. Both paths now fail the load with `invalid Date value 19723.0 for
+  property 'since': expected an integer day count or a date string` (or the
+  `DateTime` equivalent), for scalars and list items alike, nullable or not. A whole-number float such as `19723.0`
+  is a float to the loader; send the integer. Integer counts, date strings,
+  and `null` load as before. Fixes #628.
+
 - **Branch merges no longer fail on an unrelated wide row.** The ordered
   merge cursors (the general three-way walk, the adopt fallback, the
   lineage-candidate fetch, and the Blob-selection passes) now sort only the

--- a/docs/user/mutations/index.md
+++ b/docs/user/mutations/index.md
@@ -73,6 +73,12 @@ Here, `Person.email` and `Company.slug` are single-property String keys, so thei
 derived ids are exactly `ada@example.com` and `acme`. The edge uses those ids in
 `from` and `to`.
 
+A `Date` value is an integer day count since 1970-01-01 or a `YYYY-MM-DD`
+string; a `DateTime` value is an integer millisecond count since the Unix epoch
+or an ISO 8601 string. Any other JSON type (a float such as `19723.0`, a
+boolean, an object) fails the load with `invalid Date value` or `invalid
+DateTime value` naming the property.
+
 Choose the mode explicitly:
 
 | Mode | Existing id | Use |

--- a/skills/omnigraph/SKILL.md
+++ b/skills/omnigraph/SKILL.md
@@ -83,7 +83,7 @@ omnigraph load --data delta.jsonl --from main --branch review --mode merge $GRAP
 ```
 
 - `--mode`: `merge` (upsert by logical entity ID; keyed node IDs derive from their `@key` tuple) · `append` (fails on ID collision) · `overwrite` (destructive, staged). `--from <base>` forks a missing `--branch`; bare `load` needs an existing branch. Works local **and** remote.
-- **Date values**: `mutate --params` takes ISO strings. `load` accepts ISO `Date` strings (recommended) or integer epoch days, and ISO `DateTime` strings.
+- **Date values**: `mutate --params` takes ISO strings. `load` accepts ISO `Date` strings (recommended) or integer epoch days, and ISO `DateTime` strings or integer epoch milliseconds; any other JSON type for a date fails the load naming the property.
 
 ### Dispatching
 

--- a/skills/omnigraph/references/queries.md
+++ b/skills/omnigraph/references/queries.md
@@ -349,7 +349,7 @@ Prefer ISO strings on both paths:
 | Path | Date | DateTime |
 |---|---|---|
 | `mutate --params` | ISO string `"2026-04-29"` | ISO string `"2026-04-29T10:00:00Z"` |
-| `load` JSONL | ISO string `"2026-04-29"` (integer epoch days also accepted) | ISO string `"2026-04-29T10:00:00Z"` |
+| `load` JSONL | ISO string `"2026-04-29"` (integer epoch days also accepted) | ISO string `"2026-04-29T10:00:00Z"` (integer epoch milliseconds also accepted) |
 
 Integer epoch days remain useful for generated Arrow-oriented input, but are
 not required for hand-authored JSONL.


### PR DESCRIPTION
## What & why

Closes #628. A JSONL load through `omnigraph load` or `POST /graphs/{id}/load` stored NULL for a nullable `Date` or `DateTime` property whose JSON value was a float (`19723.0`), a boolean, or an object, and reported success; the same row through `POST /graphs/{id}/load/ndjson` was refused.

- Cause: both date parsers try `null`, integer, then string, and fall through to `Ok(None)`, the value a real `null` returns, so the column builder cannot tell absent from unrecognized; only the strict mode's input-versus-output null comparison recovered the difference.
- Fix: the fall-through is a typed refusal, `invalid Date value 19723.0 for property 'since': expected an integer day count or a date string` (`DateTime`: integer millisecond count or datetime string). Both conversion modes, scalars and list items, nullable or not, inherit it from the parser.
- The range errors on integer counts now name the property too, matching every neighbouring loader refusal.
- Integer counts, date strings, and `null` load as before.

## Backing issue / RFC

- [x] Fixes an **accepted** issue: Closes #628 (`wrong_typed_date_values_are_refused_in_both_modes_issue_628` and `load_refuses_float_epoch_in_nullable_date_issue_628` in `crates/omnigraph/src/loader/mod.rs` satisfy the Fix Regression Gate)

## Checklist

- [x] Change is focused (the two date parsers' fall-through, plus the property name threaded into their messages)
- [x] Tests added/updated for behavior changes (a table-driven unit test over both modes, both types, scalar and list, nullable and not, with a stored-value oracle for the accepted shapes; an end-to-end `load_jsonl` test that pins the message and an unchanged store version after the refusal)
- [x] Public docs updated if user-facing surface changed (`docs/user/mutations/index.md` §Bulk loading names the accepted shapes and the refusal; `skills/omnigraph/SKILL.md` and `references/queries.md` gain integer epoch milliseconds for `DateTime`; `docs/dev/ingestion.md` states the compatibility coercion rule and the dates exception; release note)
- [x] Reviewed against docs/dev/invariants.md — no Hard Invariant weakened, no deny-list item hit (invariant 8 is strengthened: a lost error becomes a typed failure; the deny-list's swallowed-error shape loses one instance)

## Local verification

- `cargo test -p omnigraph-engine --lib loader::` — 29 passed
- `cargo test -p omnigraph-gqt` — 116 self-tests + 13 cases passed
- `cargo clippy --workspace --all-targets` — clean
- `cargo fmt --all --check` — clean
- `scripts/check-docs.py` — OK (129 files)
- `typos` — clean
- `cargo test -p omnigraph-server` — all targets green (387 passed, 0 failed, 2 ignored)
- `cargo test -p omnigraph-cli` — all targets green (337 passed, 0 failed, 15 ignored)
- full engine integration suite, DST, `s3_storage` — not run: the change is confined to two parser functions whose only callers are the loader column arms covered above

## Notes for reviewers

- Only `Date` and `DateTime` refuse a wrong JSON type. `String`, integer, float, and `Bool` properties keep the compatibility loader's historical NULL coercion, now stated in `docs/dev/ingestion.md`. Widening the refusal to every scalar is a contract change for existing `load` users and is deliberately not part of this fix.
- Strict-mode message changes for dates: the parser refuses before the post-build check, so `strict property 'day' expects Date32, got 19723.0` becomes the `invalid Date value` message. No test asserted the old text for dates.
- A whole-number float is a float to the loader; the release note says to send the integer rather than adding a float-to-integer coercion that the strict path does not have.
- The two regression tests are Rust rather than `.gqt` because a seed load failure is a harness error, not an expectable outcome; the `FIXME(#628)` lines above them name the conversion to one `.gqt` case once GQ has a `load` statement.
- Out of scope: a `Date` string carrying a UTC offset stores the UTC day. That is the string parser, pre-existing, and reported separately.