### PR TITLE
fix: refuse a `Date` string with a time of day instead of storing its UTC day

### DIFF
--- a/crates/omnigraph-compiler/src/lib.rs
+++ b/crates/omnigraph-compiler/src/lib.rs
@@ -47,4 +47,4 @@ pub use query_input::{
     json_params_to_param_map,
 };
 pub use result::{MutationExecResult, MutationResult, QueryResult, RunResult};
-pub use types::{Direction, PropType, ScalarType};
+pub use types::{Direction, PropType, ScalarType, check_date_literal};

--- a/crates/omnigraph-compiler/src/query/typecheck.rs
+++ b/crates/omnigraph-compiler/src/query/typecheck.rs
@@ -1772,7 +1772,11 @@ fn literal_type(lit: &Literal) -> Result<PropType> {
         Literal::Integer(_) => Ok(PropType::scalar(ScalarType::I64, false)),
         Literal::Float(_) => Ok(PropType::scalar(ScalarType::F64, false)),
         Literal::Bool(_) => Ok(PropType::scalar(ScalarType::Bool, false)),
-        Literal::Date(_) => Ok(PropType::scalar(ScalarType::Date, false)),
+        Literal::Date(value) => {
+            crate::types::check_date_literal(value)
+                .map_err(|reason| CompilerError::Type(format!("T3: {reason}")))?;
+            Ok(PropType::scalar(ScalarType::Date, false))
+        }
         Literal::DateTime(_) => Ok(PropType::scalar(ScalarType::DateTime, false)),
         Literal::List(items) => {
             if items.is_empty() {

--- a/crates/omnigraph-compiler/src/query_input.rs
+++ b/crates/omnigraph-compiler/src/query_input.rs
@@ -427,7 +427,11 @@ fn json_value_to_literal_typed(
             Ok(Literal::Bool(value))
         }
         "Date" => match value {
-            Value::String(value) => Ok(Literal::Date(value.clone())),
+            Value::String(value) => {
+                crate::types::check_date_literal(value)
+                    .map_err(|reason| RunInputError::message(format!("param '{key}': {reason}")))?;
+                Ok(Literal::Date(value.clone()))
+            }
             other => Err(match mode {
                 JsonParamMode::Standard => {
                     RunInputError::message(format!("param '{}': expected date string", key))

--- a/crates/omnigraph-compiler/src/types.rs
+++ b/crates/omnigraph-compiler/src/types.rs
@@ -3,6 +3,19 @@ use serde::{Deserialize, Serialize};
 
 const MAX_VECTOR_DIM: u32 = i32::MAX as u32;
 
+/// Refuse a `Date` string that carries a time of day. Arrow's `Utf8 -> Date32`
+/// cast parses any unsigned string longer than 10 bytes as an instant and keeps
+/// its UTC calendar day, so `2024-01-01T02:00:00+05:00` would store 2023-12-31.
+pub fn check_date_literal(value: &str) -> Result<(), String> {
+    let signed_extended_year = value.starts_with(['+', '-']);
+    if signed_extended_year || value.len() <= 10 {
+        return Ok(());
+    }
+    Err(format!(
+        "invalid Date literal '{value}': a Date is a calendar day (YYYY-MM-DD); a string with a time of day belongs in a DateTime"
+    ))
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ScalarType {
     String,

--- a/crates/omnigraph-gqt/cases/issue_671_date_string_with_time_of_day_refused.gqt
+++ b/crates/omnigraph-gqt/cases/issue_671_date_string_with_time_of_day_refused.gqt
@@ -1,0 +1,88 @@
+# issue: 671
+# red_on: 2026-09-06, pre-fix build at 54afa755: the +05:00 insert succeeded and stored 2023-12-31, the date() literal and the Z param matched no rows, and a seed of the same string read back as 2023-12-31 (the filed case).
+# notes: A Date string with a time of day is refused on every user-facing entry;
+# notes: loader entry: loader/mod.rs load_refuses_date_string_with_a_time_of_day.
+
+--- schema
+node Event {
+    name: String @key
+    day: Date?
+}
+
+--- seed
+{"type":"Event","data":{"name":"west","day":"2024-01-01"}}
+
+--- mutate
+query insert_event($name: String, $day: Date) {
+    insert Event { name: $name, day: $day }
+}
+
+--- params
+{"name": "east", "day": "2024-01-01T02:00:00+05:00"}
+
+--- expect error: param 'day': invalid Date literal '2024-01-01T02:00:00+05:00': a Date is a calendar day (YYYY-MM-DD); a string with a time of day belongs in a DateTime
+
+--- mutate
+query touch_on_datetime_literal() {
+    update Event set { name: "moved" } where day = date("2024-01-01T02:00:00+05:00")
+}
+
+--- expect error: invalid Date literal '2024-01-01T02:00:00+05:00'
+
+--- query
+query filter_on_datetime_literal() {
+    match {
+        $e: Event
+        $e.day = date("2024-01-01T02:00:00+05:00")
+    }
+    return { $e.name }
+}
+
+--- expect error: invalid Date literal '2024-01-01T02:00:00+05:00': a Date is a calendar day (YYYY-MM-DD); a string with a time of day belongs in a DateTime
+
+--- query
+query filter_on_datetime_param($day: Date) {
+    match {
+        $e: Event
+        $e.day = $day
+    }
+    return { $e.name }
+}
+
+--- params
+{"day": "2024-01-01T00:00:00Z"}
+
+--- expect error: param 'day': invalid Date literal '2024-01-01T00:00:00Z'
+
+--- query
+query read_back() {
+    match {
+        $e: Event
+    }
+    return { $e.name, $e.day }
+}
+
+--- expect unordered
+{"e.name": "west", "e.day": "2024-01-01"}
+
+--- expect shape
+e.name: String
+e.day: Date?
+
+--- query
+query filter_on_callers_day($day: Date) {
+    match {
+        $e: Event
+        $e.day = $day
+    }
+    return { $e.name }
+}
+
+--- params
+{"day": "2024-01-01"}
+
+--- expect unordered
+{"e.name": "west"}
+
+--- expect shape
+e.name: String

--- a/crates/omnigraph/src/exec/mutation.rs
+++ b/crates/omnigraph/src/exec/mutation.rs
@@ -930,6 +930,7 @@ impl Omnigraph {
         // execution. A lowering/validation error returns exactly as it did
         // when this happened inside execute_named_mutation.
         let ir = self.lower_named_mutation(&txn.catalog, query_source, query_name)?;
+        super::query::check_param_date_literals(params, &ir.params)?;
         if txn
             .catalog
             .actor_provenance()

--- a/crates/omnigraph/src/exec/query.rs
+++ b/crates/omnigraph/src/exec/query.rs
@@ -547,6 +547,48 @@ fn resolve_binding_type_name<'a>(pipeline: &'a [IROp], variable: &str) -> Option
     None
 }
 
+/// A value bound through the Rust `ParamMap` API skips the JSON param arm: refuse
+/// a time-bearing `Date` string, and a non-`Date` literal on a `Date` parameter.
+pub(super) fn check_param_date_literals(
+    params: &ParamMap,
+    declared: &[omnigraph_compiler::query::ast::Param],
+) -> Result<()> {
+    fn check(name: &str, lit: &Literal) -> Result<()> {
+        match lit {
+            Literal::Date(value) => omnigraph_compiler::check_date_literal(value)
+                .map_err(|reason| OmniError::manifest(format!("param '{name}': {reason}"))),
+            Literal::List(items) => items.iter().try_for_each(|item| check(name, item)),
+            _ => Ok(()),
+        }
+    }
+    params.iter().try_for_each(|(name, lit)| check(name, lit))?;
+    for param in declared {
+        let Some(lit) = params.get(&param.name) else {
+            continue;
+        };
+        let is_date = |lit: &Literal| match lit {
+            Literal::Date(_) => true,
+            Literal::Null => param.nullable,
+            _ => false,
+        };
+        let well_typed = match param.type_name.as_str() {
+            "Date" => is_date(lit),
+            "[Date]" => match lit {
+                Literal::List(items) => items.iter().all(is_date),
+                other => is_date(other),
+            },
+            _ => true,
+        };
+        if !well_typed {
+            return Err(OmniError::manifest(format!(
+                "param '{}': expected {}, got {lit:?}",
+                param.name, param.type_name
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Execute a lowered QueryIR. Pure function — no state, no caches.
 pub async fn execute_query(
     ir: &QueryIR,
@@ -556,6 +598,7 @@ pub async fn execute_query(
     catalog: &Catalog,
     embedding: &EmbeddingResolver<'_>,
 ) -> Result<QueryResult> {
+    check_param_date_literals(params, &ir.params)?;
     let mut resolved_params = None;
     for param in &ir.params {
         if !params.contains_key(&param.name) {

--- a/crates/omnigraph/src/loader/mod.rs
+++ b/crates/omnigraph/src/loader/mod.rs
@@ -2688,7 +2688,9 @@ fn parse_date32_json_value(property: &str, value: &JsonValue) -> Result<Option<i
         return Ok(Some(checked_date32(days)?));
     }
     if let Some(value) = value.as_str() {
-        return Ok(Some(parse_date32_literal(value)?));
+        return parse_date32_literal(value)
+            .map(Some)
+            .map_err(|e| OmniError::manifest(format!("property '{property}': {e}")));
     }
     Err(OmniError::manifest(format!(
         "invalid Date value {value} for property '{property}': expected an integer day count or a date string"
@@ -2711,7 +2713,9 @@ fn parse_date64_json_value(property: &str, value: &JsonValue) -> Result<Option<i
         return Ok(Some(checked_date64(ms)?));
     }
     if let Some(value) = value.as_str() {
-        return Ok(Some(parse_date64_literal(value)?));
+        return parse_date64_literal(value)
+            .map(Some)
+            .map_err(|e| OmniError::manifest(format!("property '{property}': {e}")));
     }
     Err(OmniError::manifest(format!(
         "invalid DateTime value {value} for property '{property}': expected an integer millisecond count or a datetime string"
@@ -2741,6 +2745,14 @@ fn generate_id() -> String {
 }
 
 pub(crate) fn parse_date32_literal(value: &str) -> Result<i32> {
+    omnigraph_compiler::check_date_literal(value).map_err(OmniError::manifest)?;
+    cast_date32_literal(value)
+}
+
+/// The bare arrow `Utf8 -> Date32` cast, time-bearing strings read as their UTC day.
+/// `parse_date32_literal` fronts it with the check; the legacy explicit-id compare
+/// calls it bare, since old writers derived those ids through this very cast.
+fn cast_date32_literal(value: &str) -> Result<i32> {
     let raw: Arc<dyn Array> = Arc::new(StringArray::from(vec![Some(value)]));
     let casted = arrow_cast::cast::cast(raw.as_ref(), &DataType::Date32)
         .map_err(|e| OmniError::manifest(format!("invalid Date literal '{}': {}", value, e)))?;
@@ -3124,7 +3136,7 @@ fn explicit_id_matches_scalar_key(array: &ArrayRef, row: usize, explicit: &str) 
         let parsed = explicit
             .parse::<i32>()
             .ok()
-            .or_else(|| parse_date32_literal(explicit).ok());
+            .or_else(|| cast_date32_literal(explicit).ok());
         return Ok(parsed == Some(a.value(row)));
     }
     if let Some(a) = array.as_any().downcast_ref::<Date64Array>() {
@@ -3369,6 +3381,51 @@ edge WorksAt: Person -> Company
                 .timestamp_millis()
         );
         assert!(parse_date64_literal("+10000-13-01T00:00:00").is_err());
+    }
+
+    /// The load surface refuses a `Date` string with a time of day; a Rust test
+    /// because a `.gqt` seed refusal is a harness failure, not an expectation.
+    /// The param and literal surfaces: `cases/issue_671_date_string_with_time_of_day_refused.gqt`.
+    #[tokio::test]
+    async fn load_refuses_date_string_with_a_time_of_day() {
+        let dir = tempfile::tempdir().unwrap();
+        let uri = dir.path().to_str().unwrap();
+        let db = Omnigraph::init(uri, TEST_SCHEMA).await.unwrap();
+        let version_before = db.version().await;
+
+        let rows = r#"{"type": "Person", "data": {"name": "Alice"}}
+{"type": "Person", "data": {"name": "Bob"}}
+{"edge": "Knows", "from": "Alice", "to": "Bob", "data": {"since": "2024-01-01T02:00:00+05:00"}}
+"#;
+        let err = load_jsonl(&db, rows, LoadMode::Overwrite)
+            .await
+            .expect_err("a datetime string in a Date? property fails the load");
+        assert!(
+            err.to_string().contains(
+                "invalid Date literal '2024-01-01T02:00:00+05:00': a Date is a calendar day (YYYY-MM-DD); a string with a time of day belongs in a DateTime"
+            ),
+            "{err}"
+        );
+        assert_eq!(
+            db.version().await,
+            version_before,
+            "a refused load leaves no commit behind"
+        );
+    }
+
+    /// Pins the premise the refusal rests on: arrow's `Utf8 -> Date32` cast
+    /// routes an unsigned string over 10 bytes through its instant parser.
+    #[test]
+    fn date_string_with_a_time_of_day_takes_arrows_instant_route() {
+        let raw: Arc<dyn Array> =
+            Arc::new(StringArray::from(vec![Some("2024-01-01T02:00:00+05:00")]));
+        let casted = arrow_cast::cast::cast(raw.as_ref(), &DataType::Date32).unwrap();
+        let days = casted.as_any().downcast_ref::<Date32Array>().unwrap();
+        assert_eq!(days.value(0), 19_722, "arrow keeps the UTC day, 2023-12-31");
+
+        assert!(parse_date32_literal("2024-01-01T02:00:00+05:00").is_err());
+        assert!(parse_date32_literal("+2024-01-01T02:00:00+05:00").is_err());
+        assert_eq!(parse_date32_literal("+2024-01-01").unwrap(), 19_723);
     }
 
     #[test]
@@ -4265,6 +4322,10 @@ node Doc {
                 "1.23456789",
             ),
             (Arc::new(Date32Array::from(vec![19_723])), "2024-01-01"),
+            (
+                Arc::new(Date32Array::from(vec![19_722])),
+                "2024-01-01T02:00:00+05:00",
+            ),
             (
                 Arc::new(Date64Array::from(vec![1_704_067_200_000])),
                 "2024-01-01T00:00:00Z",

--- a/crates/omnigraph/tests/literal_filters.rs
+++ b/crates/omnigraph/tests/literal_filters.rs
@@ -186,6 +186,76 @@ query seen_eq() { match { $m: Metric { seen: datetime("2024-06-01T12:00:00Z") } 
     assert_eq!(sorted_metric_names(&mut db, q, "seen_eq").await, vec!["m1"]);
 }
 
+#[tokio::test]
+async fn date_param_with_a_time_of_day_is_refused_from_a_rust_param_map() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut db = metric_db(&dir).await;
+    let mut params = ParamMap::new();
+    params.insert(
+        "d".to_string(),
+        omnigraph_compiler::Literal::Date("2024-06-01T02:00:00+05:00".to_string()),
+    );
+    let q = r#"
+query born_eq_param($d: Date) { match { $m: Metric  $m.born = $d } return { $m.name } }
+"#;
+    let err = query_main(&mut db, q, "born_eq_param", &params)
+        .await
+        .expect_err("a Date param with a time of day is refused on read");
+    assert!(
+        err.to_string().contains(
+            "param 'd': invalid Date literal '2024-06-01T02:00:00+05:00': a Date is a calendar day (YYYY-MM-DD)"
+        ),
+        "{err}"
+    );
+
+    let m = r#"
+query touch_born($d: Date) { update Metric set { active: false } where born = $d }
+"#;
+    let err = db
+        .mutate("main", m, "touch_born", &params)
+        .await
+        .expect_err("a Date param with a time of day is refused in a mutation predicate");
+    assert!(
+        err.to_string()
+            .contains("param 'd': invalid Date literal '2024-06-01T02:00:00+05:00'"),
+        "{err}"
+    );
+
+    let mut params = ParamMap::new();
+    params.insert(
+        "d".to_string(),
+        omnigraph_compiler::Literal::String("2024-06-01T02:00:00+05:00".to_string()),
+    );
+    let err = query_main(&mut db, q, "born_eq_param", &params)
+        .await
+        .expect_err("a String literal bound to a Date parameter is refused");
+    assert!(
+        err.to_string()
+            .contains("param 'd': expected Date, got String(\"2024-06-01T02:00:00+05:00\")"),
+        "{err}"
+    );
+    let err = db
+        .mutate("main", m, "touch_born", &params)
+        .await
+        .expect_err("the same String literal is refused on the mutation route");
+    assert!(
+        err.to_string()
+            .contains("param 'd': expected Date, got String("),
+        "{err}"
+    );
+
+    let mut params = ParamMap::new();
+    params.insert("d".to_string(), omnigraph_compiler::Literal::Null);
+    let err = query_main(&mut db, q, "born_eq_param", &params)
+        .await
+        .expect_err("Null on a non-nullable Date parameter is refused");
+    assert!(
+        err.to_string()
+            .contains("param 'd': expected Date, got Null"),
+        "{err}"
+    );
+}
+
 // Exact string predicates: `starts_with` and the String overload of
 // `contains`. Standalone filters on a scanned variable are hoisted into the
 // NodeScan (the pushdown arm — Lance probes a covering BTREE/NGRAM index when

--- a/docs/releases/v0.11.0.md
+++ b/docs/releases/v0.11.0.md
@@ -124,8 +124,22 @@ Notes accumulate here until the release is cut.
   refused. Both paths now fail the load with `invalid Date value 19723.0 for
   property 'since': expected an integer day count or a date string` (or the
   `DateTime` equivalent), for scalars and list items alike, nullable or not. A whole-number float such as `19723.0`
-  is a float to the loader; send the integer. Integer counts, date strings,
-  and `null` load as before. Fixes #628.
+  is a float to the loader; send the integer. Integer counts, `YYYY-MM-DD`
+  strings, and `null` load as before. Fixes #628.
+
+- **A `Date` string with a time of day is refused.** A `Date` value given as
+  a datetime string was parsed as an instant and its UTC calendar day was
+  kept: `"2024-01-01T02:00:00+05:00"` was stored, and compared in filters,
+  as `2023-12-31`. A load row, a mutation or query param, a `date(...)`
+  literal, and a `Date` bound through the Rust `ParamMap` API now all refuse
+  any such string, including `"2024-01-01T00:00:00Z"`, with `invalid Date
+  literal '…': a Date is a calendar day (YYYY-MM-DD); a string with a time of
+  day belongs in a DateTime`. A value bound to a `Date` parameter through the
+  Rust `ParamMap` API must now be a `Date` literal (a `String` or `Integer`
+  there used to reach the comparison cast). Integer day counts and the
+  day-only spellings arrow accepted before (`2024-01-01`, `20240101`, signed
+  extended years) are unchanged; an instant belongs in a `DateTime` property.
+  Fixes #671.
 
 - **Branch merges no longer fail on an unrelated wide row.** The ordered
   merge cursors (the general three-way walk, the adopt fallback, the

--- a/docs/user/mutations/index.md
+++ b/docs/user/mutations/index.md
@@ -77,7 +77,10 @@ A `Date` value is an integer day count since 1970-01-01 or a `YYYY-MM-DD`
 string; a `DateTime` value is an integer millisecond count since the Unix epoch
 or an ISO 8601 string. Any other JSON type (a float such as `19723.0`, a
 boolean, an object) fails the load with `invalid Date value` or `invalid
-DateTime value` naming the property.
+DateTime value` naming the property. A `Date` string carries no time of day:
+`"2024-01-01T02:00:00+05:00"` fails the load with `invalid Date literal`, as it
+does in a mutation param, a `date(...)` literal, or a read filter; an instant
+belongs in a `DateTime` property.
 
 Choose the mode explicitly:
 

--- a/docs/user/queries/index.md
+++ b/docs/user/queries/index.md
@@ -168,6 +168,11 @@ its own. The spellings a consumer sees:
   (`1.0e20`, `1.0e-7`); a non-finite computed value is `null`.
 - `Vector(N)` and list properties are JSON arrays.
 
+On input, a `Date` string is a calendar day, `"2024-01-01"`; a string that
+carries a time of day, such as `"2024-01-01T02:00:00+05:00"`, is refused as a
+load value, a param, or a `date(...)` literal, and an instant belongs in a
+`DateTime` property.
+
 A `Date` or `DateTime` count outside the range the writer can format is refused
 on load. A read that meets one fails with status 500; the error names the
 column, the result row, and the count, and an `update` of that row repairs it.

--- a/skills/omnigraph/SKILL.md
+++ b/skills/omnigraph/SKILL.md
@@ -83,7 +83,7 @@ omnigraph load --data delta.jsonl --from main --branch review --mode merge $GRAP
 ```
 
 - `--mode`: `merge` (upsert by logical entity ID; keyed node IDs derive from their `@key` tuple) · `append` (fails on ID collision) · `overwrite` (destructive, staged). `--from <base>` forks a missing `--branch`; bare `load` needs an existing branch. Works local **and** remote.
-- **Date values**: `mutate --params` takes ISO strings. `load` accepts ISO `Date` strings (recommended) or integer epoch days, and ISO `DateTime` strings or integer epoch milliseconds; any other JSON type for a date fails the load naming the property.
+- **Date values**: `mutate --params` takes a calendar day (`YYYY-MM-DD`) for `Date` and ISO 8601 for `DateTime`. `load` accepts calendar-day `Date` strings (`YYYY-MM-DD`, recommended) or integer epoch days, and ISO `DateTime` strings or integer epoch milliseconds; a `Date` string carrying a time of day (`2026-04-29T10:00:00Z`) is refused on every path, and any other JSON type for a date fails the load naming the property.
 
 ### Dispatching
 

--- a/skills/omnigraph/references/queries.md
+++ b/skills/omnigraph/references/queries.md
@@ -354,11 +354,13 @@ Prefer ISO strings on both paths:
 
 | Path | Date | DateTime |
 |---|---|---|
-| `mutate --params` | ISO string `"2026-04-29"` | ISO string `"2026-04-29T10:00:00Z"` |
-| `load` JSONL | ISO string `"2026-04-29"` (integer epoch days also accepted) | ISO string `"2026-04-29T10:00:00Z"` (integer epoch milliseconds also accepted) |
+| `mutate --params` | `"2026-04-29"` (a calendar day, `YYYY-MM-DD`) | ISO string `"2026-04-29T10:00:00Z"` |
+| `load` JSONL | `"2026-04-29"` (a calendar day; integer epoch days also accepted) | ISO string `"2026-04-29T10:00:00Z"` (integer epoch milliseconds also accepted) |
 
 Integer epoch days remain useful for generated Arrow-oriented input, but are
-not required for hand-authored JSONL.
+not required for hand-authored JSONL. A `Date` string with a time of day
+(`"2026-04-29T10:00:00Z"`) is refused on both paths and in `date(...)`
+literals; an instant belongs in a `DateTime`.
 
 ## Naming Convention
 


### PR DESCRIPTION
## What & why

Closes #671. A `Date` value given as a datetime string was parsed as an instant and its UTC calendar day was kept: `"2024-01-01T02:00:00+05:00"` was stored, and compared in filters, as `2023-12-31`, with no error.

- Cause: every `Date` string reached arrow's `Utf8 -> Date32` cast, which routes any unsigned string longer than 10 bytes through its instant parser and returns the UTC day; nothing before the cast constrained the string (the `date(...)` grammar, the JSON param arm, and the loader all pass any string through).
- Fix: one predicate in the compiler, accepting arrow's day-only spellings and signed extended years and refusing the rest with `invalid Date literal '…': a Date is a calendar day (YYYY-MM-DD); a string with a time of day belongs in a DateTime`, applied at every entry: the typecheck of a `date(...)` literal, the JSON `Date` param arm, the loader string arm, and the whole `ParamMap` at query and mutation entry for values bound through the Rust API.
- Refusing at the entries rather than at the cast is what covers read filters: a literal the pushdown builder cannot type falls back to a `Utf8` literal, and DataFusion's own `CAST(Utf8 AS Date32)` applies the same arrow rule.
- A non-`Date` literal bound to a `Date` parameter through the Rust API, or a `Null` on a non-nullable one, is refused by the same entry check (`param 'd': expected Date, got String("…")`); the fallback cast accepted the former silently before, and the latter became a filter on `NULL` with zero rows.
- A load refusal names the property (`property 'day': invalid Date literal …`), like the sibling refusals from #669.
- Integer day counts, `2024-01-01`, `20240101`, and signed extended years load, bind, and compare as before; `DateTime` is untouched.

## Backing issue / RFC

- [x] Fixes an **accepted** issue: Closes #671 (`crates/omnigraph-gqt/cases/issue_671_date_string_with_time_of_day_refused.gqt` satisfies the Fix Regression Gate)

## Checklist

- [x] Change is focused (one predicate on `Date` strings and the entry points that call it; the legacy explicit-id compare keeps arrow's reading on purpose, see Notes)
- [x] Tests added/updated for behavior changes (the `.gqt` case pins the param, `date(...)` literal in a read filter and in a mutation `where`, and read-filter param refusals, and the caller's day round-tripping; a loader test pins the load refusal with no commit behind it; a Rust integration test pins the `ParamMap` route on read and in a mutation predicate plus the `String`-on-`Date` and `Null`-on-non-nullable refusals; a unit test pins the premise, arrow's cast of `"2024-01-01T02:00:00+05:00"` is `19722`, so an arrow bump that moves the route fails loudly; one row in the legacy explicit-id comparison test)
- [x] Public docs updated if user-facing surface changed (`docs/user/mutations/index.md` §Bulk loading and `docs/user/queries/index.md` §JSON result spelling state the input rule; `skills/omnigraph/SKILL.md` and `references/queries.md` say a calendar day (`YYYY-MM-DD`) for `Date`; release note, and the #669 bullet beside it now says `YYYY-MM-DD` strings)
- [x] Reviewed against docs/dev/invariants.md — no Hard Invariant weakened, no deny-list item hit (invariant 8 is strengthened: a silent day shift becomes a typed refusal before any commit)

## Local verification

- `cargo test -p omnigraph-compiler` — 339 passed
- `cargo test -p omnigraph-gqt` — 117 self-tests + 17 cases passed
- `cargo test -p omnigraph-engine --no-fail-fast` — 46 integration targets green; `--lib` 407 passed, 1 failed: `blob::tests::external_blob_file_policy_rejects_special_files`, a Unix-socket bind the session sandbox refuses, unrelated to the diff
- `cargo clippy --workspace --all-targets` — clean
- `cargo fmt --all -- --check` — clean
- `scripts/check-docs.py` — OK (129 files)
- `cargo test -p omnigraph-server`, `cargo test -p omnigraph-cli`, DST — not run: the change is confined to the compiler's literal and param arms and the engine's loader and entry checks, covered above; the server and CLI bind params through the JSON arm

## Notes for reviewers

- The contract: `"2024-01-01T00:00:00Z"` and JS `toISOString()` output into a `Date` are refused as well, although they stored the right day before. The same producer sends `2023-12-31T23:00:00.000Z` for a local midnight at UTC+1, which is exactly the bug, so truncating to the string's own day would store the wrong day for that caller too; only a refusal makes it visible. No input route in the user docs or the skill files sends a datetime string into a `Date` (15 routes checked); the fix on the producer side is `toISOString().slice(0, 10)` or a `DateTime` property. Offset-less `2024-01-01T23:00:00` falls under the same rule.
- Rust API: a value bound through `ParamMap` never meets the JSON param arm. Without the entry check the read-side pushdown fell back to `CAST(Utf8 AS Date32)` in DataFusion and a mutation `where` rendered the string verbatim, both shifting the day silently. The check runs eagerly over the whole map at query and mutation entry, so a shared map with an unused bad `Date` value is refused on both paths alike.
- The pushdown builder still swallows materialization errors for a literal it cannot type and falls back to `Utf8`; refusing there instead would drop an inline node-scan predicate, which is worse than the shift, and threading the error through the builder is a refactor outside this fix. After this change every `Date` literal reaching it has passed the predicate at an entry.
- Legacy explicit ids: the compatibility compare of a `Date`-keyed explicit id keeps arrow's reading, time-bearing strings included, so an export whose id was derived from a datetime-spelled key still matches the stored (UTC) day.
- Rust-API callers that bind every value as a `String` (the DST fixtures' `params()` helper does) will meet the new refusal the first time a query declares a `Date` parameter; none does today.
- Engine footprint: one predicate in the compiler, one entry check in the engine, no storage or format change, no kill switch (a refusal, not a mode).