### PR TITLE
docs: RFC 0059 and configuration/CLI framework

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ authority model.
 | Understand atomic writes and crashes | [Write path](docs/dev/writes.md) and [recovery](docs/dev/recovery.md) |
 | Understand query execution | [Execution](docs/dev/execution.md) |
 | Understand clusters and serving | [Control plane](docs/dev/control-plane.md) |
+| Review configuration and CLI contracts | [Configuration and CLI framework](docs/dev/config-cli-framework.md) |
 | Propose or inspect a decision | [RFC registry](docs/rfcs/README.md) |
 | Write documentation | [Documentation guide](docs/dev/documentation.md) |
 | Review shipped history | [Release notes](docs/releases/) |

--- a/docs/dev/config-cli-framework.md
+++ b/docs/dev/config-cli-framework.md
@@ -1,0 +1,905 @@
+# OmniGraph configuration and CLI framework
+
+This reference explains what OmniGraph commands address, which configuration
+and credentials they consume, what they may change, and how to keep that
+surface coherent as it grows. It covers operation families and their important
+options and omissions; the command declarations remain the exhaustive argument inventory.
+
+The deployment unit is a **cluster**: one definition, one storage root, and
+many graphs. An HTTP server is an access endpoint/process. A Kubernetes
+cluster is a **cell**, not an OmniGraph cluster.
+
+This document describes enduring configuration, operation and architecture
+contracts. Implementation status is labeled separately from framework rules;
+a proposed rule is not a claim of released support. The
+[coherency proposal](../rfcs/0059-config-cli-coherency.md) owns the proposed
+changes, compatibility analysis and rollout. The existing
+[architectural invariants](invariants.md), accepted RFCs and implementation
+remain authoritative; this guide does not accept the proposal.
+
+The proposed framework at a glance:
+
+```text
+argv -> parse -> classify -> resolve -> credentials -> connect -> execute
+                              |
+  data:    address > --profile > env profile > defaults
+  control: --config -> context or --direct
+  local:   explicit command inputs
+
+one owner/fact | no target fallback | explicit effects and outcomes
+registry -> help/docs/coverage; independent fixtures -> behavior checks
+```
+
+## 1. Status and evidence
+
+| Label | Meaning |
+| --- | --- |
+| Current | Inspected implementation at the stated commit; deployment and runtime qualification are separate. |
+| Accepted work | Triaged and accepted feature scope; implementation and qualification remain separate. |
+| Proposed | Intended behavior requiring acceptance, implementation and tests. |
+| Deferred / Open | No implementation or decided behavior should be inferred. |
+
+Implementation claims are scoped to the revisions in the
+[source index](#14-source-index). A supported operation path does not imply
+that every invocation or binary supports it; configuration variants, dispatch
+rules and transport qualification are part of the support contract.
+
+An open issue alone does not establish accepted scope. Untriaged proposals
+must not become framework requirements by implication; an accepted issue
+also does not establish released support or ratify a broader design.
+
+A source reference establishes what was inspected. A test reference establishes
+which executable assertion exists; a passing run additionally needs its
+revision and result. Local, integration, adversarial and live evidence are
+different scopes. Documentation and source inspection are not runtime proof.
+
+Read [configuration](#3-configuration-contracts) for YAML,
+[routing](#4-target-resolution) for target selection,
+[commands](#6-command-and-operation-catalog) for capabilities, and
+[invariants](#10-invariants) for the proposed enforcement contract.
+
+## 2. Concepts, authority and independent axes
+
+Hosting, execution mode, repository ownership, storage backend and transport
+are independent. Direct Core can use a plain directory or a Git checkout,
+with file or object storage. Managed execution can use an external Git
+binding or service-managed Git. HTTP alone does not imply managed service
+execution; S3 alone does not imply managed execution either.
+
+| Fact | Authority / owner | Copies and consumers |
+| --- | --- | --- |
+| Requested cluster configuration | Team definition, or exact bound repository revision | Materialized files and exact config snapshots identify their source. |
+| Effective cluster configuration | Core ledger and applied catalog | Status, planning and server boot read them. |
+| Accepted graph schema and data | Graph schema/manifest and atomic content protocol | Cluster state carries the appropriate projection, including actor settings. |
+| Managed cluster identity | Immutable root marker: cluster ID, incarnation, canonical root | Service DB and operator Cluster object are projections. |
+| Retirement and execution evidence | Owning immutable guard/receipt protocol | Views retain provenance and do not manufacture evidence. |
+| Control/data permissions | Service grants and the relevant applied server policy | Cached credentials are bounded authority, not a replacement policy. |
+| Personal connection selection | Operator configuration and explicit invocation | No mutation of the deployment follows from editing a nickname. |
+| Cluster-command binding | Exact selected directory's context | No parent search or implicit data default. |
+| Credential material | Designated credential store/provider | A cache cannot select a different target. |
+| Observed serving state | Replica boot witness and health/refresh observations | May lag the effective ledger and must identify that difference. |
+
+Every fact has a named authority. Projections identify their source, while
+immutable evidence retains the guarantees of its owning protocol.
+
+A profile/alias name is mutable and can be persisted in personal settings.
+Renaming it must preserve authoritative cluster, incarnation, graph and
+principal identity. A matching URL or a similar storage path does not prove
+those identities. Graph branches and Git configuration revisions are unrelated
+selectors; an engine branch incarnation is not a cluster incarnation.
+
+## 3. Configuration contracts
+
+### 3.1 Surfaces and discovery
+
+| Surface | Location / selection | Purpose and validation |
+| --- | --- | --- |
+| Operator YAML | `$OMNIGRAPH_HOME/config.yaml`, default `~/.omnigraph/config.yaml` | Connections, profiles, aliases, presentation and direct actor preference. Absent means empty layer; malformed errors when loaded. Current unknown keys warn. |
+| Desired cluster | `DIR/cluster.yaml` and referenced files | Team configuration. Unknown authority keys refuse; absent desired files cannot be reconstructed from observation. |
+| Folder context | `DIR/.omnigraph/context` | Versioned managed API/cluster binding for cluster commands; `DIR` defaults to `.`. |
+| Legacy credentials | Operator credentials file and environment | Named-server chain, separate from YAML; file uses restricted permissions. |
+| Control session | Separate OS-keychain namespace, bound to API origin | Intent API access; not graph-server or storage authority. |
+| Data credential | Separate OS-keychain namespace, API + cluster key | Signed offline data access and endpoint metadata. |
+| Applied deployment | Storage root, including `__cluster/state.json` and catalog | Core-owned achieved projection; not personal configuration. |
+| Public server trust | Explicit boot trust file | Keys, issuer and cluster/root/incarnation binding; contains no private signing key. |
+| Cell configuration | Terraform/platform configuration | Infrastructure; never a second graph-definition authority. |
+
+No automatic parent-directory walk is implied for any surface.
+`OMNIGRAPH_HOME` relocates a directory, not one arbitrary YAML file.
+`--config` belongs to cluster operations and `use`; it is not a global
+data-command configuration flag. There is no implemented top-level `config`
+command, `profile use`, `current_profile`, or `OMNIGRAPH_CONFIG` override.
+
+| Environment input | Scope |
+| --- | --- |
+| `OMNIGRAPH_HOME` | Operator-directory discovery. |
+| `OMNIGRAPH_PROFILE` | Ambient data/tool profile, below explicit selection. |
+| `OMNIGRAPH_TOKEN_<NAME>` | Legacy named bearer; uppercase name with hyphens replaced by underscores. |
+| `OMNIGRAPH_BEARER_TOKEN` | Existing legacy bearer fallback. |
+| `OMNIGRAPH_CONTROL_API` + `OMNIGRAPH_CONTROL_TOKEN` | Paired, explicitly origin-bound managed automation credentials. |
+
+Backend and embedding-provider environment variables belong to their own
+credential/provider contracts, not the CLI target-selection ladder.
+
+### 3.2 Current operator YAML
+
+Every top-level section below is optional. Illustrative URIs are not live
+deployment instructions.
+
+```yaml
+operator:
+  actor: act-andrew
+
+defaults:
+  output: table
+  table_max_column_width: 80
+  table_cell_layout: wrap
+  server: staging
+  default_graph: knowledge
+
+servers:
+  staging:
+    url: https://staging.graphs.example
+
+clusters:
+  local:
+    root: file:///Users/andrew/data/local-cluster
+
+profiles:
+  staging:
+    server: staging
+    default_graph: knowledge
+  maintenance:
+    cluster: local
+    default_graph: knowledge
+  scratch:
+    store: file:///Users/andrew/data/scratch
+
+aliases:
+  person:
+    server: staging
+    graph: knowledge
+    query: get_person
+    args: [slug]
+    params: {include_archived: false}
+    format: json
+```
+
+A profile selects exactly one of `server`, `cluster`, or `store`.
+A store already identifies one graph and cannot have `default_graph`.
+Flat defaults select server or store, never both. There is no current
+`defaults.cluster`. Output values are `table`, `kv`, `csv`, `jsonl`,
+`json`, `arrow`; table layout is `truncate` or `wrap`. These preferences
+do not become query/schema/policy content. Tokens never belong in this YAML.
+
+### 3.3 Proposed cluster-first connections
+
+A proposed discriminated connection variant supports cluster-first naming.
+This example requires implementation support; it is **not accepted by the
+source baseline listed in this reference**:
+
+```yaml
+clusters:
+  pilot:
+    managed: true
+    id: CLUSTER_ID
+    api: https://control.example
+    endpoint: https://pilot.graphs.example
+  local:
+    managed: false
+    root: file:///Users/andrew/data/local-cluster
+  archive:
+    # Omitting managed retains the existing storage-root form.
+    root: s3://example-bucket/archive
+
+profiles:
+  pilot:
+    cluster: pilot
+    default_graph: knowledge
+
+aliases:
+  pilot-person:
+    cluster: pilot
+    graph: knowledge
+    query: get_person
+    args: [slug]
+```
+
+| Variant | Required | Rejected |
+| --- | --- | --- |
+| `managed: true` | `id`, `api`, `endpoint` | `root`, missing/invalid authority fields, plaintext credentials. |
+| `managed: false` or omitted | `root` | Managed `id/api/endpoint` fields. |
+| Legacy `servers.NAME` | `url` | No implicit managed authentication based on matching URL. |
+| Managed alias | Managed `cluster`, explicit `graph`, stored `query` | Simultaneous `server`, root-backed cluster, global target overrides. |
+
+The canonical examples use YAML booleans `true` and `false`; no alternate
+`yes` spelling is promised. Recognized authority variants validate strictly.
+Existing ordinary preference warnings remain a separate compatibility rule.
+
+The boolean selects a connection/authentication contract. It does not create,
+enroll, transfer, authorize or resize a deployment. Existing `servers:`
+remain for compatibility; an endpoint is still necessary even when a cluster
+is the name the user selects. A future self-hosted HTTP cluster association
+is not part of the proposed connection model.
+
+### 3.4 Desired files and managed context
+
+The current desired definition has top-level `version`, `metadata`,
+`storage`, `state`, `providers`, `graphs`, and `policies`. Referenced
+schemas, queries and policy remain team-owned files. Omitting `storage`
+uses the config directory as the local storage root. Do not put operator
+connections or tokens into this definition.
+
+Context is a distinct, unchanged shared binding:
+
+```yaml
+version: 1
+cluster: CLUSTER_ID
+api: https://control.example
+```
+
+Managed external Git execution uses a pushed immutable revision. Local edits
+are not implicitly uploaded. Service-managed repository upload creates an
+immutable Git revision before planning. Exactly one config binding is
+authoritative; applied state and cached snapshots are not replacement desired
+definitions.
+
+## 4. Target resolution
+
+### 4.1 Target classes and data pipeline
+
+| Class | Address | Capability boundary |
+| --- | --- | --- |
+| H | Legacy HTTP endpoint | Server route and ordinary credential contract. |
+| G | One graph storage URI | Embedded operations with storage authority. |
+| R | Cluster root/config-root locator | Existing direct maintenance/catalog tooling. |
+| M | Proposed named managed data connection | Qualified HTTP operations with a separately bound data credential. |
+| C | Desired config directory/context | Direct Core or managed cluster-command dispatch. |
+| L | Local/session operation | Explicit operation arguments; no ambient graph target. |
+
+For data/storage commands, the intended normal order is:
+
+```text
+supported explicit address primitive
+  -> explicit --profile
+  -> OMNIGRAPH_PROFILE
+  -> flat operator defaults
+  -> missing-target refusal
+```
+
+Pure syntactic conflicts and command applicability are checked first. A
+selected invalid or unsupported target **refuses**; it does not disappear
+from the ladder. Explicit selection shadows unused ambient inputs. Local
+commands and aliases have their own input contracts.
+
+`--server NAME` resolves a legacy name; a literal HTTP URL remains legacy.
+`--store URI` identifies one graph. `--cluster VALUE` resolves a named root
+or an existing literal path/root; the proposal additionally recognizes a
+named managed variant. A cluster-root data query is not added as a side
+effect. Two explicit primitive addresses conflict.
+
+An explicit graph overrides the selected profile's graph default. An unused
+profile cannot lend its graph default to an explicit primitive. Profiles do
+not inherit unrelated flat graph defaults.
+
+### 4.2 Graph omission
+
+| Scope | Omitted graph |
+| --- | --- |
+| G | Already one graph; extra `--graph` refuses. |
+| H, graph operation | Selected profile/default graph, otherwise existing best-effort registry probe. |
+| H, `graphs list` | Registry operation; rejects explicit graph and does not use a profile graph default. |
+| R, maintenance | Consumed profile graph, otherwise sole applied graph; zero/multiple candidates refuse. |
+| R, policy/queries | Own catalog/bundle helper; currently ignores profile graph defaults. |
+| M, proposed graph operation | Selected profile graph or explicit graph required; never choose from grants. |
+| M, future registry operation | No graph selector; separately qualify registry scope and result filtering. |
+| C | Definition/context identifies cluster; token issuance explicitly selects a graph. |
+
+The current H probe rejects **any nonempty** registry, including exactly one
+graph. If the probe fails, is denied/unsupported, or returns no graphs, legacy
+behavior proceeds to the bare endpoint. This is not sole-graph selection and
+is not a new managed fallback rule.
+
+### 4.3 Cluster/config-directory pipeline
+
+```text
+cluster COMMAND --config DIR
+  -> --direct: bypass context, use supported Core path
+  -> valid DIR/.omnigraph/context: managed dispatcher
+  -> absent context: supported Core path
+  -> malformed context: refusal
+```
+
+Managed-only commands still refuse without their managed preconditions;
+`--direct` cannot convert them into Core commands. Unmerged lifecycle extensions have separate requirements in the
+[coherency proposal](../rfcs/0059-config-cli-coherency.md).
+
+A data profile never redirects `cluster plan --config DIR`. Conversely,
+context never supplies the proposed normal data destination. No merge of
+operator and context API/ID fields takes place. `--direct` plus a proposed
+managed data entry conflicts; it cannot downgrade credentials or discover
+storage.
+
+### 4.4 Access forms and support
+
+The source baseline's managed query/mutate path uses the exact working
+directory's context, an explicit graph and a separately cached data credential.
+Named managed connections and context-independent data resolution are
+Proposed. Direct/legacy examples use explicit `--direct` to select their
+existing addressing contract.
+
+Keep support for an access form separate from the enduring routing rules:
+select one target, validate its capability, bind the appropriate credentials,
+and execute only through that target's protocol. Dispatch exceptions and transition procedures belong in
+[RFC 0059](../rfcs/0059-config-cli-coherency.md).
+
+## 5. Credentials, policy and provenance
+
+| Route | Binding and lookup | Missing credential / prohibited fallback |
+| --- | --- | --- |
+| Direct | Filesystem/backend authority; direct actor from `--as` then operator preference | A control session or data token provides no storage authority. |
+| Legacy HTTP | Named keyed environment, then credentials file, then legacy bearer environment | Server's existing authenticated/unauthenticated behavior remains; no switch to managed credentials. |
+| Managed control | API-origin-bound session or explicitly bound automation credential | Refuse; never send this credential to a graph server. |
+| Managed data | Selected managed connection matched to separate API+cluster cache | Refuse absent/expired/mismatched/insufficient credentials; never use legacy bearer or storage fallback. |
+
+The authentication variant determines the namespace; flag/profile/environment
+is selection provenance. Legacy `OMNIGRAPH_TOKEN_INTEL_DEV` and
+`OMNIGRAPH_BEARER_TOKEN` remain valid within the legacy chain, including the
+existing matching-name lookup for literal URLs.
+
+For proposed named managed connections, require exact canonical
+API/cluster/endpoint agreement before sending a credential. The source
+baseline's context-based credential path compares API/cluster identity and
+validates endpoint syntax, then uses the cached endpoint; it does not yet
+compare against an independently selected operator endpoint.
+
+Managed API/endpoint origins require HTTPS, except exact supported loopback
+hosts (`localhost`, `127.0.0.1`, `::1`) may use HTTP. Reject userinfo,
+non-root paths, query and fragment; compare canonical origins, not prefixes.
+Managed requests reject redirects. Existing finite request/response bounds
+remain; the current 8 MiB JSON limit is not an export-streaming design.
+
+The server verifies signed data credentials offline: signature, issuer,
+audience, expiry and cluster/root/incarnation binding, then action grants
+intersect applied Cedar permissions. Control permission does not imply data
+permission. A data grant alone does not enroll a principal in Cedar policy.
+
+| Data action | Required grant in addition to policy |
+| --- | --- |
+| Ad-hoc read / ordinary metadata read | `read` |
+| Stored read | `read` + `invoke_query` |
+| Ad-hoc mutation/load | `change` |
+| Stored mutation | `change` + `invoke_query` |
+| Load creating a branch | `change` + `branch_create` |
+| Export / change baseline | `export` |
+| Branch create/delete/merge | Respective branch action; optional deletion is separate. |
+| Registry listing | `graph_list`, with authorized result filtering. |
+| Schema apply | Refused by this signed-token profile. |
+
+Permissions do not establish CLI route support. Managed connection eligibility
+and qualification are declared separately for each command in the catalog.
+
+Direct writes retain explicit/default attribution. Authenticated HTTP writes
+use the server-resolved principal and reject explicit actor override where
+required. Actor nodes record provenance, never permission. Actor
+materialization defaults on for new graphs; existing graphs need explicit
+planned enablement. Disabling retains existing actors and commit attribution.
+
+## 6. Command and operation catalog
+
+### 6.1 Graph and storage operations
+
+H/G/R below describe existing operation paths. Access-form and dispatch
+support are separate constraints, as described in section 4.4. The managed
+column records proposed eligibility, not released support.
+
+| Command | Current target | Important contract | Managed connection proposal |
+| --- | --- | --- | --- |
+| `query` / `read` | H; G for ad-hoc source | Stored name requires H; `--query FILE` or `-e GQ`; branch/snapshot conflict. | Proposed named-connection support. |
+| `mutate` / `change` | H; G for ad-hoc source | Write query; optional `--if-commit` exact head precondition. | Proposed named-connection support. |
+| `load` | H/G | `--data FILE --mode merge\|append\|overwrite`; optional `--branch`, explicit `--from` to create missing branch. | Later qualification. |
+| Hidden `ingest` | H/G | Separate legacy command with permissive merge/from-main defaults. | Requires independent qualification. |
+| `snapshot` | H/G | Read graph snapshot; optional branch. | Later qualification. |
+| `export` | H/G | JSONL snapshot, optional branch/type filters; output effects. | Streaming qualification. |
+| `blob get`, `blob stat` | H/G | Logical Blob cell selection and bounded/streaming output. | Streaming qualification. |
+| `branch list` | H/G | Read branch inventory. | Later qualification. |
+| `branch create/delete/merge` | H/G | Create `--from` and merge `--into` default main; deletion and merge separate effects. | Later qualification. |
+| `commit list/show/changes` | H/G | History and changes at explicit positions. | Later qualification. |
+| `changes poll` | H/G | `--start` defaults now; conflicts with `--cursor`; preserve cursor/pagination contract. | Later qualification. |
+| `changes baseline` | H/G | Required `--out`; existing POSIX durable-output restrictions. | Streaming/platform qualification. |
+| `schema show` / `schema get` | H/G | Read accepted schema. | Later qualification. |
+| `schema apply` | H/G | Existing HTTP policy rules; direct cluster-owned graph refuses. | Unsupported signed-token action. |
+| `graphs list` | H | Registry scoped; rejects graph/store/actor selectors. | Later registry qualification. |
+| `init` | Positional graph URI | `--schema FILE URI`; no `--json`; `--force` is not overwrite of an existing graph. | Unsupported. |
+| `schema plan` | G; R through profile exception | `--schema FILE`, optional `--allow-data-loss`; explicit cluster/graph rejected today. | Unsupported. |
+| `optimize` | G/R | Physical maintenance, not a data read or deployment. | Unsupported. |
+| `rebuild-full-text-indexes` | G/R | Explicit analyzer/index rebuild; branch-scoped, custom analysis implications. | Unsupported. |
+| `repair` | G/R | Preview without `--confirm`; `--force` requires confirm. | Unsupported. |
+| `cleanup` | G/R | At least one retention selector (`--keep`, `--older-than`); confirmation controls execution. | Unsupported. |
+| Graph-backed `lint` | G/R | Validates query against graph schema. | Unsupported. |
+| `policy validate/test/explain` | R | Applied policy source; tests/actor/action selectors are command-specific. | Unsupported tooling API. |
+| `queries list` | R; served CLI mapping is accepted work, not implemented | Direct listing reads the applied catalog; served listing uses the existing active-catalog HTTP endpoint. | Separate managed connection qualification required. |
+| `queries validate` | R | Validate the applied stored-query catalog through the existing direct helper. | Unsupported tooling API. |
+| `alias NAME [args]` | Own H binding | Stored read only; binding rejects global target overrides. | Additive managed alias, separately qualified. |
+
+**Accepted work: served catalog listing.** The accepted
+[CLI listing issue](https://github.com/ModernRelay/omnigraph/issues/653)
+adds `queries list --server NAME --graph ID --json`, using the existing
+`GET /graphs/{graph}/queries` endpoint and normal server/profile/default/token
+resolution. Preserve direct root listing and keep `queries validate` separate.
+The accepted mapping is not present in the inspected CLI source.
+
+Output must have a stable documented JSON shape and reflect the server's
+active catalog, including operation names/kinds and metadata the endpoint
+actually supplies. Do not invent richer descriptors or another registry.
+Preserve the endpoint's read authorization; listing an operation does not
+grant permission to invoke it. Managed named-connection support requires its
+own credential/route qualification, independently of this accepted HTTP CLI
+mapping.
+
+`--params` and `--params-file` are exclusive. Parameterize GQ instead of
+interpolating user values. A named query is a served catalog invocation, not
+an implicit local filename.
+
+### 6.2 Cluster operations
+
+Every row uses `--config DIR` (default `.`) unless otherwise stated.
+
+| Command | Direct Core | Managed context |
+| --- | --- | --- |
+| `validate` | Validate desired files. | Currently unsupported; `--direct` is explicit local validation. |
+| `plan` | Plan against ledger; takes lock unless `--observe`. | Creates saved plan run; optional pushed `--rev`, otherwise bound head; no upload; observe refuses. |
+| `apply` | Apply desired configuration through Core. | Exact `--plan RUN_ID` required; permission-based execution. |
+| `status [RUN_ID]` | Reads ledger (no managed run argument). | Cluster projection or exact run. |
+| `observe` | Read-only observations, no sweep or ledger write. | Unsupported. |
+| `refresh` | Recovery/observation update of existing ledger. | Unsupported CLI route. |
+| `import` | Initialize missing ledger from declared existing graphs. | Unsupported CLI route. |
+| `approve RESOURCE` | Existing actor-bound destructive-resource artifact. | Unsupported; no separate managed approval. |
+| `force-unlock LOCK_ID` | Exact lock recovery, existing safeguards. | Unsupported; never a writer fence. |
+| `history` | Managed-only refusal. | Limit default 100, 1–1000; optional RFC 3339 since. |
+| `cancel RUN_ID` | Managed-only refusal. | Cancel pending run or abandon unused saved plan. |
+| `token` | Managed-only refusal. | Explicit graph/actions; TTL default 3600 seconds, range 60–86400; clear is separate. |
+
+Managed run waits default to 300 seconds, timeout range 1–3600;
+`--no-wait` returns after acceptance. Reuse `--idempotency-key` and the
+same request for supported managed run replays. Wait timeout is not
+cancellation and does not establish that submission failed.
+
+Managed authorization is the caller's current scoped action permission for
+the exact plan. Direct `approve` artifacts and `--yes` prompt behavior are
+existing compatibility surfaces, not a second managed approver or per-action
+step-up.
+
+### 6.3 Lifecycle support boundary
+
+Self-service lifecycle extensions are outside the merged CLI described here.
+Do not infer support for `cluster create`, `push`, `delete`, `undo-delete`,
+`list`, `pull`, `bind`, `restore`, `eject`, operation recovery or a standalone
+purge verb from the control-command catalog. The
+[coherency RFC](../rfcs/0059-config-cli-coherency.md) records the compatibility
+requirements for lifecycle work.
+
+Current serving refuses an empty applied cluster. Lifecycle status,
+provisioning completion and a usable graph endpoint are distinct facts.
+
+### 6.4 Local/session operations
+
+| Command | Read/write contract |
+| --- | --- |
+| `version`, `--version` | Binary information, no target. |
+| `profile list` / `show [NAME]` | Read profiles; show omission uses environment profile then defaults, no sticky selection. |
+| `login SERVER` / `logout SERVER` | Legacy local credential entry; logout cannot unset another process's environment. |
+| `login --api ORIGIN` / `logout --api ORIGIN` | Native device authorization / control-session revocation and local removal. |
+| `use CLUSTER_ID --api ORIGIN --config DIR` | Validate and write exactly that directory's managed context; no operator-default mutation. |
+| `embed` | Explicit seed/input/output/spec pipeline; no graph target. |
+| `lint --schema FILE --query FILE` | Offline validation; current accepted-but-unused scope flags are a known inconsistency. |
+
+### 6.5 Argument details and output
+
+Global flags are `--direct`, `--as`, `--server`, `--graph`, `--profile`,
+`--store`, `--cluster`, `--yes`, and `--quiet`. Global parsing does not make
+every flag applicable to every command. **`--json` is command-local**;
+`init` and `policy` do not expose it. Information flags include lowercase
+`-v` / `--version` and the standard help surface.
+
+| Operation | Additional exact argument shape / omission |
+| --- | --- |
+| `query` | `[NAME] [--query FILE \| -e/--query-string GQ] [--params JSON \| --params-file FILE] [--branch B \| --snapshot ID] [--format FORMAT \| --json]`. |
+| `mutate` | Same source/params; `--branch`, `--if-commit`, `--json`; no snapshot or format flag. |
+| `branch` | `create NAME`, `list`, `delete NAME`, `merge SOURCE`; address override is `--uri URI`, not positional URI. Merge has `--into TARGET` and `--delete-branch`. |
+| `blob get/stat` | `node\|edge TYPE ID PROPERTY [--branch B \| --snapshot ID]`; get adds offset, positive length and out; stat adds JSON. |
+| `commit` | `list [URI] [--branch B]`; `show ID [--uri URI]`; `changes ID [--uri URI] [--limit N] [--page-token TOKEN]`. |
+| History/feed filters | Repeated `--kind node\|edge`, `--type T`, `--op insert\|update\|delete` where declared. Commit changes with page-token requests one page; otherwise auto-paginates. Feed polling consumes pages automatically. |
+| `changes poll` | `--uri`, `--branch`, `--cursor` or `--start now\|beginning\|after:ID`, limit and filters. |
+| `schema plan/apply` | Optional positional URI, required schema file, optional allow-data-loss and `--actor-provenance true\|false`; omission preserves accepted actor setting. |
+| `init` | Required positional URI/schema; omitted actor-provenance defaults on. |
+| `policy` | `test --tests FILE`; `explain --actor ACTOR --action ACTION [--branch B] [--target-branch B]`. Policy-test actors are inputs to evaluation, not authenticated actor overrides. |
+| `embed` | `--seed FILE` or `--input FILE --output FILE --spec FILE`; clean/reembed-all conflict; repeatable type/select; JSON available. |
+| `cluster plan` | `--rev` has alias `--revision`; omission uses bound head only on the managed route. |
+| Legacy spellings | `read`, `change`, hidden `schema get`; separate hidden `ingest`; argv rewrites `check`, `query lint`, `query check`; hidden accepted `export --jsonl`. |
+
+Read-format priority is explicit format/JSON, applicable alias format,
+operator output, then table. Table width defaults to 80 and layout to
+truncate. Fixed or streaming command outputs retain their own contracts.
+`--quiet` suppresses the existing write-target diagnostic, not failures.
+`--yes` bypasses supported destructive-write prompts; it grants no permission.
+
+## 7. Operational workflows
+
+Direct/legacy examples explicitly select their addressing contract with
+`--direct`. Managed and proposed named-connection examples are labeled
+separately. Check the deployed binary's support and operation-specific help
+before using an example.
+
+### 7.1 Current direct cluster and legacy data work
+
+```sh
+omnigraph --direct cluster validate --config ./cluster
+omnigraph --direct cluster plan --config ./cluster --json
+# After reviewing the plan and satisfying the existing direct requirements:
+omnigraph --direct cluster apply --config ./cluster --json
+omnigraph --direct cluster status --config ./cluster --json
+
+omnigraph --direct query get_person --server staging --graph knowledge \
+  --params '{"slug":"alice"}' --json
+```
+
+An apply may be partially converged; inspect its outcome and remaining plan,
+rather than treating exit/wait completion as deployment readiness. Restarting
+serving follows the existing exclusion/drain protocol independently of client
+routing.
+
+### 7.2 Current managed control and data; proposed named data selection
+
+```sh
+omnigraph login --api https://control.example
+omnigraph use CLUSTER_ID --api https://control.example --config ./cluster
+omnigraph cluster plan --config ./cluster --rev PUSHED_COMMIT --json
+omnigraph cluster apply --config ./cluster --plan PLAN_RUN_ID --json
+omnigraph cluster status --config ./cluster --json
+omnigraph cluster token --config ./cluster --graph knowledge \
+  --actions read,invoke_query
+```
+
+Current managed query/mutate use cwd context; `--config` is not their flag.
+For this access form, run from the bound directory and specify graph:
+
+```sh
+cd ./cluster
+omnigraph query get_person --graph knowledge --params '{"slug":"alice"}'
+```
+
+The proposed named-connection form uses the YAML above to select a data target
+explicitly from any directory:
+
+```sh
+# Proposed; requires named managed-connection support.
+omnigraph query get_person --profile pilot --params '{"slug":"alice"}'
+omnigraph query get_person --cluster pilot --graph knowledge \
+  --params '{"slug":"alice"}'
+```
+
+Plan/apply do not mint a data token. Logout or token-clear does not revoke an
+already issued offline credential at the server. No implicit token refresh or
+control API dependency is part of ordinary data requests.
+
+### 7.3 Current data review branch
+
+```sh
+omnigraph --direct load --store file:///Users/andrew/data/scratch \
+  --data data.jsonl --mode merge --branch review --from main --json
+omnigraph --direct query --store file:///Users/andrew/data/scratch \
+  --query queries/review.gq --branch review --json
+```
+
+Verify the intended branch/content before an explicit merge. If a write
+response is lost, inspect branch head or intended effects first. An optional
+`--if-commit` is an optimistic precondition, not a generic replay key.
+Merge followed by refused deletion is a partial outcome with two effects.
+
+### 7.4 Failure and recovery decisions
+
+| Observation | Next action / boundary |
+| --- | --- |
+| Unknown/malformed selected connection | Correct that selection; never substitute another target. |
+| Missing/expired managed credential | Explicitly mint matching access through the control flow. |
+| Endpoint metadata mismatch | Explicitly update/remint matching metadata; never let cache choose. |
+| Permission denial | Inspect relevant control grants or data grants and applied policy; actor rows grant nothing. |
+| Quarantined/missing graph | Use authorized status/recovery for the addressed resource; don't route around it. |
+| Control API down, valid data token | Data may continue within its offline lifetime; control actions fail independently. |
+| Submitted managed run, wait timeout | Retain run/key, query status, replay same request only where supported. |
+| Data write timeout | Unknown outcome; reconcile head/effects under that operation's contract before retry. |
+| Held/stale-looking lock | Inspect owner and existing recovery protocol; age or force-unlock is not writer exclusion. |
+| Effective/booted revisions differ | Report lag and follow activation protocol; do not rewrite the witness to hide it. |
+
+## 8. Effects, recovery and serving
+
+### 8.1 Effect ownership
+
+| Operation | Owned effects |
+| --- | --- |
+| Operator edit / use / login | Respective operator file, context, or credential store; never each other's authority. |
+| Read/observe/plan | No intended data mutation; declare locking, local output and any underlying recovery effects separately. |
+| Data mutation/load/branch operation | Graph publication, commit and provenance through the existing atomic protocol. |
+| Cluster apply | Successful resource outcomes, statuses, ledger CAS/revision and declared artifacts; partial progress is durable. |
+| Refresh/import | Existing recovery sweep and declared-graph observations, including inserted/changed schema and graph digests. |
+| Managed plan/apply | Exact source capture, run/lease/offer/receipt and authorized execution effects. |
+| Managed lifecycle extension (outside merged CLI; section 6.3) | Provisioning/retention/retirement checkpoints and exact authorized resources, by the lifecycle protocol. |
+| Maintenance | Explicit physical/index/retention effects under its existing storage/exclusion requirements. |
+| Server startup | Applied snapshot read; graph opening may complete graph-level recovery, not rewrite cluster ledger. |
+
+Open mode is part of **operation × transport**, not derivable from a read
+label. At the inspected baseline, direct branch listing, snapshot, commit
+reads, baseline, export and `queries validate` use read-write engine opening
+and may perform recovery. Schema show and graph-backed lint explicitly use
+read-only opening. Blob output, embedding and baseline can write local files;
+baseline has a durable output/locking protocol. A future stronger read-only
+guarantee needs an explicit implementation change and qualification.
+
+Only convergence advances apply's requested `config_digest`; changed achieved
+resources and `state_revision` can advance earlier. Import can initialize a
+missing ledger from existing declared graphs, even if no prior cluster apply
+created them. Refresh can record changed observed schema and graph digests.
+These Core transitions retain their operation-specific authority and effects
+independently of connection selection.
+
+### 8.2 Server surface
+
+`omnigraph-server` is a separate binary; it does not load personal profiles.
+
+| Input / omission | Current behavior |
+| --- | --- |
+| `--cluster DIR` | Read definition to locate storage, then boot applied ledger/catalog. |
+| `--cluster file://...`, S3 or Azure root | Direct applied snapshot from root; no desired-file reconstruction. |
+| No cluster argument | Refuse; current server is cluster-only. |
+| `--cluster pilot` | Directory name, not an operator connection lookup. |
+| `--bind` omitted | `127.0.0.1:8080`. |
+| `--data-token-trust FILE` | Opt-in public signed-token trust bound to actual root. |
+| Trust omitted | Existing static auth/policy behavior; no automatic managed token support. |
+| No configured protection or explicit unauthenticated mode | Refuse unprotected startup. |
+| `--require-all-graphs` omitted | Healthy graphs may serve alongside graph-local failures; empty/all-unservable still refuses. |
+| Shutdown grace omitted | Environment override then 25 seconds; orchestration grace must be longer. |
+
+The process boot witness is fixed; current ledger status can be newer.
+Restart activates a new cluster catalog revision under current behavior.
+Graph-level data publication/recovery is a separate protocol. A lock, lease,
+heartbeat, placement decision or bounded shutdown does not establish a
+distributed graph-writer fence. This framework claims no new G9/G11 proof.
+
+## 9. Proposed coherence framework
+
+### 9.1 Layers and their owners
+
+| Layer | Input → output | Boundary |
+| --- | --- | --- |
+| Parse | argv → typed command/arguments | Syntax and syntactic conflicts only. |
+| Classify | command → capability and option applicability | Pure; no context/keychain interception. |
+| Resolve | applicable addressing → one typed target + selector provenance | Explicit/ambient precedence; no credential-presence or target-substitution logic. |
+| Bind authority | resolved authentication variant → exact allowed credential | Separate namespaces; selected identity validated before credential-bearing request. |
+| Connect | target + authority → bounded transport/client | Central policy for origins, redirects, deadlines and response contracts. |
+| Execute/present | command + client → effects, outcome and output | Per-operation semantics; do not rebuild addressing here. |
+
+Cluster/config-directory commands have a distinct declared dispatch pipeline.
+Local/file/session commands likewise have explicit inputs. Shared error and
+inventory machinery does not imply one global target ladder.
+
+Graph derivation/probing is command-specific and declared: legacy registry
+probing needs a request, maintenance sole-graph selection needs applied state,
+and managed graph selection must not inspect grants. Do not place these under
+a blanket assertion that every selector is resolved without I/O.
+
+### 9.2 Registry contract
+
+A future registry lives with the owning CLI code, not in another handwritten
+YAML authority. It declares:
+
+- Commands/subcommands and compatibility spellings, capability/target variants,
+  supported status and owner evidence.
+- Options, positional forms and environment inputs; applicability, conflicts,
+  precedence, intentional shadowing, defaults and omission behavior.
+- Configuration surfaces, variants, discovery, validation and authority owner.
+- Credential namespace/binding, permission actions, transport contract and
+  provenance source.
+- Intended writes, lock/recovery/output effects, failure classes, uncertain
+  outcomes and replay/precondition contract.
+- Output formats and compatibility/removal boundaries.
+
+The registry generates help/reference coverage and test-case enumeration.
+**Expected routing and safety outcomes remain independently authored contract
+fixtures.** Generating both implementation and expected answers from the same
+precedence list would let a wrong rank validate itself.
+
+Undeclared commands/options should fail coverage checks after adoption.
+Current capability/help tests are partial coverage, not this full registry.
+A feature may need a new architecture boundary; it needs a reviewed design
+rather than an unregistered pre-dispatch special case.
+
+## 10. Invariants
+
+These are framework requirements, not a claim every current command already
+enforces them. F1–F13 are stable identifiers for review and verification.
+
+1. **F1 — Configuration changes use the owning protocol.** Cluster apply owns
+   planned configuration changes; partial outcomes, recovery, constrained
+   refresh/import and graph data writes retain their distinct contracts.
+   Credentials and routing edits cannot change cluster configuration.
+2. **F2 — State is observable through authorized projections.** Declare a
+   permitted read path for operationally relevant state and its provenance.
+   Requested/effective/observed may differ; disclose lag, not all state on
+   every API. Readiness stays minimal.
+3. **F3 — The surface is registered.** Each command, argument, compatibility
+   rewrite and config surface has one registry declaration after adoption.
+   Generated coverage and independent expected outcomes detect drift.
+4. **F4 — One authority owns each fact.** Name desired, effective, graph,
+   identity, guard, policy, routing and credential domains explicitly.
+   No projection silently becomes another domain's authority.
+5. **F5 — Applicable explicit selection beats ambient selection.** Preserve
+   explicit address/profile precedence within each pipeline. Unrelated
+   context cannot gate or redirect explicit data commands under the framework.
+6. **F6 — Addressing chooses the target.** Credentials/grants never select it.
+   State-derived graph selection occurs only on declared operation paths and
+   has explicit zero/one/multiple behavior.
+7. **F7 — Credentials respect their authentication variant.** Managed
+   credentials bind to exact selected identity/origin and never cross
+   namespaces. Preserve legacy lookup and direct attribution contracts.
+8. **F8 — Applicable inputs have declared treatment.** Consume, conflict,
+   explicitly shadow, or report a documented compatibility exception.
+   Locally decidable errors precede target requests and operation effects;
+   reading local configuration is permitted. Remote authorization precedes
+   protected effects. Unknown post-submission outcomes are not refusals.
+9. **F9 — Unsupported selected targets refuse.** No fallback to lower-ranked
+   targets, storage, different endpoints or another authentication mode.
+   Older clients fail closed on new managed variants.
+10. **F10 — Effects and retries are bounded by operation.** Declare lock,
+    recovery, artifact and output writes. Lost responses are unknown.
+    Reuse exact keys/requests only where that protocol supports replay;
+    otherwise reconcile effects under its existing contract.
+11. **F11 — Mutable names do not redefine durable identity.** Personal files
+    may persist names. Alias renames preserve authoritative identities;
+    similar URLs, paths or names are not identity proof.
+12. **F12 — Serving resources come from applied state.** Directory boot may
+    read desired config solely to locate storage. Report the fixed boot
+    witness; preserve graph-opening recovery and current restart activation.
+13. **F13 — Compatibility and evidence are explicit.** Parsing, routing,
+    defaults, permissions, effects, wire format and Rust source compatibility
+    are separate claims. Source inspection, existing tests and executed
+    qualification are labeled separately.
+
+## 11. Antipatterns
+
+| Antipattern | Why it fails | Required alternative |
+| --- | --- | --- |
+| Cwd file globally gates commands | Unrelated folder state can block or redirect an explicit operation. | Separate declared pipelines and explicit precedence. |
+| Unsupported selected source is skipped | Can execute against a different cluster/store. | Refuse the selected target. |
+| Cached token selects endpoint | A credential cache becomes routing authority. | Selected connection plus exact metadata validation. |
+| WorkOS login implies data/storage access | Collapses independent permissions. | Explicit credential/action contracts. |
+| Managed error falls back to bearer env | Crosses authentication boundary. | Preserve error; explicit legacy selection is separate. |
+| One token grant chooses graph | Permissions become addressing. | Explicit/profile graph, or declared non-token derivation. |
+| Root entry silently enables query | Widens storage capabilities through a connection change. | Preserve R capability boundaries. |
+| Every status API exposes entire ledger | Leaks fields and hides projection semantics. | Authorized views with provenance and lag. |
+| Only converged applies may persist progress | Loses achieved partial-state truth. | Existing per-resource outcome and ledger protocol. |
+| Refresh/import may only delete digests | Contradicts existing observation/adoption. | Preserve constrained Core transitions. |
+| Alias rename must change no persisted bytes | Personal config necessarily stores aliases. | Preserve authoritative identity, not byte equality. |
+| Every failure occurs before requests | Makes remote validation impossible. | Distinguish local refusal, remote refusal, partial/unknown outcome. |
+| Retry every write with an idempotency key | Several protocols do not support one. | Operation-specific replay or effect reconciliation. |
+| Read command implies zero physical activity | Opening/recovery/output/locks may have effects. | Declare effects and keep pure observation explicit. |
+| Lease/lock/termination timeout called a fence | Overstates writer-exclusion evidence. | Existing proof requirements and named limitations. |
+| Same generator supplies resolver and expected tests | A wrong rule passes its own test. | Independent contract assertions. |
+| New registry silently cleans up old quirks | Creates unreviewed compatibility changes. | Named follow-up decision, release note and tests. |
+
+## 12. Compatibility boundaries and known gaps
+
+Assess compatibility independently for parsing, configuration shape, target
+selection, credentials, defaults, operation effects, wire format and public
+Rust APIs. Preserving one does not prove the others. Each change needs its own
+consumer inventory, compatibility fixtures and documented adoption boundary.
+
+Known source-level differences include schema-plan root profiles versus
+rejected explicit root flags; policy/queries ignoring profile graph; offline
+lint accepting unused flags; command-specific read `--as` handling; and legacy
+graph omission probing. Keep them explicit until their owning contracts and
+implementation change; a common framework does not erase differences.
+
+Compatibility spellings include clap aliases `read`, `change`, `schema get`;
+a separate hidden `ingest` command; and argv-level lint compatibility
+rewrites. Parse preservation is not proof of identical defaults/routing.
+
+Public Rust compatibility includes struct-literal construction and
+destructuring, not just function calls. Boot compatibility includes accepted
+root forms, validation failures and trust requirements. Accepted graph-schema
+formats and provenance settings have their own upgrade/downgrade constraints;
+client configuration changes cannot relax those constraints.
+
+Broader managed command support, streaming bounds, cluster-name control
+shortcuts, optional managed endpoints, `defaults.cluster`, self-hosted
+HTTP cluster entries, empty-cluster serving, automatic failover and console/
+public routing are not completed by this framework.
+
+## 13. Verification and maintenance
+
+Use independent contract cases across command, target, explicit/ambient
+selection, context state, graph omission, credentials, policy, readiness and
+output. Exhaust the crosses that can redirect a write or disclose a credential;
+use pairwise coverage only for lower-risk presentation combinations.
+
+Framework conformance assertions (acceptance criteria, not test results):
+
+1. Explicit staging profile inside valid or malformed production context
+   targets only staging; ambient production settings cannot override it.
+2. Unsupported managed target refuses without touching any default store.
+3. New managed selection + every API/cluster/endpoint mismatch sends no token.
+4. Legacy literal server keeps its own chain even if a managed entry shares
+   the URL; no automatic managed credential selection.
+5. Credential presence, zero/one/many grants and unrelated context do not
+   choose a managed graph or endpoint.
+6. Explicit data selection does not read unrelated context; control commands
+   read only their selected directory's binding.
+7. Existing config fixtures remain valid; new mixed/missing authority fields
+   refuse, and old clients reject rootless managed entries.
+8. Local tools, init's positional URI, storage tools, aliases and registry
+   operations receive their declared inputs without a blanket context gate.
+9. Partial apply, observed digest refresh, initial import and graph recovery
+   retain their existing owner tests and effects.
+10. Status/boot tests verify each view's provenance and authorization, permit
+    lag, and do not expand public readiness disclosure.
+11. Exact managed-run replay and unknown data-write outcomes remain distinct;
+    token issuance gains no unsupported idempotency header.
+12. Runtime qualification is per command/transport: a server route, successful
+    compile or generated table alone does not qualify a managed CLI command.
+13. Accepted served query listing covers read and mutation entries, an empty
+    catalog, unknown/unauthorized graphs, profiles/defaults, address conflicts
+    and stable JSON. Results come from the active server catalog; existing
+    direct listing and direct validation retain their separate behavior.
+
+Before accepting a new command: name its authority and target classes; define
+omissions, credentials, effects, failure/retry and compatibility; register it;
+supply independent positive/negative cases; update generated help/reference;
+and record source/test/live evidence at its actual scope.
+
+Contract changes follow the [RFC process](../rfcs/README.md) before
+implementation. Changes that also affect the managed control plane require
+its decision/spec synchronization. Update this reference as verified
+support changes, retaining the distinction between rules and evidence.
+
+## 14. Source index
+
+The CLI, cluster and server implementation was checked against `500cdc29`
+on 2026-09-06. Source inspection does not assert the binary running in a
+deployment. Keep this reference aligned with the owning source and tests;
+version-specific compatibility evidence belongs in the RFC. Managed
+control-plane references retain their own draft status.
+
+Implementation and contracts:
+
+- [CLI declarations and defaults](../../crates/omnigraph-cli/src/cli.rs)
+- [Operator schema](../../crates/omnigraph-cli/src/operator.rs)
+- [Scope resolution](../../crates/omnigraph-cli/src/scope.rs)
+- [Capability rules](../../crates/omnigraph-cli/src/planes.rs)
+- [Credential and maintenance helpers](../../crates/omnigraph-cli/src/helpers.rs)
+- [Managed data cache/validation](../../crates/omnigraph-cli/src/managed/data.rs)
+- [Client transports](../../crates/omnigraph-cli/src/client.rs)
+- [Core apply/refresh/import/status](../../crates/omnigraph-cluster/src/lib.rs)
+- [Observed digest and import construction](../../crates/omnigraph-cluster/src/config.rs)
+- [Serving snapshot](../../crates/omnigraph-cluster/src/serve.rs)
+- [Server startup and boot witness](../../crates/omnigraph-server/src/lib.rs)
+- [Engine invariants](invariants.md)
+- [RFC 0011: addressing/config](../rfcs/0011-cli-addressing-and-config.md)
+- [RFC 0052: managed CLI](../rfcs/0052-managed-control-plane-cli.md)
+- [RFC 0053: offline data access](../rfcs/0053-offline-data-token-verification.md)
+
+Existing executable assertions, inspected but not rerun for this document:
+
+- [Core tests](../../crates/omnigraph-cluster/src/tests.rs):
+  `import_missing_state_creates_state_with_graph_observation` and
+  `refresh_records_live_schema_digest_and_graph_manifest_version`.
+- [CLI capability/help tests](../../crates/omnigraph-cli/tests/cli_schema_config.rs):
+  partial command-surface coverage, not a full coherence registry.
+- [Server OpenAPI drift tests](../../crates/omnigraph-server/tests/openapi.rs):
+  a precedent for artifact drift enforcement, not CLI routing proof.
+
+CP normative homes: [RFC](https://github.com/ModernRelay/og-control-plane/blob/main/specs/00-RFC-Main.md),
+[config supply](https://github.com/ModernRelay/og-control-plane/blob/main/specs/05-CFG-Config.md),
+[identity](https://github.com/ModernRelay/og-control-plane/blob/main/specs/06-IDN-Identity.md#idn-04-cluster-identity-and-incarnation-i17),
+[runs/projections](https://github.com/ModernRelay/og-control-plane/blob/main/specs/07-RUN-Runs.md#run-06-three-projections-t4),
+[interfaces](https://github.com/ModernRelay/og-control-plane/blob/main/specs/11-UIS-Interfaces.md), and
+[decisions](https://github.com/ModernRelay/og-control-plane/blob/main/specs/02-DEC-Decisions.md).

--- a/docs/dev/config-cli-framework.md
+++ b/docs/dev/config-cli-framework.md
@@ -359,6 +359,15 @@ non-root paths, query and fragment; compare canonical origins, not prefixes.
 Managed requests reject redirects. Existing finite request/response bounds
 remain; the current 8 MiB JSON limit is not an export-streaming design.
 
+For proposed managed query/mutation connections,
+[CC-11](../rfcs/0059-config-cli-coherency.md#8-credentials-actor-and-transport)
+sets a 10-second connection deadline within a 30-second total request deadline,
+including the complete response body. The inspected baseline instead has a
+10-second total deadline. The proposal retains the 8 MiB response bound and
+prohibits automatic retry, credential fallback, and data requests to the Intent
+API. A submitted mutation's timeout leaves its outcome unknown. These proposed
+bounds do not qualify other managed operations or change legacy transport.
+
 The server verifies signed data credentials offline: signature, issuer,
 audience, expiry and cluster/root/incarnation binding, then action grants
 intersect applied Cedar permissions. Control permission does not imply data
@@ -850,6 +859,11 @@ Framework conformance assertions (acceptance criteria, not test results):
     catalog, unknown/unauthorized graphs, profiles/defaults, address conflicts
     and stable JSON. Results come from the active server catalog; existing
     direct listing and direct validation retain their separate behavior.
+14. Proposed query/mutation deadline fixtures verify success after 10 seconds
+    and before 30, the 10-second connection bound, and expiry of the complete
+    request at 30 seconds even while receiving body chunks. A submitted
+    mutation remains unknown after timeout; no automatic retry or authority
+    fallback occurs.
 
 Before accepting a new command: name its authority and target classes; define
 omissions, credentials, effects, failure/retry and compatibility; register it;

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -24,6 +24,7 @@ change boundaries, and test ownership. Design history and proposals belong in
 | Three-way branch integration | [Merge](merge.md) |
 | Managed and external Blob boundaries | [Blob internals](blob.md) |
 | Cluster apply, serving snapshots, and writer ownership | [Control plane](control-plane.md) |
+| Configuration authority, CLI operations, and coherence review | [Configuration and CLI framework](config-cli-framework.md) |
 | Bounded graph-batch ingestion | [Ingestion](ingestion.md) |
 | Release, wire, storage, and dependency compatibility | [Versioning](versioning.md) |
 

--- a/docs/rfcs/0059-config-cli-coherency.md
+++ b/docs/rfcs/0059-config-cli-coherency.md
@@ -1,0 +1,938 @@
+---
+rfc: "0059"
+title: "Configuration and CLI coherency"
+track: maintainer
+status: draft
+implementation: not-started
+authors:
+  - andrew
+created: 2026-09-06
+updated: 2026-09-06
+discussion: null
+supersedes: []
+superseded_by: []
+blocked_on: []
+---
+
+# RFC 0059: Configuration and CLI coherency
+
+This RFC proposes a compatibility correction; it does not authorize new
+behavior until accepted. Requirement identifiers beginning `CC-` are local to
+this RFC and are not public error codes. Acceptance of an individual issue
+referenced here does not accept this entire proposal.
+
+The [configuration and CLI framework](../dev/config-cli-framework.md) records
+the vocabulary, current boundaries, and explicitly proposed coherence rules.
+This RFC owns the correction's requirements, rationale, alternatives,
+migration, and evidence gates. The [CLI reference](../user/cli/reference.md)
+and [operator configuration](0007-operator-config.md) own their existing
+public contracts. Conflicts are review findings to resolve, not permission to
+change an accepted contract implicitly.
+
+## 1. Summary and evidence boundary
+
+Keep offline signed data credentials, WorkOS control sessions, and the existing
+server authorization model. Replace the cwd-based data dispatcher introduced
+by PR #633 with managed connections selected through the existing operator
+scope resolver. Keep config-directory selection for cluster operations.
+
+The proposed operator syntax adds a managed variant to `clusters:` and a
+cluster binding to read aliases. Existing server entries, root entries,
+profiles, direct graph addressing, and legacy credentials remain valid.
+The first implementation enables managed `query` and `mutate` through explicit
+cluster/profile selection. Other managed HTTP operations need separate
+qualification; their existence on the server is insufficient evidence of
+CLI support.
+
+The accepted scope of [issue #653](https://github.com/ModernRelay/omnigraph/issues/653)
+is included as a separately testable served catalog CLI extension. It uses an
+existing HTTP endpoint and preserves direct listing. Accepted issue scope is
+not implementation evidence or acceptance of this entire RFC. No requirements
+are imported from other open or needs-triage issues merely because they are
+related.
+
+There is no universally transparent migration: an identical invocation can
+mean one target before #633 and another after it. A temporary refusal protects
+the ambiguous implicit `query`/`mutate` case while consumers move to explicit
+selection. It never chooses a target or supplies a credential.
+
+### 1.1 Inspected baselines
+
+| Baseline | Meaning here |
+| --- | --- |
+| `02d182b6` | Parent of #633; compatibility reference for the operator resolver and public Rust shapes. |
+| `e23778d9` | Merged #633; managed control CLI, offline data credentials, and cwd data interception. |
+| `c253f111` | Merged #663; inspected merged baseline, including actor provenance. |
+| `c9275697` | Inspected local lifecycle worktree; extra commands are not part of the merged baseline. |
+| Publication base `500cdc29` | Production CLI/cluster/server behavior inspected here is unchanged from `c253f111`; this is not an execution result. |
+| CP design references | The separately owned managed authority, permission, execution, and lifecycle contracts; not acceptance of this RFC. |
+
+“Source-verified” means a statement was checked in those source revisions.
+“Test-verified” requires a named executed test and its result. This document
+contains source findings and an acceptance plan; no new runtime, build,
+platform, or live test execution is claimed. Examples use illustrative names
+and origins. Proposed examples must not be advertised as accepted by the
+current binary.
+
+## 2. Problem
+
+Before #633, graph commands selected a target through explicit addresses,
+profiles, environment-selected profiles, and operator defaults. #633 adds a
+second dispatcher before that resolver. When cwd contains managed context,
+`query`/`mutate` use its API and cluster identity and the cached credential's
+endpoint. Explicit addressing conflicts; inherited profiles and defaults do
+not participate. Other graph/tool commands are rejected, including commands
+that could otherwise operate entirely on explicit local files or storage.
+Malformed context can fail before ordinary resolution.
+
+For example, assume the shell has `OMNIGRAPH_PROFILE=staging`, the profile
+selects a staging server, cwd has production context, and a valid production
+data credential exists:
+
+```sh
+omnigraph --graph knowledge mutate update_person --params '{"slug":"alice"}'
+```
+
+The ordinary resolver selects staging. The #633 dispatcher can instead select
+production if the graph/action grants and applied policy permit the request.
+Authentication can be correct for the endpoint while operator intent was
+misresolved. An explicit `--profile staging` currently causes a scope conflict
+rather than restoring ordinary precedence.
+
+The problem is the competing routing authority, not offline verification or
+managed permissions. The resolver and overlay are visible in
+[scope.rs](https://github.com/ModernRelay/omnigraph/blob/c253f111/crates/omnigraph-cli/src/scope.rs#L55-L151)
+and [managed/data.rs](https://github.com/ModernRelay/omnigraph/blob/e23778d9/crates/omnigraph-cli/src/managed/data.rs#L318-L377).
+The correction changes operator syntax, credential selection, and compatibility
+across existing public contracts; a local dispatch patch alone cannot establish
+those boundaries. They require this RFC and owned migration evidence.
+
+## 3. Goals and non-goals
+
+The goals are:
+
+- Restore one data-target resolver with established precedence and explicit
+  connection identity carried through authentication and transport.
+- Add managed cluster naming without repurposing legacy servers or direct
+  roots, and preserve existing valid operator configuration.
+- Preserve offline data access, least privilege, exact credential binding,
+  and no fallback across execution or credential modes.
+- Give existing #633 consumers a migration that cannot silently retarget a
+  mutation, while removing the blanket folder gate from unrelated commands.
+- Make compatibility boundaries and acceptance evidence explicit.
+
+This correction does not introduce infrastructure provisioning, a console,
+public graph routing, implicit token renewal, a new token service, sticky
+profile state, automatic endpoint discovery, or administrative ownership
+transfer. It does not repair actor-setting omission semantics from #663,
+change engine lock/CAS protocols, complete writer fencing, or change lifecycle
+retention. It does not make every server route eligible for managed CLI use.
+It does not introduce managed approvals, a second approver, or per-action
+step-up.
+
+## 4. Authority and effect boundaries
+
+**CC-01 — Keep each authority in its existing home.**
+
+| Surface | Authority | Explicit boundary |
+| --- | --- | --- |
+| `cluster.yaml` and referenced `.pg`, `.gq`, policy/config files | Requested cluster definition | Personal routing and credentials cannot replace these inputs. |
+| Managed service source binding | One external or managed repository and its revision contract | No merge of two config homes; arbitrary directory contents are not execution input. |
+| Applied ledger | Effective cluster resource projection under the Core's existing rules | Routing cannot write it or reconstruct desired source from it. |
+| Accepted schema | Effective schema and actor-setting authority under the engine contract | A requested `.pg` file and a cluster-ledger projection cannot substitute for accepted state. |
+| Root identity marker and guard records | Immutable root identity and protocol-owned exclusion/execution/lifecycle evidence | Service identity/status projections cannot replace these authoritative records. |
+| Operator `config.yaml` | Personal connections, profiles, aliases, output, direct actor preference | Does not enroll a cluster, change grants, or alter desired/effective state. |
+| Config directory `.omnigraph/context` | API origin and service cluster identity for cluster commands | Does not become a data default or credential store. |
+| Credential stores | Credentials and their scope metadata | May validate a selected target; never select a different target. |
+| Service account/principal records and server boot trust | Service-owned principal/grant facts and offline verification configuration | A cluster identity projection must agree with the root marker; an operator nickname or client actor does not create authority. |
+
+Operator names are mutable references. Renaming one may change operator YAML
+and, for legacy servers, name-keyed credential storage. It must not rename a
+service cluster/principal or alter graph identity/content. This rule applies
+to authoritative identity, not every persisted byte. Legacy URL-to-server
+credential lookup is preserved and is not a service identity mechanism.
+
+**CC-02 — Preserve existing Core and managed execution protocols.** This
+change does not add a writer of `__cluster/state.json`. Existing apply,
+partial apply, recovery, import, refresh, and serving contracts remain with
+their present owners. Partial apply can persist achieved resource state and
+advance `state_revision` before full convergence; recording the requested
+`config_digest` has its own conditional contract. Current import/refresh can
+insert or alter observed schema/graph digests as well as remove or re-status
+entries; import can admit externally created graphs. This RFC does not
+incorrectly redefine those commands as observation-only, removal-only, or
+restricted to an unchanged desired inventory. Routing must not change their
+mutation rules, lock acquisition, revision/CAS handling, or sidecar/recovery
+behavior.
+
+A read-shaped CLI verb is not a universal no-write promise. Some direct
+branch/snapshot/commit reads, baseline/export, and query validation open the
+engine for read-write operation and can perform recovery. Schema show and
+graph-backed lint use read-only opening paths. Preserve these distinctions
+and record their existing effects in fixtures; this correction must neither
+silently suppress recovery nor claim that every read is side-effect-free.
+
+Serving continues to consume the applied snapshot and report its boot
+witness, with existing quarantine, readiness, and shutdown semantics. A
+directory-based boot may read desired configuration to locate the storage
+root; applied resources remain the authority for what boots. Opening a graph
+can perform its existing recovery work without making serving a writer of the
+cluster ledger. A fixed boot witness, the later current ledger, and authorized
+status projections need not be identical; public readiness remains minimal.
+Operator connections do not become boot inputs. This RFC does not require a
+new rollout, restart policy, hot-reload protocol, universal status/readiness
+parity, or treatment of an empty applied cluster.
+
+Managed apply still executes the exact saved plan with current scoped
+permission and verified execution authority. It does not silently replan,
+commit source, approve itself, or bypass existing destructive-resource
+authority checks. Local direct prompts and the historical Core `approve`
+command retain their existing meaning; neither becomes a managed approval
+step.
+
+### 4.1 Architectural invariants and substrate alignment
+
+The [standing invariants](../dev/invariants.md) remain mandatory. The routing
+correction changes how a caller selects an existing access path; it does not
+create an exception to the publication, recovery, or trust boundaries.
+
+| Invariants | How this RFC preserves the boundary |
+| --- | --- |
+| 1, substrate ownership; 2 and 4, one graph publication | No new storage protocol, per-table writer, publication door, or Lance API. Existing engine operations continue to own effects. |
+| 3 and 5, coherent attempts and recovery | A resolved connection stays fixed for an attempt. Unknown outcomes do not trigger a new target; retry/recovery remains operation-specific. |
+| 6, stable identity | Operator names remain personal references; exact API/cluster/endpoint binding does not replace root/incarnation or accepted schema identity. |
+| 7 and 12, derived state and one authority | Credentials validate rather than select targets. Routing does not rewrite desired files, the applied ledger, accepted schema, or guard records. |
+| 8 and 9, explicit failures and typed semantics | Selected invalid/unsupported paths refuse without substitution. Query parsing, typed semantics, and source-selection contracts remain unchanged. |
+| 10, trust at the boundary and engine policy | Managed data retains verified graph/action ceilings plus Cedar; restored public actor shapes cannot manufacture verified signed authority. Direct writes retain their existing policy checks. |
+| 11, bounded observable failure and resource use | Preserve the existing managed transport bounds, distinguish unknown outcomes from refusal, and define eligibility before adding another operation. |
+| 13, evidence at the owning layer | Resolver/cache/HTTP/boot/public API changes have separate owning fixtures; source inspection and executed evidence remain distinct. |
+
+No deny-list exception is requested: in particular, no shadow source of truth,
+cloud-only engine correctness path, process-local writer fence, or silent
+retry is introduced. The transient migration guard can only refuse an
+ambiguous call; it cannot become another routing or credential authority.
+
+The repository pins Lance 11.0.0. This proposal does not change a Lance-shaped
+behavior or depend on a new undocumented substrate guarantee; it preserves
+the existing OmniGraph facade contracts. No new Lance qualification is claimed
+by this documentation change. If an implementation crosses that boundary,
+its owner must perform the complete relevant reading and compatibility checks
+required by [the Lance guide](../dev/lance.md) before changing the design.
+
+## 5. Proposed operator configuration
+
+**CC-03 — Add a flat, explicit cluster variant.** Extend the existing
+`~/.omnigraph/config.yaml`, or `$OMNIGRAPH_HOME/config.yaml`:
+
+```yaml
+operator:
+  actor: act-andrew
+
+defaults:
+  output: table
+  table_max_column_width: 80
+  table_cell_layout: wrap
+  server: legacy-local
+  default_graph: knowledge
+
+servers:
+  legacy-local:
+    url: http://localhost:8080
+
+clusters:
+  pilot:
+    managed: true
+    id: CLUSTER_ID
+    api: https://control.example
+    endpoint: https://pilot.graphs.example
+  local-root:
+    managed: false
+    root: file:///Users/andrew/data/local-cluster
+  existing-root:
+    root: s3://example-bucket/cluster
+
+profiles:
+  pilot:
+    cluster: pilot
+    default_graph: knowledge
+  maintenance:
+    cluster: local-root
+    default_graph: knowledge
+  legacy:
+    server: legacy-local
+    default_graph: knowledge
+  scratch:
+    store: file:///Users/andrew/data/scratch
+
+aliases:
+  legacy-people:
+    server: legacy-local
+    graph: knowledge
+    query: list_people
+    args: []
+    params: {}
+    format: table
+  pilot-people:
+    cluster: pilot
+    graph: knowledge
+    query: list_people
+    args: []
+    params: {}
+    format: table
+```
+
+`pilot-people` illustrates the proposed additive alias binding. Managed alias
+execution is a separately qualified extension after the initial query/mutate
+slice; its presence here is not a claim of current eligibility.
+
+### 5.1 Validation
+
+| Entry | Required | Rejected combinations |
+| --- | --- | --- |
+| `clusters.NAME` with YAML `managed: true` | `id`, `api`, `endpoint` | `root`, missing/invalid binding fields, embedded credentials. |
+| `clusters.NAME` with `managed: false` or omitted | `root` | Managed `id`, `api`, or `endpoint` fields. |
+| `servers.NAME` | Existing `url` | No new managed auth is inferred from this entry. |
+| Profile | Exactly one of `server`, `cluster`, `store` | Multiple binding kinds; a store binding with `default_graph`. |
+| Existing alias | Existing server/query binding | Global address overrides remain invalid. |
+| New cluster alias | Exactly one cluster binding, `graph`, `query` | Simultaneous server binding; root-backed cluster as a served alias. |
+
+Validate the discriminator as a YAML boolean, not a truthy string. Use the
+existing cluster-ID grammar. Validate managed API and endpoint as canonical
+origins: HTTPS, or HTTP for the existing exact loopback hosts `localhost`,
+`127.0.0.1`, and `::1`; reject userinfo, non-root paths, query, and fragment.
+Explicit valid ports remain part of canonical origin identity. These managed
+rules do not tighten the legacy server URL contract.
+
+The new variant must fail closed for misspelled, missing, contradictory, or
+unknown routing/auth fields. Ordinary unrelated preference keys retain their
+current warning behavior. A malformed new managed entry must not degrade to
+the old root variant or a legacy server. Its lack of `root` is deliberate:
+the inspected older CLI requires that field and refuses the new entry.
+That can prevent an old CLI from loading the whole operator file; migration
+must account for mixed binary versions, not promise per-entry compatibility.
+
+All existing top-level sections remain optional. No `defaults.cluster`,
+`current_profile`, token field, nested managed object, or per-profile output
+format is added. Flat defaults retain their existing server/store exclusivity.
+Output and alias parameter rules remain unchanged. Setting `managed` does
+not prove ownership or convert an existing deployment: it declares the
+connection variant used by the client.
+
+## 6. Data and storage resolution
+
+**CC-04 — Preserve the established priority order.** Resolve an address
+without network access or credential inspection:
+
+| Rank | Source | Result |
+| --- | --- | --- |
+| 1 | One explicit primitive: `--server`, `--store`, `--cluster`, or supported positional/verb-local URI | Select that address; conflicting explicit primitives refuse. |
+| 2 | Explicit `--profile NAME` | Select that profile's complete binding. |
+| 3 | `OMNIGRAPH_PROFILE` | Select that profile's complete binding. |
+| 4 | Flat operator defaults | Select the existing server/store default. |
+| 5 | None | Refuse if this command needs a target. |
+
+An explicit address intentionally shadows unused profile/environment/default
+scope. An explicit profile intentionally shadows the environment profile.
+These inputs are accounted for by precedence, not silently ignored as a
+defect. Unknown selected names and invalid selected bindings refuse; the
+resolver does not try a lower-priority source after selection fails.
+
+An explicit `--graph` overrides the graph default from the selected profile.
+The profile does not inherit a flat default graph. An explicit primitive does
+not inherit a graph from an unused profile. Flat default graph behavior
+remains attached to the flat server scope.
+
+**CC-05 — Carry the selected connection, then check capability.** The
+resolved representation distinguishes legacy HTTP, standalone graph storage,
+root tooling, and managed HTTP with exact API/ID/endpoint. It also records
+selection provenance for diagnostics. Authentication variant is a property
+of the connection, not whether a flag, profile, or environment selected it.
+No public Rust type name or enum layout is mandated here.
+
+Once selected, an unsupported target refuses in place. For example, a managed
+profile with `optimize` must not fall through to `defaults.store`. A bad
+credential must not cause another profile, endpoint, transport, or root to be
+tried. Capability checking occurs after variant resolution so a named managed
+cluster can support data access without expanding legacy root eligibility.
+
+Preserve names and literals:
+
+- `--server NAME` selects an existing server; literal `--server URL` stays
+  legacy HTTP, including its existing credential-owner lookup.
+- `--cluster NAME` recognizes a configured managed entry or existing root
+  entry; preserve current literal directory/root handling when no name binds.
+- `--store GRAPH_URI` continues to name one graph. A root is not a graph.
+- Positional storage/`--store` HTTP strings do not gain server semantics.
+- Aliases use their own binding, reject scope overrides, and eventually use
+  the same connection/authentication helper as ordinary data commands.
+- Local/session commands do not acquire graph targets from this cascade.
+
+**CC-06 — Remove cwd from final data routing.** Normal data resolution does
+not inspect `.omnigraph/context`, search parents, or scan caches. An unrelated
+or malformed context cannot affect an explicit target or local/offline tool.
+Section 10 defines the sole temporary exception, a refusal-only migration
+check for implicit query/mutate.
+
+### 6.1 Graph omissions and initial eligibility
+
+| Target/operation | Rule preserved or proposed |
+| --- | --- |
+| Standalone graph store | URI identifies the graph; an additional graph selector refuses. |
+| Legacy HTTP graph operation | Preserve selected graph defaults and existing omission probe behavior. |
+| Legacy `graphs list` | Registry operation; explicit graph refuses and default graph is not used. |
+| Root maintenance | Preserve selected profile graph and existing sole-applied-graph derivation; zero/several refuse. |
+| Root policy/query tooling | Preserve current helper's applied-source selection, including its profile-graph exception. |
+| Managed query/mutate | Require explicit graph or selected profile graph; never infer from token grants or graph inventory. |
+| Managed registry operation | Deferred qualification; cluster scope with no graph selector. |
+
+Current legacy HTTP omission is not sole-graph selection: the best-effort
+registry probe refuses any nonempty result, including one graph; empty,
+unsupported, denied, or failed probes may continue to the bare server URL.
+Repairing that behavior is a separate compatibility change.
+
+**CC-07 — Start with the existing managed operation set.**
+
+| Managed operation | First correction slice |
+| --- | --- |
+| Stored `query` / `read` | Eligible with `read` and `invoke_query`. |
+| Ad-hoc `query` | Eligible with `read`. |
+| Stored `mutate` / `change` | Eligible with `change` and `invoke_query`. |
+| Ad-hoc `mutate` | Eligible with `change`. |
+| `queries list` | Accepted served HTTP CLI mapping in section 6.2; named managed connection support needs separate qualification. |
+| New managed alias | Design included; activate only after its explicit alias-path qualification. |
+| Load/ingest, snapshot, Blob, export, branch, commit, changes, schema show, graph registry | Deferred per-operation CLI, permissions, and transport qualification. |
+| Managed schema apply, direct maintenance, initialization, graph-backed lint/schema plan, policy tooling, `queries validate` | Unsupported through this managed data connection. |
+
+Every eligible request also requires current applied Cedar authorization.
+Grant possession is not policy enrollment. Apart from CC-18's served-list
+extension, existing legacy HTTP/storage eligibility remains unchanged. In
+particular, ordinary root-backed cluster profiles still do not become direct
+query/mutate access paths.
+
+Stored names select the applied query catalog; `--query`/`-e` provide ad-hoc
+source. There is no implicit file search for a stored name. Data branch,
+snapshot, output, conditional mutation, and query-source semantics retain
+their [existing CLI contracts](../user/cli/reference.md), with omission
+exceptions recorded in the [framework](../dev/config-cli-framework.md).
+`ingest` remains a distinct hidden permissive command, not an alias for
+canonical `load`, whose mode is required.
+
+### 6.2 Accepted served query listing
+
+**CC-18 — Expose the active served catalog through the CLI.**
+[Issue #653](https://github.com/ModernRelay/omnigraph/issues/653) is labeled
+`accepted`, `feature`, `P-high`; the CLI mapping is not implemented in the
+inspected source. Include its accepted scope as a bounded extension alongside
+the resolver work:
+
+```sh
+# Accepted work; requires the served-list CLI implementation.
+omnigraph queries list --server example --graph example --json
+```
+
+- Use the existing `GET /graphs/{graph}/queries` endpoint. Preserve normal
+  server, graph, profile, default and credential resolution and conflicting
+  address handling; do not create a parallel resolver or catalog.
+- Split command classification for `queries list` from `queries validate`.
+  Listing gains served access while retaining its existing direct cluster
+  path; validation retains its existing direct helper and capabilities.
+- Return a stable documented JSON shape with operation names/kinds and the
+  metadata actually supplied by the active server catalog. Richer compiled
+  descriptors are not a dependency or an assumed response field.
+- Preserve endpoint authorization and unknown/unauthorized graph behavior.
+  Catalog visibility does not imply permission to invoke an operation; do not
+  add per-query invocation filtering as an unrequested policy change.
+- Qualify a future named managed connection separately through the common
+  bound-credential path. Accepted ordinary served CLI support alone does not
+  approve or prove that additional authentication variant.
+
+Tests cover a catalog containing a read and a mutation, an empty catalog,
+unknown and unauthorized graphs, server/profile/default selection, conflicting
+addresses, stable JSON and active-catalog authority. Existing direct listing
+and validation must retain their behavior. This extension requires no new
+graph endpoint, data writer or stored-query registry.
+
+## 7. Separate config-directory control pipeline
+
+**CC-08 — Do not retarget cluster controls through data profiles.** Keep
+`cluster COMMAND --config DIR`, with `DIR` defaulting to `.`. For ordinary
+Core-capable verbs: explicit `--direct` skips context; otherwise valid context
+dispatches managed control; absent context uses the existing Core route;
+malformed context refuses. Search only the exact selected directory.
+
+Managed-only verbs refuse without the required context or when direct is
+requested. This is not a blanket fallback rule. The lifecycle worktree's
+initial create and operation-status recovery have their own explicit
+selection rules; retain those if/when that work lands.
+
+```sh
+omnigraph cluster plan --config ./checkout
+omnigraph cluster apply --config ./checkout --plan PLAN_RUN_ID
+omnigraph cluster plan --config ./checkout --direct
+```
+
+The apply example requires a managed-bound directory and an exact saved plan.
+Existing direct apply retains its own Core arguments. `--cluster pilot` and
+data profiles cannot redirect these operations, infer desired files, or select
+a different source revision. There is no new environment override for
+`--config` in this proposal.
+
+Preserve existing `login --api`, `logout --api`, `use ... --config`, and
+`cluster token --config` behavior and strict context handling. A token/status
+shortcut by operator nickname can be considered later, independently of
+plan/apply and without inferring desired source.
+
+At `c9275697`, create, push, delete, undo-delete, and operation-status recovery
+are worktree-only additions. This correction neither releases nor qualifies
+them, changes their replay identity, nor adds a purge verb.
+That worktree's push capture is Unix-only and bounded to 4,096 files, 2 MiB
+per file, 32 MiB total, 120 seconds, and 512-byte paths. Preserve its referenced
+file checks rather than replacing them with a directory upload. Its local
+lock, pending, and last-operation records support capture/replay; they do not
+become cluster identity, execution authority, or desired/effective state.
+
+## 8. Credentials, actor, and transport
+
+**CC-09 — Select one authentication variant from the resolved connection.**
+
+| Connection | Credential contract |
+| --- | --- |
+| Graph/root storage | Existing filesystem/backend credentials; no managed credential substitution. |
+| Legacy HTTP | Existing matched server's keyed environment, then credentials file, then legacy bearer environment; existing anonymous/server-policy behavior when absent. |
+| Managed control | Separate origin-bound control session or explicitly bound automation control credential. |
+| Managed data | Existing separate data-keychain namespace, keyed by canonical API origin and cluster ID, with exact selected endpoint validation. |
+
+No cross-namespace fallback is permitted. The legacy chain intentionally has
+several sources within its own contract; preserving it is not permission for
+managed requests to use `OMNIGRAPH_BEARER_TOKEN`. Adding a managed entry at a
+legacy URL must not change a literal `--server URL` request's credentials.
+
+**CC-10 — Validate the complete selected managed binding before sending.**
+Require equality between operator selection and cached canonical API, cluster
+ID, and canonical endpoint. Preserve credential format/size, expiry, graph,
+and action validation. Read only the selected keychain entry; do not scan for
+one that happens to match grants. A cache edit, endpoint mismatch, expired
+token, or insufficient scope refuses before sending that credential.
+
+Current `Credential::validate` checks API and cluster equality, but only
+canonical syntax for endpoint. It then connects to the cached endpoint; there
+is no independently selected expected endpoint today. Exact endpoint equality
+is therefore a proposed correction, not a source-verified existing guarantee.
+See [the current check and use](https://github.com/ModernRelay/omnigraph/blob/c253f111/crates/omnigraph-cli/src/managed/data.rs#L97-L134)
+and [client construction](https://github.com/ModernRelay/omnigraph/blob/c253f111/crates/omnigraph-cli/src/managed/data.rs#L281-L315).
+
+Client metadata validation is not signature verification. The server still
+verifies the signed credential, issuer, audience, actual root/incarnation,
+expiry, graph/action ceiling, and applied policy. A matching client tuple does
+not make a graph ready or authenticate the server beyond ordinary TLS.
+
+Keep the existing keychain format and token-mint/clear output contract. Minting
+remains an explicit control request for a graph/action subset with current
+data grants; it does not edit operator YAML or defaults. Metadata output may
+be used to prepare the explicit connection. Endpoint rotation requires a
+deliberate connection update and matching newly issued/current credential;
+neither side silently wins. Clearing the local entry does not revoke an
+offline server credential, and control logout does not imply such revocation.
+Keep existing TTL validation (default 3,600 seconds; accepted range
+60–86,400 seconds). Token issuance does not gain an idempotency-key contract:
+the existing endpoint rejects one. Run/lifecycle replay guarantees must not
+be generalized to token minting.
+
+**CC-11 — Preserve bounded, offline managed transport.** Retain no redirects,
+10-second connect and request deadlines, and the existing 8 MiB JSON-response
+bound for the initially eligible requests. Preserve the 64 KiB cached-record
+and 8 KiB token bounds and existing validators. Data requests do not call the
+Intent API, mint credentials, or refresh sessions. Streaming routes need an
+explicit bounded streaming contract before qualification; they must not
+inherit an unsuitable JSON limit or remove bounds silently. Legacy transport
+does not acquire new restrictions merely because managed support is added.
+
+**CC-12 — Preserve actor attribution boundaries.** Direct writes retain
+`--as` and operator actor defaults. Authenticated served writes derive actor
+from verified server identity and reject client actor overrides. Actor
+provenance records a fact about a write; it grants no permission. Login,
+token issuance, and ordinary reads do not require materializing an actor.
+
+## 9. Failures and direct compatibility
+
+**CC-13 — Preserve explicit direct syntax without auth downgrade.** Both
+global `--direct` and its established cluster-local spelling remain accepted.
+Legacy data HTTP invocations may continue using it; the historical flag is
+not exclusively a storage selector. A newly selected managed data connection
+plus `--direct` refuses the conflict before credential transmission or storage
+access. It must not discover a root, substitute a static token, or turn into
+direct execution.
+
+Local syntax, binding, capability, and credential preflight errors should
+occur before request or operation effects. Remote authorization and readiness
+refusals necessarily follow a request; they must not be misrepresented as
+local preflight or as evidence that no request happened. Preserve their
+existing safe diagnostics and effect guarantees.
+
+A lost write/run-submission response remains an unknown outcome, not proof of
+a no-op. Do not retry against another target. Reuse the existing operation
+idempotency protocol where present; otherwise inspect the relevant head/effect
+under that operation's recovery contract before resubmitting.
+
+Use existing typed managed failures when applicable. Name any needed new
+public failure class in the owning implementation/spec review, not by silently
+turning a local `CC-` requirement into a protocol code. Current legacy errors
+are not uniformly a closed typed registry; normalizing all errors is outside
+this compatibility correction. Diagnostics may show nonsecret selected
+bindings and selection source, never bearer values or complete keychain data.
+
+## 10. Migration and removal of the temporary guard
+
+**CC-14 — Protect ambiguous old invocations without routing through context.**
+The final resolver has no data context source. During one announced transition,
+only implicit former #633 `query`/`mutate` invocations may run a migration
+refusal check. The parsed `read`/`change` aliases share those command cases.
+
+The guard is ineligible and returns before any context read for:
+
+- An explicit address primitive or explicit `--profile`.
+- Explicit global or supported local `--direct`.
+- An alias with its own binding.
+- Any other command, including local/offline tools and cluster controls.
+
+For an eligible implicit invocation, first determine the proposed selection
+using the ordinary resolver. If no exact-directory context exists, continue
+ordinary behavior. If context is malformed, refuse the migration ambiguity
+without guessing the old identity. If it exists, allow only when the old
+managed API/cluster and validated cached endpoint can be shown to agree with
+the already selected new managed API/cluster/endpoint. Comparing a legacy URL
+alone, graph-name overlap, or token grants is insufficient. If proof is absent,
+invalid, or different, request an explicit selector and execute against
+neither candidate. Normal credential and capability validation still follows
+any successful comparison.
+
+The cache can supply evidence for this narrow equivalence test; it cannot
+supply the new target. Missing cache metadata cannot turn an ambiguous call
+into an ordinary legacy write. Context in a parent directory is not searched.
+No context is rewritten and no permanent per-operator migration marker is
+created. This transitional refusal is an explicit, temporary exception to
+context-independent preflight, not a second resolver or permanent mode gate.
+
+The release owner must publish a finite removal boundary before shipping the
+guard: the introduction release, last release containing it, supported
+consumer migration interval, and removal release. No arbitrary version is
+invented by this discussion RFC. The documented boundary is a release blocker,
+not permission for indefinite retention. Automated consumers must migrate
+before upgrading past removal, or implicit legacy/default resolution could
+change a former context-dependent destination.
+
+### 10.1 Consumer rollout
+
+1. Inventory released and Git-revision consumers separately, including scripts,
+   CI images, aliases, operator files, and #633-only public Rust consumers.
+2. Save the existing binary/config/script versions and metadata-only bindings.
+   Do not export credentials into the project or commit operator secrets.
+3. Prepare the managed entry and profile using verified service/token metadata;
+   do not derive identity from an endpoint URL. Update calls to explicit
+   selection. Do not change global defaults automatically.
+4. Qualify the new binary against the prepared file and unchanged legacy file,
+   then switch each consumer's binary/config/scripts as a coordinated unit.
+   Use isolated operator homes where old and new binaries must coexist.
+5. Preserve control login and valid #633-format data credentials where their
+   metadata exactly matches. Remint explicitly only when required.
+6. Observe the declared migration boundary, then remove only the temporary
+   refusal path. Keep the independent resolver and no-fallback regressions.
+
+Proposed data calls after migration:
+
+```sh
+omnigraph --cluster pilot --graph knowledge query list_people
+omnigraph --profile pilot query list_people
+omnigraph --profile pilot mutate update_person --params '{"slug":"alice"}'
+```
+
+These are valid proposed grammar examples, not executed requests. The profile
+supplies `knowledge`. The examples require the named catalog entries and
+appropriate grants/policy. Existing explicit legacy calls remain legacy:
+
+```sh
+omnigraph --server legacy-local --graph knowledge query list_people
+omnigraph --profile legacy query list_people
+omnigraph --direct --server legacy-local --graph knowledge query list_people
+```
+
+### 10.2 Rollback
+
+Routing rollback restores the matching saved binary, operator file, and
+scripts together. Do not launch an old binary on a new root-less managed
+variant and expect it to ignore that entry. Do not restore implicit
+context-dependent mutations as a “safe default”: pin the intended legacy
+target with explicit addressing and `--direct` where #633 requires it, or
+pause that consumer until its managed path is restored.
+
+This correction does not itself require graph, service identity, infrastructure,
+or database migration. Any separately deployed server/API or public Rust
+adaptation has its own matched artifact rollback and auth regression gates.
+An engine downgrade across #663's accepted schema format is not made safe by
+rolling back routing configuration; it remains outside this procedure.
+
+## 11. HTTP, public Rust, and #663 compatibility
+
+**CC-15 — Keep wire and authority contracts stable.** The CLI routing repair
+does not need new graph routes, JSON request/response formats, token claims,
+control-session namespaces, or keychain schema. Preserve signed-only grant
+ceilings, graph filtering, static-plus-signed coexistence, and server policy
+enforcement. Compare OpenAPI and captured request shapes rather than assuming
+that an unchanged command name proves wire compatibility.
+
+PR #633 also changed public Rust struct shapes and made root canonicalization
+an unconditional snapshot step. These are separate compatibility axes from
+the data resolver and should be addressed in an isolated implementation step:
+
+- Prefer restoring the pre-633 public field shapes of `ServerConfig`,
+  `ServingSnapshot`, and `ResolvedActor`, and expose additive opt-in managed
+  boot/root-bound snapshot entry points. Exact new API names need owner review.
+- Keep verified signed claims and selected-graph state in an internal
+  authenticated-request representation. Restoring old constructible identity
+  fields must not let callers forge signed authority or omit the grant ceiling.
+- Obtain canonical root from the same resolved store as the managed snapshot;
+  validate signed trust before opening graph engines. Fail strictly on managed
+  root mismatch/canonicalization failure. A lexical or empty substitute is
+  invalid. Trust-disabled paths should not inherit the newly added fallible
+  canonicalization operation solely to support managed boot.
+- Keep static-token, policy, and explicit unauthenticated boot behavior.
+  Inspecting an added failure point is not proof that a particular old root
+  succeeded; regression fixtures must establish that comparison.
+
+The proposed API repair has three concrete seams, regardless of final names:
+
+1. The existing snapshot function retains its prior return shape and
+   trust-disabled behavior. An additive managed snapshot function returns
+   that snapshot together with a canonical-root binding obtained from the
+   same opened store. It does not reopen a caller-supplied root and assume
+   that two independent resolutions refer to the same snapshot.
+2. The existing server entry point continues to accept the restored legacy
+   `ServerConfig`. An additive managed boot entry point accepts the legacy
+   options plus the root-bound snapshot/public-trust inputs, validates their
+   agreement before engine opening, and constructs internal server state.
+   It must not default managed callers to an unverified legacy entry point
+   when validation fails.
+3. The old public `ResolvedActor` remains the identity projection consumed by
+   legacy callers. Internal authenticated request state retains whether the
+   identity was statically or cryptographically authenticated, verified token
+   claims, and selected graph. All signed authorization, including graph
+   listing and action checks, consumes that internal state through the final
+   handler; converting to the public projection cannot discard the ceiling.
+   A public actor literal or `Scope::DataToken` value is not proof of a
+   verified token. Legacy static authority retains its current Cedar path.
+
+Use one implementation of claim verification, graph selection, and policy
+intersection beneath the additive entry points. Fixtures must cover expiry,
+wrong graph/root/incarnation, graph-list filtering, and callers constructing
+the old public actor shape, as well as compilation. This keeps the public
+compatibility work substantive without freezing unreviewed API names here.
+
+One public struct cannot preserve both incompatible literal/destructuring
+shapes. `Default`, constructors, and newly adding `non_exhaustive` alone do not
+restore old struct-literal compatibility. Prefer the established pre-633 shape
+and provide migration instructions for consumers already using #633 fields.
+Inventory those consumers before landing the public API step. Existing
+`Scope`/`AuthSource` enums were non-exhaustive; do not list their added variants
+as the same source break. Source/pin consumers need compile fixtures, not a
+claim of universal zero-break compatibility.
+
+**CC-16 — Keep the actor configuration question separate.** At #663,
+actor-provenance omission means default-on for new graphs but preservation of
+the accepted setting for existing graphs. A Git revert to an omitted setting
+can therefore retain a later explicit toggle. The accepted schema is effective
+authority under that implementation; cluster state is its projection.
+Replacing this with deterministic desired-setting semantics requires a
+separate decision and migration plan. This RFC neither fixes nor endorses
+that history-sensitive desired-config behavior, changes protected `OmniActor`
+binding rules, or removes schema IR v3 upgrade/downgrade constraints.
+
+## 12. Implementation ownership and sequence
+
+All steps are proposed work. Obtain acceptance through the [RFC
+process](README.md#process), then land the affected operator/addressing and
+managed CLI/data RFC amendments before implementation changes their
+contracts. Align the separately owned CP decision/spec documents before CP
+implementation or packaging changes. Preserve existing identifiers; merging
+this draft alone does not authorize implementation.
+
+| Step | Owner/module | Deliverable and gate |
+| --- | --- | --- |
+| 1. Contract | Upstream CLI/RFC owners; CP spec owners | Amend operator/addressing and managed CLI/data RFCs, document compatibility boundary, update CP DEC/UIS/IDN/CFG references. |
+| 2. Baseline fixtures | Upstream CLI tests | Capture exact legacy routes, credential choices, refusals, and accepted syntax before replacing dispatch. |
+| 3. Config and resolver | `operator.rs`, `scope.rs`, command classification | Validated variants, selected connection identity, deterministic precedence; no auth/network selection. |
+| 4. Managed query/mutate | Managed credential helper and `GraphClient` | Exact endpoint match, existing cache/transport contract, removal of normal cwd dispatch, bounded temporary guard. |
+| Accepted catalog extension | CLI command classification, scope/client helpers and integration tests | CC-18 / #653: existing served endpoint, standard addressing, stable JSON, preserved direct list/validate; managed variant separately qualified. |
+| 5. Compatibility | Server/cluster library owners | Isolated public-shape/opt-in boot work with external compile and authorization fixtures. |
+| 6. Consumers | CLI release and CP packaging/pilot owners | Matched scripts/config/binary rollout after tests; update upstream pins only with relevant conformance results. |
+| 7. Extensions | Individual command/transport owners | Managed aliases, registry, and other HTTP verbs one qualified operation set at a time. |
+| 8. Guard removal | Release owner | Remove at the published boundary after supported consumer migration; retain target/fallback tests. |
+
+The separate framework may centralize command applicability and derive help
+or matrix fixtures from existing metadata. Building a complete generated
+registry is not a prerequisite for this bounded routing fix, and its future
+existence must not be reported as current evidence. Do not silently normalize
+unrelated legacy omissions during the refactor: schema-plan profile asymmetry,
+policy/query graph defaults, offline lint's ignored flags, and read `--as`
+exceptions need explicit subsequent compatibility choices.
+
+## 13. Acceptance criteria
+
+**CC-17 — Prove destinations, credentials, and effects.** These are required
+new or adapted tests, not results. Each fixture records argv, operator config,
+environment, context, credential metadata, expected request/storage target,
+credential identity, refusal/effect outcome, and owning source revision.
+Secrets remain test-only fixtures and are never emitted in diagnostics.
+
+| Case | Required observation |
+| --- | --- |
+| Explicit staging profile inside production context | Only staging is contacted; context is not read by the migration guard. |
+| Explicit server/store/root plus malformed context | Established target/capability behavior; no context failure. |
+| Explicit profile plus another environment profile | Explicit profile wins with its own graph default. |
+| Explicit primitive plus profile/default graph | Unused profile graph is not inherited. |
+| Unknown selected profile or invalid selected target | Refuse; do not try a lower-rank default. |
+| Selected managed profile plus direct maintenance | Refuse; no HTTP request or fallback storage open. |
+| Implicit environment/default versus unrelated valid context | Temporary ambiguity refusal before operation effects. |
+| Implicit selection and malformed context during transition | Temporary refusal; no guessed old target. |
+| Implicit exact managed API/ID/endpoint agreement | Ordinary selected managed path, followed by normal credential/grant checks. |
+| Missing cache in an ambiguous implicit call | Refuse; absence does not authorize legacy fallback. |
+| Parent-only context | Not searched or used. |
+| Explicit `--direct` with legacy HTTP and malformed context | Existing legacy request; guard never reads context. |
+| `--direct` with selected managed connection | Conflict refusal before credential transmission/storage access. |
+| Init with positional storage URI; load with `--store`; offline lint | Unrelated/malformed context cannot gate them; existing argument requirements remain. |
+| Init addressed only by unsupported `--store` | Existing refusal preserved; do not invent a supported form. |
+| Managed profile default graph versus explicit graph | Profile supplies omission; explicit graph overrides it. |
+| Managed token granting one graph, graph omitted | Refuse; grant inventory cannot choose a graph. |
+| Legacy registry probe: zero/one/several/denied/unavailable | Existing omission behavior retained explicitly. |
+| Root-backed query and schema-plan profile cases | Existing capability refusals/asymmetry retained, not broadened by managed naming. |
+| Valid #633 cached credential and exact operator binding | Reused without automatic issuance; no Intent API request during data execution. |
+| Other API, cluster, endpoint, expired or malformed managed cache | Refuse before bearer transmission, even with valid ambient legacy tokens. |
+| Managed entry added at an existing legacy URL | Literal legacy URL keeps its prior credential chain and transport. |
+| Managed redirect, timeout, oversized JSON | Bounded failure; no redirected credential, retry to another target, or silent unbounded path. |
+| Stored/ad-hoc read and mutation | Exact action ceiling plus Cedar; stored invocation additionally requires `invoke_query`. |
+| Direct actor and authenticated HTTP actor override | Direct attribution preserved; remote override refused and principal server-derived. |
+| Managed schema apply or another unqualified route | Unsupported in place; no direct/API/static fallback. |
+| Legacy alias with unrelated context | Existing bound destination and parameter/output rules; no global override. |
+| New managed alias when its extension lands | Same selected tuple/auth rules; unsupported until explicitly qualified. |
+| Served `queries list` with read/mutation entries or empty catalog | Stable documented JSON reflects the active HTTP catalog and existing metadata, not local desired files or invented descriptors. |
+| Served catalog addressing and authorization | Explicit server/graph, profiles/defaults and conflicts follow the normal resolver; unknown/unauthorized graphs retain endpoint behavior; visibility does not imply invocation permission. |
+| Direct `queries list` and `queries validate` after served listing lands | Existing direct helpers and capability/omission behavior preserved; validation does not acquire served execution accidentally. |
+| Token mint/clear and control logout | Existing output/namespace semantics; no operator-default edit or implied offline revocation. |
+| Lost mutation/run-submission response | Outcome remains unknown; no blind duplicate or alternate-target request. |
+| Legacy operator file on old/new binary | Existing supported syntax and selected behavior preserved. |
+| New managed variant on old binary | Fails closed for missing root; no degraded auth/storage path. |
+| Mixed/misspelled new authority variant | Refuse instead of interpreting partial fields as another variant. |
+| External pre-633 Rust literal/destructure fixture | Compiles after the proposed public compatibility step. |
+| Known #633 Rust consumers migrated from `canonical_root`, `data_token_trust`, and `data_claims` usage | Compile and retain root binding and verified grant behavior through the additive APIs; document the exact source migration. |
+| Opt-in signed boot and external managed API fixture | Correct binding; callers cannot bypass verified claims/grant ceiling. |
+| Static/no-trust boot versus signed root mismatch | Existing legacy boot behavior, strict managed refusal before graph opening. |
+| Control plan/apply/import/refresh, partial apply, readiness | Existing source, state/CAS, effect, and boot contracts unchanged. |
+| Consumer rollout then matched binary/config/script rollback | Intended destination and credential namespace preserved; no engine downgrade, implicit retargeting, or replay of an unknown write outcome. |
+
+Exhaust the dangerous crosses: writes × implicit selection × unrelated
+context; managed selection × every credential mismatch; direct × every
+connection kind; selected unsupported target × usable lower default; and
+aliases/registry paths that use separate helpers. Pairwise coverage may
+supplement ordinary presentation/default combinations, not replace these.
+
+Source inspection must be followed by focused unit/integration fixtures,
+external Rust compile checks, and appropriate platform checks. Keep those
+results separate from any later kind/pilot/live qualification. The inspected
+worktree's empty-cluster serving issue remains independently tracked; this
+RFC cannot claim lifecycle completion from passing routing tests.
+
+### 13.1 Existing evidence owners
+
+Follow [the testing map](../dev/testing.md) and extend an existing owner before
+creating a parallel harness. CLI examples need process/environment fixtures,
+not graph-query logic tests alone, because cwd, keychain, precedence, and
+transport are the changed boundary.
+
+| Promise | Existing owner to extend |
+| --- | --- |
+| Config variants, precedence, command applicability, legacy syntax | `omnigraph-cli` in-source operator/scope/plane tests and `tests/cli_schema_config.rs`. |
+| Managed context, cache, migration guard, and control compatibility | `omnigraph-cli` managed module tests and `tests/cli_cluster.rs`, using hermetic `tests/support` setup. |
+| Data requests and stored catalog CLI mapping | `omnigraph-cli/tests/cli_data.rs`, `cli_queries.rs`, and `parity_matrix.rs`; preserve exact destination/credential assertions. |
+| Signed/static actor and route authorization | `omnigraph-server/tests/auth_policy.rs`, `data_routes.rs`, and `stored_queries.rs`, plus data-token unit tests. |
+| Root binding and legacy boot | `omnigraph-cluster` serving tests and `omnigraph-server/tests/boot_settings.rs`. |
+| Wire stability | `omnigraph-server/tests/openapi.rs` and existing API serialization assertions. |
+| Public Rust consumer source compatibility | Extend the owning cluster/server public-API checks with representative external-consumer compile fixtures; new setup needs an explicit ownership rationale. |
+
+A focused clean baseline precedes future test/code changes. The accepted
+#653 implementation must include the repository's issue regression marker
+and the cheapest fixture that proves served listing while preserving direct
+listing/validation. Documentation publication runs documentation checks only;
+it does not mark any of the implementation acceptance rows passed.
+
+## 14. Alternatives
+
+| Alternative | Reason not selected |
+| --- | --- |
+| Keep cwd as another data source with a rank | Reintroduces shared folder routing into the personal data resolver and leaves former intent ambiguous. |
+| Permanent context conflict gate | Preserves the blanket failure mode this correction removes. |
+| Choose managed mode from a cached token or URL match | Credential state becomes routing authority and can change legacy authentication unexpectedly. |
+| Put managed auth under `servers.url` | Older clients can ignore new optional auth fields and send legacy credentials; the root-less explicit cluster variant fails closed. |
+| Replace all existing servers with clusters | Requires unnecessary config/script migration and lacks a direct-root-to-HTTP association contract. |
+| Silently install a new default profile | Changes unrelated future commands and creates hidden migration state. |
+| Immediately remove all transition checks | Can silently retarget old implicit #633 writes to ambient legacy defaults. |
+| Add another managed-only data command family | Duplicates query/mutate semantics and avoids repairing the common resolver. |
+| Qualify every HTTP command in the first patch | Couples streaming, partial-effect, and action coverage to the urgent routing correction. |
+
+## 15. Unresolved questions and deferred scope
+
+Before acceptance, settle the migration/removal boundary, public API direction
+and consumer migration obligations, and ownership of any new public failure
+class. The remaining operation extensions are deferred scope, not hidden
+prerequisites for this correction. In particular:
+
+- Publish the temporary guard's actual release/removal boundary and consumer
+  inventory; no open-ended transition.
+- Choose additive public Rust API names and migration guidance for known
+  #633-field consumers, with external compile fixtures.
+- Allocate any additional typed public failure classes through their owners;
+  local requirement labels are not protocol codes.
+- Qualify managed aliases/registry and each further HTTP operation, including
+  streaming bounds, pagination, partial effects, and platform restrictions.
+- Decide any future endpoint-rotation convenience, API-only cluster entry,
+  token/status nickname shorthand, default cluster, or self-hosted HTTP cluster
+  association separately. None is required for this correction.
+- Review historical actor-setting omission and desired/effective projection
+  semantics independently from routing. Do not hide a #663 schema behavior
+  change inside this patch.
+- Normalize existing omission/flag inconsistencies only through explicit
+  compatibility decisions. The routing fix must first expose and preserve
+  their current behavior in tests.
+
+## 16. Primary source references
+
+The links identify inspected source, not executed test results:
+
+- [RFC 0007, operator configuration](0007-operator-config.md)
+  and [RFC 0011, addressing](0011-cli-addressing-and-config.md).
+- [RFC 0052, managed cluster controls](0052-managed-control-plane-cli.md)
+  and [RFC 0053, offline data credentials](0053-offline-data-token-verification.md).
+- [Current operator configuration and credentials](https://github.com/ModernRelay/omnigraph/blob/c253f111/crates/omnigraph-cli/src/operator.rs),
+  [scope](https://github.com/ModernRelay/omnigraph/blob/c253f111/crates/omnigraph-cli/src/scope.rs),
+  [plane/capability classification](https://github.com/ModernRelay/omnigraph/blob/c253f111/crates/omnigraph-cli/src/planes.rs),
+  and [legacy helper behavior](https://github.com/ModernRelay/omnigraph/blob/c253f111/crates/omnigraph-cli/src/helpers.rs).
+- [Managed data/cache dispatch](https://github.com/ModernRelay/omnigraph/blob/c253f111/crates/omnigraph-cli/src/managed/data.rs),
+  [client construction and actor handling](https://github.com/ModernRelay/omnigraph/blob/c253f111/crates/omnigraph-cli/src/client.rs),
+  and [managed control dispatcher](https://github.com/ModernRelay/omnigraph/blob/c253f111/crates/omnigraph-cli/src/managed.rs).
+- [#633 public server configuration](https://github.com/ModernRelay/omnigraph/blob/e23778d9/crates/omnigraph-server/src/lib.rs#L173-L195),
+  [actor representation](https://github.com/ModernRelay/omnigraph/blob/e23778d9/crates/omnigraph-server/src/identity.rs#L172-L179),
+  and [snapshot root canonicalization](https://github.com/ModernRelay/omnigraph/blob/e23778d9/crates/omnigraph-cluster/src/serve.rs#L469-L485).
+- [#663 omission and accepted-binding tests](https://github.com/ModernRelay/omnigraph/blob/c253f111/crates/omnigraph-cluster/src/tests.rs#L2080-L2204).
+  These are source anchors for the separate semantic finding; they were not
+  rerun for this proposal.
+- [CP configuration](https://github.com/ModernRelay/og-control-plane/blob/main/specs/05-CFG-Config.md), [identity](https://github.com/ModernRelay/og-control-plane/blob/main/specs/06-IDN-Identity.md),
+  [runs](https://github.com/ModernRelay/og-control-plane/blob/main/specs/07-RUN-Runs.md), and [decision record](https://github.com/ModernRelay/og-control-plane/blob/main/specs/02-DEC-Decisions.md).
+
+## 17. Decision log
+
+- **2026-09-06 — Draft prepared for upstream review.** Consolidated the
+  configuration/CLI correction and local requirements CC-01 through CC-18 into
+  this canonical RFC. Preserved accepted issue #653 as a separately testable
+  served-list extension; related unaccepted issue requests were not imported.
+  Review corrections distinguish endpoint syntax from exact binding, preserve
+  explicit-profile precedence and legacy/direct exceptions, prohibit
+  unsupported-target fallback, and keep partial apply/recovery/boot authority
+  unchanged. No maintainer acceptance or implementation completion is recorded.

--- a/docs/rfcs/0059-config-cli-coherency.md
+++ b/docs/rfcs/0059-config-cli-coherency.md
@@ -7,7 +7,7 @@ implementation: not-started
 authors:
   - andrew
 created: 2026-09-06
-updated: 2026-09-06
+updated: 2026-09-08
 discussion: https://github.com/ModernRelay/omnigraph/pull/675
 supersedes: []
 superseded_by: []
@@ -204,7 +204,7 @@ create an exception to the publication, recovery, or trust boundaries.
 | 7 and 12, derived state and one authority | Credentials validate rather than select targets. Routing does not rewrite desired files, the applied ledger, accepted schema, or guard records. |
 | 8 and 9, explicit failures and typed semantics | Selected invalid/unsupported paths refuse without substitution. Query parsing, typed semantics, and source-selection contracts remain unchanged. |
 | 10, trust at the boundary and engine policy | Managed data retains verified graph/action ceilings plus Cedar; restored public actor shapes cannot manufacture verified signed authority. Direct writes retain their existing policy checks. |
-| 11, bounded observable failure and resource use | Preserve the existing managed transport bounds, distinguish unknown outcomes from refusal, and define eligibility before adding another operation. |
+| 11, bounded observable failure and resource use | Keep explicit managed transport bounds, distinguish unknown outcomes from refusal, and define eligibility before adding another operation. |
 | 13, evidence at the owning layer | Resolver/cache/HTTP/boot/public API changes have separate owning fixtures; source inspection and executed evidence remain distinct. |
 
 No deny-list exception is requested: in particular, no shadow source of truth,
@@ -538,14 +538,23 @@ Keep existing TTL validation (default 3,600 seconds; accepted range
 the existing endpoint rejects one. Run/lifecycle replay guarantees must not
 be generalized to token minting.
 
-**CC-11 — Preserve bounded, offline managed transport.** Retain no redirects,
-10-second connect and request deadlines, and the existing 8 MiB JSON-response
-bound for the initially eligible requests. Preserve the 64 KiB cached-record
-and 8 KiB token bounds and existing validators. Data requests do not call the
-Intent API, mint credentials, or refresh sessions. Streaming routes need an
-explicit bounded streaming contract before qualification; they must not
-inherit an unsuitable JSON limit or remove bounds silently. Legacy transport
-does not acquire new restrictions merely because managed support is added.
+**CC-11 — Bound offline managed query/mutation requests.** Use a 10-second
+connection deadline and a 30-second total request deadline for the initially
+eligible stored and ad-hoc queries/mutations. The total deadline includes
+connection establishment and consumption of the complete response body; body
+progress does not restart it. Retain no redirects, no automatic retries, and
+the existing 8 MiB JSON-response bound. A mutation timeout after submission
+leaves the outcome unknown; it does not prove cancellation or lack of effects.
+
+The 30-second total replaces the inspected baseline's 10-second total in this
+proposed contract; it is not a claim that those historical binaries already
+use 30 seconds. Preserve the 64 KiB cached-record and 8 KiB token bounds and
+existing validators. Data requests do not call the Intent API, mint
+credentials, refresh sessions, or fall back to another authority. Other
+operations and streaming routes require their own explicit bounded transport
+contract before qualification; they must not inherit an unsuitable JSON limit
+or remove bounds silently. Legacy transport does not acquire new restrictions
+merely because managed support is added.
 
 **CC-12 — Preserve actor attribution boundaries.** Direct writes retain
 `--as` and operator actor defaults. Authenticated served writes derive actor
@@ -760,7 +769,7 @@ this draft alone does not authorize implementation.
 | 1. Contract | Upstream CLI/RFC owners; CP spec owners | Amend operator/addressing and managed CLI/data RFCs, document compatibility boundary, update CP DEC/UIS/IDN/CFG references. |
 | 2. Baseline fixtures | Upstream CLI tests | Capture exact legacy routes, credential choices, refusals, and accepted syntax before replacing dispatch. |
 | 3. Config and resolver | `operator.rs`, `scope.rs`, command classification | Validated variants, selected connection identity, deterministic precedence; no auth/network selection. |
-| 4. Managed query/mutate | Managed credential helper and `GraphClient` | Exact endpoint match, existing cache/transport contract, removal of normal cwd dispatch, bounded temporary guard. |
+| 4. Managed query/mutate | Managed credential helper and `GraphClient` | Exact endpoint match, existing cache format and CC-11 transport bounds, removal of normal cwd dispatch, bounded temporary guard. |
 | Accepted catalog extension | CLI command classification, scope/client helpers and integration tests | CC-18 / #653: existing served endpoint, standard addressing, stable JSON, preserved direct list/validate; managed variant separately qualified. |
 | 5. Compatibility | Server/cluster library owners | Isolated public-shape/opt-in boot work with external compile and authorization fixtures. |
 | 6. Consumers | CLI release and CP packaging/pilot owners | Matched scripts/config/binary rollout after tests; update upstream pins only with relevant conformance results. |
@@ -808,6 +817,9 @@ Secrets remain test-only fixtures and are never emitted in diagnostics.
 | Other API, cluster, endpoint, expired or malformed managed cache | Refuse before bearer transmission, even with valid ambient legacy tokens. |
 | Managed entry added at an existing legacy URL | Literal legacy URL keeps its prior credential chain and transport. |
 | Managed redirect, timeout, oversized JSON | Bounded failure; no redirected credential, retry to another target, or silent unbounded path. |
+| Managed query/mutation connection stalls | Connection deadline remains 10 seconds within the 30-second total; no automatic retry or alternate authority. |
+| Managed stored/ad-hoc query/mutation completes after 10 seconds but before 30 | One request succeeds with its complete bounded response; it does not inherit the old 10-second total deadline. |
+| Managed query/mutation response headers or body remain incomplete at 30 seconds | Total request expires, including when body chunks arrive before expiry; no automatic retry, target fallback, or Intent API request. A submitted mutation's outcome remains unknown. |
 | Stored/ad-hoc read and mutation | Exact action ceiling plus Cedar; stored invocation additionally requires `invoke_query`. |
 | Direct actor and authenticated HTTP actor override | Direct attribution preserved; remote override refused and principal server-derived. |
 | Managed schema apply or another unqualified route | Unsupported in place; no direct/API/static fallback. |
@@ -936,3 +948,10 @@ The links identify inspected source, not executed test results:
   explicit-profile precedence and legacy/direct exceptions, prohibit
   unsupported-target fallback, and keep partial apply/recovery/boot authority
   unchanged. No maintainer acceptance or implementation completion is recorded.
+- **2026-09-08 — Narrow query/mutation deadline agreement.** CC-11 replaces its
+  proposed 10-second total request deadline with 30 seconds, including the
+  complete response body, while retaining the 10-second connection deadline.
+  Redirect refusal, the 8 MiB response bound, offline authority, and no
+  automatic retry remain required. CC-17 adds late-success and deadline
+  coverage, including unknown mutation outcomes. This agreement does not
+  accept the rest of this draft or record implementation completion.

--- a/docs/rfcs/0059-config-cli-coherency.md
+++ b/docs/rfcs/0059-config-cli-coherency.md
@@ -8,7 +8,7 @@ authors:
   - andrew
 created: 2026-09-06
 updated: 2026-09-06
-discussion: null
+discussion: https://github.com/ModernRelay/omnigraph/pull/675
 supersedes: []
 superseded_by: []
 blocked_on: []

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -38,7 +38,7 @@ issue and implementation PR are usually enough.
 - Do not create `pre-merge`, `final`, `v2`, `internal`, or review-ledger copies.
   Revise the canonical file; preserve meaningful changes in its decision log.
 
-The next available number is **0059**; lower gaps are historical and must
+The next available number is **0060**; lower gaps are historical and must
 not be reused (0047 and 0048 are allocated by PR #606; 0050 by the
 `rfc/0050-engine-crate-topology` branch; 0056 by PR #670; 0058 by
 PR #662 for retained merged ancestry).
@@ -183,3 +183,4 @@ This table is the human index for the canonical RFC corpus.
 | [0054](0054-default-actor-provenance.md) | Default graph actor provenance | maintainer | accepted | complete |
 | [0055](0055-gq-branch-statements.md) | Branch statements in GQ | maintainer | draft | not-started |
 | [0057](0057-bounded-merge-preparation.md) | Accepted-context reuse and bounded merge preparation | maintainer | accepted | in-progress |
+| [0059](0059-config-cli-coherency.md) | Configuration and CLI coherency | maintainer | draft | not-started |


### PR DESCRIPTION
## What & why

Add draft RFC 0059 for cluster-first managed connection selection and
compatible CLI routing, plus `docs/dev/config-cli-framework.md` for the
configuration/CLI framework, ASCII model, operation contracts, invariants and
review guidance. The RFC distinguishes inspected historical behavior from
proposed requirements and updates the documentation indexes and registry.

CC-11 now specifies a 10-second connection limit within a 30-second total
managed query/mutation deadline, including the complete response body. The
narrow deadline agreement is coordinated with
[PR #685](https://github.com/ModernRelay/omnigraph/pull/685); it does not accept
the broader resolver proposal. CC-17 includes late success, connection and
response deadlines, and unknown mutation outcomes with no automatic retry.

## Backing issue / RFC

- [x] RFC PR: [RFC 0059 — Configuration and CLI coherency](https://github.com/ModernRelay/omnigraph/blob/codex/config-cli-coherency/docs/rfcs/0059-config-cli-coherency.md).

Accepted issue #653 is included as a separately testable served catalog CLI
extension. This PR does not implement or close it. Deferred additions from
#550, #565 and #432 are excluded.

## Checklist

- [x] Documentation only; no resolver implementation or runtime qualification.
- [x] Proposed behavior remains explicitly labeled in the RFC and framework.
- [x] Reviewed against the architectural invariants; none weakened and no
  deny-list exception requested.

## Local verification

Documentation checks passed: agent/index links (47 links, 45 docs), Markdown
links and structure (133 files), spelling and `git diff --check`. Runtime
acceptance criteria remain future evidence gates for the broader proposal.

RFC 0059 remains `draft` / `not-started`. The framework preserves the inspected
baseline's 10-second deadline as a historical fact and labels 30 seconds as
the proposed contract. Offline credentials, permission-based execution and
Core configuration ownership remain intact.
