### PR TITLE
test(dst): model edges as physical rows, not a set of pairs

### DIFF
--- a/crates/omnigraph-dst/src/fixtures.rs
+++ b/crates/omnigraph-dst/src/fixtures.rs
@@ -351,11 +351,11 @@ pub async fn knows_pairs_target_mode(
     omnigraph::instrumentation::with_traversal_mode(mode, knows_pairs_target(db, target)).await
 }
 
-/// The BOUND-EDGE spelling (`$a $e:knows $b`): scans edge rows
+/// The BOUND-EDGE spelling (`$a $e:knows $b`) at ROW grain: scans edge rows
 /// directly, dispatched BEFORE mode selection and WITHOUT the visited gate —
-/// the third arm that sees ghost rows the gated modes hide. Deduped
-/// (multiple identical ghost rows are one pair at set level).
-pub async fn knows_pairs_bound_target(db: &Omnigraph, target: ReadTarget) -> Vec<(String, String)> {
+/// the third arm that sees ghost rows the gated modes hide — one entry per
+/// physical row, sorted, duplicates kept (the query-channel count observer).
+pub async fn knows_rows_bound_target(db: &Omnigraph, target: ReadTarget) -> Vec<(String, String)> {
     use arrow_array::{Array, StringArray};
     let qr = query_target(
         db,
@@ -366,7 +366,7 @@ pub async fn knows_pairs_bound_target(db: &Omnigraph, target: ReadTarget) -> Vec
     )
     .await
     .expect("all_knows_bound traversal");
-    let mut pairs = std::collections::BTreeSet::new();
+    let mut pairs = Vec::new();
     for batch in qr.batches() {
         let froms = batch
             .column(0)
@@ -380,11 +380,20 @@ pub async fn knows_pairs_bound_target(db: &Omnigraph, target: ReadTarget) -> Vec
             .expect("bound col 1 = to name");
         for i in 0..froms.len() {
             if froms.is_valid(i) && tos.is_valid(i) {
-                pairs.insert((froms.value(i).to_string(), tos.value(i).to_string()));
+                pairs.push((froms.value(i).to_string(), tos.value(i).to_string()));
             }
         }
     }
-    pairs.into_iter().collect()
+    pairs.sort();
+    pairs
+}
+
+/// [`knows_rows_bound_target`] deduped: pairs at set level (multiple
+/// identical rows, ghost or live, are one pair).
+pub async fn knows_pairs_bound_target(db: &Omnigraph, target: ReadTarget) -> Vec<(String, String)> {
+    let mut pairs = knows_rows_bound_target(db, target).await;
+    pairs.dedup();
+    pairs
 }
 
 /// `person_rows_target` on main.
@@ -401,17 +410,19 @@ pub async fn knows_pairs(db: &Omnigraph) -> Vec<(String, String)> {
 /// The PHYSICAL channel of a branch: parse `export_jsonl` (stored rows,
 /// NO query machinery — the read that classified #474's ghost row on the
 /// CLI) into the same shapes the model uses. Persons: sorted
-/// `(name, age, ver)` with missing/null → -1. Knows edges: sorted DEDUPED
-/// `(from, to)` pairs, self-loops INCLUDED (that inclusion is the whole
-/// point — the query channel hides them). Company/WorksAt lines are ignored
-/// (outside the modeled world).
+/// `(name, age, ver)` with missing/null → -1. Knows edges: sorted
+/// `(from, to)` pairs at ROW grain, DUPLICATES KEPT (the one channel that
+/// sees the multiset: an unkeyed pair inserted twice is two rows here and
+/// one pair on every query channel), self-loops INCLUDED (that inclusion is
+/// the whole point — the query channel hides them). Company/WorksAt lines
+/// are ignored (outside the modeled world).
 pub async fn physical_view_on(
     db: &Omnigraph,
     branch: &str,
 ) -> (Vec<(String, i64, i64)>, Vec<(String, String)>) {
     let dump = db.export_jsonl(branch, &[]).await.expect("export_jsonl");
     let mut persons = Vec::new();
-    let mut knows = std::collections::BTreeSet::new();
+    let mut knows = Vec::new();
     for line in dump.lines().filter(|l| !l.trim().is_empty()) {
         let value: serde_json::Value = serde_json::from_str(line).expect("export line is JSON");
         if value.get("type").and_then(|t| t.as_str()) == Some("Person") {
@@ -435,11 +446,12 @@ pub async fn physical_view_on(
                 .and_then(|t| t.as_str())
                 .expect("Knows has to")
                 .to_string();
-            knows.insert((from, to));
+            knows.push((from, to));
         }
     }
     persons.sort();
-    (persons, knows.into_iter().collect())
+    knows.sort();
+    (persons, knows)
 }
 
 /// Seeds for a fleet run: `OMNIGRAPH_DST_SEEDS` (comma-separated u64s) when

--- a/crates/omnigraph-dst/src/harness.rs
+++ b/crates/omnigraph-dst/src/harness.rs
@@ -3377,15 +3377,9 @@ async fn assert_history_matches(db: &Omnigraph, history: &[(String, Model)], whe
     }
 }
 
-/// the PHYSICAL-CHANNEL ORACLE (third audit channel): for every
-/// branch, the stored-row dump (`export_jsonl`, NO query machinery) must equal
-/// the model's PHYSICAL expectation — persons exactly, Knows = every row ∪
-/// ghost self-loops, duplicates kept (the multiset's only count oracle). The
-/// claim, query, and physical channels are three
-/// independent reads of one store; any pairwise disagreement outside the
-/// modeled ghost delta is a bug (claim-vs-query found #474; query-vs-physical is
-/// the ghost-row detector by construction; claim-vs-physical catches silent lost
-/// writes on paths the query channel never touches).
+/// PHYSICAL-CHANNEL ORACLE (third audit channel, the one that counts rows): per
+/// branch, `export_jsonl` (no query machinery) must equal the model's physical
+/// expectation — persons exactly, Knows = every row ∪ ghosts, duplicates kept.
 async fn assert_physical_matches(db: &Omnigraph, world: &WorldModel, where_: &str) {
     for branch in world.branch_names() {
         let (persons, knows) = Box::pin(physical_view_on(db, &branch)).await;

--- a/crates/omnigraph-dst/src/harness.rs
+++ b/crates/omnigraph-dst/src/harness.rs
@@ -19,10 +19,10 @@ use omnigraph::storage::{ObjectStorageAdapter, StorageAdapter};
 
 use crate::detectors::{self, Channel, Detector, ObservationSource, Oracle};
 use crate::fixtures::{
-    MUTATION_QUERIES, TEST_DATA, TEST_SCHEMA, knows_pairs, knows_pairs_bound_target,
-    knows_pairs_on, knows_pairs_target, knows_pairs_target_mode, mixed_params, mutate_on,
-    person_jsonl, person_rows, person_rows_on, person_rows_target, physical_view_on, query_main,
-    schema_with_extras,
+    MUTATION_QUERIES, TEST_DATA, TEST_SCHEMA, fixture_knows, knows_pairs, knows_pairs_bound_target,
+    knows_pairs_on, knows_pairs_target, knows_pairs_target_mode, knows_rows_bound_target,
+    mixed_params, mutate_on, person_jsonl, person_rows, person_rows_on, person_rows_target,
+    physical_view_on, query_main, schema_with_extras,
 };
 use crate::rand::SplitMix64;
 
@@ -998,13 +998,7 @@ fn milestone_op(
                     .filter(|n| slot.state.persons.contains_key(*n))
             };
             let candidate = common()
-                .find(|n| {
-                    !slot
-                        .state
-                        .edges
-                        .iter()
-                        .any(|(from, to)| from == *n || to == *n)
-                })
+                .find(|n| !slot.state.has_edges_touching(n))
                 .or_else(|| common().next())
                 .cloned();
             match candidate {
@@ -1155,8 +1149,8 @@ pub struct UniverseReport {
     /// deliberately unasserted (lance-realm compositions are
     /// process-context-sensitive) —
     /// and channel is the observation surface the ruling rested on
-    /// ("query", or "query+physical" when the ghost tie-break consulted
-    /// the physical channel). The per-death RESULT the ledger records for
+    /// ("query", or "query+bound" when the tie-break consulted the
+    /// bound-edge rows). The per-death RESULT the ledger records for
     /// hits. Deterministic and replay-compared for adapter-realm one-op
     /// rows — an arbitration that flips between same-seed runs is itself
     /// a caught bug; the keep-serving rows carry the lance-realm envelope
@@ -1181,11 +1175,17 @@ pub struct UniverseReport {
 
 // ------------------------------------------------------------------- model --
 
+/// One physical `Knows` row, keyed the way the engine's merge walk keys it:
+/// minted at insert time, never reused, copied as-is by a fork.
+type EdgeRowId = u64;
+
 #[derive(Clone, Debug, Default)]
 struct Model {
     /// name → (age, ver); ver = -1 for rows written without one.
     persons: BTreeMap<String, (i64, i64)>,
-    edges: BTreeSet<(String, String)>,
+    /// Physical rows by id — the multiset default: re-inserting a pair is
+    /// a second row (`@key(src, dst)` opts a type out, RFC 0044).
+    edges: BTreeMap<EdgeRowId, (String, String)>,
     /// The physical-vs-logical edge delta — EMPTY by construction since
     /// the #474 fix made self-loops ordinary visible edges. Kept (with its
     /// vestigial cascade/remove/fork/merge carries) so the physical-channel
@@ -1201,17 +1201,39 @@ impl Model {
             .map(|(name, (age, ver))| (name.clone(), *age, *ver))
             .collect()
     }
-    /// The raw-channel expectation: logical edges ∪ ghosts, sorted (BTreeSet
-    /// union) — the one spelling of what `physical_view_on` must show.
+    /// Membership view: the distinct pairs with at least one live row. The
+    /// query channels dedupe rows (the gated traversal's visited set, the
+    /// bound reader's set), so their oracles compare at this level.
+    fn edge_pair_set(&self) -> BTreeSet<(String, String)> {
+        self.edges.values().cloned().collect()
+    }
+    /// The query-channel expectation at pair grain: logical edges ∪ ghosts,
+    /// sorted (BTreeSet union) — what the bound reader must show.
     fn edges_with_ghosts(&self) -> Vec<(String, String)> {
-        self.edges.union(&self.ghosts).cloned().collect()
+        let mut pairs = self.edge_pair_set();
+        pairs.extend(self.ghosts.iter().cloned());
+        pairs.into_iter().collect()
+    }
+    /// The physical-channel expectation at ROW grain: every row plus every
+    /// ghost, sorted with duplicates — what `export_jsonl` must show, the one
+    /// oracle that observes the multiset.
+    fn physical_rows(&self) -> Vec<(String, String)> {
+        let mut rows: Vec<(String, String)> = self.edges.values().cloned().collect();
+        rows.extend(self.ghosts.iter().cloned());
+        rows.sort();
+        rows
+    }
+    /// The one minting site: a fresh id from the world-wide counter.
+    fn mint_edge_row(&mut self, rows: &mut EdgeRowId, pair: (String, String)) {
+        *rows += 1;
+        self.edges.insert(*rows, pair);
     }
     fn edge_pairs(&self) -> Vec<(String, String)> {
-        self.edges.iter().cloned().collect()
+        self.edge_pair_set().into_iter().collect()
     }
     fn has_edges_touching(&self, name: &str) -> bool {
         self.edges
-            .iter()
+            .values()
             .any(|(from, to)| from == name || to == name)
     }
 }
@@ -1281,11 +1303,34 @@ struct BranchSlot {
 struct WorldModel {
     main: Model,
     branches: BTreeMap<String, BranchSlot>,
+    /// Row-id counter shared by every branch, so a row minted on one side
+    /// of a fork never collides with one minted on the other.
+    edge_rows_minted: EdgeRowId,
 }
 
 impl WorldModel {
     fn state_of(&self, branch: &str) -> &Model {
         self.state_of_opt(branch).expect("live branch")
+    }
+    /// A branch's state together with the row-id counter, borrowed apart
+    /// so an op can mint a row into the branch it targets. Panics on an absent
+    /// branch: callers hold a live target; lagging state reads `state_of_opt`.
+    fn state_and_rows_mut(&mut self, branch: &str) -> (&mut Model, &mut EdgeRowId) {
+        let WorldModel {
+            main,
+            branches,
+            edge_rows_minted,
+        } = self;
+        let model = if branch == "main" {
+            main
+        } else {
+            &mut branches.get_mut(branch).expect("live branch").state
+        };
+        (model, edge_rows_minted)
+    }
+    fn add_edge_row(&mut self, branch: &str, pair: (String, String)) {
+        let (model, rows) = self.state_and_rows_mut(branch);
+        model.mint_edge_row(rows, pair);
     }
     /// Branch-absence-safe sibling of [`Self::state_of`]: `None` for a branch
     /// the model does not hold. Callers judging state that can lag or lead
@@ -1296,13 +1341,6 @@ impl WorldModel {
             Some(&self.main)
         } else {
             self.branches.get(branch).map(|slot| &slot.state)
-        }
-    }
-    fn state_of_mut(&mut self, branch: &str) -> &mut Model {
-        if branch == "main" {
-            &mut self.main
-        } else {
-            &mut self.branches.get_mut(branch).expect("live branch").state
         }
     }
     /// Deterministic observation order: main first, then branches by name.
@@ -1322,34 +1360,9 @@ impl WorldModel {
     }
 }
 
-/// Predict the engine's three-way merge (exec/merge.rs `CandidateTableState`
-/// cursor walk) at the LOGICAL-KEY level: per key compare base/source/target
-/// by content; the unchanged side yields to the changed one; both-changed-
-/// equal passes; both-changed-differently is a `MergeConflict` and the WHOLE
-/// merge is rejected (state untouched). `None` = rejection predicted.
-///
-/// One hypothesis layered on top (dual-hypothesis method, as with
-/// recorded engine discoveries — if the engine disagrees, an assert fails loudly and
-/// the real semantics get recorded with evidence):
-///   H-B: the merged state is RI-validated — an edge surviving the cursor
-///        walk whose endpoint the other side deleted rejects the merge.
-///
-/// H-A (reject edges born on both sides) is RETIRED: unkeyed born-on-both
-/// is the DOCUMENTED multiset default (the merge keeps both physical rows;
-/// `@key(src, dst)` opts a type into convergence instead). The model's
-/// edge reads are visited-gated membership, and the set model predicts the
-/// merged MEMBERSHIP for the multiset default in every sampled shape so
-/// far. Known gap: hidden multiplicity can split a delete-vs-readd fork —
-/// one side removes every row of a pair the other side has also re-added
-/// as a fresh second row; the set model sees an unchanged side and
-/// predicts absence while the engine keeps the fresh row. A pair-count
-/// edge model is the fix if the fleet ever trips it. Physical row counts
-/// are pinned by the targeted scenario
-/// `dst_merge_duplicates_born_on_both_edge` and its keyed twin. PERSON
-/// rows are `@key`-keyed: equal-content born-on-both CONVERGES to one row
-/// and divergent inserts are typed `MergeConflict{DivergentInsert}` —
-/// exactly the plain three-way arms (probed both cells,
-/// `dst_predict_born_on_both_person_probe`).
+/// The engine's three-way merge per row key (persons by name, `Knows` rows by
+/// [`EdgeRowId`]): the unchanged side yields, both-changed-differently is a
+/// `MergeConflict` (`None`); H-B then rejects a merged edge whose endpoint is gone.
 fn predict_merge(base: &Model, source: &Model, target: &Model) -> Option<Model> {
     // Predict-triage aid (env-gated): DST_PREDICT_LOG=1
     // prints WHICH rule rejected and on what evidence, so a
@@ -1395,14 +1408,8 @@ fn predict_merge(base: &Model, source: &Model, target: &Model) -> Option<Model> 
     }
 
     let persons = three_way(&base.persons, &source.persons, &target.persons)?;
-    let to_map = |m: &Model| -> BTreeMap<(String, String), ()> {
-        m.edges.iter().cloned().map(|p| (p, ())).collect()
-    };
-    let edges: BTreeSet<(String, String)> =
-        three_way(&to_map(base), &to_map(source), &to_map(target))?
-            .into_keys()
-            .collect();
-    for (from, to) in &edges {
+    let edges = three_way(&base.edges, &source.edges, &target.edges)?;
+    for (from, to) in edges.values() {
         if !persons.contains_key(from) || !persons.contains_key(to) {
             reject_log("H-B referential", format!("edge=({from:?},{to:?})"));
             return None; // H-B: merged state referentially broken
@@ -1634,7 +1641,7 @@ async fn exec_op(db: &mut Omnigraph, branch: &str, op: &Op) -> OmniResult<()> {
 /// the person (dual-hypothesis discovery: if the engine instead preserves or
 /// forbids, continuous verification fails loudly on first contact and the
 /// policy gets corrected with evidence in hand).
-fn apply_to_model(model: &mut Model, op: &Op) {
+fn apply_to_model(model: &mut Model, op: &Op, rows: &mut EdgeRowId) {
     match op {
         Op::InsertV { name, age, ver } => {
             model.persons.insert(name.clone(), (*age, *ver));
@@ -1646,7 +1653,9 @@ fn apply_to_model(model: &mut Model, op: &Op) {
         }
         Op::DeletePerson { name } => {
             model.persons.remove(name);
-            model.edges.retain(|(from, to)| from != name && to != name);
+            model
+                .edges
+                .retain(|_, (from, to)| from != name && to != name);
             // Vestigial post-#474 (ghosts is empty by construction):
             model.ghosts.retain(|(from, to)| from != name && to != name);
         }
@@ -1657,10 +1666,10 @@ fn apply_to_model(model: &mut Model, op: &Op) {
             // traversal — is dead; `ghosts` stays as the (now empty)
             // physical-vs-logical delta so the physical-channel oracle
             // still proves raw == logical by construction.
-            model.edges.insert((from.clone(), to.clone()));
+            model.mint_edge_row(rows, (from.clone(), to.clone()));
         }
         Op::RemoveFriendshipsFrom { from } => {
-            model.edges.retain(|(f, _)| f != from);
+            model.edges.retain(|_, (f, _)| f != from);
             // Vestigial post-#474 (ghosts is empty by construction):
             model.ghosts.retain(|(f, _)| f != from);
         }
@@ -2048,7 +2057,10 @@ async fn exec_world_op(db: &mut Omnigraph, wop: &WorldOp) -> OmniResult<()> {
 /// DID reject; see the success-path assert in `run_universe`).
 fn apply_world(world: &mut WorldModel, wop: &WorldOp) {
     match wop {
-        WorldOp::Data { branch, op } => apply_to_model(world.state_of_mut(branch), op),
+        WorldOp::Data { branch, op } => {
+            let (model, rows) = world.state_and_rows_mut(branch);
+            apply_to_model(model, op, rows)
+        }
         WorldOp::BranchCreate { name } => {
             world.branches.insert(
                 name.clone(),
@@ -2070,7 +2082,7 @@ fn apply_world(world: &mut WorldModel, wop: &WorldOp) {
             );
             if let Some(mut merged) = predict_merge(&slot.base, &slot.state, &world.main) {
                 // H: ghost rows ride merges like ordinary rows
-                // (set-level three-way; a bare (X,X) pair has no conflict
+                // (ghosts are set-level; a bare (X,X) pair has no conflict
                 // shape at set level). predict_merge builds the merged model
                 // from logical state only, so the ghost set is carried here.
                 merged.ghosts =
@@ -3367,8 +3379,9 @@ async fn assert_history_matches(db: &Omnigraph, history: &[(String, Model)], whe
 
 /// the PHYSICAL-CHANNEL ORACLE (third audit channel): for every
 /// branch, the stored-row dump (`export_jsonl`, NO query machinery) must equal
-/// the model's PHYSICAL expectation — persons exactly, Knows = logical edges
-/// ∪ ghost self-loops. The claim, query, and physical channels are three
+/// the model's PHYSICAL expectation — persons exactly, Knows = every row ∪
+/// ghost self-loops, duplicates kept (the multiset's only count oracle). The
+/// claim, query, and physical channels are three
 /// independent reads of one store; any pairwise disagreement outside the
 /// modeled ghost delta is a bug (claim-vs-query found #474; query-vs-physical is
 /// the ghost-row detector by construction; claim-vs-physical catches silent lost
@@ -3382,10 +3395,10 @@ async fn assert_physical_matches(db: &Omnigraph, world: &WorldModel, where_: &st
             m.person_rows(),
             "{where_}: EXPORT persons diverged from model on '{branch}'"
         );
-        let expected = m.edges_with_ghosts();
+        let expected = m.physical_rows();
         assert_eq!(
             knows, expected,
-            "{where_}: EXPORT Knows diverged from model (logical ∪ ghosts) on '{branch}'"
+            "{where_}: EXPORT Knows rows diverged from model (rows ∪ ghosts, duplicates kept) on '{branch}'"
         );
     }
 }
@@ -3777,10 +3790,11 @@ async fn reconcile_after_failure(
     // Which channel the ruling rests on — recorded so the run tables carry
     // observed provenance, never an assumption (canary lesson).
     let mut channel: &'static str = "query";
-    // GHOST TIE-BREAK (the physical-channel oracle's first catch,
+    // BOUND-ROW TIE-BREAK (the physical-channel oracle's first catch,
     // found in its first full-suite run, 2026-08-11): an op whose ONLY effect
     // is on ghost rows (a failed self-loop add_friend; a remove-from touching
-    // nothing but ghosts) is invisible to every query-channel read — the
+    // nothing but ghosts) or on row COUNT (a re-add of a pair the branch
+    // already holds, issue 681's shape) is invisible to every query-channel read — the
     // two hypotheses render identically, and the judgment above silently
     // guesses. Before the physical-channel oracle existed, that guess quietly
     // recorded ghosts that never landed (caught at final audit). The raw
@@ -3793,13 +3807,12 @@ async fn reconcile_after_failure(
             _ => None,
         };
         if let Some(branch) = touched {
-            let g_world = &world.state_of(branch).ghosts;
-            let g_with = &with.state_of(branch).ghosts;
-            if g_world != g_with {
-                channel = "query+physical";
-                let (_, knows) = Box::pin(physical_view_on(&db, branch)).await;
-                let expect_with = with.state_of(branch).edges_with_ghosts();
-                let expect_world = world.state_of(branch).edges_with_ghosts();
+            let expect_world = world.state_of(branch).physical_rows();
+            let expect_with = with.state_of(branch).physical_rows();
+            if expect_world != expect_with {
+                channel = "query+bound";
+                let knows =
+                    Box::pin(knows_rows_bound_target(&db, ReadTarget::branch(branch))).await;
                 outcome = if knows == expect_with {
                     ReconcileOutcome::Applied
                 } else if knows == expect_world {
@@ -3809,10 +3822,11 @@ async fn reconcile_after_failure(
                         DET_ARBITRATION_PHYSICAL,
                         at_op,
                         format!(
-                            "{label}: physical channel matches NEITHER ghost hypothesis \
-                             (op={wop:?}, physical={knows:?})"
+                            "{label}: bound rows match NEITHER hypothesis \
+                             (op={wop:?}, bound={knows:?}, applied={expect_with:?}, \
+                             not_applied={expect_world:?})"
                         ),
-                        "the export tie-break resolves ghost-only effects to one hypothesis",
+                        "the bound-row tie-break resolves query-invisible effects to one hypothesis",
                     )
                 };
             }
@@ -4640,7 +4654,7 @@ async fn reconcile_watch_resolution(
     }
     assert_no_recovery_residue(&storage, root, label, at_op).await;
     // Ambiguity: several compositions can render identically while their
-    // MODELS differ in ghost content. Resolve through the physical channel
+    // MODELS differ in ghost content or row count. Resolve through the bound-edge rows
     // per touched branch; a raw read matching NO tied composition is its
     // own violation. Runs BEFORE the monotonicity checks so they judge the
     // narrowed set — quantifying over pre-narrowing ties could let the
@@ -4665,7 +4679,7 @@ async fn reconcile_watch_resolution(
             touched.push(branch);
         }
         for branch in touched {
-            // The raw expectation per tied composition: edges ∪ ghosts on
+            // The raw expectation per tied composition: rows ∪ ghosts on
             // the touched branch (None = branch absent in that model —
             // uniform across ties, since the shared render lists branches).
             let expectations: Vec<Option<Vec<(String, String)>>> = after_matches
@@ -4674,15 +4688,15 @@ async fn reconcile_watch_resolution(
                     hyps[idx]
                         .world
                         .state_of_opt(branch)
-                        .map(Model::edges_with_ghosts)
+                        .map(Model::physical_rows)
                 })
                 .collect();
             let first = &expectations[0];
             if first.is_none() || expectations.iter().all(|e| e == first) {
                 continue;
             }
-            channel = "query+physical";
-            let (_, knows) = Box::pin(physical_view_on(&db, branch)).await;
+            channel = "query+bound";
+            let knows = Box::pin(knows_rows_bound_target(&db, ReadTarget::branch(branch))).await;
             let keep: Vec<usize> = after_matches
                 .iter()
                 .zip(&expectations)
@@ -4694,11 +4708,11 @@ async fn reconcile_watch_resolution(
                     DET_ARBITRATION_PHYSICAL,
                     at_op,
                     format!(
-                        "{label}: physical channel matches NO tied composition on \
-                         '{branch}' (physical={knows:?}; tied expectations: {:?})",
+                        "{label}: bound rows match NO tied composition on \
+                         '{branch}' (bound={knows:?}; tied expectations: {:?})",
                         expectations
                     ),
-                    "the export tie-break resolves ghost-only differences to one composition",
+                    "the bound-row tie-break resolves query-invisible differences to one composition",
                 );
             }
             after_matches = keep;
@@ -5046,8 +5060,14 @@ pub fn run_universe_caught(
         for (name, age, ver) in person_rows(&db).await {
             world.main.persons.insert(name, (age, ver));
         }
-        for pair in knows_pairs(&db).await {
-            world.main.edges.insert(pair);
+        let seeded = knows_pairs(&db).await;
+        debug_assert_eq!(
+            seeded.len(),
+            fixture_knows().len(),
+            "fixture Knows rows must be distinct pairs: the seed reads the gated (deduped) channel"
+        );
+        for pair in seeded {
+            world.add_edge_row("main", pair);
         }
         // history baseline (the fixture-load commit) — captured
         // before fault injection enables so the baseline read is clean.

--- a/crates/omnigraph-gqt/cases/issue_681_sibling_merge_readopts_deleted_edge.gqt
+++ b/crates/omnigraph-gqt/cases/issue_681_sibling_merge_readopts_deleted_edge.gqt
@@ -1,0 +1,81 @@
+# issue: 681
+# red_on: 2026-09-07, main @ 5f94a741, under the expectation the issue filed (no rows after the b0 merge): the final read returned {"a.name":"alice","b.name":"bob"}; ruled the multiset default the same day, and that row is the claim below
+# notes: unkeyed edge type (RFC 0044): b0's re-insert of a pair main holds is a fresh row, b1's delete
+# notes: removes the inherited row; merge b1 empties main, merge b0 adopts the fresh row. DST nightly seed 221206.
+
+--- schema
+node Person {
+    name: String @key
+}
+
+edge Knows: Person -> Person
+
+--- seed
+{"type":"Person","data":{"name":"alice"}}
+{"type":"Person","data":{"name":"bob"}}
+{"edge":"Knows","from":"alice","to":"bob"}
+
+--- mutate
+branch create b0
+
+--- expect ok
+
+--- mutate
+branch create b1
+
+--- expect ok
+
+--- mutate branch: b0
+query readd() {
+    insert Knows { from: "alice", to: "bob" }
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- mutate branch: b1
+query delete() {
+    delete Knows where from = "alice"
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- mutate
+branch merge b1
+
+--- expect ok
+
+--- query
+query after_delete_merge() {
+    match {
+        $a: Person
+        $a knows $b
+    }
+    return { $a.name, $b.name }
+}
+
+--- expect unordered
+
+--- expect shape
+a.name: String
+b.name: String
+
+--- mutate
+branch merge b0
+
+--- expect ok
+
+--- query
+query after_readd_merge() {
+    match {
+        $a: Person
+        $a knows $b
+    }
+    return { $a.name, $b.name }
+}
+
+--- expect unordered
+{"a.name": "alice", "b.name": "bob"}
+
+--- expect shape
+a.name: String
+b.name: String

--- a/crates/omnigraph-gqt/cases/keyed_edge_delete_wins_over_readd.gqt
+++ b/crates/omnigraph-gqt/cases/keyed_edge_delete_wins_over_readd.gqt
@@ -1,0 +1,66 @@
+# issue: none
+# notes: keyed twin of issue_681_sibling_merge_readopts_deleted_edge.gqt: with @key(src, dst) (RFC 0044) b0's
+# notes: re-insert upserts the same row, so b1's delete wins in both merges and the pair stays gone.
+
+--- schema
+node Person {
+    name: String @key
+}
+
+edge Knows: Person -> Person {
+    @key(src, dst)
+}
+
+--- seed
+{"type":"Person","data":{"name":"alice"}}
+{"type":"Person","data":{"name":"bob"}}
+{"edge":"Knows","from":"alice","to":"bob"}
+
+--- mutate
+branch create b0
+
+--- expect ok
+
+--- mutate
+branch create b1
+
+--- expect ok
+
+--- mutate branch: b0
+query readd() {
+    insert Knows { from: "alice", to: "bob" }
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- mutate branch: b1
+query delete() {
+    delete Knows where from = "alice"
+}
+
+--- expect affected: nodes=0 edges=1
+
+--- mutate
+branch merge b1
+
+--- expect ok
+
+--- mutate
+branch merge b0
+
+--- expect ok
+
+--- query
+query edges_on_main() {
+    match {
+        $a: Person
+        $a knows $b
+    }
+    return { $a.name, $b.name }
+}
+
+--- expect unordered
+
+--- expect shape
+a.name: String
+b.name: String

--- a/crates/omnigraph-gqt/cases/selfloop_rows_gated_once.gqt
+++ b/crates/omnigraph-gqt/cases/selfloop_rows_gated_once.gqt
@@ -1,0 +1,52 @@
+# issue: none
+# notes: two rows of one self-loop pair (unkeyed type): the gated traversal returns the pair once, the bound
+# notes: traversal counts both rows. The DST model's membership oracles rely on this grain.
+
+--- schema
+node Person {
+    name: String @key
+}
+
+edge Knows: Person -> Person
+
+--- seed
+{"type":"Person","data":{"name":"a"}}
+
+--- mutate
+query two_loops() {
+    insert Knows { from: "a", to: "a" }
+    insert Knows { from: "a", to: "a" }
+}
+
+--- expect affected: nodes=0 edges=2
+
+--- query
+query gated() {
+    match {
+        $p: Person
+        $p knows $q
+    }
+    return { $p.name, $q.name }
+}
+
+--- expect unordered
+{"p.name": "a", "q.name": "a"}
+
+--- expect shape
+p.name: String
+q.name: String
+
+--- query
+query bound_rows() {
+    match {
+        $p: Person
+        $p $e:knows $q
+    }
+    return { count($q.name) as n }
+}
+
+--- expect unordered
+{"n": 2}
+
+--- expect shape
+n: I64

--- a/docs/rfcs/0044-edge-keys.md
+++ b/docs/rfcs/0044-edge-keys.md
@@ -385,16 +385,17 @@ Owners to extend, per the testing map:
   from "tracked separately" to naming this RFC as the resolution.
 - `omnigraph-dst`: the model's H-A born-on-both carve-out retires, since
   unkeyed keep-both is documented contract rather than an illegal state.
-  The model's edge reads are visited-gated membership, so the set
-  representation (`Model.edges` as `BTreeSet<(String, String)>`) predicts
-  the merged MEMBERSHIP correctly for keyed and unkeyed types alike;
-  physical row counts, which membership cannot see, are pinned by the
-  targeted scenarios: `dst_merge_duplicates_born_on_both_edge`
-  (reclassified from bug pin to multiset-contract pin, still asserting two
-  physical rows) and its keyed twin
-  `dst_keyed_born_on_both_edge_converges` (one row). Count-level fleet
-  modeling for unkeyed edges (a multiset `Model.edges`) is deliberately
-  out of scope.
+  The model keys `Knows` rows the way the engine's merge walk does, by a
+  per-row id minted at insert and copied by a fork (`Model.edges` as
+  `BTreeMap<EdgeRowId, (String, String)>`, decision log 2026-09-08): a
+  set of pairs predicted membership for every sampled shape until the
+  delete-vs-readd fork (seed 221206, #681), where one side deletes every
+  row of a pair the other side re-adds as a fresh row and the set sees an
+  unchanged side. Physical row counts are observed by the export channel
+  at the final reopen and pinned by the targeted scenarios
+  `dst_merge_duplicates_born_on_both_edge` (reclassified from bug pin to
+  multiset-contract pin, still asserting two physical rows) and its keyed
+  twin `dst_keyed_born_on_both_edge_converges` (one row).
 - The `ir_version` acceptance and refusal owner is the compiler's schema-IR
   validation tests beside `validate_schema_ir` (`schema_ir.rs`); the CLI
   cross-version harness
@@ -463,3 +464,11 @@ unresolved question 1 tracks it.
   refused before recovery and never reinterpreted; `lifecycle.rs` pins
   that refusal. A shared number would reinterpret those graphs as keyed
   schemas. The number is still fixed here, not at implementation time.
+- 2026-09-08, from the DST model fix for
+  [#681](https://github.com/ModernRelay/omnigraph/issues/681): the
+  nightly's seed-221206 delete-vs-readd fork falsified "the set
+  representation predicts the merged MEMBERSHIP correctly for keyed and
+  unkeyed types alike", and the "deliberately out of scope" multiset
+  `Model.edges` is now the model: rows keyed by a minted id, the engine's
+  own key, with the export channel comparing row counts at the final
+  reopen. This supersedes both sentences in Evidence, `omnigraph-dst`.

--- a/docs/rfcs/0055-gq-branch-statements.md
+++ b/docs/rfcs/0055-gq-branch-statements.md
@@ -95,7 +95,11 @@ inserted on both sides of a fork is duplicated by the merge),
 merge of an already-merged branch, closed: the harness driver re-merged a
 merged branch and the engine answered correctly), and the 2026-09-04
 nightly finding on
-seed 221206, where a merge re-adopted an edge a sibling merge had deleted.
+seed 221206, where a merge re-adopted an edge a sibling merge had deleted
+(filed as [#681](https://github.com/ModernRelay/omnigraph/issues/681),
+ruled on 2026-09-07 the multiset default of RFC 0044 for an unkeyed edge
+type: the engine answered correctly and the red state belonged to the
+harness model, decision log 2026-09-08).
 Each is a five-step story (fork, write, write, merge, read) that the format
 was built to hold and cannot.
 
@@ -1083,25 +1087,29 @@ each fix must turn green.
    an issue only for a failure witnessed on an unfixed build (`0045:84-93`),
    so the [#600](https://github.com/ModernRelay/omnigraph/issues/600)
    provenance is a `# notes:` line and the case carries no `# red_on:`.
-3. The seed-221206 re-adoption (issue not yet filed, `# issue: none`),
-   named `sibling_merge_readopts_deleted_edge.gqt` under the corpus's
-   short-name rule, the scenario the harness found on 2026-09-04, in
-   full; held out, red, the nightly's finding reproduced: `step 9 (query):
-   row mismatch: expected 1 rows, got 2`, the extra row `{"a.name": "w6",
-   "b.name": "charlie"}`, with the read after the `b1` merge green. The
-   two `affected:` lines were blessed from the run: the duplicate add on
-   `b0` counts `nodes=0 edges=1`, because the engine mints a row per edge
-   insert (edges carry no logical key, the mechanism the #583 body names),
-   so the add is a no-op at the set level and one row at the table level.
-   The two `expect unordered` bodies are the claim, each followed by the
+3. The seed-221206 re-adoption
+   ([#681](https://github.com/ModernRelay/omnigraph/issues/681), ruled the
+   multiset default on 2026-09-07; decision log 2026-09-08), named
+   `issue_681_sibling_merge_readopts_deleted_edge.gqt`, the scenario the
+   harness found on 2026-09-04, in full. It witnessed one red, under the
+   expectation the issue filed: `step 9 (query): row mismatch: expected 1 rows, got 2`,
+   the extra row `{"a.name": "w6", "b.name": "charlie"}`, with the read
+   after the `b1` merge green; that extra row is the engine's correct
+   answer, and the case pins it. The two `affected:` lines were blessed
+   from the run: the duplicate add on `b0` counts `nodes=0 edges=1`,
+   because the engine mints a row per edge insert (edges carry no logical
+   key, the mechanism the #583 body names), so the add is a no-op at the
+   set level and one row at the table level; `b1`'s delete removes the
+   inherited row, and the `b0` merge adopts the fresh one. The two
+   `expect unordered` bodies are the claim, each followed by the
    `--- expect shape` section RFC 0045 makes mandatory after a rows
    expect:
 
 ```
-# issue: none
-# red_on: 2026-09-04, DST nightly run #9, seed 221206, arm window:mutation.post_no_effect_pre_gate: main returned (w6, charlie) after the b0 merge; expected only (bob, w6)
-# notes: edge born on main, both forks inherit it, a duplicate add on b0 (zero effect at the set level),
-# notes: delete on b1, merge b1 (the delete reaches main), merge b0 (re-adopts the deleted edge).
+# issue: 681
+# red_on: 2026-09-04, DST nightly run #9, seed 221206, arm window:mutation.post_no_effect_pre_gate, under the expectation issue 681 filed (only (bob, w6) after the b0 merge): main returned (w6, charlie) too; ruled the multiset default 2026-09-07, and that row is the claim below
+# notes: edge born on main, both forks inherit it, a duplicate add on b0 (a second physical row, zero effect at the set level),
+# notes: delete on b1, merge b1 (the delete reaches main), merge b0 (adopts b0's fresh row: the pair is back with one row).
 
 --- schema
 node Person {
@@ -1189,6 +1197,7 @@ query edges_on_main_after_b0() {
 
 --- expect unordered
 {"a.name": "bob", "b.name": "w6"}
+{"a.name": "w6", "b.name": "charlie"}
 
 --- expect shape
 a.name: String
@@ -1460,3 +1469,27 @@ None.
   `run_branch_statement` live in
   `crates/omnigraph-server/src/handlers/dispatch.rs`; `run_query`,
   `run_mutate`, and every `#[utoipa::path]` shell stay in `handlers.rs`.
+- 2026-09-08, from the DST model fix for
+  [#681](https://github.com/ModernRelay/omnigraph/issues/681). The
+  seed-221206 re-adoption was ruled (2026-09-07, on the issue) the multiset
+  default of RFC 0044 for an unkeyed edge type: an insert of a pair the
+  branch already holds is a second physical row, a delete removes only the
+  rows it matched, and the merge walk keys on the row id, so the sibling's
+  delete removes the inherited row and the re-add's fresh row is adopted.
+  The engine answered correctly; the red state belonged to the harness
+  model, a set of pairs that cannot hold two rows for one pair. The case
+  keeps the issue-anchored name, `issue_681_sibling_merge_readopts_deleted_edge.gqt`
+  with `# issue: 681`: it is the regression evidence the fix-regression
+  gate reads for the PR that closes the issue, and its `# red_on:` records
+  the one red it witnessed, under the expectation the issue filed, with the
+  ruling in `# notes:`; it expects the pair BACK on `main` after the `b0`
+  merge and ships green with the model fix, not held out. No Rust test
+  accompanies it: the engine is the subject and the case observes it.
+  Its keyed twin `keyed_edge_delete_wins_over_readd.gqt` (`@key(src,
+  dst)`, [#593](https://github.com/ModernRelay/omnigraph/pull/593)) pins
+  the filed expectation, the pair staying deleted after both merges. This
+  supersedes, for this case only, "held out, red, the nightly's finding
+  reproduced", the `# issue: none` header and the fragment's `# red_on:`
+  expectation in item 3 of the first-cases entry above, "both are red and
+  held out of the corpus until their fixes" in the 2026-09-06 entry, and
+  the Motivation's listing of seed 221206 among the engine findings.


### PR DESCRIPTION
## What & why

Closes #681. The DST nightly (run 9, seed 221206) fired its first `WorldDifferential` on a delete-vs-readd fork: `main` holds `alice -> bob`, `b0` inserts the pair again, `b1` deletes it; merging `b1` and then `b0` leaves the pair on `main`. The engine is right under the multiset default and the DST model was wrong.

- Engine: the merge walk keys rows on `id` alone. `b0`'s insert is a fresh row, `b1`'s delete removes the inherited one, so the second merge adopts the fresh row. That is the multiset contract for an unkeyed edge type: re-inserting a pair is a second row, and a delete removes only the rows it matched (dedup deferred to #583, identity opt-in per type via `@key(src, dst)` in #593).
- Model: `Model.edges` was a set of pairs, one entry per pair, so it saw `b0` unchanged and predicted absence. It is now a map from a minted row id to the pair, ids drawn from one counter on `WorldModel` and cloned across a fork, and `predict_merge` runs the same per-key three-way over persons and edges.
- H-A (reject an edge pair born on both sides) was retired by #593; this diff keeps that and drops its "known gap" note, since the row-id model closes the gap it named.
- Per-pair counts were rejected: base count 1 and side count 1 cannot tell "untouched" from "deleted and re-added", and that is the shape under test.
- Oracles now see the multiset: the physical channel (`export_jsonl`) keeps duplicate rows and `assert_physical_matches` compares rows ∪ ghosts at the final reopen, so a model whose row count drifts from the engine's goes red; the bound-edge reader gains a row-grain form (`knows_rows_bound_target`).
- Crash reconciliation reads rows, not pairs, when it must: an insert of a pair the branch already holds renders identically under Applied and NotApplied at pair grain, and the old Applied-first tie-break minted a phantom row the engine may lack (caught live on the issue-554 panel, seed 11, once the count oracle existed). The tie-break now triggers whenever the two hypotheses differ in rows or ghosts and rules by the bound-edge rows (`query+bound`); the widened keep-serving arbitration narrows its ties the same way.
- Pins, all `.gqt`, no Rust test: `issue_681_sibling_merge_readopts_deleted_edge.gqt` pins the engine outcome (no rows after the `b1` merge, one row after the `b0` merge); `keyed_edge_delete_wins_over_readd.gqt` pins the keyed contract (the pair stays deleted after both merges, RFC 0044 via #593); `selfloop_rows_gated_once.gqt` pins that two self-loop rows read once on the gated traversal and count 2 bound, the grain the model's membership oracles rely on. The model's own agreement is exercised by the nightly fleet (seed 221206 is the arm that found the gap) and by every existing pinned universe under the row-grain physical oracle.
- RFC 0055 (branch statements) updated: the seed-221206 case was specified there as a held-out engine bug with the delete-wins expectation; the Motivation line, the first-cases item, the fragment and a 2026-09-08 decision-log entry now carry the ruling.

## Backing issue / RFC

- [x] Fixes an **accepted** issue: Closes #681. `issue_681_sibling_merge_readopts_deleted_edge.gqt` is the regression evidence: its `# red_on:` records the red it witnessed under the expectation the issue filed, its `# notes:` the ruling, and it expects the engine's answer. The keyed twin takes RFC 0045's feature shape (`# issue: none`): no build was ever wrong on it.

## Checklist

- [x] Change is focused (the DST model's edge identity, its oracles, three `.gqt` cases and the RFC 0055 record; no engine edit)
- [x] Tests added/updated for behavior changes (three `.gqt` cases; the DST suite's existing pinned universes run under the row-grain physical oracle, 50 passed / 27 ignored)
- [x] Public docs updated if user-facing surface changed (internal harness, no public surface)
- [x] Reviewed against docs/dev/invariants.md — no Hard Invariant weakened, no deny-list item hit (no engine code touched; the model now predicts the engine's pinned multiset outcome instead of a stricter set one)

## Local verification

- `cd crates/omnigraph-dst && cargo test` — scenarios 50 passed / 27 ignored (`dst_keep_serving_wedge_issue_554` included), lane_b 1 passed, torn_init 1, lib 26
- `cargo test -p omnigraph-gqt --test gq_logic_tests` — 51 cases green on main with #593 (on the pre-#593 base the keyed twin is refused at parse, as expected)
- `cargo fmt --all -- --check` — clean
- `cd crates/omnigraph-dst && cargo clippy --workspace --all-targets` — clean
- seed 221206 replayed against the previous set model (temporary universe, deleted after) — red at op 29 with the nightly's `Store(Query)/WorldDifferential`; green under this model
- the row-grain physical oracle against the pair-grain tie-break (temporary, reverted) — red on the issue-554 panel, seed 11: model `[(Alice,Bob),(Alice,Charlie),(Alice,Charlie),(Bob,Diana)]`, export three rows — the phantom row the bound-row tie-break now rules out
- `cargo test -p omnigraph-gqt --lib` — not run to green: `branch_list_shape_and_rows_are_blessed_like_a_read_step` overflows its stack on `5f94a741` without this diff too

## Notes for reviewers

- No engine change: the multiset default for unkeyed edge types stands. With `edge Knows: Person -> Person { @key(src, dst) }` the identical insert is an upsert of the same row and the pair stays deleted after both merges; the keyed twin case pins that on main with #593 merged.
- Lane B's `World` keeps its own set model; it never merges.
- The tie-break reads the bound-edge rows, not `export_jsonl`: an export read inside a reconcile shifted the issue-554 panel's lance-realm universes by test order (the panel is green when run first and red after most predecessors with the export read; deterministic with `--test-threads=1`), while the bound query, the same read class the reconcile already issues, leaves them unchanged. The export channel keeps its role as the final-reopen physical oracle.
- Not in this PR: a `Milestone` recipe that reaches the sibling delete-vs-readd shape deliberately (today it is seed luck), and a count-aware differential at every oracle site; the final-reopen row-grain oracle covers the count claim once per universe.