### PR TITLE
feat(gqt): add failpoint injection through DST

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -543,11 +543,11 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-on-failure: true
 
-      # Own step so compile and run wall clock read apart in the log; the
-      # run step reuses these binaries (same flags, features, and env).
+      # GQ Logic Tests owns GQT in both build shapes, including its DST runtime.
+      # The run step reuses these binaries (same flags, features, and env).
       - name: Compile the workspace and failpoint test graph
         run: |
-          cargo test --workspace --locked --no-run \
+          cargo test --workspace --exclude omnigraph-gqt --locked --no-run \
             --features "$FAILPOINT_FEATURES"
 
       - name: Install genuine v0.9 release for upgrade regression
@@ -586,7 +586,7 @@ jobs:
           if [[ "$GITHUB_EVENT_NAME" != "pull_request" ]]; then
             no_fail_fast+=(--no-fail-fast)
           fi
-          cargo test --workspace --locked ${no_fail_fast[@]+"${no_fail_fast[@]}"} \
+          cargo test --workspace --exclude omnigraph-gqt --locked ${no_fail_fast[@]+"${no_fail_fast[@]}"} \
             --features "$FAILPOINT_FEATURES" \
             -- --nocapture 2>&1 | tee "$test_log"
           if grep -Fq "skipping v0.9 upgrade e2e:" "$test_log"; then

--- a/.github/workflows/gq-logic-tests.yml
+++ b/.github/workflows/gq-logic-tests.yml
@@ -142,7 +142,25 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-on-failure: true
 
-      - name: Run GQ logic tests
+      - name: Test unavailable DST runtime refusal
         if: needs.classify_changes.outputs.run_full_ci == 'true'
-        # The corpus crate: format self-tests, corpus layout check, one test per case.
+        run: cargo test -p omnigraph-gqt --locked --lib --test runner_dispatch -- --nocapture
+
+      - name: Clippy GQT with DST
+        if: needs.classify_changes.outputs.run_full_ci == 'true'
+        # Crate-local Cargo configuration enables the seeded Tokio runtime.
+        working-directory: crates/omnigraph-gqt
+        run: cargo clippy -p omnigraph-gqt --all-targets --locked -- -D warnings -W clippy::dbg_macro
+
+      - name: Run complete GQ logic tests with DST
+        if: needs.classify_changes.outputs.run_full_ci == 'true'
+        working-directory: crates/omnigraph-gqt
         run: cargo test -p omnigraph-gqt --locked -- --nocapture
+
+      - name: Retain GQT invocation reports
+        if: always() && needs.classify_changes.outputs.run_full_ci == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gqt-invocation-reports
+          path: target/gqt-artifacts/*.json
+          if-no-files-found: error

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,8 +121,9 @@ its Cargo package is `omnigraph-engine`.
 cargo build --workspace --locked
 
 # Canonical CI test graph
-cargo test --workspace --locked \
+cargo test --workspace --exclude omnigraph-gqt --locked \
   --features omnigraph-engine/failpoints,omnigraph-cluster/failpoints
+cargo test -p omnigraph-gqt --locked --lib --test runner_dispatch
 
 # Focused examples
 cargo test -p omnigraph-engine --test traversal
@@ -138,6 +139,12 @@ python3 scripts/check-docs.py
 python3 scripts/check-workflow-action-pins.py
 typos                                   # from the repository root; version pinned in ci.yml; exemptions in .typos.toml
 ```
+
+The separate `GQ Logic Tests` context owns the complete GQT corpus. From
+`crates/omnigraph-gqt`, also run `cargo test -p omnigraph-gqt --locked` and
+`cargo clippy -p omnigraph-gqt --all-targets --locked -- -D warnings -W clippy::dbg_macro`.
+Its crate-local Cargo configuration enables DST; an unconfigured build must
+refuse requested DST execution, not skip those cases.
 
 S3 suites require `OMNIGRAPH_S3_TEST_BUCKET` and the documented `AWS_*`
 environment. Azure suites require `OMNIGRAPH_AZURE_TEST_CONTAINER` and the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5638,8 +5638,12 @@ dependencies = [
  "datatest-stable",
  "futures",
  "omnigraph-compiler",
+ "omnigraph-dst",
  "omnigraph-engine",
+ "serde",
  "serde_json",
+ "serde_yaml",
+ "sha2 0.10.9",
  "tempfile",
  "tokio",
 ]

--- a/crates/omnigraph-dst/README.md
+++ b/crates/omnigraph-dst/README.md
@@ -43,6 +43,34 @@ cargo is invoked from the crate directory; from anywhere else, set
 `RUSTFLAGS="--cfg tokio_unstable"` yourself. The `failpoints` feature is a
 default of this crate.
 
+## Shared execution and storage lifetime
+
+`environment::run_universe(&environment, &scenario)` runs one complete scenario
+under one selected root seed. `UniverseEnvironment` creates resources inside
+the seeded runtime; `UniverseScenario` owns the operation loop and checks.
+Rust recipes and GQT use this executor with their respective scenario types.
+The ordinary GQT engine target retains its ordinary runtime.
+
+`MemoryEnvironment` supplies a fresh control-object adapter and an empty owned
+Lance graph namespace. It refuses nonempty or actively owned namespaces.
+The same resources survive an `Omnigraph` reopen within a scenario. Teardown
+clears only the owned Lance prefix, through the raw provider after scenario
+observations, and releases the adapter. This preserves a fresh graph, not a
+reset of shared-backend ETag counters or incomplete multipart state.
+
+`UniverseRun` records the execution phase, primary outcome, and cleanup outcome
+separately. Setup guards partial acquisitions; scenario errors and panics still
+run teardown. Panic payloads remain available to the Rust caller. The caller
+owns process-start settings, failpoint registration, isolation, wall deadlines,
+and containment of hung or killed workers. GQT still executes each replay in a
+fresh child process and verifies the frozen inputs and observations.
+
+The existing `harness::run_universe(root, &Scenario)` and
+`harness::run_universe_caught` calls translate `Scenario.seed` into the explicit
+environment. The four child streams retain their draw order; `FaultPlan.seed`
+continues to select the independent storage-fault stream. Rust fault wrappers,
+counters, and final census remain available through prepared resources.
+
 ## What a universe checks (the oracles)
 
 The five GROUPS below are the reader's map; the enforced census counts

--- a/crates/omnigraph-dst/src/entropy.rs
+++ b/crates/omnigraph-dst/src/entropy.rs
@@ -114,3 +114,10 @@ unsafe extern "C" fn CCRandomGenerateBytes(buf: *mut u8, buflen: usize) -> i32 {
         -1
     }
 }
+
+/// Return process-wide entropy requests to the operating system.
+pub(crate) fn disarm() {
+    *STREAM
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+}

--- a/crates/omnigraph-dst/src/environment.rs
+++ b/crates/omnigraph-dst/src/environment.rs
@@ -1,0 +1,192 @@
+//! Shared seeded execution for caller-owned scenarios.
+
+use std::future::Future;
+
+use futures::FutureExt;
+
+use crate::harness::{UNIVERSE_STACK_BYTES, clear_process_slots};
+use crate::rand::SplitMix64;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UniverseProcess {
+    Shared,
+    Isolated,
+}
+
+/// Configuration creates resources only after seeded execution is installed.
+/// Setup must guard partial resources; teardown borrows the complete set.
+/// Resources remain owned until all runtime tasks have been dropped.
+pub trait UniverseEnvironment: Sync {
+    type Resources;
+    fn seed(&self) -> u64;
+    fn process(&self) -> UniverseProcess;
+    fn setup(&self) -> impl Future<Output = Result<Self::Resources, String>>;
+    fn teardown(&self, resources: &mut Self::Resources)
+    -> impl Future<Output = Result<(), String>>;
+}
+
+/// A scenario owns its operations, checks and output; the universe owns execution.
+pub trait UniverseScenario<R>: Sync {
+    type Output: Send;
+
+    fn run<'a>(
+        &'a self,
+        resources: &'a mut R,
+        workload_seed: u64,
+    ) -> impl Future<Output = Self::Output> + 'a;
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UniversePhase {
+    Runtime,
+    Setup,
+    Scenario,
+}
+
+/// Teardown evidence is retained even when the scenario fails or panics.
+pub struct UniverseRun<T> {
+    pub phase: UniversePhase,
+    pub result: std::thread::Result<Result<T, String>>,
+    pub cleanup: std::thread::Result<Result<(), String>>,
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for UniverseRun<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UniverseRun")
+            .field("phase", &self.phase)
+            .field("result", &self.result.as_ref().map_err(|_| "panic"))
+            .field("cleanup", &self.cleanup.as_ref().map_err(|_| "panic"))
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+struct InstalledEnvironment(UniverseProcess);
+
+impl Drop for InstalledEnvironment {
+    fn drop(&mut self) {
+        omnigraph::dst_clock::uninstall_logical_clock();
+        omnigraph::dst_ids::uninstall_seeded_ulids();
+        omnigraph::dst_gate::uninstall_gate_hook();
+        clear_process_slots();
+        if self.0 == UniverseProcess::Isolated {
+            crate::entropy::disarm();
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ProcessSlots;
+
+impl Drop for ProcessSlots {
+    fn drop(&mut self) {
+        clear_process_slots();
+    }
+}
+
+/// Run one complete scenario in a fresh seeded runtime.
+///
+/// The caller owns process isolation, pool configuration, failpoint registration
+/// and the wall-clock deadline. Panics retain their original payloads.
+/// A hard-killed worker requires caller-owned containment, not Rust teardown.
+pub fn run_universe<E: UniverseEnvironment, S: UniverseScenario<E::Resources>>(
+    environment: &E,
+    scenario: &S,
+) -> UniverseRun<S::Output> {
+    let mut seeds = SplitMix64(environment.seed());
+    let runtime_seed = seeds.next_u64();
+    let ulid_seed = seeds.next_u64();
+    let workload_seed = seeds.next_u64();
+    let entropy_seed = seeds.next_u64();
+    let process = environment.process();
+
+    clear_process_slots();
+    let _slots = ProcessSlots;
+    if process == UniverseProcess::Shared {
+        crate::entropy::arm(entropy_seed);
+    }
+
+    std::thread::scope(|scope| {
+        let thread = std::thread::Builder::new()
+            .name("dst-universe".into())
+            .stack_size(UNIVERSE_STACK_BYTES)
+            .spawn_scoped(scope, move || {
+                let _environment = InstalledEnvironment(process);
+                if process == UniverseProcess::Isolated {
+                    crate::entropy::arm(entropy_seed);
+                }
+                rand::rng().reseed().expect("reseed DST thread entropy");
+                let mut resources = None;
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_time()
+                    .start_paused(true)
+                    .rng_seed(tokio::runtime::RngSeed::from_bytes(
+                        &runtime_seed.to_le_bytes(),
+                    ))
+                    .build_local(Default::default())
+                    .expect("seeded current-thread runtime");
+
+                let run = runtime.block_on(Box::pin(async {
+                    omnigraph::dst_ids::install_seeded_ulids(ulid_seed);
+                    omnigraph::dst_clock::install_logical_clock();
+                    let setup = std::panic::AssertUnwindSafe(async { environment.setup().await })
+                        .catch_unwind()
+                        .await;
+                    let owned_resources = match setup {
+                        Ok(Ok(resources)) => resources,
+                        Ok(Err(error)) => {
+                            return UniverseRun {
+                                phase: UniversePhase::Setup,
+                                result: Ok(Err(error)),
+                                cleanup: Ok(Ok(())),
+                            };
+                        }
+                        Err(panic) => {
+                            return UniverseRun {
+                                phase: UniversePhase::Setup,
+                                result: Err(panic),
+                                cleanup: Ok(Ok(())),
+                            };
+                        }
+                    };
+                    let resources = resources.insert(owned_resources);
+                    let result = std::panic::AssertUnwindSafe(async {
+                        scenario.run(resources, workload_seed).await
+                    })
+                    .catch_unwind()
+                    .await
+                    .map(Ok);
+                    let cleanup = std::panic::AssertUnwindSafe(async {
+                        environment.teardown(resources).await
+                    })
+                    .catch_unwind()
+                    .await;
+                    UniverseRun {
+                        phase: UniversePhase::Scenario,
+                        result,
+                        cleanup,
+                    }
+                }));
+                drop(runtime);
+                drop(resources);
+                run
+            });
+        match thread {
+            Ok(thread) => thread.join().unwrap_or_else(|panic| UniverseRun {
+                phase: UniversePhase::Runtime,
+                result: Err(panic),
+                cleanup: Ok(Err(
+                    "runtime exited before resource cleanup could be verified".into(),
+                )),
+            }),
+            Err(error) => UniverseRun {
+                phase: UniversePhase::Runtime,
+                result: Ok(Err(format!("spawn universe thread: {error}"))),
+                cleanup: Ok(Ok(())),
+            },
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/omnigraph-dst/src/environment/tests.rs
+++ b/crates/omnigraph-dst/src/environment/tests.rs
@@ -1,0 +1,255 @@
+use std::cell::Cell;
+use std::rc::Rc;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use super::*;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Event {
+    Setup,
+    Scenario,
+    Teardown,
+    ResourceDropped,
+    TaskDropped,
+}
+
+#[derive(Debug)]
+struct DropProbe {
+    events: Arc<Mutex<Vec<Event>>>,
+    event: Event,
+}
+
+impl Drop for DropProbe {
+    fn drop(&mut self) {
+        self.events.lock().unwrap().push(self.event);
+    }
+}
+
+#[derive(Debug)]
+struct Resources {
+    value: Rc<Cell<u64>>,
+    started: tokio::time::Instant,
+    lifetime: DropProbe,
+}
+
+#[derive(Debug, Default)]
+struct Environment {
+    events: Arc<Mutex<Vec<Event>>>,
+    setup_error: bool,
+    teardown_error: bool,
+}
+
+impl UniverseEnvironment for Environment {
+    type Resources = Resources;
+
+    fn seed(&self) -> u64 {
+        42
+    }
+
+    fn process(&self) -> UniverseProcess {
+        UniverseProcess::Shared
+    }
+
+    async fn setup(&self) -> Result<Resources, String> {
+        self.events.lock().unwrap().push(Event::Setup);
+        let resources = Resources {
+            value: Rc::new(Cell::new(0)),
+            started: tokio::time::Instant::now(),
+            lifetime: DropProbe {
+                events: self.events.clone(),
+                event: Event::ResourceDropped,
+            },
+        };
+        tokio::time::sleep(Duration::from_millis(7)).await;
+        if self.setup_error {
+            return Err("setup failed".into());
+        }
+        Ok(resources)
+    }
+
+    async fn teardown(&self, resources: &mut Resources) -> Result<(), String> {
+        self.events.lock().unwrap().push(Event::Teardown);
+        assert_eq!(resources.value.get(), 1);
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        if self.teardown_error {
+            Err("teardown failed".into())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Outcome {
+    Pass,
+    Error,
+    Panic,
+    SpawnLocal,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct Observation {
+    workload_seed: u64,
+    setup_elapsed: Duration,
+    scenario_elapsed: Duration,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ScenarioPanic(u64);
+
+impl UniverseScenario<Resources> for Outcome {
+    type Output = Result<Observation, String>;
+
+    async fn run(&self, resources: &mut Resources, workload_seed: u64) -> Self::Output {
+        resources
+            .lifetime
+            .events
+            .lock()
+            .unwrap()
+            .push(Event::Scenario);
+        resources.value.set(resources.value.get() + 1);
+        let setup_elapsed = resources.started.elapsed();
+        tokio::time::sleep(Duration::from_millis(11)).await;
+        match self {
+            Self::Pass => {}
+            Self::Error => return Err("scenario failed".into()),
+            Self::Panic => std::panic::panic_any(ScenarioPanic(71)),
+            Self::SpawnLocal => {
+                let probe = DropProbe {
+                    events: resources.lifetime.events.clone(),
+                    event: Event::TaskDropped,
+                };
+                let value = resources.value.clone();
+                let (started, ready) = tokio::sync::oneshot::channel();
+                tokio::task::spawn_local(async move {
+                    let _probe = probe;
+                    let _value = value;
+                    started.send(()).unwrap();
+                    std::future::pending::<()>().await;
+                });
+                ready.await.unwrap();
+            }
+        }
+        Ok(Observation {
+            workload_seed,
+            setup_elapsed,
+            scenario_elapsed: resources.started.elapsed() - setup_elapsed,
+        })
+    }
+}
+
+#[test]
+#[serial_test::serial]
+fn partial_setup_failure_drops_resources_without_running_scenario() {
+    let environment = Environment {
+        setup_error: true,
+        ..Default::default()
+    };
+    let run = run_universe(&environment, &Outcome::Pass);
+    assert_eq!(run.phase, UniversePhase::Setup);
+    assert_eq!(run.result.unwrap().unwrap_err(), "setup failed");
+    run.cleanup.unwrap().unwrap();
+    assert_eq!(
+        *environment.events.lock().unwrap(),
+        [Event::Setup, Event::ResourceDropped]
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn non_send_resources_survive_until_async_teardown() {
+    let environment = Environment::default();
+    let run = run_universe(&environment, &Outcome::Pass);
+    assert_eq!(run.phase, UniversePhase::Scenario);
+    run.result.unwrap().unwrap().unwrap();
+    run.cleanup.unwrap().unwrap();
+    assert_eq!(
+        *environment.events.lock().unwrap(),
+        [
+            Event::Setup,
+            Event::Scenario,
+            Event::Teardown,
+            Event::ResourceDropped,
+        ]
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn setup_and_scenario_share_virtual_time_and_preserve_seed_derivation() {
+    let environment = Environment::default();
+    let first = run_universe(&environment, &Outcome::Pass);
+    first.cleanup.unwrap().unwrap();
+    let first = first.result.unwrap().unwrap().unwrap();
+    let second = run_universe(&environment, &Outcome::Pass);
+    second.cleanup.unwrap().unwrap();
+    assert_eq!(first, second.result.unwrap().unwrap().unwrap());
+    assert_eq!(
+        first,
+        Observation {
+            workload_seed: 5_139_283_748_462_763_858,
+            setup_elapsed: Duration::from_millis(7),
+            scenario_elapsed: Duration::from_millis(11),
+        }
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn scenario_panic_preserves_payload_and_still_tears_down() {
+    let environment = Environment::default();
+    let run = run_universe(&environment, &Outcome::Panic);
+    assert_eq!(run.phase, UniversePhase::Scenario);
+    let panic = run.result.unwrap_err();
+    assert_eq!(
+        panic.downcast_ref::<ScenarioPanic>(),
+        Some(&ScenarioPanic(71))
+    );
+    run.cleanup.unwrap().unwrap();
+    assert_eq!(
+        *environment.events.lock().unwrap(),
+        [
+            Event::Setup,
+            Event::Scenario,
+            Event::Teardown,
+            Event::ResourceDropped,
+        ]
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn scenario_and_teardown_failures_are_both_retained() {
+    let environment = Environment {
+        teardown_error: true,
+        ..Default::default()
+    };
+    let run = run_universe(&environment, &Outcome::Error);
+    assert_eq!(run.phase, UniversePhase::Scenario);
+    assert_eq!(run.result.unwrap().unwrap().unwrap_err(), "scenario failed");
+    assert_eq!(run.cleanup.unwrap().unwrap_err(), "teardown failed");
+    assert_eq!(
+        environment.events.lock().unwrap().last(),
+        Some(&Event::ResourceDropped)
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn pending_local_tasks_drop_before_universe_returns() {
+    let environment = Environment::default();
+    let run = run_universe(&environment, &Outcome::SpawnLocal);
+    run.result.unwrap().unwrap().unwrap();
+    run.cleanup.unwrap().unwrap();
+    assert_eq!(
+        *environment.events.lock().unwrap(),
+        [
+            Event::Setup,
+            Event::Scenario,
+            Event::Teardown,
+            Event::TaskDropped,
+            Event::ResourceDropped,
+        ]
+    );
+}

--- a/crates/omnigraph-dst/src/harness.rs
+++ b/crates/omnigraph-dst/src/harness.rs
@@ -18,12 +18,14 @@ use omnigraph::loader::{LoadMode, load_jsonl};
 use omnigraph::storage::{ObjectStorageAdapter, StorageAdapter};
 
 use crate::detectors::{self, Channel, Detector, ObservationSource, Oracle};
+use crate::environment::{UniverseEnvironment, UniverseProcess, UniverseScenario};
 use crate::fixtures::{
     MUTATION_QUERIES, TEST_DATA, TEST_SCHEMA, fixture_knows, knows_pairs, knows_pairs_bound_target,
     knows_pairs_on, knows_pairs_target, knows_pairs_target_mode, knows_rows_bound_target,
     mixed_params, mutate_on, person_jsonl, person_rows, person_rows_on, person_rows_target,
     physical_view_on, query_main, schema_with_extras,
 };
+use crate::memory::{MemoryEnvironment, MemoryStorage};
 use crate::rand::SplitMix64;
 
 /// Process-static debug toggles; the DST_PREDICT_LOG / DST_OP_LOG env
@@ -4953,13 +4955,6 @@ async fn resolve_keep_serving_watch(
     (db, ruling.e_outcome.map(|o| (o, channel)))
 }
 
-pub fn run_universe(root: &str, sc: &Scenario) -> UniverseReport {
-    match run_universe_caught(root, sc) {
-        Ok(report) => report,
-        Err(panic) => std::panic::resume_unwind(panic),
-    }
-}
-
 /// META ORACLE — strict replay, detector-tagged: two same-seed
 /// reports must be equal, row order included. The pins' comparison funnel;
 /// a red names (HarnessOutput, StrictReplay) in its recorded row.
@@ -4991,18 +4986,97 @@ pub fn panic_message(panic: &(dyn std::any::Any + Send)) -> String {
     }
 }
 
-/// the fleet's universe entry: a VIOLATION becomes a recorded
-/// row instead of killing the whole pass. Identical execution to
-/// `run_universe` (same dedicated 16 MiB thread — its join already carries
-/// the panic; the pinned-suite path rethrows, this path returns it). The
-/// caller records (scenario, message) — a complete repro — and continues.
-pub fn run_universe_caught(
-    root: &str,
-    sc: &Scenario,
-) -> Result<UniverseReport, Box<dyn std::any::Any + Send>> {
-    // Seed logging: the knobs the pinned scenarios vary, so a failed run's
-    // line names its universe (remaining Scenario knobs come from the
-    // test's own source).
+#[derive(Debug)]
+struct RustEnvironment {
+    memory: MemoryEnvironment,
+    faults: Option<FaultPlan>,
+    die_at_write: Option<usize>,
+}
+
+#[derive(Debug)]
+struct RustResources {
+    memory: MemoryStorage,
+    storage: Arc<dyn StorageAdapter>,
+    failing: Option<Arc<FailingStorage>>,
+    lance_faults_state: Option<Arc<crate::lance_faults::LanceFaultState>>,
+    kill_state: Option<Arc<KillState>>,
+}
+
+impl UniverseEnvironment for RustEnvironment {
+    type Resources = RustResources;
+
+    fn seed(&self) -> u64 {
+        self.memory.seed()
+    }
+
+    fn process(&self) -> UniverseProcess {
+        self.memory.process()
+    }
+
+    async fn setup(&self) -> Result<RustResources, String> {
+        let memory = self.memory.setup().await?;
+        let concrete_adapter = memory.adapter.clone();
+        let base: Arc<dyn StorageAdapter> = concrete_adapter.clone();
+        let base: Arc<dyn StorageAdapter> = if crate::cost::armed() {
+            crate::lance_faults::install();
+            Arc::new(crate::cost::CostStorage::new(base))
+        } else {
+            base
+        };
+        let lance_faults_state = self
+            .faults
+            .as_ref()
+            .filter(|plan| plan.lance_realm)
+            .map(crate::lance_faults::LanceFaultState::from_plan);
+        let kill_state = self.die_at_write.map(KillState::new);
+        if lance_faults_state.is_some() || kill_state.is_some() {
+            crate::lance_faults::install();
+        }
+        crate::lance_faults::set_active(lance_faults_state.clone());
+        crate::lance_faults::set_kill(kill_state.clone());
+        FOREIGN_SIDECAR_ROWS.lock().unwrap().clear();
+        let failing: Option<Arc<FailingStorage>> = if self.faults.is_some() || kill_state.is_some()
+        {
+            Some(Arc::new(FailingStorage::new(
+                base.clone(),
+                self.faults.clone().unwrap_or_else(FaultPlan::none),
+                lance_faults_state.clone(),
+                kill_state.clone(),
+            )))
+        } else {
+            None
+        };
+        let storage: Arc<dyn StorageAdapter> = match &failing {
+            Some(f) => f.clone(),
+            None => base,
+        };
+
+        Ok(RustResources {
+            memory,
+            storage,
+            failing,
+            lance_faults_state,
+            kill_state,
+        })
+    }
+
+    async fn teardown(&self, resources: &mut RustResources) -> Result<(), String> {
+        crate::lance_faults::set_active(None);
+        crate::lance_faults::set_kill(None);
+        self.memory.teardown(&mut resources.memory).await
+    }
+}
+
+/// Run the Rust recipe using its existing root seed and fault-plan seeds.
+pub fn run_universe(root: &str, scenario: &Scenario) -> UniverseReport {
+    match run_universe_caught(root, scenario) {
+        Ok(report) => report,
+        Err(panic) => std::panic::resume_unwind(panic),
+    }
+}
+
+/// Retain detector panic payloads while the shared executor finalizes resources.
+pub fn run_universe_caught(root: &str, sc: &Scenario) -> std::thread::Result<UniverseReport> {
     println!(
         "dst universe [root={root} seed={} ops={} crash={:?} crash_on_match={:?} faults={} kill={:?} keep_serving={}]",
         sc.seed,
@@ -5019,111 +5093,57 @@ pub fn run_universe_caught(
         sc.die_at_write,
         sc.keep_serving_ops
     );
-    // Structural scope-out: the ack-loss client-retry re-executes an op the
-    // keep-serving machinery may have already judged at a watch resolution —
-    // the combination is undesigned. Enforced here, not by comment alone.
     assert!(
         sc.keep_serving_ops == 0 || !sc.faults.as_ref().map(|p| p.client_retry).unwrap_or(false),
         "keep_serving_ops and FaultPlan::client_retry are mutually scoped out"
     );
 
-    let mut seeds = SplitMix64(sc.seed);
-    let runtime_seed = seeds.next_u64();
-    let ulid_seed = seeds.next_u64();
-    let workload_seed = seeds.next_u64();
-    let entropy_seed = seeds.next_u64();
-
     detectors::install_violation_panic_hook();
-    clear_process_slots();
     crate::env_knobs::require_pool_env();
-
-    // Lance's retry backoff draws REAL entropy (the REPLAY-ENVELOPE NOTE on
-    // `UniverseReport`). Close what is closable in-process: (re)arm the
-    // entropy shim with a per-universe stream and force this thread's
-    // ThreadRng to re-pull from it — every jitter draw becomes a
-    // deterministic function of the universe seed, no matter what earlier
-    // universes consumed.
-    crate::entropy::arm(entropy_seed);
-
-    // THE UNIVERSE THREAD: every universe runs on a dedicated 16 MiB thread
-    // — the systemic fix for the 2 MiB test stack (supersedes per-frame
-    // Box::pin whack-a-mole). ThreadRng is THREAD-LOCAL, so the
-    // per-universe entropy reseed must happen INSIDE this thread; panics
-    // (oracle verdicts) propagate via resume_unwind so test messages
-    // survive. One fresh thread per universe keeps replay exact.
-    let result = std::thread::scope(|scope| {
-        std::thread::Builder::new()
-            .name("dst-universe".into())
-            .stack_size(UNIVERSE_STACK_BYTES)
-            .spawn_scoped(scope, || {
-                let _ = rand::rng().reseed();
-                let runtime = tokio::runtime::Builder::new_current_thread()
-                    .enable_time()
-                    .start_paused(true)
-                    .rng_seed(tokio::runtime::RngSeed::from_bytes(
-                        &runtime_seed.to_le_bytes(),
-                    ))
-                    .build_local(Default::default())
-                    .expect("seeded current-thread runtime");
-
-    // The WHOLE universe future is heap-allocated: the
-    // accumulated session/oracle state pushed the inline state machine past
-    // the 2 MiB test stack — boxing at the outermost boundary composes with
-    // the 16 MiB universe thread above.
-    runtime.block_on(Box::pin(async move {
-        omnigraph::dst_ids::install_seeded_ulids(ulid_seed);
-        omnigraph::dst_clock::install_logical_clock();
-
-        // The concrete handle survives beside the dyn one so the write
-        // census can bottom-list the store itself at universe end
-        // (`dst_list_all_keys` is inherent, not on the trait).
-        let concrete_adapter = Arc::new(ObjectStorageAdapter::in_memory());
-        let base: Arc<dyn StorageAdapter> = concrete_adapter.clone();
-        // Bench counting pass: when a cost ledger is armed, count at the
-        // innermost adapter layer (exactly the calls that reach the store)
-        // and make sure the Lance-realm decorator is interposed so its
-        // tallies fire too. Disarmed: zero change.
-        let base: Arc<dyn StorageAdapter> = if crate::cost::armed() {
-            crate::lance_faults::install();
-            Arc::new(crate::cost::CostStorage::new(base))
-        } else {
-            base
-        };
-        // the same plan storms BOTH realms — the adapter realm via
-        // FailingStorage, the Lance realm via the interposed provider. The
-        // slot is set unconditionally so a panicked faulty universe cannot
-        // leak weather into the next universe in this process.
-        let lance_faults_state = sc
-            .faults
-            .as_ref()
-            .filter(|plan| plan.lance_realm)
-            .map(crate::lance_faults::LanceFaultState::from_plan);
-        // the crash-state enumeration needs the same wrapped storage (its
-        // write counter lives in the wrappers of both realms).
-        let kill_state = sc.die_at_write.map(KillState::new);
-        if lance_faults_state.is_some() || kill_state.is_some() {
-            crate::lance_faults::install();
+    let environment = RustEnvironment {
+        memory: MemoryEnvironment::new(root, sc.seed, UniverseProcess::Shared),
+        faults: sc.faults.clone(),
+        die_at_write: sc.die_at_write,
+    };
+    let run = crate::environment::run_universe(&environment, sc);
+    let cleanup = run
+        .cleanup
+        .map_err(|panic| panic_message(panic.as_ref()))
+        .and_then(|result| result);
+    match run.result {
+        Err(panic) => {
+            if let Err(error) = cleanup {
+                eprintln!(
+                    "universe cleanup failed: {error}; original panic: {}",
+                    panic_message(panic.as_ref())
+                );
+            }
+            Err(panic)
         }
-        crate::lance_faults::set_active(lance_faults_state.clone());
-        crate::lance_faults::set_kill(kill_state.clone());
-        // Persisted tier: per-universe sink for the foreign-sidecar carve-out
-        // rows — cleared unconditionally (same leak-safety rule as the
-        // lance slots: a panicked predecessor must not bleed rows in).
-        FOREIGN_SIDECAR_ROWS.lock().unwrap().clear();
-        let failing: Option<Arc<FailingStorage>> = if sc.faults.is_some() || kill_state.is_some() {
-            Some(Arc::new(FailingStorage::new(
-                base.clone(),
-                sc.faults.clone().unwrap_or_else(FaultPlan::none),
-                lance_faults_state.clone(),
-                kill_state.clone(),
-            )))
-        } else {
-            None
-        };
-        let storage: Arc<dyn StorageAdapter> = match &failing {
-            Some(f) => f.clone(),
-            None => base,
-        };
+        Ok(result) => match cleanup {
+            Ok(()) => result.map_err(|error| Box::new(error) as Box<dyn std::any::Any + Send>),
+            Err(error) => Err(Box::new(format!(
+                "universe cleanup failed: {error}; original={result:?}"
+            ))),
+        },
+    }
+}
+
+impl UniverseScenario<RustResources> for Scenario {
+    type Output = UniverseReport;
+
+    async fn run<'a>(
+        &'a self,
+        resources: &'a mut RustResources,
+        workload_seed: u64,
+    ) -> UniverseReport {
+        let sc = self;
+        let root = resources.memory.root.as_str();
+        let concrete_adapter = &resources.memory.adapter;
+        let storage = resources.storage.clone();
+        let failing = resources.failing.clone();
+        let lance_faults_state = resources.lance_faults_state.clone();
+        let kill_state = resources.kill_state.clone();
 
         let mut db = Omnigraph::init_with_storage(
             root,
@@ -5657,8 +5677,8 @@ pub fn run_universe_caught(
                                     i,
                                     format!(
                                         "writes wedged on pending recovery operation {}: \
-                                         {} consecutive RecoveryRequired refusals on the \
-                                         live handle (first at op{}), reopen deferred",
+                                             {} consecutive RecoveryRequired refusals on the \
+                                             live handle (first at op{}), reopen deferred",
                                         watch.operation_id, watch.streak, watch.first_op
                                     ),
                                     Oracle::LiveWriteAvailability.doc(),
@@ -5714,10 +5734,7 @@ pub fn run_universe_caught(
                         // own reads. Captured once, pre-resolution, shared by
                         // the uncertainty classifier and the attribution
                         // below.
-                        let damaged_now = failing
-                            .as_ref()
-                            .map(|f| f.damage_events())
-                            .unwrap_or(0)
+                        let damaged_now = failing.as_ref().map(|f| f.damage_events()).unwrap_or(0)
                             > damage_before;
                         if let Some(watch) = keep_serving_watch.take() {
                             let err_text = format!("{err:?}");
@@ -5793,8 +5810,8 @@ pub fn run_universe_caught(
                                     i,
                                     format!(
                                         "writes wedged on pending recovery operation {}: \
-                                         refused on first contact with a keep-serving budget \
-                                         of {}, reopen deferred",
+                                             refused on first contact with a keep-serving budget \
+                                             of {}, reopen deferred",
                                         watch.operation_id, sc.keep_serving_ops
                                     ),
                                     Oracle::LiveWriteAvailability.doc(),
@@ -5856,12 +5873,19 @@ pub fn run_universe_caught(
                             let retry = Box::pin(exec_world_op(&mut db, &wop)).await;
                             if let Err(retry_err) = &retry
                                 && !(matches!(retry_err, OmniError::RecoveryRequired { .. })
-                                    || is_legal_rejection(retry_err, &world, &wop, expected_conflict))
+                                    || is_legal_rejection(
+                                        retry_err,
+                                        &world,
+                                        &wop,
+                                        expected_conflict,
+                                    ))
                             {
                                 detectors::violation(
                                     DET_ACK_LOSS,
                                     i,
-                                    format!("illegal RETRY failure after ack-loss (op={wop:?}): {retry_err:?}"),
+                                    format!(
+                                        "illegal RETRY failure after ack-loss (op={wop:?}): {retry_err:?}"
+                                    ),
                                     "a retry against the client's own durable success fails only in cataloged shapes",
                                 );
                             }
@@ -5883,12 +5907,6 @@ pub fn run_universe_caught(
                                 Some((outcome, channel, "watch-interrupt"))
                             } else if format!("{err:?}").contains(FAULT_MARKER)
                                 || format!("{err:?}").contains(ACK_LOSS_MARKER)
-                                // corruption-attributed failures (and
-                                // marked latent sector errors, which advance the
-                                // same ledger) MUST reconcile — the op may have
-                                // durably written before its poisoned read, and
-                                // only the two-picture arbitration can rule
-                                // Applied vs NotApplied on a garbage-fed op.
                                 || damaged_now
                                 || is_recovery_barrier_rejection(&wop, &err)
                             {
@@ -6119,7 +6137,10 @@ pub fn run_universe_caught(
             );
             FOREIGN_SIDECAR_ROWS.lock().unwrap().push(format!(
                 "s11b-foreign-sidecar-blocks-maintenance@final-audit: {}",
-                text.replace(root, "<root>").chars().take(160).collect::<String>()
+                text.replace(root, "<root>")
+                    .chars()
+                    .take(160)
+                    .collect::<String>()
             ));
         }
         // closing capture — the loop's final op plus the closing
@@ -6278,7 +6299,7 @@ pub fn run_universe_caught(
                     sc.ops,
                     format!(
                         "OCC invariant: duplicate graph_commit_id on '{name}' \
-                         ({} ids, {} unique)",
+                             ({} ids, {} unique)",
                         branch_ids.len(),
                         unique.len()
                     ),
@@ -6321,8 +6342,14 @@ pub fn run_universe_caught(
         let latent_errors = failing.as_ref().map(|f| f.latent_errors()).unwrap_or(0);
         let writes_corrupted = failing.as_ref().map(|f| f.writes_corrupted()).unwrap_or(0);
         let writes_lost = failing.as_ref().map(|f| f.writes_lost()).unwrap_or(0);
-        let writes_misdirected = failing.as_ref().map(|f| f.writes_misdirected()).unwrap_or(0);
-        let persisted_consumed = failing.as_ref().map(|f| f.persisted_consumed()).unwrap_or(0);
+        let writes_misdirected = failing
+            .as_ref()
+            .map(|f| f.writes_misdirected())
+            .unwrap_or(0);
+        let persisted_consumed = failing
+            .as_ref()
+            .map(|f| f.persisted_consumed())
+            .unwrap_or(0);
         let stale_reads_served = failing.as_ref().map(|f| f.stale_reads_count()).unwrap_or(0);
         let stale_lists_served = failing.as_ref().map(|f| f.stale_lists_count()).unwrap_or(0);
         // Persisted tier: drain the foreign-sidecar carve-out rows into the
@@ -6364,15 +6391,7 @@ pub fn run_universe_caught(
             stale_reads_served,
             stale_lists_served,
         }
-    }))
-            })
-            .expect("spawn universe thread")
-            .join()
-    });
-    // Exit-side leak clear, BOTH outcomes — rationale on
-    // [`clear_process_slots`].
-    clear_process_slots();
-    result
+    }
 }
 
 // Pure-classifier honesty (unit level): the mutation

--- a/crates/omnigraph-dst/src/lib.rs
+++ b/crates/omnigraph-dst/src/lib.rs
@@ -35,11 +35,18 @@ pub mod cost;
 pub mod detectors;
 pub mod entropy;
 pub mod env_knobs;
+pub mod environment;
 pub mod fixtures;
 pub mod harness;
 pub mod lance_faults;
 pub mod lane_b;
+pub mod memory;
 pub mod oplog;
 pub mod rand;
 pub mod trace;
 pub mod write_census;
+
+pub use environment::{
+    UniverseEnvironment, UniversePhase, UniverseProcess, UniverseRun, UniverseScenario,
+    run_universe,
+};

--- a/crates/omnigraph-dst/src/memory.rs
+++ b/crates/omnigraph-dst/src/memory.rs
@@ -1,0 +1,245 @@
+//! Fresh graph namespaces over the shared-memory Lance provider.
+//! Backend ETag counters and incomplete multipart uploads are not reset.
+
+use std::collections::BTreeSet;
+use std::sync::{Arc, LazyLock, Mutex};
+
+use futures::{StreamExt, TryStreamExt};
+use lance_io::object_store::providers::shared_memory::SharedMemoryStoreProvider;
+use lance_io::object_store::{ObjectStoreParams, ObjectStoreProvider};
+use object_store::path::Path;
+use omnigraph::storage::ObjectStorageAdapter;
+use url::Url;
+
+use crate::environment::{UniverseEnvironment, UniverseProcess};
+
+static ACTIVE_AUTHORITIES: LazyLock<Mutex<BTreeSet<String>>> =
+    LazyLock::new(|| Mutex::new(BTreeSet::new()));
+
+#[derive(Clone, Debug)]
+pub struct MemoryEnvironment {
+    root: String,
+    seed: u64,
+    process: UniverseProcess,
+}
+
+impl MemoryEnvironment {
+    pub fn new(root: impl Into<String>, seed: u64, process: UniverseProcess) -> Self {
+        Self {
+            root: root.into(),
+            seed,
+            process,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct MemoryStorage {
+    pub root: String,
+    pub adapter: Arc<ObjectStorageAdapter>,
+    lance: Arc<dyn object_store::ObjectStore>,
+    prefix: Path,
+    _lease: AuthorityLease,
+}
+
+#[derive(Debug)]
+struct AuthorityLease(String);
+
+impl AuthorityLease {
+    fn acquire(authority: &str) -> Result<Self, String> {
+        let mut active = ACTIVE_AUTHORITIES
+            .lock()
+            .map_err(|_| "memory environment ownership lock poisoned".to_string())?;
+        if !active.insert(authority.to_string()) {
+            return Err(format!(
+                "memory environment authority is already active: {authority}"
+            ));
+        }
+        Ok(Self(authority.to_string()))
+    }
+}
+
+impl Drop for AuthorityLease {
+    fn drop(&mut self) {
+        ACTIVE_AUTHORITIES
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .remove(&self.0);
+    }
+}
+
+impl UniverseEnvironment for MemoryEnvironment {
+    type Resources = MemoryStorage;
+
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
+    fn process(&self) -> UniverseProcess {
+        self.process
+    }
+
+    async fn setup(&self) -> Result<MemoryStorage, String> {
+        let url = Url::parse(&self.root)
+            .map_err(|error| format!("invalid memory environment root: {error}"))?;
+        if url.scheme() != "shared-memory"
+            || url.host_str().is_none()
+            || !url.username().is_empty()
+            || url.password().is_some()
+            || url.query().is_some()
+            || url.fragment().is_some()
+        {
+            return Err(format!(
+                "memory environment requires a shared-memory root with an authority and no credentials, query or fragment: {}",
+                self.root
+            ));
+        }
+        let lease = AuthorityLease::acquire(url.authority())?;
+        let provider = SharedMemoryStoreProvider::default();
+        let prefix = provider
+            .extract_path(&url)
+            .map_err(|error| format!("invalid memory environment path: {error}"))?;
+        let lance = provider
+            .new_store(url, &ObjectStoreParams::default())
+            .await
+            .map_err(|error| format!("memory environment storage setup failed: {error}"))?
+            .inner;
+        if lance
+            .list(Some(&prefix))
+            .try_next()
+            .await
+            .map_err(|error| format!("memory environment preflight listing failed: {error}"))?
+            .is_some()
+        {
+            return Err(format!(
+                "memory environment root is not empty: {}",
+                self.root
+            ));
+        }
+        Ok(MemoryStorage {
+            root: self.root.clone(),
+            adapter: Arc::new(ObjectStorageAdapter::in_memory()),
+            lance,
+            prefix,
+            _lease: lease,
+        })
+    }
+
+    async fn teardown(&self, resources: &mut MemoryStorage) -> Result<(), String> {
+        let locations = resources
+            .lance
+            .list(Some(&resources.prefix))
+            .map_ok(|metadata| metadata.location)
+            .boxed();
+        resources
+            .lance
+            .delete_stream(locations)
+            .try_for_each(|_| async { Ok(()) })
+            .await
+            .map_err(|error| format!("memory environment cleanup failed: {error}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use object_store::{ObjectStoreExt, PutPayload};
+    use omnigraph::storage::StorageAdapter;
+
+    use super::*;
+
+    async fn raw_store(root: &str) -> Arc<dyn object_store::ObjectStore> {
+        SharedMemoryStoreProvider::default()
+            .new_store(Url::parse(root).unwrap(), &ObjectStoreParams::default())
+            .await
+            .unwrap()
+            .inner
+    }
+
+    async fn put(store: &dyn object_store::ObjectStore, path: &str) {
+        store
+            .put(&Path::from(path), PutPayload::from_static(b"stored"))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn repeated_descriptor_preserves_both_realms_until_teardown() {
+        let environment = MemoryEnvironment::new(
+            "shared-memory://memory-env-repeat/graph",
+            17,
+            UniverseProcess::Shared,
+        );
+        let mut first = environment.setup().await.unwrap();
+        let old_adapter = first.adapter.clone();
+        let uri = format!("{}/control", first.root);
+        first.adapter.write_text(&uri, "control").await.unwrap();
+        put(first.lance.as_ref(), "graph/table").await;
+        assert_eq!(first.adapter.read_text(&uri).await.unwrap(), "control");
+        assert!(first.lance.head(&Path::from("graph/table")).await.is_ok());
+        environment.teardown(&mut first).await.unwrap();
+        drop(first);
+
+        let mut second = environment.setup().await.unwrap();
+        assert!(!Arc::ptr_eq(&old_adapter, &second.adapter));
+        assert!(second.adapter.dst_list_all_keys().await.unwrap().is_empty());
+        assert!(
+            second
+                .lance
+                .list(Some(&second.prefix))
+                .try_next()
+                .await
+                .unwrap()
+                .is_none()
+        );
+        environment.teardown(&mut second).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn refuses_preexisting_namespace_without_deleting_it() {
+        let root = "shared-memory://memory-env-existing/graph";
+        let store = raw_store(root).await;
+        put(store.as_ref(), "graph/foreign").await;
+        let environment = MemoryEnvironment::new(root, 1, UniverseProcess::Shared);
+        assert!(environment.setup().await.unwrap_err().contains("not empty"));
+        assert!(store.head(&Path::from("graph/foreign")).await.is_ok());
+        store.delete(&Path::from("graph/foreign")).await.unwrap();
+        let mut resources = environment.setup().await.unwrap();
+        environment.teardown(&mut resources).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn cleanup_preserves_sibling_prefix() {
+        let root = "shared-memory://memory-env-prefix/graph";
+        let store = raw_store(root).await;
+        put(store.as_ref(), "graph-other/foreign").await;
+        let environment = MemoryEnvironment::new(root, 1, UniverseProcess::Shared);
+        let mut resources = environment.setup().await.unwrap();
+        put(resources.lance.as_ref(), "graph/owned").await;
+        environment.teardown(&mut resources).await.unwrap();
+        assert!(store.head(&Path::from("graph/owned")).await.is_err());
+        assert!(store.head(&Path::from("graph-other/foreign")).await.is_ok());
+        store
+            .delete(&Path::from("graph-other/foreign"))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn refuses_overlapping_authority_until_resources_drop() {
+        let first = MemoryEnvironment::new(
+            "shared-memory://memory-env-lease/first",
+            1,
+            UniverseProcess::Shared,
+        );
+        let second = MemoryEnvironment::new(
+            "shared-memory://memory-env-lease/second",
+            2,
+            UniverseProcess::Shared,
+        );
+        let resources = first.setup().await.unwrap();
+        assert!(second.setup().await.unwrap_err().contains("already active"));
+        drop(resources);
+        let mut resources = second.setup().await.unwrap();
+        second.teardown(&mut resources).await.unwrap();
+    }
+}

--- a/crates/omnigraph-gqt/.cargo/config.toml
+++ b/crates/omnigraph-gqt/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg", "tokio_unstable"]

--- a/crates/omnigraph-gqt/Cargo.toml
+++ b/crates/omnigraph-gqt/Cargo.toml
@@ -19,8 +19,15 @@ futures = { workspace = true }
 omnigraph = { package = "omnigraph-engine", path = "../omnigraph", version = "0.10.0" }
 omnigraph-compiler = { path = "../omnigraph-compiler", version = "0.10.0" }
 serde_json = { workspace = true }
+serde = { workspace = true }
+serde_yaml = { workspace = true }
+sha2 = { workspace = true }
+omnigraph-dst = { path = "../omnigraph-dst" }
 tempfile = { workspace = true }
 tokio = { workspace = true }
+
+[build-dependencies]
+sha2 = { workspace = true }
 
 [dev-dependencies]
 datatest-stable = "0.3"

--- a/crates/omnigraph-gqt/README.md
+++ b/crates/omnigraph-gqt/README.md
@@ -1,35 +1,170 @@
 # omnigraph-gqt
 
-The GQ logic-test corpus and its runner. Never part of a release build:
-`publish = false`, not a workspace default member, not in `release.yml`. A
-bare `cargo test` at the workspace root therefore skips it; `-p omnigraph-gqt`
-or `--workspace` reaches it.
+GQ describes operations; GQT describes the scenario and expectations; DST
+controls execution. This private test package is not shipped in release builds.
+Each top-level `cases/*.gqt` file is one test in the complete corpus.
+The format contract and future extensions live in
+[RFC 0045](../../docs/rfcs/0045-gq-logic-tests.md).
 
-- `cases/*.gqt`: the corpus. One file is one case: a `.pg` schema, JSONL
-  seed rows, and steps (queries, mutations, restarts, loops) with expected
-  outcomes. Format, refusal set, and comparison semantics: RFC 0045
-  (`docs/rfcs/0045-gq-logic-tests.md`). A regression for a merged fix is
-  `issue_NNN_<short_name>.gqt`; `scripts/check-fix-regression.py` looks for it
-  here.
-- `src/lib.rs`: the runner (case parsing, execution against a fresh
-  temporary store, the `--- expect shape` check of each rows step's result
-  columns, the result-schema check against the compiler's inferred schema,
-  row comparison, bless); `src/shape.rs` parses and compares the shape
-  section (a `.pg` type per column, or a node type name such as `p: Person`
-  for a bare node projection). Format self-tests and the corpus layout check are its unit
-  tests (`src/tests.rs`).
-- `tests/gq_logic_tests.rs`: one libtest test per case, named
-  `case::<file>.gqt`, registered at run time by `datatest-stable`
-  (`harness = false`). A new case file is picked up without any Rust change.
+## Explicit execution
 
-```bash
-cargo test -p omnigraph-gqt                                      # everything
-cargo test -p omnigraph-gqt --test gq_logic_tests issue_563      # cases whose name contains issue_563
-cargo test -p omnigraph-gqt --test gq_logic_tests -- --list      # one line per case
-cargo test -p omnigraph-gqt --test gq_logic_tests -- --test-threads=2
-OMNIGRAPH_GQ_BLESS=1 cargo test -p omnigraph-gqt --test gq_logic_tests my_case   # rewrite the failing expect
+Every case starts with its existing issue header, followed by required runner,
+schema and seed sections, with an optional `known_failure` section after runner.
+Configuration has no default target, storage, seed
+or timeout:
+
+```yaml
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+  - target: omnigraph-engine-dst
+    storage: in-memory-object-store
+    seeds: [0, 42]
 ```
 
-`OMNIGRAPH_GQ_CASE_TIMEOUT_SECS=<n>` (default 10) bounds each case's wall
-time; a case over budget belongs in a `heavy-repro:` `#[ignore]`d Rust test,
-not here.
+The complete scenario executes against a fresh graph for each environment.
+These two target/storage combinations are implemented. Direct engine execution
+currently refuses faults. Server targets, direct-engine memory storage, cloud
+storage and other combinations fail admission explicitly; their names do not
+imply implementation or qualification.
+
+One engine instance survives ordinary steps and expected errors. Only
+`--- restart` replaces it, reopening the same storage. GQ operations and GQT
+rows, shape, affected counts, errors and loop semantics are shared by both paths.
+Unordered row comparison preserves duplicate counts.
+
+The configuration accepts 1–16 distinct environment parameter sets,
+1–600000 milliseconds, and 1–64 distinct unsigned 64-bit seeds per DST
+environment. The required corpus refuses budgets above 10000 milliseconds;
+longer standalone reproductions must be selected deliberately. Unknown, duplicate, missing and inapplicable YAML fields are
+refused, as are aliases, anchors, merge keys and tags. Each DST seed runs twice
+in fresh worker processes; completed assertion failures also replay and later
+seeds still run within the file budget. Matching replay of a failing graph
+assertion remains a failure unless it meets the explicit known-failure contract below.
+
+## Fault placement
+
+Place a fault directly before its query or mutate operation:
+
+```yaml
+--- fault
+at: branch_merge.post_authority_capture
+occurrence: 1
+action: return_error
+scope: next_step
+```
+
+All four fields are required. The occurrence counts crossings inside that
+operation, including production retries; setup and preceding operations cannot
+consume it. The guard is removed before the next operation or restart. Fault directives inside loops are currently refused. GQT does not add retries.
+
+Supported returned-error hooks are `branch_merge.post_authority_capture`,
+`branch_merge.post_sidecar_pre_fork`, `branch_merge.post_effects_pre_confirm`,
+`branch_merge.post_phase_b_pre_manifest_commit` and
+`mutation.post_sidecar_pre_fork`. Occurrences must be 1–1000000. Delivery must
+appear exactly once in the selected operation's typed `Manifest` error message
+or `RecoveryRequired` reason. Text in data or an unrelated error cannot satisfy
+this check. An unknown hook or an unobserved occurrence fails.
+
+Process crashes, additional fault actions, server/CLI sessions and network
+simulation are future extensions. The engine recovery fixes remain separate:
+the three failure-then-write corpus cases continue to expect successful writes.
+
+## Known recovery failures
+
+An optional `--- known_failure` section directly after `--- runner` and before
+`--- schema` can retain a known recovery defect in the corpus:
+
+```yaml
+--- known_failure
+step: 4
+match:
+  error: RecoveryRequired
+  reason: "the exact OmniError::RecoveryRequired reason"
+```
+
+`step` and `match` are required. The step is a positive operation ordinal.
+The typed matcher currently supports only `error: RecoveryRequired`, with a
+nonempty exact `reason` of at most 2048 bytes. Unknown error names, including
+`Unknown`, and extra fields are refused. The old `--- fixme` syntax is refused.
+Use the existing `# issue` and `# notes` headers for issue identity and context;
+`# issue: none` remains valid when no issue has been assigned. This marker admits only
+engine-DST/in-memory cases without loops, targeting an ordinary mutate with
+its healthy `ok` or `affected` expectation. At least one supported fault must
+precede that step; no fault may occur at or after it.
+
+Every preceding assertion must pass, and each declared fault must have exact
+typed delivery evidence at its declared operation. The marked assertion must
+fail because that mutate returned the typed `OmniError::RecoveryRequired`
+variant with exactly the declared reason. An operation ID is retained in raw
+evidence but is not part of the marker. Text in rows, another error variant,
+another step, a changed reason, or missing fault evidence cannot match.
+
+The runner keeps the healthy assertions unchanged and stops at the failing
+step; later steps remain unexecuted. Every selected seed and its mandatory
+fresh replay must satisfy the marker and match the complete raw reports.
+Accepted attempts carry `known_failure: true`; the summary code is
+`known_failure`, and stdout prints `KNOWN_FAILURE`. This is an accepted known defect,
+not a genuine passing scenario. Partial selection remains `scope: partial`.
+An unexpectedly passing execution fails with `unexpected_pass`, requiring the
+stale marker to be removed. Setup, panic, timeout, cleanup and report failures
+are never waived. Replay re-derives marker acceptance and refuses forged
+status. Blessing a marked case is refused.
+
+## Run and reproduce
+
+Run the complete package from this directory, whose Cargo configuration enables
+seeded Tokio:
+
+```bash
+cd crates/omnigraph-gqt
+cargo test -p omnigraph-gqt --locked
+cargo test -p omnigraph-gqt --test gq_logic_tests -- --list
+cargo test -p omnigraph-gqt --test gq_logic_tests -- --test-threads=2
+cargo run --bin omnigraph-gqt -- cases/dst_restart_preserves_rows.gqt
+cargo run --bin omnigraph-gqt -- cases/dst_restart_preserves_rows.gqt --target omnigraph-engine-dst --storage in-memory-object-store --seed 42
+cargo run --bin omnigraph-gqt -- --replay ../../target/gqt-artifacts/invocation-EXAMPLE.json
+```
+
+`--target`, `--storage` and `--seed` only narrow declared executions; all supplied
+filters must match. There are no environment IDs or runner format versions.
+Reports identify each environment by its full declared parameters. Unknown selections
+fail; a selected subset is recorded explicitly. A workspace-root build without
+seeded Tokio refuses any selected DST environment. The required GQT CI context
+owns both this unavailable-build check and the entire configured corpus; Test
+Workspace explicitly excludes this separately tested package.
+
+The supervisor freezes the case bytes and selection before graph setup. Workers
+consume that input rather than reopening the case. The executable digest and a
+build-time source revision/content digest bind reproduction to the tested build.
+Each worker verifies those identities. Workers start with a cleared environment
+and explicit pool/entropy settings, preserving no inherited fault configuration.
+
+Every file invocation retains a JSON summary under workspace
+`target/gqt-artifacts/` and prints its path and replay command. Reports include
+frozen inputs, environment/seed/attempt attribution, assertion evidence,
+executed Arrow column types and rows, mutation counts, fault delivery, lifetime
+events and DST main snapshots. Failed assertions retain actual evidence too.
+Replay compares the recorded observations; it does not claim identical internal
+I/O or complete unqueried graph state. A changed executable or mismatched report
+fails. Direct-engine execution has no deterministic replay guarantee.
+
+Case input, worker reports and the terminal summary each have a 16 MiB limit.
+Observation collection also has a 100000-event limit; exceeding a bound fails
+explicitly. Missing or unwritable reports fail the invocation. The file timeout
+covers preflight and all selected worker attempts; overdue workers are killed
+and reaped within a separate 250 ms containment allowance. Failure to confirm
+containment stops further dispatch and retains the worker context. Remaining
+attempts are accounted for when execution cannot continue. The supervisor uses
+synchronous local-file reads and report writes; these host I/O operations are
+not interruptible by its worker deadline.
+
+`OMNIGRAPH_GQ_BLESS=1` is supported only for a case declaring one direct-engine
+environment. A subset selection cannot bless a multi-environment case. It rewrites a failing row or shape expectation and still returns
+failure until a subsequent run confirms it. DST cannot bless. The legacy
+`OMNIGRAPH_GQ_CASE_TIMEOUT_SECS` helper applies to library mechanism tests;
+file invocations refuse that ambient override and take their timeout from the
+runner section. Ambient fault, entropy, pool and traversal overrides also refuse
+admission, including replay.

--- a/crates/omnigraph-gqt/build.rs
+++ b/crates/omnigraph-gqt/build.rs
@@ -1,0 +1,63 @@
+use sha2::{Digest, Sha256};
+use std::process::Command;
+
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(tokio_unstable)");
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let revision = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(&root)
+        .output()
+        .expect("read source revision");
+    assert!(revision.status.success(), "source revision unavailable");
+    let revision = String::from_utf8(revision.stdout).expect("UTF-8 revision");
+    let inventory = Command::new("git")
+        .args([
+            "ls-files",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "-z",
+            "--",
+            "crates",
+            "Cargo.toml",
+            "Cargo.lock",
+            "rust-toolchain.toml",
+            ".cargo",
+        ])
+        .current_dir(&root)
+        .output()
+        .expect("read source inventory");
+    assert!(inventory.status.success(), "source inventory unavailable");
+    let mut paths = inventory
+        .stdout
+        .split(|b| *b == 0)
+        .filter(|p| !p.is_empty())
+        .collect::<Vec<_>>();
+    paths.sort();
+    paths.dedup();
+    let mut hash = Sha256::new();
+    for bytes in paths {
+        let name = std::str::from_utf8(bytes).expect("UTF-8 source path");
+        let path = root.join(name);
+        if !path.is_file() {
+            continue;
+        }
+        let contents = std::fs::read(&path).expect("read source snapshot");
+        hash.update((bytes.len() as u64).to_le_bytes());
+        hash.update(bytes);
+        hash.update((contents.len() as u64).to_le_bytes());
+        hash.update(contents);
+        println!("cargo::rerun-if-changed={}", path.display());
+    }
+    println!(
+        "cargo::rerun-if-changed={}",
+        root.join(".git/index").display()
+    );
+    println!(
+        "cargo::rerun-if-changed={}",
+        root.join(".git/HEAD").display()
+    );
+    println!("cargo::rustc-env=GQT_SOURCE_REVISION={}", revision.trim());
+    println!("cargo::rustc-env=GQT_SOURCE_DIGEST={:x}", hash.finalize());
+}

--- a/crates/omnigraph-gqt/cases/bare_node_projection_object_fields.gqt
+++ b/crates/omnigraph-gqt/cases/bare_node_projection_object_fields.gqt
@@ -1,6 +1,12 @@
 # issue: none
 # notes: the node object keeps `id` and the declared non-Blob, non-Vector properties (the engine rewrites Blob columns before executing, so the exclusion only runs here).
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/bare_node_projection_search_scan.gqt
+++ b/crates/omnigraph-gqt/cases/bare_node_projection_search_scan.gqt
@@ -1,6 +1,12 @@
 # issue: none
 # notes: the node object from a search scan and from an rrf-fused batch carries no `_score`, `_distance` or vector column.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Chunk {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/branch_merge_after_owner_reforks.gqt
+++ b/crates/omnigraph-gqt/cases/branch_merge_after_owner_reforks.gqt
@@ -3,6 +3,12 @@
 # notes: A replacement branch then writes and fast-forwards into feature.
 # notes: Further writes on feature and replacement stay isolated; child retains its old rows.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/branch_statement_lifecycle.gqt
+++ b/crates/omnigraph-gqt/cases/branch_statement_lifecycle.gqt
@@ -6,6 +6,12 @@
 # notes: The merge of b0 is a three-way merge (both sides wrote after the
 # notes: fork), so the outcome is `merged` rather than a fast forward.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/conjunction_filter_prefilters_nearest.gqt
+++ b/crates/omnigraph-gqt/cases/conjunction_filter_prefilters_nearest.gqt
@@ -4,6 +4,12 @@
 # notes: 0..9, the conjunction admits 7, 8, 9: exactly limit 3, so the scan
 # notes: returns k matching rows and the unfiltered top-3 (0, 1, 2) is not it.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/count_over_traversal_nearest_counts_window.gqt
+++ b/crates/omnigraph-gqt/cases/count_over_traversal_nearest_counts_window.gqt
@@ -7,6 +7,12 @@
 # notes: (0, 1) has no edge. Rust twin (probes: no overfetch on an aggregate):
 # notes: issue_567_aggregate_over_a_nearest_traversal_counts_the_window.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/diverged_merge_into_switched_owner.gqt
+++ b/crates/omnigraph-gqt/cases/diverged_merge_into_switched_owner.gqt
@@ -7,6 +7,12 @@
 # notes: three-way merge whose target side is unchanged. bob, written on main before the switch,
 # notes: is visible on feature only if the reclaimed fork starts from main's lineage.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/dst_fault_on_second_merge.gqt
+++ b/crates/omnigraph-gqt/cases/dst_fault_on_second_merge.gqt
@@ -1,0 +1,42 @@
+# issue: none
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine-dst
+    storage: in-memory-object-store
+    seeds: [42]
+
+--- schema
+node Person {
+    name: String @key
+}
+--- seed
+{"type":"Person","data":{"name":"alice"}}
+--- mutate
+branch create source
+--- expect ok
+--- mutate branch: source
+query add() { insert Person { name: "bob" } }
+--- expect affected: nodes=1 edges=0
+--- mutate
+branch merge source into main
+--- expect ok
+--- mutate branch: source
+query add_again() { insert Person { name: "carol" } }
+--- expect affected: nodes=1 edges=0
+--- fault
+at: branch_merge.post_authority_capture
+occurrence: 1
+action: return_error
+scope: next_step
+
+--- mutate
+branch merge source into main
+--- expect error: injected failpoint triggered: branch_merge.post_authority_capture
+--- query
+query accepted() { match { $p: Person } return { $p.name } }
+--- expect unordered
+{"p.name":"alice"}
+{"p.name":"bob"}
+--- expect shape
+p.name: String

--- a/crates/omnigraph-gqt/cases/dst_mutation_failure_keeps_writing.gqt
+++ b/crates/omnigraph-gqt/cases/dst_mutation_failure_keeps_writing.gqt
@@ -1,0 +1,49 @@
+# issue: none
+# notes: An effect-free mutation failure leaves the same Omnigraph writable.
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine-dst
+    storage: in-memory-object-store
+    seeds: [0, 42]
+
+--- known_failure
+step: 4
+match:
+  error: RecoveryRequired
+  reason: "pending Mutation recovery operation on branch 'work' blocks the synchronous write/control recovery barrier (datasets dataset for node type 'Person'); reopen the graph read-write before retrying"
+
+--- schema
+node Person {
+    name: String @key
+}
+--- seed
+{"type":"Person","data":{"name":"alice"}}
+--- mutate
+branch create work
+--- expect ok
+--- fault
+at: mutation.post_sidecar_pre_fork
+occurrence: 1
+action: return_error
+scope: next_step
+
+--- mutate branch: work
+query add() { insert Person { name: "bob" } }
+--- expect error: injected failpoint triggered: mutation.post_sidecar_pre_fork
+--- query branch: work
+query unchanged() { match { $p: Person } return { $p.name } }
+--- expect unordered
+{"p.name":"alice"}
+--- expect shape
+p.name: String
+--- mutate branch: work
+query retry() { insert Person { name: "carol" } }
+--- expect affected: nodes=1 edges=0
+--- query branch: work
+query after_write() { match { $p: Person } return { $p.name } }
+--- expect unordered
+{"p.name":"alice"}
+{"p.name":"carol"}
+--- expect shape
+p.name: String

--- a/crates/omnigraph-gqt/cases/dst_restart_preserves_rows.gqt
+++ b/crates/omnigraph-gqt/cases/dst_restart_preserves_rows.gqt
@@ -1,0 +1,27 @@
+# issue: none
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+  - target: omnigraph-engine-dst
+    storage: in-memory-object-store
+    seeds: [0, 42]
+
+--- schema
+node Person {
+    name: String @key
+}
+--- seed
+{"type":"Person","data":{"name":"alice"}}
+--- mutate
+query add() { insert Person { name: "bob" } }
+--- expect affected: nodes=1 edges=0
+--- restart
+--- query
+query all() { match { $p: Person } return { $p.name } }
+--- expect unordered
+{"p.name":"alice"}
+{"p.name":"bob"}
+--- expect shape
+p.name: String

--- a/crates/omnigraph-gqt/cases/empty_merge_preserves_lazy_child_first_write.gqt
+++ b/crates/omnigraph-gqt/cases/empty_merge_preserves_lazy_child_first_write.gqt
@@ -3,6 +3,12 @@
 # notes: Parent writes successfully; child's first write after restart starts from its old pin.
 # notes: Both writes stay isolated across a second restart.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/filtered_nearest_fewer_matches_than_limit.gqt
+++ b/crates/omnigraph-gqt/cases/filtered_nearest_fewer_matches_than_limit.gqt
@@ -3,6 +3,12 @@
 # notes: it is the 8th nearest, outside the unfiltered top-3 (rows 0..2). The
 # notes: answer is that one row, no padding from non-matching rows.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/filtered_nearest_more_matches_than_limit.gqt
+++ b/crates/omnigraph-gqt/cases/filtered_nearest_more_matches_than_limit.gqt
@@ -4,6 +4,12 @@
 # notes: filter, so the answer is the top-3 of the MATCHING rows, d004 (1.7),
 # notes: d005 (2.7), d006 (3.7), never the unfiltered top-3 filtered afterwards.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/filtered_nearest_no_match_is_empty.gqt
+++ b/crates/omnigraph-gqt/cases/filtered_nearest_no_match_is_empty.gqt
@@ -3,6 +3,12 @@
 # notes: matches (0 < 2), so the prefilter admits nothing and the answer is
 # notes: empty, no error, no unfiltered rows.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/inline_property_filter_prefilters_nearest.gqt
+++ b/crates/omnigraph-gqt/cases/inline_property_filter_prefilters_nearest.gqt
@@ -3,6 +3,12 @@
 # notes: `$d.n = 7` clause (I64 literal). One row matches (1 < 3), outside the
 # notes: unfiltered top-3; the answer is that row alone.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/issue_473_merge_net_zero_branch.gqt
+++ b/crates/omnigraph-gqt/cases/issue_473_merge_net_zero_branch.gqt
@@ -7,6 +7,12 @@
 # notes: merge reports `fast_forward` and publishes no registration for the
 # notes: table, and `main` still reads its one edge.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/issue_563_aggregate_uncapped.gqt
+++ b/crates/omnigraph-gqt/cases/issue_563_aggregate_uncapped.gqt
@@ -6,6 +6,12 @@
 # notes: Seed geometry: 20 chunks all matching "needle", strict tf gradient
 # notes: (tf = 20 - c) so BM25 has a real order with no ties.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Chunk {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/issue_563_underfill_retry.gqt
+++ b/crates/omnigraph-gqt/cases/issue_563_underfill_retry.gqt
@@ -7,6 +7,12 @@
 # notes: itself; the cap is the aggregate case's job. Rust twin:
 # notes: bm25_join_fills_limit_when_capped_scan_underfills_issue_563 (crates/omnigraph/tests/search.rs).
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Chunk {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/issue_567_filtered_nearest_returns_exact_matches.gqt
+++ b/crates/omnigraph-gqt/cases/issue_567_filtered_nearest_returns_exact_matches.gqt
@@ -6,6 +6,12 @@
 # notes: issue_567_ladder_stops_when_the_prefilter_admits_fewer_rows_than_k
 # notes: (tests/search.rs).
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/issue_567_traversal_nearest_fills_limit.gqt
+++ b/crates/omnigraph-gqt/cases/issue_567_traversal_nearest_fills_limit.gqt
@@ -9,6 +9,12 @@
 # notes: leave d00, d04 and d08 only. Rust twin:
 # notes: issue_567_nearest_traversal_prefilters_then_overfetches (tests/search.rs).
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/issue_583_keyed_edge_born_on_both_sides_merges_once.gqt
+++ b/crates/omnigraph-gqt/cases/issue_583_keyed_edge_born_on_both_sides_merges_once.gqt
@@ -5,6 +5,12 @@
 # notes: one logical edge changed identically and main holds it once: the bound
 # notes: traversal returns one row and counts 1. Unkeyed edge types keep both rows (multiset default, RFC 0044).
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/issue_603_negation_string_predicate_outer_var.gqt
+++ b/crates/omnigraph-gqt/cases/issue_603_negation_string_predicate_outer_var.gqt
@@ -4,6 +4,12 @@
 # notes: runs in the anti-join's inner pipeline, whose string column carries no
 # notes: null buffer; the in-memory arm folded nulls unconditionally.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/issue_605_two_anonymous_destinations.gqt
+++ b/crates/omnigraph-gqt/cases/issue_605_two_anonymous_destinations.gqt
@@ -4,6 +4,12 @@
 # notes: outer variable inside not {} whose filter was dropped; one outgoing
 # notes: edge per source keeps each step at one row per source.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/issue_613_self_loop_pinned_hop_distance.gqt
+++ b/crates/omnigraph-gqt/cases/issue_613_self_loop_pinned_hop_distance.gqt
@@ -1,6 +1,12 @@
 # issue: 613
 # red_on: 2026-09-03, pre-fix build: knows{2,2} from alice returned bob, one hop away, instead of no rows.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/issue_618_json_f32_datetime_null_spelling.gqt
+++ b/crates/omnigraph-gqt/cases/issue_618_json_f32_datetime_null_spelling.gqt
@@ -5,6 +5,12 @@
 # notes: and without milliseconds (no `Z`, no `.000`), and a null cell's key
 # notes: omitted from its row (the expected row carries no `p.note`).
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Point {
     name: String @key

--- a/crates/omnigraph-gqt/cases/issue_620_duplicate_projection_alias_refused.gqt
+++ b/crates/omnigraph-gqt/cases/issue_620_duplicate_projection_alias_refused.gqt
@@ -1,6 +1,12 @@
 # issue: 620
 # red_on: 2026-09-03, main @ 0ff0ae3b: the query succeeded, one column `value` holding 7, the name silently dropped (step 1); steps 2-9 succeed the same way on 44211fce, which has no refusal to name.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Pair {
     name: String @key

--- a/crates/omnigraph-gqt/cases/issue_623_min_max_over_date_and_bool.gqt
+++ b/crates/omnigraph-gqt/cases/issue_623_min_max_over_date_and_bool.gqt
@@ -1,6 +1,12 @@
 # issue: 623
 # red_on: 2026-09-04, main @ 8ca9b12c: refused at typecheck (min requires numeric or string type, got Date?); the Bool and DateTime columns are refused by the same rule.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/issue_631_bare_node_projection_returns_node.gqt
+++ b/crates/omnigraph-gqt/cases/issue_631_bare_node_projection_returns_node.gqt
@@ -1,6 +1,12 @@
 # issue: 631
 # red_on: 2026-09-05, stock main at 8ca9b12c: `return { $p }` gave `{"p": "alice"}`, the id string, instead of the node object.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/issue_634_blob_property_keeps_search_ranking.gqt
+++ b/crates/omnigraph-gqt/cases/issue_634_blob_property_keeps_search_ranking.gqt
@@ -9,6 +9,12 @@
 # notes: expected orders are the reverse of the id tie-break order, so a
 # notes: present-but-constant ranking column fails the step.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Chunk {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/issue_639_shared_merged_parent_base.gqt
+++ b/crates/omnigraph-gqt/cases/issue_639_shared_merged_parent_base.gqt
@@ -4,6 +4,12 @@
 # notes: sets b's age. The base of the t-into-main merge must be x's commit; the
 # notes: fork point (a=0) makes x's write look like an edit on both sides.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/issue_640_search_score_projection.gqt
+++ b/crates/omnigraph-gqt/cases/issue_640_search_score_projection.gqt
@@ -4,6 +4,12 @@
 # notes: `{var}._score`) and must repeat the leading `order` key (T33); `_distance` is the squared L2 distance.
 # notes: the bm25 values pin Lance 11's BM25 (k1 1.2, b 0.75, default tokenizer) on this corpus; a Lance bump that changes scoring reds that step by design.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/issue_665_nearest_retry_same_limit.gqt
+++ b/crates/omnigraph-gqt/cases/issue_665_nearest_retry_same_limit.gqt
@@ -4,6 +4,12 @@
 # notes: which has no out-edge; the scan's top-1 is dropped by the traversal and
 # notes: the under-fill retry reruns with the same k, so the answer stays empty.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/issue_671_date_string_with_time_of_day_refused.gqt
+++ b/crates/omnigraph-gqt/cases/issue_671_date_string_with_time_of_day_refused.gqt
@@ -3,6 +3,12 @@
 # notes: A Date string with a time of day is refused on every user-facing entry;
 # notes: loader entry: loader/mod.rs load_refuses_date_string_with_a_time_of_day.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Event {
     name: String @key

--- a/crates/omnigraph-gqt/cases/issue_681_sibling_merge_readopts_deleted_edge.gqt
+++ b/crates/omnigraph-gqt/cases/issue_681_sibling_merge_readopts_deleted_edge.gqt
@@ -3,6 +3,12 @@
 # notes: unkeyed edge type (RFC 0044): b0's re-insert of a pair main holds is a fresh row, b1's delete
 # notes: removes the inherited row; merge b1 empties main, merge b0 adopts the fresh row. DST nightly seed 221206.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/issue_683_owner_writes_after_fast_forward_with_child.gqt
+++ b/crates/omnigraph-gqt/cases/issue_683_owner_writes_after_fast_forward_with_child.gqt
@@ -4,6 +4,12 @@
 # notes: The lazy child b1 keeps its former b0 rows across a restart;
 # notes: the new b0 write remains isolated from both b1 and main.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/issue_694_effect_free_merge_keeps_writing.gqt
+++ b/crates/omnigraph-gqt/cases/issue_694_effect_free_merge_keeps_writing.gqt
@@ -1,0 +1,115 @@
+# issue: 694
+# red_on: ed3ea500 (2026-09-09): step 6 rejects the unrelated write with pending BranchMerge
+# notes: The runner section injects one merge failure under DST.
+# notes: Reads and the next unrelated write use the same Omnigraph without reopening.
+
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine-dst
+    storage: in-memory-object-store
+    seeds: [0, 42]
+
+--- known_failure
+step: 6
+match:
+  error: RecoveryRequired
+  reason: "pending BranchMerge recovery operation on branch 'target' blocks the synchronous write/control recovery barrier (datasets dataset for node type 'Person'); reopen the graph read-write before retrying"
+
+--- schema
+node Person {
+    name: String @key
+}
+
+node Marker {
+    name: String @key
+}
+
+--- seed
+{"type":"Person","data":{"name":"alice"}}
+{"type":"Marker","data":{"name":"initial"}}
+
+--- mutate
+branch create source
+
+--- expect ok
+
+--- mutate
+branch create target
+
+--- expect ok
+
+--- mutate branch: source
+query add_source_row() {
+    insert Person { name: "bob" }
+}
+
+--- expect affected: nodes=1 edges=0
+
+--- fault
+at: branch_merge.post_sidecar_pre_fork
+occurrence: 1
+action: return_error
+scope: next_step
+
+--- mutate
+branch merge source into target
+
+--- expect error: injected failpoint triggered: branch_merge.post_sidecar_pre_fork
+
+--- query branch: target
+query read_after_failure() {
+    match { $p: Person }
+    return { $p.name }
+}
+
+--- expect unordered
+{"p.name": "alice"}
+
+--- expect shape
+p.name: String
+
+--- mutate branch: target
+query unrelated_write() {
+    insert Marker { name: "after_failure" }
+}
+
+--- expect affected: nodes=1 edges=0
+
+--- query branch: target
+query markers_after_write() {
+    match { $m: Marker }
+    return { $m.name }
+}
+
+--- expect unordered
+{"m.name":"initial"}
+{"m.name":"after_failure"}
+
+--- expect shape
+m.name: String
+
+--- query branch: target
+query target_after_write() {
+    match { $p: Person }
+    return { $p.name }
+}
+
+--- expect unordered
+{"p.name": "alice"}
+
+--- expect shape
+p.name: String
+
+--- query branch: source
+query source_unchanged() {
+    match { $p: Person }
+    return { $p.name }
+}
+
+--- expect unordered
+{"p.name": "alice"}
+{"p.name": "bob"}
+
+--- expect shape
+p.name: String

--- a/crates/omnigraph-gqt/cases/issue_694_unconfirmed_merge_keeps_writing.gqt
+++ b/crates/omnigraph-gqt/cases/issue_694_unconfirmed_merge_keeps_writing.gqt
@@ -1,0 +1,119 @@
+# issue: 694
+# red_on: ed3ea500 (2026-09-09): step 6 rejects the unrelated write with pending BranchMerge
+# notes: The runner section injects one merge failure under DST.
+# notes: Reads and the next unrelated write use the same Omnigraph without reopening.
+
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine-dst
+    storage: in-memory-object-store
+    seeds: [0, 42]
+
+--- known_failure
+step: 6
+match:
+  error: RecoveryRequired
+  reason: "pending BranchMerge recovery operation on branch 'main' blocks the synchronous write/control recovery barrier (datasets dataset for node type 'Person'); reopen the graph read-write before retrying"
+
+--- schema
+node Person {
+    name: String @key
+}
+
+node Marker {
+    name: String @key
+}
+
+--- seed
+{"type":"Person","data":{"name":"alice"}}
+{"type":"Marker","data":{"name":"initial"}}
+
+--- mutate
+branch create source
+
+--- expect ok
+
+--- mutate branch: source
+query add_source_row() {
+    insert Person { name: "bob" }
+}
+
+--- expect affected: nodes=1 edges=0
+
+--- mutate
+query advance_target() {
+    insert Person { name: "carol" }
+}
+
+--- expect affected: nodes=1 edges=0
+
+--- fault
+at: branch_merge.post_effects_pre_confirm
+occurrence: 1
+action: return_error
+scope: next_step
+
+--- mutate
+branch merge source into main
+
+--- expect error: injected failpoint triggered: branch_merge.post_effects_pre_confirm
+
+--- query branch: main
+query read_after_failure() {
+    match { $p: Person }
+    return { $p.name }
+}
+
+--- expect unordered
+{"p.name": "alice"}
+{"p.name": "carol"}
+
+--- expect shape
+p.name: String
+
+--- mutate branch: main
+query unrelated_write() {
+    insert Marker { name: "after_failure" }
+}
+
+--- expect affected: nodes=1 edges=0
+
+--- query branch: main
+query markers_after_write() {
+    match { $m: Marker }
+    return { $m.name }
+}
+
+--- expect unordered
+{"m.name":"initial"}
+{"m.name":"after_failure"}
+
+--- expect shape
+m.name: String
+
+--- query branch: main
+query target_after_write() {
+    match { $p: Person }
+    return { $p.name }
+}
+
+--- expect unordered
+{"p.name": "alice"}
+{"p.name": "carol"}
+
+--- expect shape
+p.name: String
+
+--- query branch: source
+query source_unchanged() {
+    match { $p: Person }
+    return { $p.name }
+}
+
+--- expect unordered
+{"p.name": "alice"}
+{"p.name": "bob"}
+
+--- expect shape
+p.name: String

--- a/crates/omnigraph-gqt/cases/keyed_edge_delete_wins_over_readd.gqt
+++ b/crates/omnigraph-gqt/cases/keyed_edge_delete_wins_over_readd.gqt
@@ -2,6 +2,12 @@
 # notes: keyed twin of issue_681_sibling_merge_readopts_deleted_edge.gqt: with @key(src, dst) (RFC 0044) b0's
 # notes: re-insert upserts the same row, so b1's delete wins in both merges and the pair stays gone.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/long_branch_names_first_touch.gqt
+++ b/crates/omnigraph-gqt/cases/long_branch_names_first_touch.gqt
@@ -1,5 +1,11 @@
 # issue: none
 # notes: First-touch table refs stay bounded when logical names are long or encoded.
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/merge_adopt_equal_source_version_collides.gqt
+++ b/crates/omnigraph-gqt/cases/merge_adopt_equal_source_version_collides.gqt
@@ -5,6 +5,12 @@
 # notes: version number on different native branches. Adopting `main` into
 # notes: `feature` must fast-forward and show all four edges.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/merge_adopt_equal_version_return_trip.gqt
+++ b/crates/omnigraph-gqt/cases/merge_adopt_equal_version_return_trip.gqt
@@ -6,6 +6,12 @@
 # notes: `feature` and the branch merges back; `main` must keep all four edges
 # notes: across a restart.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/merge_adopt_lazy_target_below_inherited_version.gqt
+++ b/crates/omnigraph-gqt/cases/merge_adopt_lazy_target_below_inherited_version.gqt
@@ -5,6 +5,12 @@
 # notes: table is `main`'s at a version above `feature`'s. Merging `feature`
 # notes: into `child` must show feature's value on child.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/merge_adopt_lower_source_version_keeps_edges.gqt
+++ b/crates/omnigraph-gqt/cases/merge_adopt_lower_source_version_keeps_edges.gqt
@@ -6,6 +6,12 @@
 # notes: on `feature`. Then edit only a node on `feature` and merge back: `main`
 # notes: must keep the edge.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/merge_base_one_sided_deleted_parent.gqt
+++ b/crates/omnigraph-gqt/cases/merge_base_one_sided_deleted_parent.gqt
@@ -4,6 +4,12 @@
 # notes: walk reaches x's commit before shared history, so it is not a base
 # notes: candidate and the merge proceeds on the fork point (RFC 0063 step 1).
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/merge_confirmed_failure_keeps_writing.gqt
+++ b/crates/omnigraph-gqt/cases/merge_confirmed_failure_keeps_writing.gqt
@@ -1,0 +1,113 @@
+# issue: none
+# notes: The runner section injects one merge failure under DST.
+# notes: Reads and the next unrelated write use the same Omnigraph without reopening.
+
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine-dst
+    storage: in-memory-object-store
+    seeds: [0, 42]
+
+--- schema
+node Person {
+    name: String @key
+}
+
+node Marker {
+    name: String @key
+}
+
+--- seed
+{"type":"Person","data":{"name":"alice"}}
+{"type":"Marker","data":{"name":"initial"}}
+
+--- mutate
+branch create source
+
+--- expect ok
+
+--- mutate branch: source
+query add_source_row() {
+    insert Person { name: "bob" }
+}
+
+--- expect affected: nodes=1 edges=0
+
+--- mutate
+query advance_target() {
+    insert Person { name: "carol" }
+}
+
+--- expect affected: nodes=1 edges=0
+
+--- fault
+at: branch_merge.post_phase_b_pre_manifest_commit
+occurrence: 1
+action: return_error
+scope: next_step
+
+--- mutate
+branch merge source into main
+
+--- expect error: injected failpoint triggered: branch_merge.post_phase_b_pre_manifest_commit
+
+--- query branch: main
+query read_after_failure() {
+    match { $p: Person }
+    return { $p.name }
+}
+
+--- expect unordered
+{"p.name": "alice"}
+{"p.name": "carol"}
+
+--- expect shape
+p.name: String
+
+--- mutate branch: main
+query unrelated_write() {
+    insert Marker { name: "after_failure" }
+}
+
+--- expect affected: nodes=1 edges=0
+
+--- query branch: main
+query markers_after_write() {
+    match { $m: Marker }
+    return { $m.name }
+}
+
+--- expect unordered
+{"m.name":"initial"}
+{"m.name":"after_failure"}
+
+--- expect shape
+m.name: String
+
+--- query branch: main
+query target_after_write() {
+    match { $p: Person }
+    return { $p.name }
+}
+
+--- expect unordered
+{"p.name": "alice"}
+{"p.name": "carol"}
+{"p.name": "bob"}
+
+--- expect shape
+p.name: String
+
+--- query branch: source
+query source_unchanged() {
+    match { $p: Person }
+    return { $p.name }
+}
+
+--- expect unordered
+{"p.name": "alice"}
+{"p.name": "bob"}
+
+--- expect shape
+p.name: String

--- a/crates/omnigraph-gqt/cases/merge_pre_arm_failure_keeps_writing.gqt
+++ b/crates/omnigraph-gqt/cases/merge_pre_arm_failure_keeps_writing.gqt
@@ -1,0 +1,112 @@
+# issue: none
+# notes: The runner section injects one merge failure under DST.
+# notes: Reads and the next unrelated write use the same Omnigraph without reopening.
+
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine-dst
+    storage: in-memory-object-store
+    seeds: [0, 42]
+
+--- schema
+node Person {
+    name: String @key
+}
+
+node Marker {
+    name: String @key
+}
+
+--- seed
+{"type":"Person","data":{"name":"alice"}}
+{"type":"Marker","data":{"name":"initial"}}
+
+--- mutate
+branch create source
+
+--- expect ok
+
+--- mutate branch: source
+query add_source_row() {
+    insert Person { name: "bob" }
+}
+
+--- expect affected: nodes=1 edges=0
+
+--- mutate
+query advance_target() {
+    insert Person { name: "carol" }
+}
+
+--- expect affected: nodes=1 edges=0
+
+--- fault
+at: branch_merge.post_authority_capture
+occurrence: 1
+action: return_error
+scope: next_step
+
+--- mutate
+branch merge source into main
+
+--- expect error: injected failpoint triggered: branch_merge.post_authority_capture
+
+--- query branch: main
+query read_after_failure() {
+    match { $p: Person }
+    return { $p.name }
+}
+
+--- expect unordered
+{"p.name": "alice"}
+{"p.name": "carol"}
+
+--- expect shape
+p.name: String
+
+--- mutate branch: main
+query unrelated_write() {
+    insert Marker { name: "after_failure" }
+}
+
+--- expect affected: nodes=1 edges=0
+
+--- query branch: main
+query markers_after_write() {
+    match { $m: Marker }
+    return { $m.name }
+}
+
+--- expect unordered
+{"m.name":"initial"}
+{"m.name":"after_failure"}
+
+--- expect shape
+m.name: String
+
+--- query branch: main
+query target_after_write() {
+    match { $p: Person }
+    return { $p.name }
+}
+
+--- expect unordered
+{"p.name": "alice"}
+{"p.name": "carol"}
+
+--- expect shape
+p.name: String
+
+--- query branch: source
+query source_unchanged() {
+    match { $p: Person }
+    return { $p.name }
+}
+
+--- expect unordered
+{"p.name": "alice"}
+{"p.name": "bob"}
+
+--- expect shape
+p.name: String

--- a/crates/omnigraph-gqt/cases/mutation_error_typed.gqt
+++ b/crates/omnigraph-gqt/cases/mutation_error_typed.gqt
@@ -4,6 +4,12 @@
 # notes: merely misses is not an error: delete on an absent key succeeds with zero
 # notes: affected counts.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/nearest_corpus_smaller_than_limit.gqt
+++ b/crates/omnigraph-gqt/cases/nearest_corpus_smaller_than_limit.gqt
@@ -4,6 +4,12 @@
 # notes: no error. One case for both spellings of this regime (a 1-doc corpus
 # notes: under limit 3 and a 50-doc corpus under limit 100 sat on this path).
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/nearest_interleaves_rows_around_the_query.gqt
+++ b/crates/omnigraph-gqt/cases/nearest_interleaves_rows_around_the_query.gqt
@@ -3,6 +3,12 @@
 # notes: d005 (0.3), d006 (0.7), d004 (1.3), interleaved around the point, so a
 # notes: row-order or insertion-order answer fails. No filter, no traversal.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/nearest_ranks_updated_embedding.gqt
+++ b/crates/omnigraph-gqt/cases/nearest_ranks_updated_embedding.gqt
@@ -4,6 +4,12 @@
 # notes: SECOND by its new vector (0.7, between d000 at 0.3 and d001 at 1.3) and
 # notes: exactly 5 rows come back, so its old position is gone, not a sixth row.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/nearest_sees_rows_inserted_after_index_build.gqt
+++ b/crates/omnigraph-gqt/cases/nearest_sees_rows_inserted_after_index_build.gqt
@@ -5,6 +5,12 @@
 # notes: ranking spans indexed and unindexed fragments. Then `--- restart` and
 # notes: the same query: the committed rows survive the reopen, same answer.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/nearest_skips_deleted_rows_and_fills_limit.gqt
+++ b/crates/omnigraph-gqt/cases/nearest_skips_deleted_rows_and_fills_limit.gqt
@@ -4,6 +4,12 @@
 # notes: masking deletions after the top-k answers nothing. Deleted rows never
 # notes: return and the limit fills from the 5 survivors (5 > 3): d003, d004, d005.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/negated_filter_nearest_refetches_survivors.gqt
+++ b/crates/omnigraph-gqt/cases/negated_filter_nearest_refetches_survivors.gqt
@@ -5,6 +5,12 @@
 # notes: rerun asks for 16 of the 20 live rows (16 < 20, a wider rung) and holds
 # notes: survivors 10..15 (6 > 4): d010, d011, d012, d013.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/negated_filter_nearest_sparse_survivors.gqt
+++ b/crates/omnigraph-gqt/cases/negated_filter_nearest_sparse_survivors.gqt
@@ -6,6 +6,12 @@
 # notes: d049, d050. Short here = the exact pass did not run; more rows = a
 # notes: `not` block was pushed or the anti-join leaked.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/order_clause_aggregate_refused.gqt
+++ b/crates/omnigraph-gqt/cases/order_clause_aggregate_refused.gqt
@@ -4,6 +4,12 @@
 # notes: supported spelling. The refusal message carries no error-code prefix, so
 # notes: the raw fragment is the pin.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/ordered_two_key_sort.gqt
+++ b/crates/omnigraph-gqt/cases/ordered_two_key_sort.gqt
@@ -4,6 +4,12 @@
 # notes: expect may depend on: it is the `@key` value for keyed node types and a
 # notes: per-load ULID otherwise; the second key here is what makes the order total.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/owner_rewrites_after_pointer_switch.gqt
+++ b/crates/omnigraph-gqt/cases/owner_rewrites_after_pointer_switch.gqt
@@ -4,6 +4,12 @@
 # notes: old fork is an orphan and the write reclaims it and succeeds. bob, written on main before
 # notes: the switch, is visible on the branch only if the reclaimed fork starts from main's lineage.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/owner_write_after_child_forked_from_former_ref.gqt
+++ b/crates/omnigraph-gqt/cases/owner_write_after_child_forked_from_former_ref.gqt
@@ -3,6 +3,12 @@
 # notes: Feature writes successfully while that ancestor is still required by child.
 # notes: Both branches retain independent rows after restart and further writes.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/param_filter_prefilters_nearest.gqt
+++ b/crates/omnigraph-gqt/cases/param_filter_prefilters_nearest.gqt
@@ -3,6 +3,12 @@
 # notes: docs, limit 3: one row matches (1 < 3), outside the unfiltered top-3;
 # notes: the answer is that row alone.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/parent_retirement.gqt
+++ b/crates/omnigraph-gqt/cases/parent_retirement.gqt
@@ -4,6 +4,12 @@
 # notes: Cleanup and native storage assertions live
 # notes: in branching.rs::branch_delete_retires_native_parent_and_cleanup_preserves_live_child.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/restart_survives_reopen.gqt
+++ b/crates/omnigraph-gqt/cases/restart_survives_reopen.gqt
@@ -2,6 +2,12 @@
 # notes: pins that committed mutations survive a store reopen; exercises
 # notes: mutate, loop, restart, and read steps in one case.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/reverse_traversal_nearest_ranks_targets.gqt
+++ b/crates/omnigraph-gqt/cases/reverse_traversal_nearest_ranks_targets.gqt
@@ -4,6 +4,12 @@
 # notes: prefilters from the incoming adjacency), limit 2 (3 > 2): d010, d020. An
 # notes: engine reading the outgoing side answers d009, d019.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/rrf_nearest_and_bm25_agreeing_arms.gqt
+++ b/crates/omnigraph-gqt/cases/rrf_nearest_and_bm25_agreeing_arms.gqt
@@ -3,6 +3,12 @@
 # notes: same order as nearest from -0.3: both arms agree, so the fused top-3 is
 # notes: rows 0..2 (unordered set: rrf refuses ordered expects).
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/rrf_nearest_arm_under_traversal.gqt
+++ b/crates/omnigraph-gqt/cases/rrf_nearest_arm_under_traversal.gqt
@@ -4,6 +4,12 @@
 # notes: eligible rows in row order and the unfiltered top-2 (0, 1) has no edge,
 # notes: so the fused set is the two nearest docs with an edge (3 > 2): d003, d006.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/second_merge_of_merged_branch.gqt
+++ b/crates/omnigraph-gqt/cases/second_merge_of_merged_branch.gqt
@@ -8,6 +8,12 @@
 # notes: correctly then as now, so no build was ever red on it: this is a
 # notes: feature case that pins the answer.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/selfloop_rows_gated_once.gqt
+++ b/crates/omnigraph-gqt/cases/selfloop_rows_gated_once.gqt
@@ -2,6 +2,12 @@
 # notes: two rows of one self-loop pair (unkeyed type): the gated traversal returns the pair once, the bound
 # notes: traversal counts both rows. The DST model's membership oracles rely on this grain.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Person {
     name: String @key

--- a/crates/omnigraph-gqt/cases/traversal_nearest_empty_after_sources_deleted.gqt
+++ b/crates/omnigraph-gqt/cases/traversal_nearest_empty_after_sources_deleted.gqt
@@ -5,6 +5,12 @@
 # notes: answer is empty. Rust twin (probes: no scan runs):
 # notes: issue_567_proven_empty_eligible_set_runs_no_scan_and_no_overfetch.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/traversal_nearest_fanout_counts_rows.gqt
+++ b/crates/omnigraph-gqt/cases/traversal_nearest_fanout_counts_rows.gqt
@@ -6,6 +6,12 @@
 # notes: 4: the two nearest docs' four (d, t) pairs (6 > 4); the order within one
 # notes: d is unspecified, so the expect is the unordered set.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/traversal_nearest_gate_ranks_eligible_docs.gqt
+++ b/crates/omnigraph-gqt/cases/traversal_nearest_gate_ranks_eligible_docs.gqt
@@ -6,6 +6,12 @@
 # notes: (5.3), d040 (14.7), so the answer is the exact order among the eligible
 # notes: ids, not row order. The unfiltered top-3 (25, 26, 24) has no edge.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/traversal_nearest_over_empty_corpus.gqt
+++ b/crates/omnigraph-gqt/cases/traversal_nearest_over_empty_corpus.gqt
@@ -1,6 +1,12 @@
 # issue: none
 # notes: an empty corpus with a traversal: nearest limit 10 returns no rows and no error.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/traversal_nearest_overfetch_fills_limit.gqt
+++ b/crates/omnigraph-gqt/cases/traversal_nearest_overfetch_fills_limit.gqt
@@ -8,6 +8,12 @@
 # notes: Rust twin (probes: one overfetch, no exact pass):
 # notes: issue_567_nearest_gate_falls_back_above_the_ratio.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/traversal_nearest_rare_survivors_exact_pass.gqt
+++ b/crates/omnigraph-gqt/cases/traversal_nearest_rare_survivors_exact_pass.gqt
@@ -10,6 +10,12 @@
 # notes: issue_567_nearest_traversal_prefilters_then_overfetches (tests/search.rs),
 # notes: forced-postfilter half.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/traversal_nearest_single_eligible_doc.gqt
+++ b/crates/omnigraph-gqt/cases/traversal_nearest_single_eligible_doc.gqt
@@ -4,6 +4,12 @@
 # notes: Limit 3 with 1 eligible (1 < 3): the prefiltered scan admits fewer rows
 # notes: than k and the answer is that one row, no padding, no error.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/traversal_nearest_with_source_and_target_filters.gqt
+++ b/crates/omnigraph-gqt/cases/traversal_nearest_with_source_and_target_filters.gqt
@@ -13,6 +13,12 @@
 # notes: k 2 (16, 17) and 8 (16..23: one source, 20) are short, k 32 fills:
 # notes: d020, d025. Three different answers, one per path.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/cases/two_hop_nearest_ranks_chain_heads.gqt
+++ b/crates/omnigraph-gqt/cases/two_hop_nearest_ranks_chain_heads.gqt
@@ -6,6 +6,12 @@
 # notes: adds nothing; the next rung (32) would cover the 20 live rows, so the
 # notes: exact pass runs and the answer is the two nearest heads, d000, d010.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Doc {
     slug: String @key

--- a/crates/omnigraph-gqt/src/dst_runner.rs
+++ b/crates/omnigraph-gqt/src/dst_runner.rs
@@ -1,0 +1,1383 @@
+use std::cell::RefCell;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use omnigraph::error::OmniError;
+use omnigraph_compiler::QueryResult;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::runner_config::{Environment, Execution, Fault};
+use crate::{CaseOutcome, parse_case, stem_of};
+
+mod known_failure;
+mod settings;
+
+pub(crate) fn validate_known_failure(case: &crate::Case) -> Result<(), String> {
+    known_failure::validate(case)
+}
+
+const WORKER_INPUT: &str = "OMNIGRAPH_GQT_WORKER_INPUT";
+const WORKER_REPORT: &str = "OMNIGRAPH_GQT_WORKER_REPORT";
+const LIMIT: usize = 16 * 1024 * 1024;
+
+tokio::task_local! {
+    static OBSERVATIONS: RefCell<Observations>;
+}
+
+#[derive(Default)]
+struct Observations {
+    values: Vec<String>,
+    bytes: usize,
+    overflow: bool,
+    fault_hits: Vec<String>,
+    operation: Option<serde_json::Value>,
+    evidence: Vec<serde_json::Value>,
+    lifecycle: Option<[std::sync::Arc<std::sync::atomic::AtomicU64>; 2]>,
+}
+
+pub(crate) fn observe(value: impl FnOnce() -> String) {
+    OBSERVATIONS
+        .try_with(|events| {
+            let mut events = events.borrow_mut();
+            if events.overflow {
+                return;
+            }
+            let value = value();
+            events.bytes += value.len();
+            if events.bytes > LIMIT || events.values.len() + events.evidence.len() >= 100_000 {
+                events.overflow = true;
+            } else {
+                events.values.push(value);
+            }
+        })
+        .unwrap_or_default();
+}
+
+pub(crate) fn lifetime_counts() -> Option<[u64; 2]> {
+    OBSERVATIONS
+        .try_with(|events| {
+            events.borrow().lifecycle.as_ref().map(|counts| {
+                counts
+                    .each_ref()
+                    .map(|c| c.load(std::sync::atomic::Ordering::Relaxed))
+            })
+        })
+        .ok()
+        .flatten()
+}
+
+#[cfg(tokio_unstable)]
+fn lifecycle_probe() -> (
+    [std::sync::Arc<std::sync::atomic::AtomicU64>; 2],
+    Vec<omnigraph::failpoints::ScopedFailPoint>,
+) {
+    let counts = [
+        std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
+        std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
+    ];
+    let guards = [
+        omnigraph::failpoints::names::INIT_AFTER_SCHEMA_CONTRACT_WRITTEN,
+        omnigraph::failpoints::names::OPEN_BEFORE_SCHEMA_CONTRACT_READ,
+    ]
+    .into_iter()
+    .zip(counts.iter())
+    .map(|(name, count)| {
+        let count = count.clone();
+        omnigraph::failpoints::ScopedFailPoint::with_callback(name, move || {
+            count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        })
+    })
+    .collect();
+    (counts, guards)
+}
+
+pub(crate) fn begin_operation(value: serde_json::Value) {
+    OBSERVATIONS
+        .try_with(|events| events.borrow_mut().operation = Some(value))
+        .unwrap_or_default();
+}
+
+pub(crate) fn record(kind: &str, value: serde_json::Value) {
+    OBSERVATIONS
+        .try_with(|events| {
+            let mut events = events.borrow_mut();
+            if events.overflow {
+                return;
+            }
+            let event =
+                serde_json::json!({"kind": kind, "operation": events.operation, "value": value});
+            events.bytes += event.to_string().len();
+            if events.bytes > LIMIT || events.values.len() + events.evidence.len() >= 100_000 {
+                events.overflow = true;
+            } else {
+                events.evidence.push(event);
+            }
+        })
+        .unwrap_or_default();
+}
+
+pub(crate) fn observe_result(result: &QueryResult, ordered: bool) {
+    let schema = result.schema().fields().iter().map(|field| serde_json::json!({"name": field.name(), "type": field.data_type().to_string(), "nullable": field.is_nullable(), "metadata": field.metadata()})).collect::<Vec<_>>();
+    let rows = result
+        .to_rust_json()
+        .map(|rows| {
+            if let serde_json::Value::Array(mut rows) = rows {
+                if !ordered {
+                    rows.sort_by_key(crate::canonical_json);
+                }
+                serde_json::Value::Array(rows)
+            } else {
+                rows
+            }
+        })
+        .map_err(|error| error.to_string());
+    record(
+        "query_result",
+        serde_json::json!({"schema": schema, "rows": rows, "ordered": ordered}),
+    );
+    observe(|| format!("actual schema: {:?}", result.schema()));
+}
+
+pub(crate) fn observe_query<E: std::fmt::Display>(result: &Result<QueryResult, E>, ordered: bool) {
+    match result {
+        Ok(result) => observe_result(result, ordered),
+        Err(error) => record(
+            "query_error",
+            serde_json::json!({"message": error.to_string()}),
+        ),
+    }
+}
+
+pub(crate) fn observe_fault(error: &OmniError) {
+    if let OmniError::RecoveryRequired {
+        operation_id,
+        reason,
+    } = error
+    {
+        record(
+            "typed_error",
+            serde_json::json!({"error": "RecoveryRequired", "reason": reason, "operation_id": operation_id, "message": error.to_string()}),
+        );
+    }
+    let message = match error {
+        OmniError::Manifest(error) => &error.message,
+        OmniError::RecoveryRequired { reason, .. } => reason,
+        _ => return,
+    };
+    if let Some(name) = message.strip_prefix("injected failpoint triggered: ") {
+        OBSERVATIONS
+            .try_with(|events| events.borrow_mut().fault_hits.push(name.to_string()))
+            .unwrap_or_default();
+        record("fault_delivered", serde_json::json!({"hook": name}));
+        observe(|| format!("fault delivered: {name}"));
+    }
+}
+
+fn supported_fault(fault: &Fault) -> bool {
+    [
+        "branch_merge.post_authority_capture",
+        "branch_merge.post_sidecar_pre_fork",
+        "branch_merge.post_effects_pre_confirm",
+        "branch_merge.post_phase_b_pre_manifest_commit",
+        "mutation.post_sidecar_pre_fork",
+    ]
+    .contains(&fault.at.as_str())
+}
+
+#[cfg(tokio_unstable)]
+pub(crate) fn arm_fault(
+    fault: Option<&Fault>,
+) -> Result<Option<omnigraph::failpoints::ScopedFailPoint>, String> {
+    OBSERVATIONS
+        .try_with(|events| events.borrow_mut().fault_hits.clear())
+        .unwrap_or_default();
+    fault
+        .map(|fault| {
+            if !supported_fault(fault) {
+                return Err(format!(
+                    "unsupported_environment: unsupported DST failpoint: {}",
+                    fault.at
+                ));
+            }
+            let action = if fault.occurrence == 1 {
+                "1*return".into()
+            } else {
+                format!("{}*off->1*return", fault.occurrence - 1)
+            };
+            Ok(omnigraph::failpoints::ScopedFailPoint::new(
+                &fault.at, &action,
+            ))
+        })
+        .transpose()
+}
+
+#[cfg(not(tokio_unstable))]
+pub(crate) fn arm_fault(fault: Option<&Fault>) -> Result<Option<()>, String> {
+    if fault.is_some() {
+        Err("unsupported_environment: DST runner is unavailable".into())
+    } else {
+        Ok(None)
+    }
+}
+
+pub(crate) fn finish_fault(fault: Option<&Fault>) -> Result<(), String> {
+    let Some(fault) = fault else {
+        return Ok(());
+    };
+    let hits = OBSERVATIONS
+        .try_with(|events| events.borrow().fault_hits.clone())
+        .unwrap_or_default();
+    if hits != [fault.at.clone()] {
+        Err(format!(
+            "fault_unobserved: configured faults were not observed exactly once by the selected operation: {}; observed: {hits:?}",
+            fault.at
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Input {
+    case_path: PathBuf,
+    stem: String,
+    #[serde(with = "shared_text")]
+    text: std::sync::Arc<str>,
+    case_digest: String,
+    plan_digest: String,
+    executable_digest: String,
+    source_revision: String,
+    source_digest: String,
+    environment: Environment,
+    seed: Option<u64>,
+    effective_settings: settings::EffectiveSettings,
+    bless: bool,
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WorkerReport {
+    code: String,
+    phase: String,
+    input_digest: String,
+    result: Result<(), String>,
+    observations: Vec<String>,
+    evidence: Vec<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Attempt {
+    environment: Environment,
+    seed: Option<u64>,
+    replay: usize,
+    known_failure: bool,
+    input: Input,
+    outcome: Result<WorkerReport, String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Planned {
+    environment: Environment,
+    seed: Option<u64>,
+    replay: usize,
+    selected: bool,
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NotRun {
+    execution: Option<Planned>,
+    reason: NotRunReason,
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+enum NotRunReason {
+    Unselected,
+    CoverageUnavailable { error: String },
+    PreflightFailed { error: String },
+    Suppressed { trigger: Planned, error: String },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Summary {
+    invocation_id: String,
+    replay_of: Option<String>,
+    planned: Vec<Planned>,
+    scope: String,
+    code: String,
+    case_path: Option<PathBuf>,
+    source_report: Option<PathBuf>,
+    case_digest: Option<String>,
+    executable_digest: Option<String>,
+    declared: Option<Vec<Environment>>,
+    attempts: Vec<Attempt>,
+    not_run: Vec<NotRun>,
+    result: Result<(), String>,
+}
+
+fn new_summary(case_path: Option<PathBuf>) -> Summary {
+    Summary {
+        invocation_id: invocation_id(),
+        replay_of: None,
+        planned: vec![],
+        scope: "unavailable".into(),
+        code: "pending".into(),
+        case_path,
+        source_report: None,
+        case_digest: None,
+        executable_digest: None,
+        declared: None,
+        attempts: vec![],
+        not_run: vec![],
+        result: Ok(()),
+    }
+}
+
+fn invocation_id() -> String {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let time = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!(
+        "{}-{time}-{}",
+        std::process::id(),
+        NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    )
+}
+
+fn refuse_ambient() -> Result<(), String> {
+    for name in [
+        "FAILPOINTS",
+        "DST_ENTROPY_SEED",
+        "RAYON_NUM_THREADS",
+        "LANCE_CPU_THREADS",
+        "LANCE_DETERMINISTIC_BACKOFF",
+        crate::CASE_TIMEOUT_ENV,
+        "OMNIGRAPH_TRAVERSAL_MODE",
+    ] {
+        if std::env::var_os(name).is_some() {
+            return Err(format!(
+                "invalid_case: ambient {name} conflicts with file-owned execution; unset it"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn error_code(error: &str) -> &'static str {
+    for code in [
+        "invalid_case",
+        "unsupported_environment",
+        "environment_changed",
+        "fault_unobserved",
+        "fault_cleanup_failed",
+        "replay_mismatch",
+        "worker_failed",
+        "report_failed",
+        "timeout",
+        "unexpected_pass",
+    ] {
+        if error.starts_with(&format!("{code}:")) {
+            return code;
+        }
+    }
+    "assertion_failed"
+}
+
+fn result_code(result: &Result<(), String>) -> &'static str {
+    match result {
+        Ok(()) => "passed",
+        Err(error) => error_code(error),
+    }
+}
+
+fn summary_code(summary: &Summary) -> &str {
+    if summary.result.is_ok() && summary.attempts.iter().any(|attempt| attempt.known_failure) {
+        return "known_failure";
+    }
+    let code = result_code(&summary.result);
+    if code != "assertion_failed" {
+        return code;
+    }
+    for attempt in &summary.attempts {
+        match &attempt.outcome {
+            Ok(report) if report.result.is_err() => return &report.code,
+            Err(error) => return error_code(error),
+            _ => (),
+        }
+    }
+    code
+}
+
+fn digest(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+fn executable_digest(path: &Path) -> Result<String, String> {
+    let mut file = std::fs::File::open(path)
+        .map_err(|e| format!("environment_changed: open executable: {e}"))?;
+    let mut hash = Sha256::new();
+    let mut buffer = vec![0; 1024 * 1024];
+    loop {
+        let n = file
+            .read(&mut buffer)
+            .map_err(|e| format!("environment_changed: hash executable: {e}"))?;
+        if n == 0 {
+            break;
+        }
+        hash.update(&buffer[..n]);
+    }
+    Ok(format!("{:x}", hash.finalize()))
+}
+
+fn read_bounded(path: &Path) -> Result<Vec<u8>, String> {
+    if !std::fs::metadata(path)
+        .map_err(|e| format!("report_failed: inspect {}: {e}", path.display()))?
+        .is_file()
+    {
+        return Err("report_failed: input must be a regular file".into());
+    }
+    let file = std::fs::File::open(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    let mut bytes = Vec::new();
+    file.take((LIMIT + 1) as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|e| format!("read {}: {e}", path.display()))?;
+    if bytes.len() > LIMIT {
+        return Err(format!(
+            "report_failed: {} exceeds {LIMIT} byte limit",
+            path.display()
+        ));
+    }
+    Ok(bytes)
+}
+
+mod shared_text {
+    pub fn serialize<S: serde::Serializer>(
+        text: &std::sync::Arc<str>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(text)
+    }
+    pub fn deserialize<'de, D: serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<std::sync::Arc<str>, D::Error> {
+        <String as serde::Deserialize>::deserialize(deserializer).map(Into::into)
+    }
+}
+
+fn json<T: Serialize>(value: &T) -> Result<Vec<u8>, String> {
+    struct Bounded(Vec<u8>);
+    impl std::io::Write for Bounded {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            if bytes.len() > LIMIT.saturating_sub(self.0.len()) {
+                return Err(std::io::Error::other(
+                    "serialized evidence exceeds the byte limit",
+                ));
+            }
+            self.0.extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    let mut output = Bounded(Vec::new());
+    serde_json::to_writer(&mut output, value).map_err(|e| format!("report_failed: encode: {e}"))?;
+    Ok(output.0)
+}
+
+/// Execute the complete fast-tier corpus case with explicit admission.
+pub fn run_corpus_case(path: &Path, executable: &Path, bless: bool) -> CaseOutcome {
+    run_with_selection(
+        path,
+        executable,
+        bless,
+        Selection {
+            target: None,
+            storage: None,
+            seed: None,
+            fast_tier: true,
+        },
+    )
+}
+
+/// Select only declared environment/seed values; omission executes the complete case.
+pub fn run_selected(
+    path: &Path,
+    executable: &Path,
+    bless: bool,
+    target: Option<&str>,
+    storage: Option<&str>,
+    seed: Option<u64>,
+) -> CaseOutcome {
+    run_with_selection(
+        path,
+        executable,
+        bless,
+        Selection {
+            target,
+            storage,
+            seed,
+            fast_tier: false,
+        },
+    )
+}
+
+struct Selection<'a> {
+    target: Option<&'a str>,
+    storage: Option<&'a str>,
+    seed: Option<u64>,
+    fast_tier: bool,
+}
+
+fn run_with_selection(
+    path: &Path,
+    executable: &Path,
+    bless: bool,
+    selection: Selection<'_>,
+) -> CaseOutcome {
+    let started = Instant::now();
+    let mut summary = new_summary(Some(path.to_path_buf()));
+    summary.result = run_invocation(path, executable, bless, &selection, started, &mut summary);
+    (summary.scope, summary.not_run) = coverage(&summary);
+    summary.code = summary_code(&summary).into();
+    let result = match save_summary(&summary) {
+        Ok(()) => summary.result,
+        Err(error) => Err(format!("{error}; original result: {:?}", summary.result)),
+    };
+    CaseOutcome {
+        stem: stem_of(path),
+        elapsed: started.elapsed(),
+        result,
+    }
+}
+
+fn save_summary(summary: &Summary) -> Result<(), String> {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target/gqt-artifacts");
+    std::fs::create_dir_all(&root).map_err(|e| {
+        format!(
+            "report_failed: create artifact directory: {e}; original: {:?}",
+            summary.result
+        )
+    })?;
+    let mut file = tempfile::Builder::new()
+        .prefix("invocation-")
+        .suffix(".json")
+        .tempfile_in(&root)
+        .map_err(|e| format!("report_failed: create summary: {e}"))?;
+    use std::io::Write;
+    file.write_all(&json(summary)?)
+        .map_err(|e| format!("report_failed: write summary: {e}"))?;
+    let (_, path) = file
+        .keep()
+        .map_err(|e| format!("report_failed: retain summary: {e}"))?;
+    println!("GQT report: {}", path.display());
+    println!("GQT replay: omnigraph-gqt --replay '{}'", path.display());
+    Ok(())
+}
+
+fn coverage(summary: &Summary) -> (String, Vec<NotRun>) {
+    let terminal_error = || {
+        summary
+            .result
+            .as_ref()
+            .err()
+            .cloned()
+            .unwrap_or_else(|| "report_failed: execution has no terminal result".into())
+    };
+    if summary.planned.is_empty() {
+        return (
+            "unavailable".into(),
+            vec![NotRun {
+                execution: None,
+                reason: NotRunReason::CoverageUnavailable {
+                    error: terminal_error(),
+                },
+            }],
+        );
+    }
+    let scope = if summary.planned.iter().any(|p| !p.selected) {
+        "partial"
+    } else {
+        "full"
+    };
+    let not_run = summary
+        .planned
+        .iter()
+        .filter_map(|planned| {
+            let reason = if !planned.selected {
+                NotRunReason::Unselected
+            } else if summary.attempts.iter().any(|attempt| {
+                attempt.environment == planned.environment
+                    && attempt.seed == planned.seed
+                    && attempt.replay == planned.replay
+            }) {
+                return None;
+            } else if let Some((attempt, error)) = summary.attempts.iter().find_map(|attempt| {
+                attempt
+                    .outcome
+                    .as_ref()
+                    .err()
+                    .filter(|error| {
+                        attempt.environment == planned.environment
+                            || error.starts_with("fault_cleanup_failed:")
+                            || error.starts_with("timeout:")
+                            || error
+                                .starts_with("report_failed: invocation evidence budget exhausted")
+                    })
+                    .map(|error| (attempt, error))
+            }) {
+                NotRunReason::Suppressed {
+                    trigger: Planned {
+                        environment: attempt.environment.clone(),
+                        seed: attempt.seed,
+                        replay: attempt.replay,
+                        selected: true,
+                    },
+                    error: error.clone(),
+                }
+            } else {
+                NotRunReason::PreflightFailed {
+                    error: terminal_error(),
+                }
+            };
+            Some(NotRun {
+                execution: Some(planned.clone()),
+                reason,
+            })
+        })
+        .collect();
+    (scope.into(), not_run)
+}
+
+/// Retain a terminal report for command-line refusals before execution begins.
+pub fn report_cli_refusal(
+    case_path: Option<PathBuf>,
+    source_report: Option<PathBuf>,
+    error: String,
+) -> String {
+    let mut summary = new_summary(case_path);
+    summary.source_report = source_report;
+    summary.result = Err(error.clone());
+    summary.code = summary_code(&summary).into();
+    (summary.scope, summary.not_run) = coverage(&summary);
+    match save_summary(&summary) {
+        Ok(()) => error,
+        Err(report_error) => format!("{report_error}; original result: {error}"),
+    }
+}
+
+fn run_invocation(
+    path: &Path,
+    executable: &Path,
+    bless: bool,
+    selection: &Selection<'_>,
+    started: Instant,
+    summary: &mut Summary,
+) -> Result<(), String> {
+    refuse_ambient()?;
+    let selected = selection.target;
+    let selected_storage = selection.storage;
+    let selected_seed = selection.seed;
+    let text =
+        String::from_utf8(read_bounded(path)?).map_err(|e| format!("invalid_case: UTF-8: {e}"))?;
+    let text: std::sync::Arc<str> = text.into();
+    summary.case_digest = Some(digest(text.as_bytes()));
+    let case =
+        parse_case(&stem_of(path), &text).map_err(|error| format!("invalid_case: {error}"))?;
+    summary.declared = Some(case.runner.environments.clone());
+    for env in &case.runner.environments {
+        for seed in env.seeds() {
+            for replay in 0..if seed.is_some() { 2 } else { 1 } {
+                summary.planned.push(Planned {
+                    environment: env.clone(),
+                    seed,
+                    replay,
+                    selected: env.matches(selected, selected_storage)
+                        && selected_seed.is_none_or(|s| seed == Some(s)),
+                });
+            }
+        }
+    }
+    summary.scope = if summary.planned.iter().any(|p| !p.selected) {
+        "partial"
+    } else {
+        "full"
+    }
+    .into();
+    let plan_digest = digest(&json(&summary.planned)?);
+    if selection.fast_tier && case.runner.timeout_ms > 10_000 {
+        return Err("invalid_case: the required corpus admits timeout_ms at most 10000; use a standalone heavy reproduction".into());
+    }
+    if selected_seed.is_some() && selected.is_none() && selected_storage.is_none() {
+        return Err("invalid_case: --seed requires --target or --storage".into());
+    }
+    let selected_envs = case
+        .runner
+        .environments
+        .iter()
+        .filter(|env| {
+            env.matches(selected, selected_storage)
+                && selected_seed.is_none_or(|seed| env.seeds().contains(&Some(seed)))
+        })
+        .collect::<Vec<_>>();
+    if selected_envs.is_empty() {
+        return Err("invalid_case: environment selector matches no declared environment".into());
+    }
+    for env in &selected_envs {
+        env.admit(!case.faults.is_empty())?;
+    }
+    for (ordinal, fault) in &case.faults {
+        if !supported_fault(fault) {
+            return Err(format!(
+                "unsupported_environment: unsupported DST failpoint: {}",
+                fault.at
+            ));
+        }
+        let step = case
+            .items
+            .iter()
+            .flat_map(|item| match item {
+                crate::Item::Step(step) => std::slice::from_ref(step),
+                crate::Item::Loop { steps, .. } => steps.as_slice(),
+            })
+            .find(|step| step.ordinal() == *ordinal);
+        let compatible = match step {
+            Some(crate::Step::Mutate(_)) => fault.at.starts_with("mutation."),
+            Some(crate::Step::Control(crate::ControlStep {
+                write: crate::ControlWrite::Merge { .. },
+                ..
+            })) => fault.at.starts_with("branch_merge."),
+            _ => false,
+        };
+        if !compatible {
+            return Err(format!(
+                "unsupported_environment: fault {} is incompatible with operation {ordinal}",
+                fault.at
+            ));
+        }
+    }
+    if bless && case.known_failure.is_some() {
+        return Err("invalid_case: bless is refused for known_failure cases".into());
+    }
+    if bless
+        && (case.runner.environments.len() != 1
+            || !matches!(selected_envs[0].execution, Execution::Engine { .. }))
+    {
+        return Err("invalid_case: bless requires exactly one direct engine environment".into());
+    }
+    let build = executable_digest(executable)?;
+    summary.executable_digest = Some(build.clone());
+    let budget = Duration::from_millis(case.runner.timeout_ms);
+    let remaining = || {
+        budget
+            .checked_sub(started.elapsed())
+            .filter(|left| !left.is_zero())
+            .ok_or_else(|| format!("timeout: case exceeded wall-time budget {budget:?}"))
+    };
+    let mut failures = Vec::new();
+    let mut isolation_lost = false;
+    let mut deadline_expired = false;
+    let mut retained_bytes = 0usize;
+    let mut evidence_exhausted = false;
+    for env in selected_envs {
+        let mut worker_failed = false;
+        for seed in env.seeds() {
+            if selected_seed.is_some() && seed != selected_seed {
+                continue;
+            }
+            let repetitions = if seed.is_some() { 2 } else { 1 };
+            let mut reports = Vec::new();
+            for replay in 0..repetitions {
+                if worker_failed || isolation_lost || evidence_exhausted || deadline_expired {
+                    continue;
+                }
+                let left = match remaining() {
+                    Ok(left) => left,
+                    Err(error) => {
+                        failures.push(error);
+                        return Err(failures.join("\n"));
+                    }
+                };
+                let input = Input {
+                    case_path: path.to_path_buf(),
+                    stem: stem_of(path),
+                    text: text.clone(),
+                    case_digest: digest(text.as_bytes()),
+                    plan_digest: plan_digest.clone(),
+                    executable_digest: build.clone(),
+                    source_revision: env!("GQT_SOURCE_REVISION").into(),
+                    source_digest: env!("GQT_SOURCE_DIGEST").into(),
+                    environment: env.clone(),
+                    seed,
+                    effective_settings: settings::EffectiveSettings::for_seed(seed),
+                    bless,
+                };
+                let mut outcome = run_child(&input, executable, left);
+                if let Ok(report) = &outcome {
+                    let size = json(report)?.len();
+                    retained_bytes = retained_bytes.saturating_add(size);
+                    if retained_bytes > LIMIT / 2 {
+                        evidence_exhausted = true;
+                        outcome = Err("report_failed: invocation evidence budget exhausted; remaining attempts not run".into());
+                    }
+                }
+                let mut known_failure = false;
+                match &outcome {
+                    Ok(report) => {
+                        match known_failure::classify(&case, report) {
+                            Ok(accepted) => {
+                                known_failure = accepted;
+                                if accepted {
+                                    println!(
+                                        "KNOWN_FAILURE environment={} seed={seed:?} replay={replay}: known recovery failure",
+                                        env
+                                    );
+                                }
+                            }
+                            Err(error) => {
+                                failures.push(format!(
+                                    "{error}; environment={} seed={seed:?} replay={replay}",
+                                    env
+                                ));
+                            }
+                        }
+                        reports.push(json(report)?);
+                    }
+                    Err(error) => {
+                        failures.push(error.clone());
+                        isolation_lost |= error.starts_with("fault_cleanup_failed:");
+                        deadline_expired |= error.starts_with("timeout:");
+                        worker_failed = true;
+                    }
+                }
+                summary.attempts.push(Attempt {
+                    environment: env.clone(),
+                    seed,
+                    replay,
+                    known_failure,
+                    input,
+                    outcome,
+                });
+            }
+            if reports.len() == 2 {
+                if reports[0] != reports[1] {
+                    failures.push(format!(
+                        "replay_mismatch: {} seed={seed:?}; both reports retained",
+                        env
+                    ));
+                } else {
+                    println!("DST environment={} seed={seed:?} replay matched", env);
+                }
+            }
+        }
+    }
+    if let Err(error) = remaining() {
+        failures.push(error);
+    }
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(failures.join("\n"))
+    }
+}
+
+fn run_child(input: &Input, executable: &Path, budget: Duration) -> Result<WorkerReport, String> {
+    input.effective_settings.verify_expected(input.seed)?;
+    let started = Instant::now();
+    let dir =
+        tempfile::tempdir().map_err(|e| format!("worker_failed: create output directory: {e}"))?;
+    let input_path = dir.path().join("input.json");
+    let report_path = dir.path().join("report.json");
+    let bytes = json(input)?;
+    std::fs::write(&input_path, &bytes).map_err(|e| format!("report_failed: write input: {e}"))?;
+    let mut cmd = Command::new(executable);
+    cmd.arg(&input.case_path)
+        .env_clear()
+        .env(WORKER_INPUT, &input_path)
+        .env("TMPDIR", dir.path())
+        .env(WORKER_REPORT, &report_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    input.effective_settings.configure(&mut cmd);
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("worker_failed: spawn: {e}"))?;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                if !status.success() {
+                    return Err(format!(
+                        "worker_failed: {} seed={:?} exited {status}",
+                        input.environment, input.seed
+                    ));
+                }
+                break;
+            }
+            Ok(None) if started.elapsed() < budget => std::thread::sleep(
+                budget
+                    .saturating_sub(started.elapsed())
+                    .min(Duration::from_millis(10)),
+            ),
+            other => {
+                let containment =
+                    contain_child(&mut child, Instant::now() + Duration::from_millis(250));
+                if let Err(error) = containment {
+                    let retained = dir.keep();
+                    return Err(format!(
+                        "fault_cleanup_failed: {error}; original poll={other:?}; wall-time budget={budget:?}; retained context={retained:?}"
+                    ));
+                }
+                return Err(format!(
+                    "timeout: worker exceeded wall-time budget {budget:?}; original poll={other:?}; contained=true"
+                ));
+            }
+        }
+    }
+    let report: WorkerReport = serde_json::from_slice(&read_bounded(&report_path)?)
+        .map_err(|e| format!("report_failed: decode worker report: {e}"))?;
+    if report.input_digest != digest(&bytes) {
+        return Err("environment_changed: worker input digest differs".into());
+    }
+    Ok(report)
+}
+
+fn contain_child(child: &mut std::process::Child, deadline: Instant) -> Result<(), String> {
+    let killed = child.kill();
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return Ok(()),
+            Ok(None) if Instant::now() < deadline => std::thread::sleep(Duration::from_millis(1)),
+            result => {
+                return Err(format!(
+                    "worker pid={} containment unavailable; kill={killed:?}; reap={result:?}",
+                    child.id()
+                ));
+            }
+        }
+    }
+}
+
+/// Execute only the internal request, never rereading the original case file.
+pub fn run_worker_if_requested(_path: &Path) -> Result<bool, String> {
+    match (
+        std::env::var_os(WORKER_INPUT),
+        std::env::var_os(WORKER_REPORT),
+    ) {
+        (None, None) => Ok(false),
+        (Some(input), Some(output)) => {
+            let bytes = read_bounded(Path::new(&input))?;
+            let input: Input = serde_json::from_slice(&bytes)
+                .map_err(|e| format!("invalid_case: worker input: {e}"))?;
+            let input_digest = digest(&bytes);
+            let report = match worker_report(&input, input_digest.clone()) {
+                Ok(report) => report,
+                Err(error) => WorkerReport {
+                    code: error_code(&error).into(),
+                    phase: "preflight".into(),
+                    input_digest,
+                    result: Err(error),
+                    observations: vec![],
+                    evidence: vec![],
+                },
+            };
+            std::fs::write(output, json(&report)?)
+                .map_err(|e| format!("report_failed: write worker report: {e}"))?;
+            Ok(true)
+        }
+        _ => Err("invalid_case: incomplete internal worker request".into()),
+    }
+}
+
+fn worker_report(input: &Input, input_digest: String) -> Result<WorkerReport, String> {
+    input.effective_settings.verify_expected(input.seed)?;
+    input.effective_settings.verify_process()?;
+    if input.source_revision != env!("GQT_SOURCE_REVISION")
+        || input.source_digest != env!("GQT_SOURCE_DIGEST")
+    {
+        return Err("environment_changed: worker source identity differs".into());
+    }
+    if digest(input.text.as_bytes()) != input.case_digest {
+        return Err("environment_changed: worker case digest differs".into());
+    }
+    let executable = std::env::current_exe()
+        .map_err(|e| format!("environment_changed: locate executable: {e}"))?;
+    if executable_digest(&executable)? != input.executable_digest {
+        return Err("environment_changed: worker executable digest differs".into());
+    }
+    let case = parse_case(&input.stem, &input.text)?;
+    if !case.runner.environments.contains(&input.environment)
+        || !input.environment.seeds().contains(&input.seed)
+    {
+        return Err("environment_changed: worker selection is not declared".into());
+    }
+    input.environment.admit(!case.faults.is_empty())?;
+    match input.seed {
+        None => {
+            let settings::TokioRuntime::MultiThread {
+                worker_threads,
+                thread_stack_bytes,
+            } = input.effective_settings.tokio
+            else {
+                return Err(
+                    "environment_changed: direct engine requires its multi-thread runtime settings"
+                        .into(),
+                );
+            };
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(worker_threads)
+                .enable_all()
+                .thread_stack_size(thread_stack_bytes)
+                .build()
+                .map_err(|e| format!("worker_failed: runtime: {e}"))?;
+            runtime.block_on(capture(
+                input_digest,
+                crate::execute_case(&case, &input.case_path, input.bless),
+            ))
+        }
+        Some(seed) => dst_report(input, &case, seed, input_digest),
+    }
+}
+
+async fn capture(
+    input_digest: String,
+    future: impl std::future::Future<Output = Result<(), String>>,
+) -> Result<WorkerReport, String> {
+    use futures::FutureExt;
+    let mut initial = Observations::default();
+    #[cfg(tokio_unstable)]
+    let _guards = {
+        let (counts, guards) = lifecycle_probe();
+        initial.lifecycle = Some(counts);
+        guards
+    };
+    #[cfg(not(tokio_unstable))]
+    {
+        initial.lifecycle = None;
+    }
+    OBSERVATIONS
+        .scope(RefCell::new(initial), async {
+            let result = std::panic::AssertUnwindSafe(future)
+                .catch_unwind()
+                .await
+                .unwrap_or_else(|panic| {
+                    Err(format!(
+                        "worker_failed: case panicked: {}",
+                        crate::panic_message(panic.as_ref())
+                    ))
+                });
+            let observations = OBSERVATIONS.with(|events| events.take());
+            let result = if observations.overflow {
+                Err(format!(
+                    "report_failed: observation limit exceeded; original={result:?}"
+                ))
+            } else {
+                result
+            };
+            Ok(WorkerReport {
+                code: result_code(&result).into(),
+                phase: if observations.operation.is_some() {
+                    "execution"
+                } else {
+                    "setup"
+                }
+                .into(),
+                input_digest,
+                result,
+                observations: observations.values,
+                evidence: observations.evidence,
+            })
+        })
+        .await
+}
+
+#[cfg(tokio_unstable)]
+#[derive(Debug)]
+struct GqtScenario<'a> {
+    input: &'a Input,
+    case: &'a crate::Case,
+    input_digest: String,
+}
+
+#[cfg(tokio_unstable)]
+impl omnigraph_dst::UniverseScenario<omnigraph_dst::memory::MemoryStorage> for GqtScenario<'_> {
+    type Output = Result<WorkerReport, String>;
+
+    async fn run(
+        &self,
+        resources: &mut omnigraph_dst::memory::MemoryStorage,
+        _workload_seed: u64,
+    ) -> Self::Output {
+        capture(
+            self.input_digest.clone(),
+            crate::execute_case_with_storage(
+                self.case,
+                &self.input.case_path,
+                &resources.root,
+                resources.adapter.clone(),
+            ),
+        )
+        .await
+    }
+}
+
+#[cfg(tokio_unstable)]
+fn dst_report(
+    input: &Input,
+    case: &crate::Case,
+    seed: u64,
+    input_digest: String,
+) -> Result<WorkerReport, String> {
+    for (key, expected) in omnigraph_dst::env_knobs::QUIESCE_ENV {
+        let actual = std::env::var(key).ok();
+        if actual.as_deref() != Some(expected) {
+            return Err(format!(
+                "DST requires {key}={expected} at process start, got {actual:?}"
+            ));
+        }
+    }
+    let _failpoints = omnigraph::failpoints::FailScenario::setup();
+    let environment = omnigraph_dst::memory::MemoryEnvironment::new(
+        "shared-memory://gqt-dst/case",
+        seed,
+        omnigraph_dst::UniverseProcess::Isolated,
+    );
+    let scenario = GqtScenario {
+        input,
+        case,
+        input_digest: input_digest.clone(),
+    };
+    let run = omnigraph_dst::run_universe(&environment, &scenario);
+    let result = run
+        .result
+        .map_err(|panic| {
+            format!(
+                "DST universe panicked: {}",
+                crate::panic_message(panic.as_ref())
+            )
+        })
+        .and_then(|result| result)
+        .and_then(|result| result);
+    let mut report = match result {
+        Ok(report) => report,
+        Err(error) => WorkerReport {
+            code: "worker_failed".into(),
+            phase: match run.phase {
+                omnigraph_dst::UniversePhase::Runtime => "runtime",
+                omnigraph_dst::UniversePhase::Setup => "setup",
+                omnigraph_dst::UniversePhase::Scenario => "execution",
+            }
+            .into(),
+            input_digest,
+            result: Err(format!("worker_failed: {error}")),
+            observations: Vec::new(),
+            evidence: Vec::new(),
+        },
+    };
+    let cleanup = run
+        .cleanup
+        .map_err(|panic| format!("cleanup panicked: {}", crate::panic_message(panic.as_ref())))
+        .and_then(|result| result);
+    if let Err(error) = cleanup {
+        report.result = Err(format!(
+            "fault_cleanup_failed: {error}; original={:?}",
+            report.result
+        ));
+        report.code = "fault_cleanup_failed".into();
+        report.phase = "teardown".into();
+    }
+    Ok(report)
+}
+
+#[cfg(not(tokio_unstable))]
+fn dst_report(
+    _input: &Input,
+    _case: &crate::Case,
+    _seed: u64,
+    _digest: String,
+) -> Result<WorkerReport, String> {
+    Err("unsupported_environment: DST runner is unavailable".into())
+}
+
+/// Replay retained inputs against the identical executable, preserving failed assertions.
+pub fn replay_report(path: &Path, executable: &Path) -> Result<(), String> {
+    let decoded = read_bounded(path).and_then(|bytes| {
+        serde_json::from_slice::<Summary>(&bytes)
+            .map_err(|e| format!("report_failed: decode replay: {e}"))
+    });
+    let prior = match decoded {
+        Ok(summary) => summary,
+        Err(error) => {
+            let mut summary = new_summary(None);
+            summary.source_report = Some(path.to_path_buf());
+            summary.code = "report_failed".into();
+            summary.result = Err(error);
+            (summary.scope, summary.not_run) = coverage(&summary);
+            save_summary(&summary)?;
+            return summary.result;
+        }
+    };
+    let mut summary = new_summary(prior.case_path.clone());
+    summary.source_report = Some(path.to_path_buf());
+    summary.replay_of = Some(prior.invocation_id.clone());
+    summary.planned = prior.planned.clone();
+    summary.case_digest = prior.case_digest.clone();
+    summary.executable_digest = prior.executable_digest.clone();
+    summary.declared = prior.declared.clone();
+    summary.result = replay_attempts(&prior, executable, &mut summary.attempts);
+    (summary.scope, summary.not_run) = coverage(&summary);
+    summary.code = summary_code(&summary).into();
+    match save_summary(&summary) {
+        Ok(()) => summary.result,
+        Err(error) => Err(format!("{error}; original result: {:?}", summary.result)),
+    }
+}
+
+fn replay_attempts(
+    summary: &Summary,
+    executable: &Path,
+    executed: &mut Vec<Attempt>,
+) -> Result<(), String> {
+    refuse_ambient()?;
+    for attempt in &summary.attempts {
+        attempt
+            .input
+            .effective_settings
+            .verify_expected(attempt.input.seed)?;
+    }
+    if summary.code != summary_code(summary) {
+        return Err("report_failed: inconsistent invocation status".into());
+    }
+    if summary.attempts.is_empty() {
+        return Err("report_failed: no replayable executions".into());
+    }
+    let selected = summary
+        .planned
+        .iter()
+        .filter(|p| p.selected)
+        .cloned()
+        .collect::<std::collections::BTreeSet<_>>();
+    let actual = summary
+        .attempts
+        .iter()
+        .map(|a| Planned {
+            environment: a.environment.clone(),
+            seed: a.seed,
+            replay: a.replay,
+            selected: true,
+        })
+        .collect::<std::collections::BTreeSet<_>>();
+    if selected != actual
+        || actual.len() != summary.attempts.len()
+        || summary
+            .planned
+            .iter()
+            .collect::<std::collections::BTreeSet<_>>()
+            .len()
+            != summary.planned.len()
+    {
+        return Err("report_failed: incomplete or duplicate execution inventory".into());
+    }
+    let (scope, not_run) = coverage(summary);
+    if summary.scope != scope || summary.not_run != not_run {
+        return Err("report_failed: inconsistent execution coverage".into());
+    }
+    let plan_digest = digest(&json(&summary.planned)?);
+    let started = Instant::now();
+    let build = executable_digest(executable)?;
+    let mut failures = Vec::new();
+    let mut budget = None;
+    for attempt in &summary.attempts {
+        if attempt.input.plan_digest != plan_digest {
+            return Err("environment_changed: execution plan digest differs".into());
+        }
+        if Some(&attempt.input.executable_digest) != summary.executable_digest.as_ref()
+            || Some(&attempt.input.case_digest) != summary.case_digest.as_ref()
+            || Some(&attempt.input.case_path) != summary.case_path.as_ref()
+            || attempt.environment != attempt.input.environment
+            || attempt.seed != attempt.input.seed
+            || attempt.replay > usize::from(attempt.seed.is_some())
+        {
+            return Err("report_failed: inconsistent execution attribution".into());
+        }
+        if attempt.input.executable_digest != build {
+            return Err("environment_changed: replay executable differs".into());
+        }
+        if attempt.input.bless {
+            return Err("invalid_case: blessing invocations cannot replay".into());
+        }
+        let prior = attempt
+            .outcome
+            .as_ref()
+            .map_err(|e| format!("report_failed: incomplete prior execution: {e}"))?;
+        let case = parse_case(&attempt.input.stem, &attempt.input.text)?;
+        known_failure::verify_status(&case, prior, attempt.known_failure)?;
+        if summary.declared.as_ref() != Some(&case.runner.environments) {
+            return Err("report_failed: declared environments differ from frozen input".into());
+        }
+        if prior.input_digest != digest(&json(&attempt.input)?) {
+            return Err("environment_changed: prior input digest differs".into());
+        }
+
+        budget = Some(Duration::from_millis(case.runner.timeout_ms));
+        let remaining = Duration::from_millis(case.runner.timeout_ms)
+            .checked_sub(started.elapsed())
+            .filter(|left| !left.is_zero())
+            .ok_or("timeout: replay exceeded wall-time budget")?;
+        let outcome = run_child(&attempt.input, executable, remaining);
+        let report = match outcome {
+            Ok(report) => report,
+            Err(error) => {
+                failures.push(error.clone());
+                executed.push(Attempt {
+                    environment: attempt.environment.clone(),
+                    seed: attempt.seed,
+                    replay: attempt.replay,
+                    known_failure: false,
+                    input: attempt.input.clone(),
+                    outcome: Err(error),
+                });
+                return Err(failures.join("\n"));
+            }
+        };
+        if &report != prior {
+            failures.push(format!(
+                "replay_mismatch: {} seed={:?}",
+                attempt.environment, attempt.seed
+            ));
+        }
+        let known_failure = match known_failure::classify(&case, &report) {
+            Ok(known_failure) => known_failure,
+            Err(error) => {
+                failures.push(error);
+                false
+            }
+        };
+        executed.push(Attempt {
+            environment: attempt.environment.clone(),
+            seed: attempt.seed,
+            replay: attempt.replay,
+            known_failure,
+            input: attempt.input.clone(),
+            outcome: Ok(report),
+        });
+    }
+    if budget.is_some_and(|budget| started.elapsed() >= budget) {
+        failures.push("timeout: replay exceeded wall-time budget".into());
+    }
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(failures.join("\n"))
+    }
+}

--- a/crates/omnigraph-gqt/src/dst_runner/known_failure.rs
+++ b/crates/omnigraph-gqt/src/dst_runner/known_failure.rs
@@ -1,0 +1,130 @@
+use super::WorkerReport;
+use crate::runner_config::{ErrorMatch, Execution, Storage};
+use crate::{Case, Item, MutateExpect, Step};
+
+pub(super) fn validate(case: &Case) -> Result<(), String> {
+    let Some(marker) = &case.known_failure else {
+        return Ok(());
+    };
+    if case.has_loops()
+        || !case.runner.environments.iter().all(|environment| {
+            matches!(
+                environment.execution,
+                Execution::Dst {
+                    storage: Storage::InMemoryObjectStore,
+                    ..
+                }
+            )
+        })
+        || case.faults.is_empty()
+        || case.faults.keys().any(|ordinal| *ordinal >= marker.step)
+        || !case.items.iter().any(|item| {
+            matches!(item, Item::Step(Step::Mutate(step))
+                if step.ordinal == marker.step
+                    && matches!(step.expect, MutateExpect::Ok | MutateExpect::Affected { .. }))
+        })
+    {
+        return Err("invalid_case: known_failure requires an engine-DST/in-memory case without loops, a healthy mutate expectation at its step, and faults only at earlier steps".into());
+    }
+    Ok(())
+}
+
+pub(super) fn classify(case: &Case, report: &WorkerReport) -> Result<bool, String> {
+    let Some(marker) = &case.known_failure else {
+        return report.result.clone().map(|()| false);
+    };
+    let Err(failure) = &report.result else {
+        return Err(format!(
+            "unexpected_pass: known_failure step {} passed; remove the stale marker after verifying the fix",
+            marker.step
+        ));
+    };
+    if report.code != "assertion_failed" || report.phase != "execution" {
+        return Err(failure.clone());
+    }
+    let assertions = report
+        .evidence
+        .iter()
+        .filter(|event| event["kind"] == "assertion")
+        .collect::<Vec<_>>();
+    if assertions.len() != marker.step
+        || assertions.iter().enumerate().any(|(index, event)| {
+            event["operation"]["ordinal"].as_u64() != u64::try_from(index + 1).ok()
+                || !event["operation"]["loop_binding"].is_null()
+                || event["value"]["status"]
+                    != if index + 1 == marker.step {
+                        "failed"
+                    } else {
+                        "passed"
+                    }
+        })
+    {
+        return Err(failure.clone());
+    }
+    let errors = report
+        .evidence
+        .iter()
+        .filter(|event| {
+            event["kind"] == "typed_error"
+                && event["operation"]["ordinal"].as_u64() == u64::try_from(marker.step).ok()
+        })
+        .collect::<Vec<_>>();
+    let [error] = errors.as_slice() else {
+        return Err(failure.clone());
+    };
+    let matches = match &marker.matcher {
+        ErrorMatch::RecoveryRequired { reason } => {
+            error["value"]["error"] == "RecoveryRequired"
+                && error["value"]["reason"].as_str() == Some(reason.as_str())
+        }
+    };
+    if !matches {
+        return Err(failure.clone());
+    }
+    let Some(message) = error["value"]["message"].as_str() else {
+        return Err(failure.clone());
+    };
+    let assertion_message = format!("mutation failed: {message}");
+    let Some(last) = assertions.last() else {
+        return Err(failure.clone());
+    };
+    if last["value"]["message"] != assertion_message
+        || *failure != format!("step {} (mutate): {assertion_message}", marker.step)
+    {
+        return Err(failure.clone());
+    }
+    let delivered = report
+        .evidence
+        .iter()
+        .filter(|event| event["kind"] == "fault_delivered")
+        .map(|event| {
+            (
+                event["operation"]["ordinal"].as_u64(),
+                event["value"]["hook"].as_str(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let required = case
+        .faults
+        .iter()
+        .map(|(ordinal, fault)| (u64::try_from(*ordinal).ok(), Some(fault.at.as_str())))
+        .collect::<Vec<_>>();
+    if delivered != required {
+        return Err(failure.clone());
+    }
+    Ok(true)
+}
+
+pub(super) fn verify_status(
+    case: &Case,
+    report: &WorkerReport,
+    known_failure: bool,
+) -> Result<(), String> {
+    if classify(case, report).unwrap_or(false) != known_failure {
+        return Err("report_failed: inconsistent known_failure status".into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/omnigraph-gqt/src/dst_runner/known_failure/tests.rs
+++ b/crates/omnigraph-gqt/src/dst_runner/known_failure/tests.rs
@@ -1,0 +1,228 @@
+use super::*;
+use omnigraph::error::OmniError;
+use serde_json::json;
+
+const CASE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/cases/dst_mutation_failure_keeps_writing.gqt"
+));
+
+fn fixture() -> (Case, WorkerReport) {
+    let case = crate::parse_case("dst_mutation_failure_keeps_writing", CASE).unwrap();
+    let marker = case.known_failure.as_ref().unwrap();
+    let ErrorMatch::RecoveryRequired { reason } = &marker.matcher;
+    let error = OmniError::RecoveryRequired {
+        operation_id: "operation-17".into(),
+        reason: reason.clone(),
+    };
+    let message = format!("mutation failed: {error}");
+    let mut evidence = Vec::new();
+    for ordinal in 1..=marker.step {
+        let operation = json!({"ordinal": ordinal, "loop_binding": null});
+        if let Some(fault) = case.faults.get(&ordinal) {
+            evidence.push(json!({"kind": "fault_delivered", "operation": operation, "value": {"hook": fault.at}}));
+        }
+        if ordinal == marker.step {
+            evidence.push(json!({"kind": "typed_error", "operation": operation, "value": {"error": "RecoveryRequired", "reason": reason, "operation_id": "operation-17", "message": error.to_string()}}));
+        }
+        let value = if ordinal == marker.step {
+            json!({"status": "failed", "code": "assertion_failed", "message": message})
+        } else {
+            json!({"status": "passed"})
+        };
+        evidence.push(json!({"kind": "assertion", "operation": operation, "value": value}));
+    }
+    let report = WorkerReport {
+        code: "assertion_failed".into(),
+        phase: "execution".into(),
+        input_digest: "frozen-input".into(),
+        result: Err(format!("step {} (mutate): {message}", marker.step)),
+        observations: vec![],
+        evidence,
+    };
+    (case, report)
+}
+
+#[test]
+fn accepts_only_the_exact_typed_recovery_failure_and_keeps_raw_evidence() {
+    let (case, report) = fixture();
+    let raw = serde_json::to_vec(&report).unwrap();
+    assert_eq!(classify(&case, &report), Ok(true));
+    assert_eq!(serde_json::to_vec(&report).unwrap(), raw);
+    verify_status(&case, &report, true).unwrap();
+    assert!(verify_status(&case, &report, false).is_err());
+}
+
+#[test]
+fn refuses_different_reasons_steps_faults_and_incomplete_assertions() {
+    for mutation in 0..10 {
+        let (case, mut report) = fixture();
+        match mutation {
+            0 => report
+                .evidence
+                .retain(|event| event["kind"] != "typed_error"),
+            1 => report
+                .evidence
+                .retain(|event| event["kind"] != "fault_delivered"),
+            2 => {
+                let error = report
+                    .evidence
+                    .iter_mut()
+                    .find(|e| e["kind"] == "typed_error")
+                    .unwrap();
+                error["value"]["reason"] = "another recovery problem".into();
+            }
+            3 => {
+                let error = report
+                    .evidence
+                    .iter_mut()
+                    .find(|e| e["kind"] == "typed_error")
+                    .unwrap();
+                error["operation"]["ordinal"] = 3.into();
+            }
+            4 => {
+                let first = report
+                    .evidence
+                    .iter_mut()
+                    .find(|e| e["kind"] == "assertion")
+                    .unwrap();
+                first["value"]["status"] = "failed".into();
+            }
+            5 => {
+                let fault = report
+                    .evidence
+                    .iter_mut()
+                    .find(|e| e["kind"] == "fault_delivered")
+                    .unwrap();
+                fault["value"]["hook"] = "another.hook".into();
+            }
+            6 => report.result = Err("step 4 (mutate): affected counts mismatch".into()),
+            7 => {
+                let fault = report
+                    .evidence
+                    .iter()
+                    .find(|e| e["kind"] == "fault_delivered")
+                    .unwrap()
+                    .clone();
+                report.evidence.push(fault);
+            }
+            8 => {
+                let error = report
+                    .evidence
+                    .iter_mut()
+                    .find(|e| e["kind"] == "typed_error")
+                    .unwrap();
+                error["value"]["error"] = "Manifest".into();
+            }
+            9 => {
+                let error = report
+                    .evidence
+                    .iter_mut()
+                    .find(|e| e["kind"] == "typed_error")
+                    .unwrap();
+                error["kind"] = "query_result".into();
+            }
+            _ => unreachable!(),
+        }
+        assert!(
+            classify(&case, &report).is_err(),
+            "accepted mutation {mutation}"
+        );
+        assert!(verify_status(&case, &report, true).is_err());
+    }
+}
+
+#[test]
+fn never_waives_harness_errors_or_an_unexpected_pass() {
+    for code in [
+        "worker_failed",
+        "timeout",
+        "fault_cleanup_failed",
+        "report_failed",
+        "fault_unobserved",
+    ] {
+        let (case, mut report) = fixture();
+        report.code = code.into();
+        report.result = Err(format!("{code}: original cause"));
+        assert_eq!(
+            classify(&case, &report),
+            Err(format!("{code}: original cause"))
+        );
+    }
+    let (case, mut report) = fixture();
+    report.phase = "setup".into();
+    assert!(classify(&case, &report).is_err());
+    report.result = Ok(());
+    report.code = "passed".into();
+    assert!(
+        classify(&case, &report)
+            .unwrap_err()
+            .starts_with("unexpected_pass:")
+    );
+    assert!(verify_status(&case, &report, true).is_err());
+}
+
+#[test]
+fn marker_is_closed_and_cannot_replace_healthy_expectations() {
+    for text in [
+        CASE.replace("step: 4", "step: 0"),
+        CASE.replace("step: 4", "step: 99"),
+        CASE.replace("step: 4", "step: 3"),
+        CASE.replace("step: 4", "step: 4\nunknown: value"),
+        CASE.replace("step: 4", "step: 4\nstep: 4"),
+        CASE.replace("--- known_failure", "--- known_failure ignored"),
+        CASE.replace("--- known_failure", "--- fixme"),
+        CASE.replace("error: RecoveryRequired", "error: Unknown"),
+        CASE.replace("  error: RecoveryRequired\n", ""),
+        CASE.replace("match:\n", "match: {}\n"),
+        CASE.replace("  reason:", "  other_reason:"),
+        CASE.replace("match:\n", "match:\n  reason: \"\"\n"),
+        CASE.replace("error: RecoveryRequired", "error: Manifest"),
+        CASE.replace("error: RecoveryRequired", "error: recovery_required"),
+        CASE.replace("error: RecoveryRequired", "error: RecoveryRequired\n  error: RecoveryRequired"),
+        CASE.replace("error: RecoveryRequired", "error: RecoveryRequired\n  unknown: value"),
+        CASE.replace("--- known_failure", "--- known_failure\nnotes: \"\""),
+        CASE.replace("--- expect affected: nodes=1 edges=0", "--- expect error: recovery required"),
+        CASE.replace("--- fault\nat: mutation.post_sidecar_pre_fork\noccurrence: 1\naction: return_error\nscope: next_step\n", ""),
+        CASE.replace("target: omnigraph-engine-dst", "target: omnigraph-engine"),
+    ] {
+        assert!(crate::parse_case("dst_mutation_failure_keeps_writing", &text).is_err(), "accepted {text}");
+    }
+}
+
+#[tokio::test]
+async fn typed_error_evidence_comes_from_the_engine_variant() {
+    let error = OmniError::RecoveryRequired {
+        operation_id: "operation-17".into(),
+        reason: "pending typed recovery".into(),
+    };
+    let report = super::super::capture("input".into(), async {
+        super::super::begin_operation(json!({"ordinal": 4}));
+        super::super::observe_fault(&error);
+        Err("assertion failed".into())
+    })
+    .await
+    .unwrap();
+    let typed = report
+        .evidence
+        .iter()
+        .find(|event| event["kind"] == "typed_error")
+        .unwrap();
+    assert_eq!(typed["value"]["error"], "RecoveryRequired");
+    assert_eq!(typed["value"]["operation_id"], "operation-17");
+    assert_eq!(typed["value"]["reason"], "pending typed recovery");
+    assert_eq!(typed["value"]["message"], error.to_string());
+}
+
+#[tokio::test]
+async fn scenario_panic_cannot_become_a_known_failure() {
+    let (case, _) = fixture();
+    let report = super::super::capture("input".into(), async {
+        super::super::begin_operation(json!({"ordinal": 4}));
+        panic!("recovery required for operation 17: pending typed recovery");
+    })
+    .await
+    .unwrap();
+    assert_eq!(report.code, "worker_failed");
+    assert!(classify(&case, &report).is_err());
+}

--- a/crates/omnigraph-gqt/src/dst_runner/settings.rs
+++ b/crates/omnigraph-gqt/src/dst_runner/settings.rs
@@ -1,0 +1,186 @@
+//! Recorded process settings configure each worker and are verified before setup.
+
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct EffectiveSettings {
+    rayon_num_threads: usize,
+    lance_cpu_threads: usize,
+    lance_deterministic_backoff: bool,
+    dst_entropy_seed: Option<u64>,
+    lance_memory_pool: LanceMemoryPool,
+    pub(super) tokio: TokioRuntime,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum LanceMemoryPool {
+    DependencyDefault,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub(super) enum TokioRuntime {
+    MultiThread {
+        worker_threads: usize,
+        thread_stack_bytes: usize,
+    },
+    SeededCurrentThread,
+}
+
+impl EffectiveSettings {
+    pub(super) fn for_seed(seed: Option<u64>) -> Self {
+        Self {
+            rayon_num_threads: 1,
+            lance_cpu_threads: 1,
+            lance_deterministic_backoff: true,
+            dst_entropy_seed: seed,
+            lance_memory_pool: LanceMemoryPool::DependencyDefault,
+            tokio: if seed.is_some() {
+                TokioRuntime::SeededCurrentThread
+            } else {
+                TokioRuntime::MultiThread {
+                    worker_threads: 2,
+                    thread_stack_bytes: 16 * 1024 * 1024,
+                }
+            },
+        }
+    }
+
+    pub(super) fn verify_expected(&self, seed: Option<u64>) -> Result<(), String> {
+        if self != &Self::for_seed(seed) {
+            return Err(
+                "environment_changed: effective worker settings differ from this build".into(),
+            );
+        }
+        Ok(())
+    }
+
+    fn environment(&self) -> [(&'static str, Option<String>); 5] {
+        [
+            (
+                "RAYON_NUM_THREADS",
+                Some(self.rayon_num_threads.to_string()),
+            ),
+            (
+                "LANCE_CPU_THREADS",
+                Some(self.lance_cpu_threads.to_string()),
+            ),
+            (
+                "LANCE_DETERMINISTIC_BACKOFF",
+                Some(u8::from(self.lance_deterministic_backoff).to_string()),
+            ),
+            (
+                "DST_ENTROPY_SEED",
+                self.dst_entropy_seed.map(|seed| seed.to_string()),
+            ),
+            ("LANCE_MEM_POOL_SIZE", None),
+        ]
+    }
+
+    pub(super) fn configure(&self, command: &mut Command) {
+        for (key, value) in self.environment() {
+            if let Some(value) = value {
+                command.env(key, value);
+            } else {
+                command.env_remove(key);
+            }
+        }
+    }
+
+    pub(super) fn verify_process(&self) -> Result<(), String> {
+        self.verify_environment(|key| std::env::var_os(key))
+    }
+
+    fn verify_environment(
+        &self,
+        read: impl Fn(&str) -> Option<std::ffi::OsString>,
+    ) -> Result<(), String> {
+        for (key, expected) in self.environment() {
+            let expected = expected.map(std::ffi::OsString::from);
+            if read(key) != expected {
+                return Err(format!(
+                    "environment_changed: process {key} differs from recorded effective settings"
+                ));
+            }
+        }
+        for key in ["FAILPOINTS", "OMNIGRAPH_TRAVERSAL_MODE"] {
+            if read(key).is_some() {
+                return Err(format!("environment_changed: worker inherited {key}"));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn settings_drive_the_spawn_and_refuse_process_drift() {
+        for seed in [None, Some(0), Some(u64::MAX)] {
+            let settings = EffectiveSettings::for_seed(seed);
+            let mut command = Command::new("unused-worker");
+            settings.configure(&mut command);
+            let environment = command
+                .get_envs()
+                .map(|(key, value)| (key.to_os_string(), value.map(ToOwned::to_owned)))
+                .collect::<std::collections::BTreeMap<_, _>>();
+            let read = |key: &str| {
+                environment
+                    .get(std::ffi::OsStr::new(key))
+                    .cloned()
+                    .flatten()
+            };
+            assert!(settings.verify_environment(read).is_ok());
+            for key in [
+                "RAYON_NUM_THREADS",
+                "LANCE_CPU_THREADS",
+                "LANCE_DETERMINISTIC_BACKOFF",
+                "DST_ENTROPY_SEED",
+                "LANCE_MEM_POOL_SIZE",
+                "FAILPOINTS",
+                "OMNIGRAPH_TRAVERSAL_MODE",
+            ] {
+                assert!(
+                    settings
+                        .verify_environment(|name| {
+                            if name == key {
+                                Some("changed".into())
+                            } else {
+                                read(name)
+                            }
+                        })
+                        .is_err(),
+                    "accepted process drift for {key}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn recorded_settings_cannot_change_the_execution() {
+        let expected = EffectiveSettings::for_seed(Some(42));
+        let mut changed = expected.clone();
+        changed.rayon_num_threads = 2;
+        assert!(changed.verify_expected(Some(42)).is_err());
+        assert!(expected.verify_expected(Some(0)).is_err());
+        assert!(expected.verify_expected(None).is_err());
+        let mut value = serde_json::to_value(&expected).unwrap();
+        value["unknown"] = true.into();
+        assert!(serde_json::from_value::<EffectiveSettings>(value).is_err());
+    }
+
+    #[cfg(tokio_unstable)]
+    #[test]
+    fn seeded_pool_settings_match_the_dst_owner() {
+        let settings = EffectiveSettings::for_seed(Some(0));
+        for (key, value) in omnigraph_dst::env_knobs::QUIESCE_ENV {
+            assert!(settings.environment().contains(&(key, Some(value.into()))));
+        }
+    }
+}

--- a/crates/omnigraph-gqt/src/lib.rs
+++ b/crates/omnigraph-gqt/src/lib.rs
@@ -17,7 +17,7 @@
 //! integration tests carry.
 #![recursion_limit = "512"]
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::ffi::OsStr;
 use std::fmt::Write as _;
 use std::future::Future;
@@ -45,6 +45,16 @@ use omnigraph_compiler::schema::parser::parse_schema;
 use omnigraph_compiler::{JsonParamMode, QueryResult, json_params_to_param_map};
 use serde_json::Value;
 
+mod dst_runner;
+mod runner_config;
+pub use dst_runner::{
+    replay_report, report_cli_refusal, run_corpus_case, run_selected, run_worker_if_requested,
+};
+use omnigraph::storage::StorageAdapter;
+use runner_config::{
+    Execution, Fault, KnownFailure, RunnerConfig, parse_fault, parse_known_failure, parse_runner,
+};
+
 mod shape;
 use shape::{ShapeExpect, bless_shape_lines, parse_shape_body, shape_mismatch};
 
@@ -54,6 +64,11 @@ pub const BLESS_ENV: &str = "OMNIGRAPH_GQ_BLESS";
 
 #[derive(Debug)]
 struct Case {
+    input_text: String,
+    runner: RunnerConfig,
+    known_failure: Option<KnownFailure>,
+    faults: BTreeMap<usize, Fault>,
+    source_lines: BTreeMap<usize, usize>,
     schema: String,
     seed: String,
     /// The `# traversal:` pin; `None` runs the production path unscoped.
@@ -88,6 +103,16 @@ enum Step {
 }
 
 impl Step {
+    fn ordinal(&self) -> usize {
+        match self {
+            Self::Query(s) => s.ordinal,
+            Self::Mutate(s) => s.ordinal,
+            Self::Control(s) => s.ordinal,
+            Self::List(s) => s.ordinal,
+            Self::Restart { ordinal } => *ordinal,
+        }
+    }
+
     /// The rows-or-error expect of a read step (`--- query`), which is the
     /// one kind that carries a shape section.
     fn read_expect(&self) -> Option<&QueryExpect> {
@@ -1086,6 +1111,31 @@ fn parse_case(stem: &str, text: &str) -> Result<Case, String> {
     let header = parse_header(&header_lines)?;
     check_file_name(stem, &header.issue)?;
 
+    let (runner, sections) = if sections.first().is_some_and(|s| s.name == "runner") {
+        let body = sections[0]
+            .body
+            .iter()
+            .map(|(_, line)| *line)
+            .collect::<Vec<_>>()
+            .join("\n");
+        (parse_runner(&body)?, &sections[1..])
+    } else {
+        return Err(
+            "invalid_case: the first section must be `--- runner` with explicit configuration"
+                .into(),
+        );
+    };
+    let (known_failure, sections) = if sections.first().is_some_and(|s| s.name == "known_failure") {
+        let body = sections[0]
+            .body
+            .iter()
+            .map(|(_, line)| *line)
+            .collect::<Vec<_>>()
+            .join("\n");
+        (Some(parse_known_failure(&body)?), &sections[1..])
+    } else {
+        (None, sections)
+    };
     if sections.first().map(|s| s.name.as_str()) != Some("schema") {
         return Err("the first section must be `--- schema`".into());
     }
@@ -1116,6 +1166,9 @@ fn parse_case(stem: &str, text: &str) -> Result<Case, String> {
     let mut pending: Option<Pending> = None;
     let mut awaiting_shape: Option<Step> = None;
     let mut ordinal = 0usize;
+    let mut faults = BTreeMap::new();
+    let mut source_lines = BTreeMap::new();
+    let mut awaiting_fault_step = false;
     let mut qm_steps = 0usize;
     let mut substitutable_lines: HashSet<usize> = HashSet::new();
 
@@ -1152,8 +1205,38 @@ fn parse_case(stem: &str, text: &str) -> Result<Case, String> {
         {
             return Err(missing_shape(waiting));
         }
+        if awaiting_fault_step && !matches!(kind, "query" | "mutate") {
+            return Err(
+                "invalid_case: a fault must directly precede its query or mutate step".into(),
+            );
+        }
+        if matches!(kind, "query" | "mutate" | "restart") {
+            source_lines.insert(ordinal + 1, section.header_line + 1);
+            awaiting_fault_step = false;
+        }
         match kind {
-            "schema" | "seed" => {
+            "fault" => {
+                if open_loop.is_some() {
+                    return Err(
+                        "invalid_case: fault directives inside loops are not supported".into(),
+                    );
+                }
+                if faults.len() >= 16 {
+                    return Err("invalid_case: a case admits at most 16 fault directives".into());
+                }
+                if !rest.is_empty() || pending.is_some() {
+                    return Err("invalid_case: fault takes no header arguments and must precede a complete step".into());
+                }
+                let body = section
+                    .body
+                    .iter()
+                    .map(|(_, line)| *line)
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                faults.insert(ordinal + 1, parse_fault(&body)?);
+                awaiting_fault_step = true;
+            }
+            "runner" | "schema" | "seed" => {
                 return Err(format!(
                     "line {}: `--- {kind}` is out of position; schema then seed lead the file, once each",
                     section.header_line + 1
@@ -1379,6 +1462,9 @@ fn parse_case(stem: &str, text: &str) -> Result<Case, String> {
             _ => return Err(format!("unknown section `--- {}`", section.name)),
         }
     }
+    if awaiting_fault_step {
+        return Err("invalid_case: fault has no following operation".into());
+    }
     if pending.is_some() {
         return Err("the final step is missing its `--- expect`".into());
     }
@@ -1401,13 +1487,20 @@ fn parse_case(stem: &str, text: &str) -> Result<Case, String> {
             ));
         }
     }
-    Ok(Case {
+    let case = Case {
+        input_text: text.into(),
+        runner,
+        known_failure,
+        faults,
+        source_lines,
         schema,
         seed,
         traversal: header.traversal,
         items,
         needs_indices,
-    })
+    };
+    dst_runner::validate_known_failure(&case)?;
+    Ok(case)
 }
 
 fn normalize_number(n: &serde_json::Number) -> String {
@@ -1720,7 +1813,10 @@ async fn run_query_step(
         Ok(params) => params,
         Err(e) => {
             return match &step.expect {
-                QueryExpect::Error { needle } if e.contains(needle) => Ok(()),
+                QueryExpect::Error { needle } if e.contains(needle) => {
+                    dst_runner::record("parameter_error", serde_json::json!({"message": e}));
+                    Ok(())
+                }
                 QueryExpect::Error { needle } => {
                     Err(fail(format!("error does not contain \"{needle}\": {e}")))
                 }
@@ -1738,6 +1834,10 @@ async fn run_query_step(
         ),
     )
     .await;
+    dst_runner::observe_query(
+        &outcome,
+        matches!(step.expect, QueryExpect::Rows { ordered: true, .. }),
+    );
     let require_expand =
         step.expects_expand && outcome.is_ok() && matches!(step.expect, QueryExpect::Rows { .. });
     if let Some(violation) = check_pin(mode, &counts, require_expand) {
@@ -1805,6 +1905,13 @@ fn check_rows(
     let Value::Array(actual) = rows else {
         return Err(fail("engine returned a non-array row set".into()));
     };
+    dst_runner::observe(|| {
+        let mut rows = actual.iter().map(Value::to_string).collect::<Vec<_>>();
+        if !ordered {
+            rows.sort();
+        }
+        format!("{label} rows: {rows:?}")
+    });
     let expected = parse_expect_rows(&substitute(body_raw, binding)).map_err(&fail)?;
     compare_rows(&expected, &actual, ordered).map_err(|(message, rows)| StepFail {
         label: label.to_string(),
@@ -1826,6 +1933,7 @@ fn check_error_expect<T, E: std::fmt::Display>(
         )),
         Err(e) => {
             let msg = e.to_string();
+            dst_runner::observe(|| format!("error: {msg}"));
             if msg.contains(needle) {
                 Ok(())
             } else {
@@ -1859,7 +1967,14 @@ async fn run_list_step(
         message,
         bless_lines: None,
     };
-    let outcome = db.branch_list().await;
+    let outcome = match db.branch_list().await {
+        Ok(names) => Ok(list_result(names).map_err(&fail)?),
+        Err(error) => Err(error),
+    };
+    dst_runner::observe_query(
+        &outcome,
+        matches!(step.expect, QueryExpect::Rows { ordered: true, .. }),
+    );
     match &step.expect {
         QueryExpect::Rows {
             ordered,
@@ -1867,8 +1982,7 @@ async fn run_list_step(
             span,
             shape,
         } => {
-            let names = outcome.map_err(|e| fail(format!("`branch list` failed: {e}")))?;
-            let result = list_result(names).map_err(&fail)?;
+            let result = outcome.map_err(|e| fail(format!("`branch list` failed: {e}")))?;
             let catalog = db.catalog();
             if let Some(mismatch) = shape_mismatch(&shape.lines, &result, result.schema(), &catalog)
             {
@@ -1930,6 +2044,7 @@ async fn run_control_step(
             let outcome = db
                 .branch_create_from_as(ReadTarget::branch(parent), branch, None)
                 .await;
+            dst_runner::observe(|| format!("actual control: {outcome:?}"));
             check_write_expect(name, expect, outcome).map_err(fail)
         }
         ControlWrite::Delete {
@@ -1937,6 +2052,7 @@ async fn run_control_step(
             expect,
         } => {
             let outcome = db.branch_delete_as(branch, None).await;
+            dst_runner::observe(|| format!("actual control: {outcome:?}"));
             check_write_expect(name, expect, outcome).map_err(fail)
         }
         ControlWrite::Merge {
@@ -1945,9 +2061,14 @@ async fn run_control_step(
             expect,
         } => {
             let target = into.as_deref().unwrap_or(MAIN_BRANCH);
-            let outcome = db.branch_merge_as(source, target, None).await;
+            let outcome = db
+                .branch_merge_as(source, target, None)
+                .await
+                .inspect_err(dst_runner::observe_fault);
+            dst_runner::observe(|| format!("actual merge: {outcome:?}"));
             match expect {
                 MergeExpect::Write(expect) => {
+                    dst_runner::observe(|| format!("actual control: {outcome:?}"));
                     check_write_expect(name, expect, outcome).map_err(fail)
                 }
                 MergeExpect::Outcome(want) => match outcome {
@@ -1980,7 +2101,10 @@ async fn run_mutate_step(
         Ok(params) => params,
         Err(e) => {
             return match &step.expect {
-                MutateExpect::Error { needle } if e.contains(needle) => Ok(()),
+                MutateExpect::Error { needle } if e.contains(needle) => {
+                    dst_runner::record("parameter_error", serde_json::json!({"message": e}));
+                    Ok(())
+                }
                 MutateExpect::Error { needle } => {
                     Err(fail(format!("error does not contain \"{needle}\": {e}")))
                 }
@@ -1993,6 +2117,23 @@ async fn run_mutate_step(
         db.mutate(&step.branch, &step.source, &step.name, &params),
     )
     .await;
+    let outcome = outcome.inspect_err(dst_runner::observe_fault);
+    dst_runner::record(
+        "mutation_result",
+        match &outcome {
+            Ok(result) => {
+                serde_json::json!({"nodes": result.affected_nodes, "edges": result.affected_edges})
+            }
+            Err(error) => serde_json::json!({"error": error.to_string()}),
+        },
+    );
+    dst_runner::observe(|| match &outcome {
+        Ok(result) => format!(
+            "actual affected: nodes={} edges={}",
+            result.affected_nodes, result.affected_edges
+        ),
+        Err(error) => format!("actual mutation error: {error}"),
+    });
     if let Some(violation) = check_pin(mode, &counts, false) {
         return Err(fail(violation));
     }
@@ -2030,8 +2171,13 @@ async fn open_case_store(case: &Case) -> Result<(Omnigraph, String, tempfile::Te
     let db = Omnigraph::init(&uri, &case.schema)
         .await
         .map_err(|e| format!("init failed: {e}"))?;
+    seed_case(&db, case).await?;
+    Ok((db, uri, dir))
+}
+
+async fn seed_case(db: &Omnigraph, case: &Case) -> Result<(), String> {
     if !case.seed.trim().is_empty() {
-        load_jsonl(&db, &case.seed, LoadMode::Overwrite)
+        load_jsonl(db, &case.seed, LoadMode::Overwrite)
             .await
             .map_err(|e| format!("seed load failed: {e}"))?;
     }
@@ -2040,7 +2186,7 @@ async fn open_case_store(case: &Case) -> Result<(Omnigraph, String, tempfile::Te
             .await
             .map_err(|e| format!("ensure_indices failed: {e}"))?;
     }
-    Ok((db, uri, dir))
+    Ok(())
 }
 
 // Keep the complete case state machine off its callers' stack. In particular,
@@ -2055,9 +2201,46 @@ fn execute_case<'a>(
 }
 
 async fn execute_case_inner(case: &Case, path: &Path, bless: bool) -> Result<(), String> {
-    let (mut db, uri, _dir) = open_case_store(case).await?;
+    let (db, uri, _dir) = open_case_store(case).await?;
+    execute_steps(case, path, bless, db, &uri, None).await
+}
 
+#[cfg(tokio_unstable)]
+async fn execute_case_with_storage(
+    case: &Case,
+    path: &Path,
+    uri: &str,
+    storage: Arc<dyn StorageAdapter>,
+) -> Result<(), String> {
+    let db = Omnigraph::init_with_storage(uri, &case.schema, storage.clone(), Default::default())
+        .await
+        .map_err(|e| format!("init failed: {e}"))?;
+    seed_case(&db, case).await?;
+    execute_steps(case, path, false, db, uri, Some(storage)).await
+}
+
+fn execute_steps<'a>(
+    case: &'a Case,
+    path: &'a Path,
+    bless: bool,
+    db: Omnigraph,
+    uri: &'a str,
+    storage: Option<Arc<dyn StorageAdapter>>,
+) -> futures::future::BoxFuture<'a, Result<(), String>> {
+    execute_steps_inner(case, path, bless, db, uri, storage).boxed()
+}
+
+async fn execute_steps_inner(
+    case: &Case,
+    path: &Path,
+    bless: bool,
+    mut db: Omnigraph,
+    uri: &str,
+    storage: Option<Arc<dyn StorageAdapter>>,
+) -> Result<(), String> {
     let mut first_fail: Option<StepFail> = None;
+    let mut generation = 0usize;
+    dst_runner::observe(|| "lifetime: initialized generation 0".into());
     'run: for item in &case.items {
         let (values, var, steps): (Vec<Option<&str>>, Option<&str>, Vec<&Step>) = match item {
             Item::Step(step) => (vec![None], None, vec![step]),
@@ -2070,6 +2253,41 @@ async fn execute_case_inner(case: &Case, path: &Path, bless: bool) -> Result<(),
         for value in values {
             let binding = var.zip(value);
             for step in &steps {
+                let ordinal = step.ordinal();
+                dst_runner::observe(|| {
+                    format!(
+                        "operation: ordinal={ordinal} line={:?} binding={binding:?} generation={generation} expected={step:?}",
+                        case.source_lines.get(&ordinal)
+                    )
+                });
+                dst_runner::begin_operation(
+                    serde_json::json!({"ordinal": ordinal, "source_line": case.source_lines.get(&ordinal), "loop_binding": binding, "generation": generation}),
+                );
+                dst_runner::record(
+                    "expectation",
+                    match step {
+                        Step::Query(q) => read_expect_evidence(&q.expect),
+                        Step::List(l) => read_expect_evidence(&l.expect),
+                        Step::Mutate(m) => match &m.expect {
+                            MutateExpect::Ok => serde_json::json!({"kind": "ok"}),
+                            MutateExpect::Affected { nodes, edges } => {
+                                serde_json::json!({"kind": "affected", "nodes": nodes, "edges": edges})
+                            }
+                            MutateExpect::Error { needle } => {
+                                serde_json::json!({"kind": "error", "contains": needle})
+                            }
+                        },
+                        Step::Control(c) => {
+                            serde_json::json!({"control": c.name, "expectation": format!("{:?}", c.write)})
+                        }
+                        Step::Restart { .. } => {
+                            serde_json::json!({"kind": "restart", "storage": "preserved"})
+                        }
+                    },
+                );
+                let fault = case.faults.get(&ordinal);
+                let guard = dst_runner::arm_fault(fault)?;
+                let lifetime_before = dst_runner::lifetime_counts();
                 let outcome = match step {
                     Step::Query(q) => run_query_step(&db, case.traversal, q, binding).await,
                     Step::Mutate(m) => run_mutate_step(&db, case.traversal, m, binding).await,
@@ -2077,7 +2295,15 @@ async fn execute_case_inner(case: &Case, path: &Path, bless: bool) -> Result<(),
                     Step::List(l) => run_list_step(&db, l, binding).await,
                     Step::Restart { ordinal } => {
                         drop(db);
-                        db = Omnigraph::open(&uri).await.map_err(|e| {
+                        generation += 1;
+                        dst_runner::observe(|| format!("lifetime: reopen generation {generation}"));
+                        let reopened = match &storage {
+                            Some(storage) => {
+                                Omnigraph::open_with_storage(uri, storage.clone()).await
+                            }
+                            None => Omnigraph::open(uri).await,
+                        };
+                        db = reopened.map_err(|e| {
                             format!(
                                 "{}: reopen failed: {e}",
                                 step_label(*ordinal, "restart", binding)
@@ -2086,6 +2312,52 @@ async fn execute_case_inner(case: &Case, path: &Path, bless: bool) -> Result<(),
                         Ok(())
                     }
                 };
+                #[cfg(tokio_unstable)]
+                drop(guard);
+                #[cfg(not(tokio_unstable))]
+                let _ = guard;
+                let lifetime_after = dst_runner::lifetime_counts();
+                dst_runner::record(
+                    "engine_lifetime",
+                    serde_json::json!({"before": lifetime_before, "after": lifetime_after}),
+                );
+                if let (Some(before), Some(after)) = (lifetime_before, lifetime_after) {
+                    let opens = u64::from(matches!(step, Step::Restart { .. }));
+                    if after != [before[0], before[1] + opens] {
+                        return Err(format!(
+                            "worker_failed: unexpected engine init/open call during step {ordinal}: {before:?} -> {after:?}"
+                        ));
+                    }
+                }
+                let fault_result = dst_runner::finish_fault(fault);
+                dst_runner::record(
+                    "assertion",
+                    match &outcome {
+                        Ok(()) => serde_json::json!({"status": "passed"}),
+                        Err(error) => {
+                            serde_json::json!({"status": "failed", "code": "assertion_failed", "message": error.message})
+                        }
+                    },
+                );
+                dst_runner::observe(|| {
+                    format!(
+                        "operation result: {:?}",
+                        outcome.as_ref().map_err(|f| (&f.label, &f.message))
+                    )
+                });
+                if let Err(error) = fault_result {
+                    return Err(format!(
+                        "{error}; operation result: {:?}",
+                        outcome.as_ref().map_err(|f| (&f.label, &f.message))
+                    ));
+                }
+                if storage.is_some() {
+                    let snapshot = db
+                        .resolve_snapshot("main")
+                        .await
+                        .map_err(|e| format!("observe main snapshot: {e}"))?;
+                    dst_runner::observe(|| format!("main snapshot: {snapshot}"));
+                }
                 if let Err(fail) = outcome {
                     first_fail = Some(fail);
                     break 'run;
@@ -2102,7 +2374,7 @@ async fn execute_case_inner(case: &Case, path: &Path, bless: bool) -> Result<(),
             if case.has_loops() {
                 detail.push_str("\nbless: refused, the case contains loops");
             } else {
-                bless_rewrite(path, *span, lines)?;
+                bless_rewrite(path, *span, lines, &case.input_text)?;
                 let _ = write!(
                     detail,
                     "\nbless: expect rewritten in place ({} lines), re-run to confirm",
@@ -2112,6 +2384,20 @@ async fn execute_case_inner(case: &Case, path: &Path, bless: bool) -> Result<(),
         }
     }
     Err(detail)
+}
+
+fn read_expect_evidence(expect: &QueryExpect) -> Value {
+    match expect {
+        QueryExpect::Rows {
+            ordered,
+            body_raw,
+            shape,
+            ..
+        } => {
+            serde_json::json!({"kind": "rows", "ordered": ordered, "rows_jsonl": body_raw, "shape": format!("{:?}", shape.lines)})
+        }
+        QueryExpect::Error { needle } => serde_json::json!({"kind": "error", "contains": needle}),
+    }
 }
 
 fn splice_lines(original: &str, span: BodySpan, lines: &[String]) -> String {
@@ -2131,9 +2417,17 @@ fn splice_lines(original: &str, span: BodySpan, lines: &[String]) -> String {
     joined
 }
 
-fn bless_rewrite(path: &Path, span: BodySpan, lines: &[String]) -> Result<(), String> {
+fn bless_rewrite(
+    path: &Path,
+    span: BodySpan,
+    lines: &[String],
+    expected: &str,
+) -> Result<(), String> {
     let original =
         std::fs::read_to_string(path).map_err(|e| format!("bless: cannot re-read case: {e}"))?;
+    if original != expected {
+        return Err("environment_changed: case changed before bless".into());
+    }
     std::fs::write(path, splice_lines(&original, span, lines))
         .map_err(|e| format!("bless: cannot write case: {e}"))
 }
@@ -2145,6 +2439,15 @@ pub async fn run_case(path: PathBuf, bless: bool) -> Result<(), String> {
     let stem = stem_of(&path);
     let text = std::fs::read_to_string(&path).map_err(|e| format!("cannot read case file: {e}"))?;
     let case = parse_case(&stem, &text).map_err(|e| format!("refused: {e}"))?;
+    if case.runner.environments.len() != 1
+        || !matches!(
+            case.runner.environments[0].execution,
+            Execution::Engine { .. }
+        )
+    {
+        return Err("DST cases require the file dispatcher; the async normal runner cannot execute mode: dst".into());
+    }
+    case.runner.environments[0].admit(!case.faults.is_empty())?;
     execute_case(&case, &path, bless).await
 }
 

--- a/crates/omnigraph-gqt/src/main.rs
+++ b/crates/omnigraph-gqt/src/main.rs
@@ -1,0 +1,144 @@
+#![recursion_limit = "512"]
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+struct Selection {
+    path: PathBuf,
+    target: Option<String>,
+    storage: Option<String>,
+    seed: Option<u64>,
+}
+
+enum Invocation {
+    Replay(PathBuf),
+    Case(Selection),
+}
+
+fn parse(args: &[OsString]) -> Result<Invocation, String> {
+    let mut args = args.iter();
+    let first = args.next().ok_or("usage: omnigraph-gqt <case.gqt> [--target <target>] [--storage <storage>] [--seed <u64>] | --replay <report.json>")?;
+    if first == "--replay" {
+        let path = args
+            .next()
+            .map(PathBuf::from)
+            .ok_or("--replay requires a report path")?;
+        if args.next().is_some() {
+            return Err("--replay accepts only its report path".into());
+        }
+        return Ok(Invocation::Replay(path));
+    }
+    if first.to_string_lossy().starts_with("--") {
+        return Err("expected a case path or --replay".into());
+    }
+    let mut selection = Selection {
+        path: first.into(),
+        target: None,
+        storage: None,
+        seed: None,
+    };
+    while let Some(arg) = args.next() {
+        match arg.to_str() {
+            Some("--target") if selection.target.is_none() => {
+                selection.target = Some(
+                    args.next()
+                        .and_then(|v| v.to_str())
+                        .ok_or("--target requires a target")?
+                        .into(),
+                );
+            }
+            Some("--storage") if selection.storage.is_none() => {
+                selection.storage = Some(
+                    args.next()
+                        .and_then(|v| v.to_str())
+                        .ok_or("--storage requires a storage value")?
+                        .into(),
+                );
+            }
+            Some("--seed") if selection.seed.is_none() => {
+                selection.seed = Some(
+                    args.next()
+                        .and_then(|v| v.to_str())
+                        .ok_or("--seed requires u64")?
+                        .parse::<u64>()
+                        .map_err(|e| format!("invalid seed: {e}"))?,
+                );
+            }
+            _ => {
+                return Err(
+                    "unknown or repeated option; configuration belongs in the case file".into(),
+                );
+            }
+        }
+    }
+    Ok(Invocation::Case(selection))
+}
+
+fn run() -> Result<(), String> {
+    let args: Vec<_> = std::env::args_os().skip(1).collect();
+    let replay = args.first().is_some_and(|arg| arg == "--replay");
+    let case_path = args
+        .first()
+        .filter(|arg| !arg.to_string_lossy().starts_with("--"))
+        .map(PathBuf::from);
+    if let Some(path) = &case_path {
+        if omnigraph_gqt::run_worker_if_requested(path)? {
+            return Ok(());
+        }
+    }
+    let source_report = if replay {
+        args.get(1).map(PathBuf::from)
+    } else {
+        None
+    };
+    let refusal =
+        |error| omnigraph_gqt::report_cli_refusal(case_path.clone(), source_report.clone(), error);
+    let invocation = parse(&args).map_err(|error| refusal(format!("invalid_case: {error}")))?;
+    let executable = std::env::current_exe().map_err(|error| {
+        refusal(format!(
+            "environment_changed: locate GQT executable: {error}"
+        ))
+    })?;
+    match invocation {
+        Invocation::Replay(path) => omnigraph_gqt::replay_report(&path, &executable),
+        Invocation::Case(selection) => {
+            let outcome = omnigraph_gqt::run_selected(
+                &selection.path,
+                &executable,
+                omnigraph_gqt::bless_from_env(),
+                selection.target.as_deref(),
+                selection.storage.as_deref(),
+                selection.seed,
+            );
+            println!(
+                "{} {} {:.2}s",
+                if outcome.result.is_ok() {
+                    if selection.target.is_some()
+                        || selection.storage.is_some()
+                        || selection.seed.is_some()
+                    {
+                        "ok (selected execution)"
+                    } else {
+                        "ok"
+                    }
+                } else {
+                    "FAIL"
+                },
+                outcome.stem,
+                outcome.elapsed.as_secs_f64()
+            );
+            outcome.result
+        }
+    }
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("{error}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/crates/omnigraph-gqt/src/runner_config.rs
+++ b/crates/omnigraph-gqt/src/runner_config.rs
@@ -1,0 +1,279 @@
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RunnerConfig {
+    pub(crate) timeout_ms: u64,
+    pub(crate) environments: Vec<Environment>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(transparent)]
+pub(crate) struct Environment {
+    pub(crate) execution: Execution,
+}
+
+impl std::fmt::Display for Environment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&serde_json::to_string(self).map_err(|_| std::fmt::Error)?)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(tag = "target", deny_unknown_fields)]
+pub(crate) enum Execution {
+    #[serde(rename = "omnigraph-engine")]
+    Engine { storage: Storage },
+    #[serde(rename = "omnigraph-engine-dst")]
+    Dst { storage: Storage, seeds: Vec<u64> },
+    #[serde(rename = "omnigraph-server")]
+    Server { storage: Storage },
+    #[serde(rename = "omnigraph-server-dst")]
+    ServerDst { storage: Storage, seeds: Vec<u64> },
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum Storage {
+    LocalFilesystem,
+    InMemoryObjectStore,
+    S3Compatible,
+    #[serde(rename = "azure-blob-storage")]
+    AzureBlob,
+}
+
+impl Environment {
+    pub(crate) fn matches(&self, target: Option<&str>, storage: Option<&str>) -> bool {
+        let (actual_target, actual_storage) = match self.execution {
+            Execution::Engine { storage } => ("omnigraph-engine", storage),
+            Execution::Dst { storage, .. } => ("omnigraph-engine-dst", storage),
+            Execution::Server { storage } => ("omnigraph-server", storage),
+            Execution::ServerDst { storage, .. } => ("omnigraph-server-dst", storage),
+        };
+        let actual_storage = match actual_storage {
+            Storage::LocalFilesystem => "local-filesystem",
+            Storage::InMemoryObjectStore => "in-memory-object-store",
+            Storage::S3Compatible => "s3-compatible",
+            Storage::AzureBlob => "azure-blob-storage",
+        };
+        target.is_none_or(|value| value == actual_target)
+            && storage.is_none_or(|value| value == actual_storage)
+    }
+
+    pub(crate) fn seeds(&self) -> Vec<Option<u64>> {
+        match &self.execution {
+            Execution::Dst { seeds, .. } | Execution::ServerDst { seeds, .. } => {
+                seeds.iter().copied().map(Some).collect()
+            }
+            _ => vec![None],
+        }
+    }
+
+    pub(crate) fn admit(&self, has_faults: bool) -> Result<(), String> {
+        match self.execution {
+            Execution::Engine {
+                storage: Storage::LocalFilesystem,
+            } if !has_faults => Ok(()),
+            Execution::Dst {
+                storage: Storage::InMemoryObjectStore,
+                ..
+            } => {
+                if cfg!(tokio_unstable) {
+                    Ok(())
+                } else {
+                    Err("unsupported_environment: DST runner is unavailable in this build; build from crates/omnigraph-gqt".into())
+                }
+            }
+            _ => Err(format!(
+                "unsupported_environment: {} requests an unavailable combination; implemented combinations are omnigraph-engine/local-filesystem without faults and omnigraph-engine-dst/in-memory-object-store",
+                self
+            )),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Fault {
+    pub(crate) at: String,
+    pub(crate) occurrence: usize,
+    pub(crate) action: FaultAction,
+    pub(crate) scope: FaultScope,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct KnownFailure {
+    pub(crate) step: usize,
+    #[serde(rename = "match")]
+    pub(crate) matcher: ErrorMatch,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(tag = "error", deny_unknown_fields)]
+pub(crate) enum ErrorMatch {
+    RecoveryRequired { reason: String },
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum FaultAction {
+    ReturnError,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum FaultScope {
+    NextStep,
+}
+
+fn yaml<T: serde::de::DeserializeOwned>(body: &str) -> Result<T, String> {
+    if body
+        .split(|c: char| c.is_whitespace() || "[]{},:".contains(c))
+        .any(|word| word.starts_with(['&', '*', '!']) || word == "<<")
+    {
+        return Err("invalid_case: YAML aliases, anchors, tags and merge keys are refused".into());
+    }
+    serde_yaml::from_str(body)
+        .map_err(|error| format!("invalid_case: invalid runner configuration: {error}"))
+}
+
+pub(crate) fn parse_runner(body: &str) -> Result<RunnerConfig, String> {
+    let config: RunnerConfig = yaml(body)?;
+    if !(1..=600_000).contains(&config.timeout_ms) {
+        return Err("invalid_case: timeout_ms must be between 1 and 600000".into());
+    }
+    if !(1..=16).contains(&config.environments.len()) {
+        return Err("invalid_case: environments must contain between 1 and 16 entries".into());
+    }
+    let mut environments = BTreeSet::new();
+    for env in &config.environments {
+        if !environments.insert(env) {
+            return Err(format!(
+                "invalid_case: duplicate environment parameters: {env}"
+            ));
+        }
+        if let Execution::Dst { seeds, .. } | Execution::ServerDst { seeds, .. } = &env.execution {
+            if !(1..=64).contains(&seeds.len())
+                || seeds.iter().collect::<BTreeSet<_>>().len() != seeds.len()
+            {
+                return Err("invalid_case: DST seeds require 1 to 64 distinct u64 values".into());
+            }
+        }
+    }
+    Ok(config)
+}
+
+pub(crate) fn parse_fault(body: &str) -> Result<Fault, String> {
+    let fault: Fault = yaml(body)?;
+    if !(1..=1_000_000).contains(&fault.occurrence) {
+        return Err("invalid_case: fault occurrence must be between 1 and 1000000".into());
+    }
+    Ok(fault)
+}
+
+pub(crate) fn parse_known_failure(body: &str) -> Result<KnownFailure, String> {
+    let known_failure: KnownFailure = yaml(body)?;
+    let ErrorMatch::RecoveryRequired { reason } = &known_failure.matcher;
+    if known_failure.step == 0 || reason.trim().is_empty() || reason.len() > 2048 {
+        return Err("invalid_case: known_failure requires a positive step and a nonempty RecoveryRequired reason (at most 2048 bytes)".into());
+    }
+    Ok(known_failure)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ENGINE: &str = "timeout_ms: 10000\nenvironments:\n  - target: omnigraph-engine\n    storage: local-filesystem\n";
+
+    #[test]
+    fn explicit_config_and_admission() {
+        let config = parse_runner(ENGINE).unwrap();
+        assert!(config.environments[0].admit(false).is_ok());
+        assert!(config.environments[0].admit(true).is_err());
+        let server = ENGINE.replace("omnigraph-engine", "omnigraph-server");
+        assert!(
+            parse_runner(&server).unwrap().environments[0]
+                .admit(false)
+                .is_err()
+        );
+        let dst = ENGINE
+            .replace("omnigraph-engine", "omnigraph-engine-dst")
+            .replace("local-filesystem", "in-memory-object-store")
+            + "    seeds: [0, 42]\n";
+        assert_eq!(
+            parse_runner(&dst).unwrap().environments[0].seeds(),
+            vec![Some(0), Some(42)]
+        );
+    }
+
+    #[test]
+    fn refuses_missing_unknown_duplicate_and_inapplicable_fields() {
+        for body in [
+            ENGINE.replace("timeout_ms: 10000\n", ""),
+            ENGINE.replace("    storage: local-filesystem\n", ""),
+            ENGINE.replace("  - target: omnigraph-engine\n", "  - "),
+            format!("version: 1\n{ENGINE}"),
+            format!("{ENGINE}    id: engine\n"),
+            ENGINE.replace("10000", "0"),
+            ENGINE.replace("10000", "600001"),
+            ENGINE.replace("target:", "runtime:"),
+            format!("{ENGINE}    seeds: [0]\n"),
+            format!("{ENGINE}    target: omnigraph-engine\n"),
+            ENGINE.replace(
+                "target: omnigraph-engine",
+                "target: &alias omnigraph-engine",
+            ),
+            ENGINE.replace("target: omnigraph-engine", "target: *alias"),
+            ENGINE.replace("target: omnigraph-engine", "target: !str omnigraph-engine"),
+            ENGINE.replace("environments:", "environments: []\nignored:"),
+        ] {
+            assert!(parse_runner(&body).is_err(), "accepted {body}");
+        }
+    }
+
+    #[test]
+    fn seed_and_environment_bounds() {
+        let dst = ENGINE.replace("omnigraph-engine", "omnigraph-engine-dst");
+        for seeds in [
+            "[]".into(),
+            "[0, 0]".into(),
+            "[-1]".into(),
+            format!("{:?}", (0..65).collect::<Vec<_>>()),
+        ] {
+            assert!(parse_runner(&format!("{dst}    seeds: {seeds}\n")).is_err());
+        }
+        let entry = ENGINE.split_once("environments:\n").unwrap().1;
+        assert!(parse_runner(&format!("{ENGINE}{entry}")).is_err());
+        let first = format!("{dst}    seeds: [0]\n");
+        let other = first
+            .split_once("environments:\n")
+            .unwrap()
+            .1
+            .replace("[0]", "[42]");
+        assert_eq!(
+            parse_runner(&format!("{first}{other}"))
+                .unwrap()
+                .environments
+                .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn fault_fields_are_required_and_closed() {
+        let fault = "at: branch_merge.post_authority_capture\noccurrence: 1\naction: return_error\nscope: next_step";
+        assert!(parse_fault(fault).is_ok());
+        for text in [
+            fault.replace("scope: next_step", ""),
+            fault.replace("next_step", "workload"),
+            fault.replace("occurrence: 1", "occurrence: 0"),
+            fault.replace("return_error", "panic"),
+        ] {
+            assert!(parse_fault(&text).is_err());
+        }
+    }
+}

--- a/crates/omnigraph-gqt/src/tests.rs
+++ b/crates/omnigraph-gqt/src/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 const HDR: &str = "# issue: none\n";
-const SCHEMA: &str = "--- schema\nnode Person {\n    name: String @key\n}\n";
+const SCHEMA: &str = "--- runner\ntimeout_ms: 10000\nenvironments:\n  - target: omnigraph-engine\n    storage: local-filesystem\n\n--- schema\nnode Person {\n    name: String @key\n}\n";
 const SEED: &str = "--- seed\n{\"type\":\"Person\",\"data\":{\"name\":\"alice\"}}\n";
 const QUERY: &str =
     "--- query\nquery all() {\n    match { $p: Person }\n    return { $p.name }\n}\n";
@@ -391,7 +391,7 @@ fn refuses_substitution_marker_in_a_statement_body() {
     );
     assert_eq!(
         refusal("x", &text),
-        "line 10: `${` may appear only inside a params or expect body"
+        "line 16: `${` may appear only inside a params or expect body"
     );
 }
 
@@ -669,7 +669,7 @@ fn refuses_ordered_expect_without_an_order_clause() {
 
 #[test]
 fn refuses_embed_schema() {
-    let schema = "--- schema\nnode Doc {\n    slug: String @key\n    text: String\n    vec: Vector(4) @embed(\"text\")\n}\n";
+    let schema = "--- runner\ntimeout_ms: 10000\nenvironments:\n  - target: omnigraph-engine\n    storage: local-filesystem\n\n--- schema\nnode Doc {\n    slug: String @key\n    text: String\n    vec: Vector(4) @embed(\"text\")\n}\n";
     let seed = "--- seed\n";
     let text = format!("{HDR}{schema}{seed}{QUERY}{EXPECT}")
         .replace("$p: Person", "$p: Doc")
@@ -701,7 +701,7 @@ fn accepts_empty_expect_body_as_empty_result_assertion() {
 
 #[test]
 fn search_construct_sets_the_index_decision() {
-    let schema = "--- schema\nnode Doc {\n    slug: String @key\n    text: String @index\n}\n";
+    let schema = "--- runner\ntimeout_ms: 10000\nenvironments:\n  - target: omnigraph-engine\n    storage: local-filesystem\n\n--- schema\nnode Doc {\n    slug: String @key\n    text: String @index\n}\n";
     let query = "--- query\nquery q($q: String) {\n    match {\n        $d: Doc\n        search($d.text, $q)\n    }\n    return { $d.slug }\n}\n";
     let text = format!(
         "{HDR}{schema}--- seed\n{query}--- params\n{{\"q\": \"needle\"}}\n--- expect unordered\n--- expect shape\nd.slug: String\n"
@@ -925,7 +925,7 @@ mod shape_section {
         );
     }
 
-    const AGE_SCHEMA: &str = "--- schema\nnode Person {\n    name: String @key\n    age: I32?\n}\n";
+    const AGE_SCHEMA: &str = "--- runner\ntimeout_ms: 10000\nenvironments:\n  - target: omnigraph-engine\n    storage: local-filesystem\n\n--- schema\nnode Person {\n    name: String @key\n    age: I32?\n}\n";
     const AGE_SEED: &str = "--- seed\n{\"type\":\"Person\",\"data\":{\"name\":\"alice\",\"age\":30}}\n{\"type\":\"Person\",\"data\":{\"name\":\"bob\"}}\n";
     const AGE_QUERY: &str =
         "--- query\nquery all() {\n    match { $p: Person }\n    return { $p.name, $p.age }\n}\n";
@@ -954,7 +954,7 @@ mod shape_section {
             format!("{HDR}{SCHEMA}{SEED}{QUERY}--- expect unordered\n{{\"p.name\": \"alice\"}}\n");
         let reason = refusal("x", &text);
         assert!(
-            reason.contains("line 13: the rows expect needs an `--- expect shape` section"),
+            reason.contains("line 19: the rows expect needs an `--- expect shape` section"),
             "{reason}"
         );
         assert!(reason.contains("OMNIGRAPH_GQ_BLESS=1"), "{reason}");
@@ -1441,7 +1441,7 @@ fn expects_expand_ignores_bound_edges_and_plain_bindings() {
 }
 
 /// A two-node, one-edge graph with a one-hop traversal, for the pin tests.
-const TRAVERSAL_SCHEMA: &str = "--- schema\nnode Person {\n    name: String @key\n}\n\n\
+const TRAVERSAL_SCHEMA: &str = "--- runner\ntimeout_ms: 10000\nenvironments:\n  - target: omnigraph-engine\n    storage: local-filesystem\n\n--- schema\nnode Person {\n    name: String @key\n}\n\n\
                                 edge Knows: Person -> Person {\n    since: I64\n}\n";
 const TRAVERSAL_SEED: &str = "--- seed\n{\"type\":\"Person\",\"data\":{\"name\":\"alice\"}}\n\
                               {\"type\":\"Person\",\"data\":{\"name\":\"bob\"}}\n\
@@ -1701,4 +1701,50 @@ fn bless_splice_inserts_into_an_empty_expect_body() {
     let rows = vec!["{\"n\":1}".to_string()];
     let out = splice_lines(original, span, &rows);
     assert_eq!(out, "--- expect unordered\n{\"n\":1}\n--- restart\n");
+}
+
+#[test]
+fn runner_is_required_and_cannot_be_repeated() {
+    let text = format!("{HDR}{SCHEMA}{SEED}{QUERY}{EXPECT}");
+    let case = parse_case("normal", &text).unwrap();
+    assert!(
+        case.runner.environments[0].matches(Some("omnigraph-engine"), Some("local-filesystem"))
+    );
+    let runner_end = text.find("--- schema").unwrap();
+    let missing = format!("{HDR}{}", &text[runner_end..]);
+    assert!(refusal("normal", &missing).contains("--- runner"));
+    let duplicate = text.replacen(
+        "--- schema",
+        &format!("{}--- schema", &text[HDR.len()..runner_end]),
+        1,
+    );
+    assert!(parse_case("normal", &duplicate).is_err());
+}
+
+#[test]
+fn fault_limits_and_loop_scope_are_enforced() {
+    let fault = "--- fault\nat: mutation.post_sidecar_pre_fork\noccurrence: 1\naction: return_error\nscope: next_step\n";
+    let operation = "--- mutate\nquery add() { insert Person { name: \"bob\" } }\n--- expect error: injected failpoint\n";
+    let prefix = format!("{HDR}{SCHEMA}{SEED}");
+    assert!(
+        parse_case(
+            "fault_limit",
+            &format!("{prefix}{}", format!("{fault}{operation}").repeat(16))
+        )
+        .is_ok()
+    );
+    assert!(
+        refusal(
+            "fault_limit",
+            &format!("{prefix}{}", format!("{fault}{operation}").repeat(17))
+        )
+        .contains("at most 16")
+    );
+    assert!(
+        refusal(
+            "fault_loop",
+            &format!("{prefix}--- loop $i 0 1\n{fault}{operation}--- endloop\n")
+        )
+        .contains("inside loops")
+    );
 }

--- a/crates/omnigraph-gqt/tests/fixtures/runner/deadline.gqt
+++ b/crates/omnigraph-gqt/tests/fixtures/runner/deadline.gqt
@@ -1,0 +1,25 @@
+# issue: none
+--- runner
+timeout_ms: 1
+environments:
+  - target: omnigraph-engine-dst
+    storage: in-memory-object-store
+    seeds: [42]
+
+--- schema
+node Person {
+    name: String @key
+}
+--- seed
+{"type":"Person","data":{"name":"alice"}}
+--- mutate
+query add() { insert Person { name: "bob" } }
+--- expect affected: nodes=1 edges=0
+--- restart
+--- query
+query all() { match { $p: Person } return { $p.name } }
+--- expect unordered
+{"p.name":"alice"}
+{"p.name":"bob"}
+--- expect shape
+p.name: String

--- a/crates/omnigraph-gqt/tests/fixtures/runner/spoofed_error_fault.gqt
+++ b/crates/omnigraph-gqt/tests/fixtures/runner/spoofed_error_fault.gqt
@@ -1,0 +1,19 @@
+# issue: none
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine-dst
+    storage: in-memory-object-store
+    seeds: [42]
+
+--- schema
+node Person { name: String @key }
+--- seed
+--- fault
+at: branch_merge.post_sidecar_pre_fork
+occurrence: 1
+action: return_error
+scope: next_step
+--- mutate
+branch merge "injected failpoint triggered: branch_merge.post_sidecar_pre_fork" into main
+--- expect error: injected failpoint triggered: branch_merge.post_sidecar_pre_fork

--- a/crates/omnigraph-gqt/tests/fixtures/runner/spoofed_fault.gqt
+++ b/crates/omnigraph-gqt/tests/fixtures/runner/spoofed_fault.gqt
@@ -1,0 +1,29 @@
+# issue: none
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine-dst
+    storage: in-memory-object-store
+    seeds: [42]
+
+--- schema
+node Person { name: String @key }
+--- seed
+{"type": "Person", "data": {"name": "injected failpoint triggered: branch_merge.post_sidecar_pre_fork"}}
+--- query
+query all() { match { $p: Person } return { $p.name } }
+--- expect unordered
+{"p.name": "injected failpoint triggered: branch_merge.post_sidecar_pre_fork"}
+--- expect shape
+p.name: String
+--- mutate
+branch create source
+--- expect ok
+--- fault
+at: branch_merge.post_sidecar_pre_fork
+occurrence: 1
+action: return_error
+scope: next_step
+--- mutate
+branch merge source into main
+--- expect ok

--- a/crates/omnigraph-gqt/tests/fixtures/runner/unknown_fault.gqt
+++ b/crates/omnigraph-gqt/tests/fixtures/runner/unknown_fault.gqt
@@ -1,0 +1,31 @@
+# issue: none
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine-dst
+    storage: in-memory-object-store
+    seeds: [42]
+
+--- schema
+node Person {
+    name: String @key
+}
+--- seed
+{"type":"Person","data":{"name":"alice"}}
+--- fault
+at: branch_merge.typo
+occurrence: 1
+action: return_error
+scope: next_step
+
+--- mutate
+query add() { insert Person { name: "bob" } }
+--- expect affected: nodes=1 edges=0
+--- restart
+--- query
+query all() { match { $p: Person } return { $p.name } }
+--- expect unordered
+{"p.name":"alice"}
+{"p.name":"bob"}
+--- expect shape
+p.name: String

--- a/crates/omnigraph-gqt/tests/fixtures/runner/unreached_fault.gqt
+++ b/crates/omnigraph-gqt/tests/fixtures/runner/unreached_fault.gqt
@@ -1,0 +1,29 @@
+# issue: none
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine-dst
+    storage: in-memory-object-store
+    seeds: [42]
+
+--- schema
+node Person { name: String @key }
+--- seed
+{"type": "Person", "data": {"name": "alice"}}
+--- query
+query all() { match { $p: Person } return { $p.name } }
+--- expect unordered
+{"p.name": "alice"}
+--- expect shape
+p.name: String
+--- mutate
+branch create source
+--- expect ok
+--- fault
+at: branch_merge.post_sidecar_pre_fork
+occurrence: 1
+action: return_error
+scope: next_step
+--- mutate
+branch merge source into main
+--- expect ok

--- a/crates/omnigraph-gqt/tests/gq_logic_tests.rs
+++ b/crates/omnigraph-gqt/tests/gq_logic_tests.rs
@@ -11,66 +11,25 @@
 #![recursion_limit = "512"]
 
 use std::path::Path;
-use std::sync::OnceLock;
-
-use omnigraph_gqt::{
-    bless_from_env, case_budget_from_env, run_case_bounded, traversal_override_refusal,
-};
-use tokio::runtime::Runtime;
-
-/// Worker stack for the case runtime: the engine's query futures overflow
-/// the 2 MiB default (CI sets `RUST_MIN_STACK` to this same value for the
-/// engine test jobs; pinning it here keeps this target's cases independent
-/// of it; the crate's unit tests run on libtest's own threads).
-const WORKER_STACK_BYTES: usize = 16 * 1024 * 1024;
-
-/// One multi-thread runtime shared by every case; libtest calls `case`
-/// from its own worker threads, each call spawns its case onto the runtime
-/// and blocks on the join handle.
-fn runtime() -> &'static Runtime {
-    static RT: OnceLock<Runtime> = OnceLock::new();
-    RT.get_or_init(|| {
-        tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .thread_stack_size(WORKER_STACK_BYTES)
-            .build()
-            .expect("tokio runtime")
-    })
-}
 
 fn case(path: &Path) -> datatest_stable::Result<()> {
-    if let Some(reason) =
-        traversal_override_refusal(std::env::var_os("OMNIGRAPH_TRAVERSAL_MODE").as_deref())
-    {
+    if let Some(reason) = omnigraph_gqt::traversal_override_refusal(
+        std::env::var_os("OMNIGRAPH_TRAVERSAL_MODE").as_deref(),
+    ) {
         return Err(reason.into());
     }
-    let rt = runtime();
-    let task = rt.spawn(run_case_bounded(
-        path.to_path_buf(),
-        case_budget_from_env(),
-        bless_from_env(),
-    ));
-    // `run_case_bounded` catches the case's own panics; the task around it
-    // holds nothing that can panic.
-    let outcome = rt.block_on(task).expect("a case task never panics");
-    let secs = outcome.elapsed.as_secs_f64();
-    match outcome.result {
-        Ok(()) => {
-            println!("ok {} {secs:.2}s", outcome.stem);
-            Ok(())
-        }
-        Err(detail) => {
-            // The detail (row diff, refusal, panic text, budget overrun) goes
-            // to stdout under the FAIL line: the harness renders a returned
-            // error Debug-escaped on one line, which hides a multi-line diff.
-            println!(
-                "FAIL {} {secs:.2}s\n  {}",
-                outcome.stem,
-                detail.replace('\n', "\n  ")
-            );
-            Err(format!("{}: see its FAIL block above", outcome.stem).into())
-        }
-    }
+    let outcome = omnigraph_gqt::run_corpus_case(
+        path,
+        Path::new(env!("CARGO_BIN_EXE_omnigraph-gqt")),
+        omnigraph_gqt::bless_from_env(),
+    );
+    println!(
+        "{} {} {:.2}s",
+        if outcome.result.is_ok() { "ok" } else { "FAIL" },
+        outcome.stem,
+        outcome.elapsed.as_secs_f64()
+    );
+    outcome.result.map_err(Into::into)
 }
 
 datatest_stable::harness! {

--- a/crates/omnigraph-gqt/tests/replay_coverage.rs
+++ b/crates/omnigraph-gqt/tests/replay_coverage.rs
@@ -1,0 +1,82 @@
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+fn report(output: &Output) -> (PathBuf, serde_json::Value) {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let paths = stdout
+        .lines()
+        .filter_map(|line| line.strip_prefix("GQT report: "))
+        .collect::<Vec<_>>();
+    assert_eq!(paths.len(), 1, "{stdout}");
+    let path = PathBuf::from(paths[0]);
+    let summary = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+    (path, summary)
+}
+
+#[test]
+fn replay_reports_only_current_attempts_after_refusal_or_mismatch() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("replay_coverage.gqt");
+    let text = include_str!("../cases/dst_restart_preserves_rows.gqt").replace(
+        "  - target: omnigraph-engine-dst\n    storage: in-memory-object-store\n    seeds: [0, 42]\n",
+        "",
+    );
+    std::fs::write(&path, text).unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+        .arg(&path)
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{output:?}");
+    let (prior_path, prior) = report(&output);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+        .arg("--replay")
+        .arg(&prior_path)
+        .env("OMNIGRAPH_TRAVERSAL_MODE", "invalid")
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let (_, refused) = report(&output);
+    assert_ne!(refused["invocation_id"], prior["invocation_id"]);
+    assert_eq!(refused["replay_of"], prior["invocation_id"]);
+    assert!(refused["attempts"].as_array().unwrap().is_empty());
+    assert_eq!(refused["planned"], prior["planned"]);
+    assert_eq!(refused["not_run"].as_array().unwrap().len(), 1);
+    assert_eq!(refused["not_run"][0]["execution"], prior["planned"][0]);
+    assert_eq!(
+        refused["not_run"][0]["reason"]["error"],
+        refused["result"]["Err"]
+    );
+    assert!(
+        refused["result"]["Err"]
+            .as_str()
+            .unwrap()
+            .contains("OMNIGRAPH_TRAVERSAL_MODE")
+    );
+
+    let mut changed = prior.clone();
+    changed["attempts"][0]["outcome"]["Ok"]["observations"]
+        .as_array_mut()
+        .unwrap()
+        .push("observation absent from the executed worker".into());
+    let changed_path = directory.path().join("changed_observations.json");
+    std::fs::write(&changed_path, serde_json::to_vec(&changed).unwrap()).unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+        .arg("--replay")
+        .arg(&changed_path)
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let (_, mismatch) = report(&output);
+    assert_eq!(mismatch["code"], "replay_mismatch");
+    assert!(mismatch["not_run"].as_array().unwrap().is_empty());
+    assert_eq!(mismatch["attempts"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        mismatch["attempts"][0]["outcome"],
+        prior["attempts"][0]["outcome"]
+    );
+    assert_ne!(
+        mismatch["attempts"][0]["outcome"],
+        changed["attempts"][0]["outcome"]
+    );
+}

--- a/crates/omnigraph-gqt/tests/result_evidence.rs
+++ b/crates/omnigraph-gqt/tests/result_evidence.rs
@@ -1,0 +1,114 @@
+use std::path::Path;
+use std::process::{Command, Output};
+
+use serde_json::{Value, json};
+
+fn execute(stem: &str, text: &str) -> Output {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join(format!("{stem}.gqt"));
+    std::fs::write(&path, text).unwrap();
+    Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+        .arg(path)
+        .output()
+        .expect("execute result-evidence case")
+}
+
+fn report(output: &Output) -> Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let path = stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("GQT report: "))
+        .expect("retained result-evidence report");
+    serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap()
+}
+
+#[test]
+fn regression_gate_skeleton_executes_with_the_current_parser() {
+    let script =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../scripts/check-fix-regression.py");
+    let generated = Command::new("python3")
+        .args([
+            "-c",
+            "import runpy, sys; gate = runpy.run_path(sys.argv[1]); print(gate['failure_message']('563', [], []))",
+        ])
+        .arg(script)
+        .output()
+        .expect("generate the regression gate's actual skeleton");
+    assert!(
+        generated.status.success(),
+        "{}",
+        String::from_utf8_lossy(&generated.stderr)
+    );
+    let message = String::from_utf8(generated.stdout).unwrap();
+    let skeleton = message
+        .lines()
+        .skip_while(|line| !line.starts_with("    # issue: 563"))
+        .map(|line| line.strip_prefix("    ").unwrap_or(line))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let output = execute("issue_563_gate_skeleton", &skeleton);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let summary = report(&output);
+    assert_eq!(summary["attempts"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        summary["attempts"][0]["environment"],
+        json!({"target": "omnigraph-engine", "storage": "local-filesystem"})
+    );
+    assert_eq!(summary["result"], json!({"Ok": null}));
+}
+
+#[test]
+fn unexpected_branch_list_success_retains_actual_rows_and_schema() {
+    for (setup, rows) in [
+        ("", json!([{"name": "main"}])),
+        (
+            "--- mutate\nbranch create extra\n--- expect ok\n",
+            json!([{"name": "extra"}, {"name": "main"}]),
+        ),
+    ] {
+        let text = format!(
+            r#"# issue: none
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+--- schema
+node Person {{ name: String @key }}
+--- seed
+{setup}--- query
+branch list
+--- expect error: branch list must fail
+"#
+        );
+        let output = execute("unexpected_branch_list", &text);
+        assert!(!output.status.success(), "unexpected success must fail");
+        let summary = report(&output);
+        let attempts = summary["attempts"].as_array().unwrap();
+        assert_eq!(attempts.len(), 1);
+        let worker = &attempts[0]["outcome"]["Ok"];
+        assert!(
+            worker["result"]["Err"]
+                .as_str()
+                .unwrap()
+                .contains("`branch list` succeeded")
+        );
+        let results = worker["evidence"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|event| event["kind"] == "query_result")
+            .collect::<Vec<_>>();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0]["value"]["rows"], json!({"Ok": rows}));
+        assert_eq!(
+            results[0]["value"]["schema"],
+            json!([{"name": "name", "type": "Utf8", "nullable": false, "metadata": {}}])
+        );
+        assert_eq!(results[0]["value"]["ordered"], false);
+    }
+}

--- a/crates/omnigraph-gqt/tests/review_regressions.rs
+++ b/crates/omnigraph-gqt/tests/review_regressions.rs
@@ -1,0 +1,177 @@
+use std::process::{Command, Output};
+
+const SIMPLE: &str = "# issue: none\n# notes: Exercise runner selection and terminal reporting.\n\n--- runner\ntimeout_ms: 10000\nenvironments:\n  - target: omnigraph-engine\n    storage: local-filesystem\n\n--- schema\nnode Person { name: String @key }\n--- seed\n{\"type\":\"Person\",\"data\":{\"name\":\"alice\"}}\n--- query\nquery all() { match { $p: Person } return { $p.name } }\n--- expect unordered\n{\"p.name\":\"alice\"}\n--- expect shape\np.name: String\n";
+
+fn summary(output: &Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let paths: Vec<_> = stdout
+        .lines()
+        .filter_map(|line| line.strip_prefix("GQT report: "))
+        .collect();
+    assert_eq!(paths.len(), 1, "exactly one terminal report: {stdout}");
+    serde_json::from_slice(&std::fs::read(paths[0]).unwrap()).unwrap()
+}
+
+#[test]
+fn cli_refusals_always_keep_one_terminal_report() {
+    for args in [
+        vec![],
+        vec!["--replay"],
+        vec!["--replay", "missing.json", "extra"],
+        vec!["case.gqt", "--seed", "bad"],
+        vec!["case.gqt", "--seed"],
+        vec!["case.gqt", "--target"],
+        vec!["case.gqt", "--storage"],
+        vec!["case.gqt", "--seed", "0", "--seed", "42"],
+        vec![
+            "case.gqt",
+            "--target",
+            "omnigraph-engine",
+            "--target",
+            "omnigraph-engine",
+        ],
+        vec!["case.gqt", "--unknown"],
+        vec!["--unknown"],
+    ] {
+        let output = Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+            .args(&args)
+            .output()
+            .unwrap();
+        assert!(!output.status.success(), "{args:?}");
+        let report = summary(&output);
+        assert_eq!(report["code"], "invalid_case", "{args:?}");
+        assert_eq!(report["scope"], "unavailable");
+        assert_eq!(report["attempts"].as_array().unwrap().len(), 0);
+        assert_eq!(
+            report["not_run"][0]["reason"]["kind"],
+            "coverage_unavailable"
+        );
+        assert_eq!(
+            report["not_run"][0]["reason"]["error"],
+            report["result"]["Err"]
+        );
+    }
+}
+
+#[test]
+fn ambient_refusal_and_parse_failure_preserve_their_causes() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("case.gqt");
+    std::fs::write(&path, SIMPLE).unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+        .arg(&path)
+        .env("OMNIGRAPH_TRAVERSAL_MODE", "invalid")
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let report = summary(&output);
+    assert_eq!(report["code"], "invalid_case");
+    assert!(
+        report["not_run"][0]["reason"]["error"]
+            .as_str()
+            .unwrap()
+            .contains("OMNIGRAPH_TRAVERSAL_MODE")
+    );
+    std::fs::write(&path, "--- schema\nnode Person { name: String @key }\n").unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+        .arg(&path)
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let report = summary(&output);
+    assert_eq!(
+        report["not_run"][0]["reason"]["error"],
+        report["result"]["Err"]
+    );
+}
+
+#[cfg(tokio_unstable)]
+#[test]
+fn seed_selection_intersects_all_declared_environment_parameters() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("case.gqt");
+    let text = SIMPLE.replace("    storage: local-filesystem", "    storage: local-filesystem\n  - target: omnigraph-engine-dst\n    storage: in-memory-object-store\n    seeds: [0]\n  - target: omnigraph-engine-dst\n    storage: in-memory-object-store\n    seeds: [42]");
+    std::fs::write(&path, text).unwrap();
+    for selectors in [
+        ["--target", "omnigraph-engine-dst", "--seed", "42"],
+        ["--storage", "in-memory-object-store", "--seed", "42"],
+    ] {
+        let output = Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+            .arg(&path)
+            .args(selectors)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let report = summary(&output);
+        assert_eq!(report["scope"], "partial");
+        let attempts = report["attempts"].as_array().unwrap();
+        assert_eq!(attempts.len(), 2);
+        assert!(attempts.iter().all(|attempt| attempt["seed"] == 42));
+        assert!(
+            report["not_run"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|n| n["reason"]["kind"] == "unselected")
+        );
+    }
+    let output = Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+        .arg(&path)
+        .args(["--target", "omnigraph-engine-dst", "--seed", "99"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let report = summary(&output);
+    assert_eq!(report["code"], "invalid_case");
+    assert!(report["attempts"].as_array().unwrap().is_empty());
+}
+
+#[cfg(tokio_unstable)]
+#[test]
+fn deadline_stops_every_environment_without_inventing_attempts() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("case.gqt");
+    let text = SIMPLE
+        .replace("timeout_ms: 10000", "timeout_ms: 1")
+        .replace(
+            "target: omnigraph-engine\n    storage: local-filesystem",
+            "target: omnigraph-engine-dst\n    storage: in-memory-object-store\n    seeds: [0]\n  - target: omnigraph-engine-dst\n    storage: in-memory-object-store\n    seeds: [42]",
+        );
+    std::fs::write(&path, text).unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+        .arg(&path)
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let report = summary(&output);
+    let attempts = report["attempts"].as_array().unwrap();
+    assert!(
+        attempts.len() <= 1,
+        "deadline expiry cannot start another environment"
+    );
+    assert_eq!(
+        report["not_run"].as_array().unwrap().len(),
+        4 - attempts.len()
+    );
+    for missing in report["not_run"].as_array().unwrap() {
+        if attempts.is_empty() {
+            assert_eq!(missing["reason"]["kind"], "preflight_failed");
+            assert_eq!(missing["reason"]["error"], report["result"]["Err"]);
+        } else {
+            assert_eq!(missing["reason"]["kind"], "suppressed");
+            assert_eq!(missing["reason"]["trigger"]["seed"], 0);
+            assert_eq!(missing["reason"]["trigger"]["replay"], 0);
+            assert_eq!(missing["reason"]["error"], attempts[0]["outcome"]["Err"]);
+        }
+        assert!(
+            missing["reason"]["error"]
+                .as_str()
+                .unwrap()
+                .contains("timeout:")
+        );
+    }
+}

--- a/crates/omnigraph-gqt/tests/runner_dispatch.rs
+++ b/crates/omnigraph-gqt/tests/runner_dispatch.rs
@@ -1,0 +1,488 @@
+use std::path::Path;
+use std::process::Command;
+
+#[test]
+fn refuses_unknown_or_unobserved_faults() {
+    let expected = if cfg!(tokio_unstable) {
+        [
+            "unsupported DST failpoint",
+            "configured faults were not observed",
+            "configured faults were not observed",
+            "configured faults were not observed",
+        ]
+    } else {
+        [
+            "DST runner is unavailable",
+            "DST runner is unavailable",
+            "DST runner is unavailable",
+            "DST runner is unavailable",
+        ]
+    };
+    for (name, expected) in [
+        "unknown_fault",
+        "unreached_fault",
+        "spoofed_fault",
+        "spoofed_error_fault",
+    ]
+    .into_iter()
+    .zip(expected)
+    {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/runner")
+            .join(format!("{name}.gqt"));
+        let output = Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+            .arg(path)
+            .output()
+            .expect("run GQT worker refusal fixture");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(!output.status.success(), "accepted {name}");
+        assert!(stderr.contains(expected), "{name}: {stderr}");
+    }
+}
+
+#[cfg(tokio_unstable)]
+#[test]
+fn binary_dispatches_both_runner_modes() {
+    let dst = Path::new(env!("CARGO_MANIFEST_DIR")).join("cases/dst_restart_preserves_rows.gqt");
+    let normal =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("cases/second_merge_of_merged_branch.gqt");
+    for path in [dst, normal] {
+        let output = Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+            .arg(&path)
+            .output()
+            .expect("execute case");
+        assert!(
+            output.status.success(),
+            "{}: {}",
+            path.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+#[cfg(tokio_unstable)]
+#[test]
+fn file_deadline_bounds_the_worker() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/runner/deadline.gqt");
+    let output = Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+        .arg(path)
+        .output()
+        .expect("run file deadline fixture");
+    assert!(!output.status.success());
+    let error = String::from_utf8_lossy(&output.stderr);
+    assert!(error.contains("exceeded wall-time budget"), "{error}");
+}
+
+#[cfg(tokio_unstable)]
+fn report(output: &std::process::Output) -> (std::path::PathBuf, serde_json::Value) {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let path = stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("GQT report: "))
+        .expect("terminal report path");
+    let path = std::path::PathBuf::from(path);
+    let value = serde_json::from_slice(&std::fs::read(&path).expect("read retained report"))
+        .expect("structured summary");
+    (path, value)
+}
+
+#[cfg(tokio_unstable)]
+#[test]
+fn explicit_environment_selection_and_lifetime_evidence() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let path = root.join("cases/dst_restart_preserves_rows.gqt");
+    let output = Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+        .arg(&path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let (_, summary) = report(&output);
+    let attempts = summary["attempts"].as_array().unwrap();
+    assert!(
+        attempts
+            .iter()
+            .any(|a| a["environment"]["target"] == "omnigraph-engine")
+    );
+    assert!(
+        attempts
+            .iter()
+            .any(|a| a["environment"]["target"] == "omnigraph-engine-dst")
+    );
+    for attempt in attempts {
+        let events = attempt["outcome"]["Ok"]["observations"].as_array().unwrap();
+        let lifetimes = attempt["outcome"]["Ok"]["evidence"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|event| event["kind"] == "engine_lifetime")
+            .collect::<Vec<_>>();
+        assert_eq!(lifetimes.len(), 3);
+        let mut opens = 0;
+        for event in lifetimes {
+            let before = event["value"]["before"].as_array().unwrap();
+            let after = event["value"]["after"].as_array().unwrap();
+            assert_eq!(
+                before[0], after[0],
+                "ordinary steps cannot initialize a graph"
+            );
+            opens += after[1].as_u64().unwrap() - before[1].as_u64().unwrap();
+        }
+        assert_eq!(
+            opens, 1,
+            "the engine's real open hook must fire only for restart"
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|e| e.as_str().unwrap().starts_with("lifetime: initialized"))
+                .count(),
+            1
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|e| e.as_str().unwrap().starts_with("lifetime: reopen"))
+                .count(),
+            1
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| e.as_str().unwrap().contains("actual schema:"))
+        );
+        assert!(events.iter().any(|e| {
+            e.as_str()
+                .unwrap()
+                .contains("actual affected: nodes=1 edges=0")
+        }));
+    }
+    let selected = Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+        .arg(&path)
+        .args(["--storage", "in-memory-object-store", "--seed", "42"])
+        .output()
+        .unwrap();
+    assert!(
+        selected.status.success(),
+        "{}",
+        String::from_utf8_lossy(&selected.stderr)
+    );
+    let (_, selected) = report(&selected);
+    assert_eq!(selected["scope"], "partial");
+    let attempts = selected["attempts"].as_array().unwrap();
+    assert_eq!(attempts.len(), 2);
+    for attempt in attempts {
+        assert_eq!(
+            attempt["environment"],
+            serde_json::json!({
+                "target": "omnigraph-engine-dst", "storage": "in-memory-object-store", "seeds": [0, 42]
+            })
+        );
+        assert_eq!(attempt["seed"], 42);
+    }
+    for args in [
+        vec!["--target", "missing"],
+        vec!["--storage", "missing"],
+        vec![
+            "--target",
+            "omnigraph-engine",
+            "--storage",
+            "in-memory-object-store",
+        ],
+        vec!["--target", "omnigraph-engine-dst", "--seed", "999"],
+    ] {
+        let output = Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+            .arg(&path)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(!output.status.success());
+        assert!(String::from_utf8_lossy(&output.stderr).contains("matches no declared"));
+        assert!(report(&output).1["attempts"].as_array().unwrap().is_empty());
+    }
+}
+
+#[cfg(tokio_unstable)]
+#[test]
+fn replay_uses_frozen_case_and_rejects_changed_evidence() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let dir = tempfile::tempdir().unwrap();
+    let case_path = dir.path().join("frozen.gqt");
+    std::fs::copy(
+        root.join("cases/dst_restart_preserves_rows.gqt"),
+        &case_path,
+    )
+    .unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+        .arg(&case_path)
+        .args(["--target", "omnigraph-engine-dst", "--seed", "42"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let (path, mut summary) = report(&output);
+    let complete = summary.clone();
+    std::fs::write(&case_path, "this is no longer a GQT file").unwrap();
+    let replay = |path: &Path| {
+        Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+            .arg("--replay")
+            .arg(path)
+            .output()
+            .unwrap()
+    };
+    let output = replay(&path);
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    summary["attempts"][0]["outcome"]["Ok"]["observations"][0] = "changed actual evidence".into();
+    let tampered = dir.path().join("tampered.json");
+    for field in ["scope", "not_run"] {
+        let mut incorrect = complete.clone();
+        incorrect[field] = if field == "scope" {
+            "full".into()
+        } else {
+            serde_json::json!([])
+        };
+        std::fs::write(&tampered, serde_json::to_vec(&incorrect).unwrap()).unwrap();
+        let output = replay(&tampered);
+        assert!(!output.status.success());
+        assert!(String::from_utf8_lossy(&output.stderr).contains("execution coverage"));
+        assert_eq!(report(&output).1["scope"], "partial");
+    }
+    std::fs::write(&tampered, serde_json::to_vec(&summary).unwrap()).unwrap();
+    let output = replay(&tampered);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("replay_mismatch"));
+    for duplicate in [false, true] {
+        let mut incomplete = complete.clone();
+        let attempts = incomplete["attempts"].as_array_mut().unwrap();
+        if duplicate {
+            attempts.push(attempts[0].clone());
+        } else {
+            attempts.pop();
+        }
+        std::fs::write(&tampered, serde_json::to_vec(&incomplete).unwrap()).unwrap();
+        let output = replay(&tampered);
+        assert!(!output.status.success());
+        assert!(String::from_utf8_lossy(&output.stderr).contains("execution inventory"));
+    }
+    summary["executable_digest"] = "changed executable".into();
+    for attempt in summary["attempts"].as_array_mut().unwrap() {
+        attempt["input"]["executable_digest"] = "changed executable".into();
+    }
+    std::fs::write(&tampered, serde_json::to_vec(&summary).unwrap()).unwrap();
+    let output = replay(&tampered);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("environment_changed"));
+}
+
+#[cfg(tokio_unstable)]
+#[test]
+fn occurrence_is_counted_inside_the_selected_operation() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let text = std::fs::read_to_string(root.join("cases/dst_fault_on_second_merge.gqt")).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("unreached_occurrence.gqt");
+    std::fs::write(&path, text.replace("occurrence: 1", "occurrence: 2")).unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+        .arg(path)
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("fault_unobserved"));
+    let (_, summary) = report(&output);
+    assert_eq!(
+        summary["attempts"].as_array().unwrap().len(),
+        2,
+        "the completed failure must replay"
+    );
+}
+
+#[test]
+fn fast_corpus_refuses_a_heavy_budget_before_execution() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let text = std::fs::read_to_string(root.join("cases/dst_restart_preserves_rows.gqt")).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("heavy_budget.gqt");
+    std::fs::write(
+        &path,
+        text.replace("timeout_ms: 10000", "timeout_ms: 10001"),
+    )
+    .unwrap();
+    let outcome = omnigraph_gqt::run_corpus_case(
+        &path,
+        Path::new(env!("CARGO_BIN_EXE_omnigraph-gqt")),
+        false,
+    );
+    assert!(
+        outcome
+            .result
+            .unwrap_err()
+            .contains("required corpus admits timeout_ms at most 10000")
+    );
+}
+
+#[test]
+fn ambient_execution_overrides_are_refused() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("cases/dst_restart_preserves_rows.gqt");
+    for name in [
+        "FAILPOINTS",
+        "OMNIGRAPH_GQ_CASE_TIMEOUT_SECS",
+        "DST_ENTROPY_SEED",
+    ] {
+        let output = Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+            .arg(&path)
+            .env(name, "999")
+            .output()
+            .unwrap();
+        assert!(!output.status.success());
+        assert!(String::from_utf8_lossy(&output.stderr).contains(&format!("ambient {name}")));
+    }
+}
+
+#[cfg(tokio_unstable)]
+#[test]
+fn selecting_engine_does_not_allow_blessing_a_shared_case() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("cases/dst_restart_preserves_rows.gqt");
+    let before = std::fs::read(&path).unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+        .arg(&path)
+        .args(["--target", "omnigraph-engine"])
+        .env("OMNIGRAPH_GQ_BLESS", "1")
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("bless requires"));
+    assert_eq!(std::fs::read(&path).unwrap(), before);
+}
+
+#[cfg(tokio_unstable)]
+#[test]
+fn known_recovery_failure_is_explicit_and_replay_status_is_verified() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let path = root.join("cases/dst_mutation_failure_keeps_writing.gqt");
+    let output = Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+        .arg(&path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("KNOWN_FAILURE environment="));
+    let (report_path, summary) = report(&output);
+    assert_eq!(summary["code"], "known_failure");
+    assert_eq!(summary["scope"], "full");
+    let attempts = summary["attempts"].as_array().unwrap();
+    assert_eq!(attempts.len(), 4);
+    for attempt in attempts {
+        assert_eq!(attempt["known_failure"], true);
+        assert_eq!(attempt["outcome"]["Ok"]["code"], "assertion_failed");
+        assert!(
+            attempt["outcome"]["Ok"]["result"]["Err"]
+                .as_str()
+                .unwrap()
+                .contains("step 4 (mutate)")
+        );
+    }
+    let replay = |path: &Path| {
+        Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+            .arg("--replay")
+            .arg(path)
+            .output()
+            .unwrap()
+    };
+    let replayed = replay(&report_path);
+    assert!(
+        replayed.status.success(),
+        "{}",
+        String::from_utf8_lossy(&replayed.stderr)
+    );
+    assert_eq!(report(&replayed).1["code"], "known_failure");
+    let dir = tempfile::tempdir().unwrap();
+    let tampered = dir.path().join("tampered.json");
+    for field in ["attempt", "summary"] {
+        let mut forged = summary.clone();
+        if field == "attempt" {
+            forged["attempts"][0]["known_failure"] = false.into();
+        } else {
+            forged["code"] = "passed".into();
+        }
+        std::fs::write(&tampered, serde_json::to_vec(&forged).unwrap()).unwrap();
+        let output = replay(&tampered);
+        assert!(!output.status.success(), "accepted forged {field} status");
+        assert!(String::from_utf8_lossy(&output.stderr).contains("report_failed"));
+    }
+    let selected = Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+        .arg(&path)
+        .args(["--target", "omnigraph-engine-dst", "--seed", "42"])
+        .output()
+        .unwrap();
+    assert!(selected.status.success());
+    assert_eq!(report(&selected).1["scope"], "partial");
+}
+
+#[cfg(tokio_unstable)]
+#[test]
+fn known_failure_does_not_waive_changed_failure_missing_fault_or_unexpected_pass() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let text =
+        std::fs::read_to_string(root.join("cases/dst_mutation_failure_keeps_writing.gqt")).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("known_failure_refusals.gqt");
+    let selected = text.replace("seeds: [0, 42]", "seeds: [42]");
+    for (text, expected) in [
+        (
+            selected.replace("pending Mutation recovery", "different Mutation recovery"),
+            "recovery required",
+        ),
+        (
+            selected.replace("occurrence: 1", "occurrence: 2"),
+            "fault_unobserved",
+        ),
+        (
+            selected.replace("step: 4", "step: 5").replace(
+                "--- mutate branch: work\nquery retry",
+                "--- restart\n\n--- mutate branch: work\nquery retry",
+            ),
+            "unexpected_pass",
+        ),
+    ] {
+        std::fs::write(&path, text).unwrap();
+        let output = Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+            .arg(&path)
+            .output()
+            .unwrap();
+        assert!(!output.status.success(), "accepted {expected}");
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains(expected),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            report(&output).1["attempts"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|a| a["known_failure"] == false)
+        );
+    }
+    std::fs::write(&path, &selected).unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+        .arg(&path)
+        .env("OMNIGRAPH_GQ_BLESS", "1")
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("bless is refused for known_failure"));
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), selected);
+}

--- a/docs/dev/ci.md
+++ b/docs/dev/ci.md
@@ -18,10 +18,13 @@ Branch protection currently requires these reporting contexts:
 - `GQ Logic Tests`
 - `Fix Regression Gate`
 
-`GQ Logic Tests` (`gq-logic-tests.yml`) runs the `.gqt` logic-test corpus on
-every pull request as its own required context; `Test Workspace` runs the same
-target again inside the full workspace suite, also on every pull request but as
-a reporting context. `GQ Logic Tests` takes the documentation-only skip the way
+`GQ Logic Tests` (`gq-logic-tests.yml`) owns the complete `.gqt` corpus as a
+required context. It first checks unit tests and unavailable-DST refusal from
+the workspace root, then runs the whole package and Clippy from
+`crates/omnigraph-gqt`, whose Cargo configuration enables the seeded Tokio
+runtime. Every corpus case is enrolled, including cases whose required graph
+behavior currently fails. `Test Workspace` excludes this separately tested
+package; it does not silently skip DST cases. `GQ Logic Tests` takes the documentation-only skip the way
 the AWS job does and reports success without building; its workflow carries a
 verbatim copy of the `Classify Changes` job under the name
 `Classify Changes (GQ Logic Tests)`, and `scripts/check-classify-copy.py`
@@ -115,10 +118,10 @@ Container entrypoint and Azure deployment-validation jobs test argument composit
 
 ## Full correctness graphs
 
-The full workspace suite (`Test Workspace`) runs on every non-documentation pull request, on every push to `main`, on release tags, and by manual dispatch. The `main`, tag, and dispatch form (a pull request drops `--no-fail-fast`):
+The workspace suite (`Test Workspace`) runs on every non-documentation pull request, on every push to `main`, on release tags, and by manual dispatch. GQT has its own configured owner above. The `main`, tag, and dispatch form (a pull request drops `--no-fail-fast`):
 
 ```bash
-cargo test --workspace --locked --no-fail-fast \
+cargo test --workspace --exclude omnigraph-gqt --locked --no-fail-fast \
   --features omnigraph-engine/failpoints,omnigraph-cluster/failpoints
 ```
 
@@ -169,7 +172,7 @@ CI checks OpenAPI drift but never rewrites `openapi.json`. Regenerate an intenti
 
 ## DST tiers
 
-Two workflows own deterministic simulation testing; both set
+Two workflows own the simulator's pinned tests and generated fleets; both set
 `RUSTFLAGS: --cfg tokio_unstable` themselves (the `omnigraph-dst` crate
 compiles empty without it, so the default jobs are unaffected):
 
@@ -184,6 +187,10 @@ compiles empty without it, so the default jobs are unaffected):
   seed intervals. Failures are logs with seed rows, not required contexts;
   the concurrent fleet's `wild` mode makes no replay claim.
 
+`gq-logic-tests.yml` separately owns authored GQT execution through DST. Its
+configured step runs from `crates/omnigraph-gqt` to load `tokio_unstable`.
+An unavailable-runtime refusal test does not replace executing the DST cases.
+
 ## Local pre-push checks
 
 For Rust changes:
@@ -194,8 +201,16 @@ cargo clippy --workspace --all-targets --locked -- -D warnings -W clippy::dbg_ma
 cargo clippy --workspace --all-targets --locked \
   --features omnigraph-engine/failpoints,omnigraph-cluster/failpoints \
   -- -D warnings -W clippy::dbg_macro
-cargo test --workspace --locked \
+cargo test --workspace --exclude omnigraph-gqt --locked \
   --features omnigraph-engine/failpoints,omnigraph-cluster/failpoints
+cargo test -p omnigraph-gqt --locked --lib --test runner_dispatch
+```
+
+From `crates/omnigraph-gqt`, also run the complete configured package:
+
+```bash
+cargo test -p omnigraph-gqt --locked
+cargo clippy -p omnigraph-gqt --all-targets --locked -- -D warnings -W clippy::dbg_macro
 ```
 
 For repository metadata and workflow changes:

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -114,13 +114,19 @@ Focused iteration:
 ```bash
 cargo test -p omnigraph-engine --test traversal
 cargo test -p omnigraph-engine --test writes concurrent
-cargo test -p omnigraph-gqt                                      # every .gqt case + the format self-tests
-cargo test -p omnigraph-gqt --test gq_logic_tests issue_563      # the cases whose file name contains issue_563
-cargo test -p omnigraph-gqt --test gq_logic_tests -- --list      # one line per case
 cargo test -p omnigraph-server --test data_routes
 cargo test -p omnigraph-cli --test cli_data
 cargo test -p omnigraph-cluster --test failpoints --features failpoints
 cargo test -p omnigraph-bench --locked
+```
+
+Run GQT commands from `crates/omnigraph-gqt` so its Cargo configuration enables
+the DST runtime requested by corpus files:
+
+```bash
+cargo test -p omnigraph-gqt --locked                            # complete corpus and harness tests
+cargo test -p omnigraph-gqt --test gq_logic_tests issue_563      # matching case names
+cargo test -p omnigraph-gqt --test gq_logic_tests -- --list      # one line per case
 ```
 
 Every `.gqt` case is its own libtest test named `case::<file>.gqt`, registered
@@ -146,11 +152,12 @@ that matches no case is libtest's ordinary green zero-test run; read the
 Canonical workspace graph:
 
 ```bash
-cargo test --workspace --locked \
+cargo test --workspace --exclude omnigraph-gqt --locked \
   --features omnigraph-engine/failpoints,omnigraph-cluster/failpoints
+cargo test -p omnigraph-gqt --locked --lib --test runner_dispatch
 ```
 
-The feature-superset command is the canonical graph because it compiles the current tree once with failpoint hooks present but inert unless a test enables one. Also run formatting and both Clippy graphs before pushing; [ci.md](ci.md) lists the exact gates.
+The feature-superset command compiles the current tree with failpoint hooks present but inert unless a test enables one. The separate `GQ Logic Tests` context owns GQT: the root command above tests unavailable-DST refusal, and the complete corpus command from the GQT crate runs both execution targets. Neither command substitutes for the other. Also run formatting and both workspace Clippy graphs plus configured GQT Clippy; [ci.md](ci.md) lists the exact gates.
 
 AWS server support has a separate feature owner:
 
@@ -159,6 +166,20 @@ cargo test -p omnigraph-server --features aws
 ```
 
 S3-backed tests skip unless `OMNIGRAPH_S3_TEST_BUCKET` and the corresponding AWS endpoint/credential variables are set. Azure-backed tests skip unless `OMNIGRAPH_AZURE_TEST_CONTAINER` and the documented Azure/Azurite variables are set. A configured CI backend treats a skip as failure.
+
+### GQT execution through DST
+
+GQT files select their execution target in a `--- runner` YAML section before
+the schema. The file owns its storage, seeds and explicit faults;
+the runner preserves GQT assertions and uses isolated seeded processes.
+Build from `crates/omnigraph-gqt` to enable its Tokio configuration.
+Workspace-root builds without that configuration explicitly refuse DST
+cases. The [GQT README](../../crates/omnigraph-gqt/README.md)
+defines supported targets, hooks, replay observations, and limits. The configured
+CI owner enrolls the complete corpus. A strict `--- known_failure` marker admits only
+the recorded typed recovery failure at its declared step, with verified fault
+delivery and matching replay. Reports label it `known_failure`; changed failures
+and unexpected passes fail CI. The healthy assertion stays in the case.
 
 ### OpenAPI
 

--- a/docs/rfcs/0045-gq-logic-tests.md
+++ b/docs/rfcs/0045-gq-logic-tests.md
@@ -7,7 +7,7 @@ implementation: partial
 authors:
   - azimafroozeh
 created: 2026-08-29
-updated: 2026-09-06
+updated: 2026-09-10
 discussion: https://github.com/ModernRelay/omnigraph/pull/584
 supersedes: []
 superseded_by: []
@@ -50,6 +50,18 @@ assertions, scale symptoms, and cases needing process environment
 (examples in the AGENTS.md sentences below). No second toolchain enters
 the repo, and the harness calls only public engine surfaces.
 
+This amendment makes ***agent experience (AX)***, an agent's ability to
+construct, execute, diagnose, and reproduce a case without guessing,
+the format's design priority. Cases state the execution target, storage,
+and fault conditions that matter to a failure. Concision removes repetition, not
+required evidence. Convenience for a human author does not justify hidden
+configuration, automatic repair, or a weaker assertion.
+
+The proposed environment and fault contract is specified in Design.
+It extends the existing format; its target combinations are not a claim
+of implemented support. GQ declarations, schemas, and result comparison
+retain their existing owners.
+
 ## Motivation
 
 Query-behavior tests today are hand-written Rust (the `_issue_NNN`
@@ -77,7 +89,36 @@ omitted; its run-both-plans verification is deferred (Compatibility below).
 (small schemas, seeds, queries with known-correct answers) doubles as
 seed material for the DST generators.
 
+A fault reached during setup instead of the intended merge tests a different
+failure. A case rerun on local files instead of the original object store
+tests different storage behavior. A seed without the case and execution
+configuration cannot identify the original experiment. File-owned controls
+and explicit execution evidence address these ambiguities.
+
 ## User and operational behavior
+
+For the proposed environment extension, author one set of steps and
+expectations, list exact target/storage combinations before the schema,
+and place a fault immediately before its target operation. The harness
+validates all selected combinations first. An unsupported combination is
+a named failure, never a skipped assertion or a fallback environment.
+
+| Attempt to bypass the contract | Required refusal or evidence |
+|---|---|
+| Request DST from a build without it | Refuse before case setup. |
+| Omit runner configuration to inherit a backend | Refuse before case setup; every case declares its execution. |
+| Point an S3 case at another backend | Verify actual backend against the file. |
+| Match injected text without firing the hook | Require correlated typed delivery evidence. |
+| Run one environment and claim full coverage | Report the exact selection and omitted executions. |
+| Hide a failed write with retry or reopen | Execute only authored operations; no harness recovery. |
+
+| Supported author route | Accepted behavior |
+|---|---|
+| Existing engine/filesystem case | Add its explicit engine/filesystem environment before execution. |
+| Explicit environment list | Fresh graph and shared assertions for each supported entry. |
+| Fault before one operation | Injection, delivery verification, and cleanup at that operation. |
+| Exact environment/seed rerun | Declared subset only, with complete reproduction context. |
+
 
 Authoring a regression for a fixed issue:
 
@@ -92,7 +133,7 @@ behavior with no failure to witness): write
 `<short_name>.gqt` with `# issue: none`; `red_on:` is omitted, or kept when
 the case did witness a red state during development.
 
-Running:
+Running from `crates/omnigraph-gqt`, whose Cargo configuration enables DST:
 
 ```bash
 cargo test -p omnigraph-gqt
@@ -106,8 +147,9 @@ target prints one line per case with its elapsed time
 failing cases and, per failure, the failing step named by ordinal and kind
 (`step 3 (mutate)`), the iteration binding when the step sits in a loop
 (`$who=carol`), and the expected-versus-actual row diff, count mismatch,
-or error mismatch. A case stops at its first failing step (later steps
-would run against a store state the failed step no longer vouches for);
+or error mismatch. Each execution stops at its first failing step (later
+steps would use state the failed step no longer vouches for); explicit
+environments follow the replay and continuation rules in Design;
 across cases the target runs every case before failing, so one broken
 case never hides another. A file the harness refuses (any fail-closed
 check in the Design section) reports as a failing case carrying the
@@ -152,18 +194,18 @@ counts, or the reverse, it reports the mismatch instead of rewriting.
 Bless refuses cases containing loops (one expect body serves every
 iteration).
 
-CI: the workspace `Test Workspace` job picks the target up automatically
-and, since the pull-request tier landed, runs it on pull requests as a
-reporting context (`ci.yml`); regressions must block a merge, and only a
-required context can, so a per-change job (`GQ Logic Tests`) in a new
-workflow file, `.github/workflows/gq-logic-tests.yml`, runs
+CI: the required per-change job `GQ Logic Tests` in
+`.github/workflows/gq-logic-tests.yml` owns the complete corpus and runs
 `cargo test -p omnigraph-gqt --locked -- --nocapture`
-on every PR. The workflow triggers on push to `main`, `workflow_dispatch`,
+on every code-bearing PR, from `crates/omnigraph-gqt`,
+where its `.cargo/config.toml` enables seeded Tokio. The job must build
+the `omnigraph-gqt` worker binary and dispatch that executable from the same
+build. The workflow triggers on push to `main`, `workflow_dispatch`,
 and `pull_request` with only its code-bearing types declared (`opened`,
 `synchronize`, `reopened`); the gate below lives in its own workflow and
 declares the body-edit and label types itself, so a body edit or a label
 change never re-runs the Rust build. The test job compiles the engine
-crate, the `omnigraph-gqt` library, and its two test binaries: minutes
+crate, the `omnigraph-gqt` library, and its test binaries: minutes
 with a warm cache, tens of minutes cold. The test job honors the
 docs-only classification of `ci.yml`'s `Classify Changes` job, the way
 the other required Rust jobs do, through a verbatim copy of that job
@@ -174,9 +216,25 @@ docs-only PR it skips its build and reports success (the
 `Test omnigraph-server --features aws` job's pattern), so the required
 context never stays pending. The gate job always runs, at seconds-scale.
 Action references are pinned, per the
-repo's workflow-pin check; no failpoints features are needed. What a
-green `GQ Logic Tests` job promises, quotable: every `.gqt` case parsed,
-ran, and matched its expects, none refused.
+repo's workflow-pin check. Explicit fault/DST enrollment requires the
+test-only failpoint and seeded-runtime build owned by the environment
+extension; fault-free engine execution alone needs neither. On a code-bearing
+run,
+a green `GQ Logic Tests` job guarantees that every corpus case passed
+admission, every declared environment and mandatory seed/replay executed,
+and each execution either matched all expectations or satisfied the explicit
+Known recovery failures contract. Known failures remain separately reported;
+they do not establish that the graph defect is fixed. The docs-only success above
+reports classification, not corpus execution. A separate DST package job
+or an environment-filtered GQT invocation cannot discharge this guarantee.
+`Test Workspace` excludes GQT from both its compile and test commands with
+`--exclude omnigraph-gqt`; the separate required context owns that package.
+The GQT job also runs unit and dispatch tests from the workspace root to
+prove that an unconfigured build refuses requested DST execution, and runs
+Clippy in the configured build. Both dispatcher and worker in the complete
+corpus run must use the seeded build configuration. This changes build
+ownership, not coverage: every corpus case remains enrolled in the required
+GQT job. The unavailable-runtime refusal check cannot substitute for that run.
 
 Fix-PR gate: a required CI check (`Fix Regression Gate`, a job in its
 own workflow, `.github/workflows/fix-regression-gate.yml`, on
@@ -235,8 +293,8 @@ definition, not a run: the gate consults only the required contexts, and
 among Rust test targets only `omnigraph-gqt`'s (the corpus target and its
 unit tests), `Test omnigraph-server --features aws`, and `DST pinned suite`
 (`cargo test -p omnigraph-dst`, `dst.yml`) run on a pull request as
-required contexts (`Test Workspace` runs every workspace target on the
-pull request too, but as a reporting context, CI above); a test-attributed
+required contexts (`Test Workspace` runs the remaining workspace targets on
+the pull request as a reporting context, CI above); a test-attributed
 `issue_N` function inside `crates/omnigraph-gqt/`, `crates/omnigraph-server/`,
 or `crates/omnigraph-dst/` therefore runs in a required context, and the
 Rust shape stays a naming check everywhere else, where a defined
@@ -290,6 +348,12 @@ issue. The regression shape, one read step:
 # red_on: 2026-08-29, pre-fix build: total was 8, not 20.
 # notes: free text.
 
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+
 --- schema
 node Chunk {
     slug: String @key
@@ -324,6 +388,12 @@ A multi-step feature case, showing mutation steps, a restart, and a loop:
 ```
 # issue: none
 # notes: pins that committed writes survive a store reopen.
+
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
 
 --- schema
 node Person {
@@ -390,11 +460,14 @@ declaration step to that mode, for cases whose subject is one traversal
 path (Execution semantics owns the default); a statement step traverses
 nothing and runs outside the pin.
 
-A file is: `--- schema`, then `--- seed`, then one or more steps, of
-which at least one is a query or mutate step; a file missing either
-leading section, ordering them the other way, or carrying no query or
+A file is: required `--- runner` (Explicit execution environments),
+optional `--- known_failure` (Known recovery failures), then `--- schema`, then
+`--- seed`, then one or more steps, of
+which at least one is a query or mutate step; a file missing any of these
+three leading sections, ordering them differently, or carrying no query or
 mutate step (nothing would be asserted, a restart-only step list
-included) is refused. A step is one of:
+included) is refused. A `--- fault` may precede an operation as specified
+in Faults at an explicit step. A step is one of:
 
 - `--- query` holding exactly one GQ declaration with a read body, followed
   by an optional `--- params` section (JSON object) and a mandatory
@@ -536,9 +609,440 @@ seed too large to sit inline belongs to the heavy-repro tier below, not
 this format; there are deliberately no external-file references, or single
 files decay back into directories.
 
+### Explicit execution environments
+
+A ***test environment*** is one execution target, storage backend, and
+configuration for a complete case. Exactly one required `--- runner` YAML
+section before `--- schema` declares the environments. Every case, including
+an existing fault-free engine case, carries it. The following syntax specifies
+the amendment contract; the examples do not establish implementation
+qualification.
+
+```yaml
+--- runner
+timeout_ms: 10000
+environments:
+  - target: omnigraph-engine
+    storage: local-filesystem
+  - target: omnigraph-engine-dst
+    storage: in-memory-object-store
+    seeds: [0, 42]
+```
+
+`timeout_ms` and `environments` are required in every case.
+An environment requires `target` and `storage`, plus the parameters required
+by that target. Its full parameter set defines the environment; there is no
+separate environment ID. Exact duplicate entries are refused. There is no
+runner format version: the parser and corpus migrate together, and replay
+requires the recorded source and executable identities. Omitted configuration
+has no default execution route. There are 1 to 16 environments, executed in
+listed order. The file budget is 1 to 600000 milliseconds of wall time,
+starting before case reading and preflight. It measures profile resolution,
+setup, every environment, both executions of every DST seed, and ordinary
+teardown through the supervisor's final execution check. The supervisor checks
+the remaining budget before each worker dispatch and after execution. Expiry
+fails the case; unstarted executions are reported as not run. Worker execution
+is interruptible through process containment, which has a separate bounded
+allowance and cannot extend the case into success. Synchronous host-file reads,
+executable hashing, and file cleanup are not interruptible; their elapsed time
+counts when the supervisor next checks the budget. Terminal summary encoding
+and publication happen outside this execution budget. This is not a hard bound
+on total command wall time. Fast-tier admission independently
+limits which budgets may enter the per-PR corpus, as defined in Runner
+mechanics; selection cannot bypass that check.
+
+Each environment starts from a fresh isolated graph, applies the schema
+and seed, performs the existing index setup, then executes the complete
+step list. Branch targets, parameters, rows, result shapes, affected
+counts, and expected errors have one definition shared by all environments.
+Each environment is checked against the file's expectations. Cross-target
+identity of generated IDs, timestamps, or internal operation order is not
+asserted. A target-specific expected result belongs in a separate case.
+Target and storage selection cannot change inside a case execution.
+
+| Target | Execution |
+|---|---|
+| `omnigraph-engine` | Direct calls to `Omnigraph`. |
+| `omnigraph-engine-dst` | Direct engine execution under the seeded DST environment. |
+| `omnigraph-server` | Requests through the server's HTTP API. |
+| `omnigraph-server-dst` | Requests through the server's HTTP API with server tasks and its embedded engine under a qualified seeded DST environment. |
+
+`target` is the only execution selector. There is no separate `runtime` or
+DST-mode field. The server embeds `Omnigraph`; these names do not assert an
+independent server-to-engine network connection. Server-DST requires its own
+execution qualification; engine-DST qualification alone cannot establish it.
+
+| Storage | Meaning |
+|---|---|
+| `local-filesystem` | A fresh temporary directory on the local filesystem. |
+| `in-memory-object-store` | An injected object store whose contents live in process memory. |
+| `s3-compatible` | An explicitly configured S3-compatible service. |
+| `azure-blob-storage` | An explicitly configured Azure Blob service or emulator. |
+
+These names are GQT configuration values. `StorageAdapter` is the existing
+Rust interface, and `ObjectStorageAdapter` provides these storage
+implementations. Selecting a control-object adapter alone is insufficient:
+the environment must connect Lance dataset I/O to the corresponding
+isolated storage too. The storage name does not certify a provider's
+compatibility or change its existing qualification status.
+
+| Target roadmap | Local filesystem | In-memory object store | S3-compatible | Azure Blob |
+|---|---|---|---|---|
+| `omnigraph-engine` | Intended | Intended | Intended | Intended |
+| `omnigraph-engine-dst` | Refused | Intended | Refused | Refused |
+| `omnigraph-server` | Intended | Refused | Intended | Intended |
+| `omnigraph-server-dst` | Refused | Intended | Refused | Refused |
+
+`Intended` means potential support gated by Rollout; it does not mean
+implemented or qualified. Initial implementation admission is limited to
+`omnigraph-engine` with `local-filesystem` and no fault directives, and
+`omnigraph-engine-dst` with `in-memory-object-store`. Every other combination
+must report `unsupported_environment` before case setup. Further targets,
+storage combinations and controls require their own acceptance evidence.
+A requested combination unavailable in the running build
+fails before case setup. There is no automatic substitution or skip.
+
+S3, Azure, and every server environment additionally require `profile`.
+A ***connection profile*** supplies connection details and test lifecycle
+control outside the case. It cannot override target, storage, seeds,
+faults, assertions, or the file budget. The file carries the profile name;
+the report carries its resolved non-secret configuration and digest.
+Credentials stay outside the case and report. Profiles distinguish actual
+services, including different S3-compatible providers and Azure emulators.
+They record effective storage options, including request retry settings.
+Changing a provider or these options changes the recorded environment.
+
+For example, a future HTTP environment can declare:
+
+```yaml
+  - target: omnigraph-server
+    storage: s3-compatible
+    profile: gqt-server-s3
+```
+
+The profile must verify the server's actual backend and provide an
+exclusively owned graph with fresh schema and seed state. The server is
+cluster-only; graph provisioning follows cluster configuration and
+lifecycle controls, not an invented graph-creation HTTP endpoint. Reuse
+the server test support's lifecycle owner. A URL and credentials alone
+cannot satisfy this contract. A profile that cannot prove isolation,
+required result types, or a requested test control is refused.
+
+#### Seeds and reproducibility
+
+`seeds` is required for `omnigraph-engine-dst` and `omnigraph-server-dst`:
+1 to 64 distinct unsigned 64-bit integers. Other targets reject it.
+Declaring seeds does not make an unsupported target admissible. Each seed
+executes twice in
+fresh child processes, with seeded scheduling, engine IDs, engine time,
+and in-memory storage setup. Process-global initialization happens after
+the child receives its resolved configuration. Known ambient overrides
+of test semantics, including inherited `FAILPOINTS` and traversal pins,
+are refused rather than silently combined with the file.
+
+DST replay first requires equal validated input and build identities,
+as defined in Validation and agent diagnostics. It then compares all
+assertion-relevant actual observations: rows, executed result types,
+affected node/edge counts, and error codes with their compared payloads.
+It also compares main snapshot IDs, the reached operation sequence, and
+the final verdict. Each observation identifies its step ordinal and loop
+iteration, when present. Verdict includes the failure classification and
+structured assertion failure values; equality cannot rely on readable
+error text alone. A mismatch fails even when both executions fail the
+same assertion. Missing required observation evidence fails explicitly.
+This observation comparison does not prove equality of every storage call,
+unqueried branch state, or Lance thread schedule. `omnigraph-engine` and
+`omnigraph-server` runs have no deterministic replay guarantee. Their value is repeatable
+inputs and recorded conditions with the same explicit assertions.
+
+The harness issues each authored operation once. It never adds a mutation
+retry or reopens `Omnigraph` after an error. Engine and storage-client
+retries remain their production behavior, with effective configuration
+recorded. An authored retry is another explicit operation step.
+
+### Shared seeded execution
+
+`omnigraph-dst::run_universe(&environment, &scenario)` executes one selected
+seed. The environment supplies configuration and resource setup through
+`UniverseEnvironment`; the scenario supplies operations and checks through
+`UniverseScenario`. This entry point is for seeded execution. The ordinary
+engine target retains its ordinary runtime and the same GQT step comparisons.
+
+The caller must establish process isolation, process-start pool and entropy
+settings, failpoint registration, and the invocation wall deadline before
+entering the universe. Environment setup must not attempt to repair already
+initialized process settings. GQT's supervisor continues to own immutable input
+validation, seed/replay expansion, containment, terminal reporting, and the
+continuation rules in Validation and agent diagnostics.
+
+The executor installs seeded scheduling, clock, IDs, and entropy before
+constructing per-execution storage and controls. Configuration is not a live
+store. `MemoryEnvironment` creates a fresh control-object adapter and requires
+an empty, exclusively owned Lance graph namespace. It refuses existing graph
+contents rather than deleting them during setup. Both storage paths remain
+alive across a scenario's handle reopen. Teardown removes only that owned
+Lance namespace after observations are collected; it does not reset shared
+backend ETag counters or incomplete multipart state. GQT's fresh worker process
+per attempt remains required for its replay contract.
+
+Setup must guard partial acquisitions. `UniverseRun` retains the execution
+phase, scenario/setup outcome, and cleanup outcome separately, including
+original panic payloads. Teardown runs after a completed scenario returns or
+unwinds; a cleanup failure must not replace its original failure evidence.
+Required Rust census and fault-counter handles remain alive until their final
+checks finish. A hung or killed process cannot establish cleanup through Rust
+guards; the supervisor must apply the bounded containment rules above.
+
+The environment's selected root seed is authoritative. The existing Rust
+`harness::run_universe(root, scenario)` boundary translates `Scenario.seed`
+once into the environment, preserving the runtime, ULID, workload, and entropy
+child-seed draw order. Explicit `FaultPlan.seed` values keep their independent
+meaning. Rust generated scenarios and GQT scenarios retain their own loops,
+fixture setup, checks, and outputs; neither language is interpreted by the
+shared executor.
+
+### Faults at an explicit step
+
+A ***fault directive*** is a `--- fault` YAML section immediately before
+one query or mutate step. It arms a named engine hook only during that
+operation; schema creation, seed loading, and earlier steps cannot consume
+it. The following example begins after branch setup:
+
+```text
+--- fault
+at: branch_merge.post_sidecar_pre_fork
+occurrence: 1
+action: return_error
+scope: next_step
+
+--- mutate
+branch merge source into target
+
+--- expect error: injected failpoint triggered: branch_merge.post_sidecar_pre_fork
+
+--- mutate branch: target
+query unrelated_write() {
+    insert Marker { name: "after_failure" }
+}
+
+--- expect affected: nodes=1 edges=0
+```
+
+All four fault fields are required. `scope` accepts only `next_step`;
+`action` accepts only `return_error`. `occurrence` is 1 to 1000000 and
+counts crossings of that hook attributable to the selected operation,
+including its production retries. It starts at zero when the operation
+is armed. The selected crossing injects once; subsequent crossings do
+not inject. Target and storage do not change this meaning.
+
+The hook must be supported for the operation and selected environment.
+No caller-supplied code or arbitrary failpoint action string is accepted.
+Initial hook ownership is the prototype's merge hooks
+(`branch_merge.post_authority_capture`,
+`branch_merge.post_sidecar_pre_fork`,
+`branch_merge.post_effects_pre_confirm`,
+`branch_merge.post_phase_b_pre_manifest_commit`) and mutation hook
+`mutation.post_sidecar_pre_fork`. New hooks require an implementation,
+scope proof, and negative tests before the parser accepts them.
+
+The selected operation must finish before fault cleanup can be considered
+complete. On cancellation or timeout, stop the isolated worker or quarantine
+the dedicated server graph until outstanding work has stopped and hooks are
+disarmed. Use a bounded supervisor cleanup deadline; failure to establish
+cleanup prevents reuse and is reported, never an unbounded wait. A killed
+worker or quarantined graph does not count as a successful replay.
+
+The operation must observe the exact injected error through a typed error
+or an equivalent correlated server result. Matching text in query rows or
+an unrelated error is insufficient. The runner verifies delivery and
+disarms the hook before the following operation, including after an
+assertion failure. An unreached hook, failed cleanup, timeout, or lost
+delivery evidence fails the execution. A fault that leaked into another
+operation or graph fails isolation even if the expected rows match.
+
+One fault directive attaches to one operation; adjacent directives,
+directives before restart/setup, orphan directives, and directives inside
+loops are refused in this phase. Multiple faults in one operation and
+faults during setup remain out of scope. A case may contain up to 16
+fault directives at separate operations. No fault state survives a
+restart, environment change, seed, or replay.
+
+Initial `omnigraph-engine` admission rejects faults. A future fault-capable
+direct-engine implementation can use process isolation where failpoints are
+global. A server implementation needs equivalent isolation and explicit
+operation attribution; a shared server-wide toggle does not satisfy it.
+This amendment defines no production fault-control endpoint. HTTP fault
+execution stays unavailable until the test-only lifecycle/control owner
+proves this contract.
+
+`--- restart` continues to mean closing the graph handle and reopening
+the same stored graph. It does not mean process crash or HTTP reconnect.
+In-memory contents must survive that handle reopen. A server environment
+must perform the equivalent graph reopen or refuse the case. Process
+crashes, multi-connection interleavings, and randomized fault discovery
+remain outside this format extension.
+
+### Known recovery failures
+
+An optional `--- known_failure` section immediately after `--- runner` records one
+known recovery failure while keeping the healthy operation expectations.
+It is a narrow corpus admission rule, not an expected-error assertion:
+
+```yaml
+--- known_failure
+step: 4
+match:
+  error: RecoveryRequired
+  reason: "the exact OmniError::RecoveryRequired reason"
+```
+
+`step` and `match` are required, and other fields are refused. `step` is a
+positive operation ordinal. `match` is a typed error matcher: the only supported
+variant is `error: RecoveryRequired`, with a nonempty exact `reason` of at most
+2048 bytes. It names `OmniError::RecoveryRequired` directly; there is no wildcard
+or fallback variant. Unknown error names, including `Unknown`, are refused,
+as is the old `--- fixme` syntax. The existing `# issue` and `# notes` headers
+provide issue identity and context; `none` remains valid for an unassigned
+issue. The marker does not repeat notes or contain the generated operation ID.
+
+Admission requires only `omnigraph-engine-dst` with
+`in-memory-object-store`, no loops, and an ordinary mutate at the declared
+step with its healthy `ok` or `affected` expectation. At least one supported
+fault must precede that step. Faults at or after the marked step are refused.
+
+An execution qualifies only when every preceding assertion passes, every
+declared fault has exact typed delivery evidence at its own operation, and
+the marked assertion fails because that mutate returned the typed
+`OmniError::RecoveryRequired` variant with exactly the declared reason.
+The operation's typed error and the failed assertion must identify the same
+step and actual error. Matching text in data, a different error variant,
+another reason or step, and missing fault evidence never qualify.
+
+The step loop still stops at its first failure; later healthy assertions
+remain unchanged and unexecuted. Every selected seed and mandatory fresh
+replay must qualify. The full raw worker reports, including their assertion
+failures, operation IDs and other actual evidence, must still match. An
+accepted attempt carries `known_failure: true`, the invocation code is
+`known_failure`, and the runner prints `KNOWN_FAILURE`. This status permits a
+successful CI exit while explicitly retaining the graph defect. It does
+not mean that the scenario passed. Partial selection stays partial.
+
+If the scenario passes, the marker is stale and the invocation fails with
+`unexpected_pass`. Setup, worker panic, timeout, cleanup, observation and
+report failures are never waived. Replay derives acceptance again from the
+frozen marker and raw evidence and refuses inconsistent stored status.
+Blessing a marked case is refused. Removing the marker after a fix restores
+the ordinary requirement that every healthy assertion pass.
+
+### Validation and agent diagnostics
+
+Parse the complete file, resolve profiles, and check every selected
+environment's capabilities before creating case state. Reject unknown or
+duplicate YAML keys, YAML aliases/merge keys/tags, misplaced sections,
+unknown enum values, empty selections, duplicate environment parameters or seeds, and fields
+that do not apply to the chosen target. Do not infer a target from a
+storage URI or repair a misspelled field during execution.
+
+Preflight must produce one immutable input for the invocation: the exact
+validated case bytes, declared and selected executions, resolved non-secret
+profile settings, and expected engine/runner build identities. Every
+execution consumes that input; workers cannot reopen the original case or
+resolve a profile name again as configuration authority. The runner records
+the input digest. Before setup, each worker verifies that digest and its
+actual executable identity against the input. Known identity differences
+fail with `environment_changed`; unknown identities remain explicitly
+unverified and cannot support a verified reproduction or DST replay.
+Server execution additionally revalidates its effective configuration and
+build identity at readiness, before creating case state. Credentials remain
+external and excluded from the recorded input. This binds tested inputs;
+it does not freeze the external service's internal execution schedule.
+
+Capability requirements are derived from actual steps and configuration.
+For example, `--- fault` requires its exact hook, and `--- expect shape`
+requires result type evidence. There is no second hand-maintained
+`requires` list that can disagree with the case. A server cannot substitute
+inferred types for missing executed types or omit an existing comparison.
+
+Every result identifies its scope using the following applicability rules.
+The result carries the invocation's case path and content hash when the
+bytes were read, input digest when resolved, and known engine/runner build
+identities. A required but unavailable value carries an explicit reason;
+an inapplicable value is marked separately. No synthetic environment,
+profile, step, or seed may stand in for missing evidence.
+
+| Result scope | Applicable context |
+|---|---|
+| Case/preflight | Source span when locatable; environment parameters only when parsed unambiguously; profile digest only after resolution. No operation ordinal is required for malformed YAML. |
+| Execution/step | Target, storage, full declared parameters, effective settings, profile digest when required, and seed/replay index for DST. Step ordinal, loop iteration, source span, and expected/actual values apply to operation assertions; setup/teardown failures identify their phase instead. |
+| Replay comparison | Environment parameters, seed, both attempt identities, their verdicts, and differing observations when available. A comparison does not invent a single failing step when attempts reached different steps. |
+| Supervisor | The affected execution or invocation, containment outcome, and original failure reference. Operation context is included only when known. |
+| Invocation summary | Final outcome and coverage of every declared execution: selected or unselected, then passed, accepted known failure, failed, or not run with a reason. If parsing cannot establish that inventory, coverage is explicitly unavailable and the invocation fails. |
+
+Within one invocation, full environment parameters and seed/replay index identify an
+execution. Step ordinal and loop iteration identify an observation inside
+it. Reports from different invocations must retain their invocation boundary;
+case path or digest alone cannot identify a run. A replay compares operation
+identities and values, not run-specific report references.
+
+Build identity includes executable digests and source revision plus
+dirty-source identity when available. Unknown identity is reported explicitly
+and cannot claim a verified reproduction. Secret values are excluded.
+Observation and diagnostic collection must be bounded; exceeding the bound
+fails explicitly and cannot truncate compared evidence into success.
+Structured failures retain applicable expected/actual values and a stable
+error code alongside the readable explanation. Contract codes include
+`invalid_case`, `unsupported_environment`, `environment_changed`,
+`fault_unobserved`, `fault_cleanup_failed`, `assertion_failed`,
+`replay_mismatch`, `worker_failed`, `report_failed`, `timeout`, and
+`unexpected_pass`. `known_failure` is a separate accepted status defined
+in Known recovery failures; its raw worker result remains an assertion failure.
+Every invocation must emit a terminal summary. A missing, malformed,
+incomplete, or unwritable report fails the invocation and cannot yield
+a successful exit. If the structured output cannot be written, the runner
+also reports `report_failed` through stderr and exits unsuccessfully.
+Cleanup failure preserves the original operation failure as well as its
+own outcome; it never replaces the evidence that triggered cleanup.
+
+The runner supplies an exact rerun command plus the required build and
+profile references. The `--target`, `--storage` and `--seed` filters select all
+matching declared executions. Supplied filters combine with AND and only
+narrow the file's declared executions; they cannot change them. A seed filter
+requires a target or storage filter. The report lists
+selected and unselected executions, and a partial run never claims the
+whole case passed. Zero matching environments or seeds is a refusal.
+Each individual execution stops its step loop at the first failed step.
+A completed failing DST execution still gets its fresh replay, and later
+selected seeds continue while the deadline and isolation permit. A replay
+mismatch fails the case but does not suppress later seeds. A worker failure
+without a complete report stops that environment's remaining executions;
+other selected environments continue only after containment is confirmed.
+Deadline exhaustion or uncontained cleanup stops all further dispatch.
+Every suppressed execution, including a mandatory replay, is reported as
+not run with its terminal cause. Overall success requires every selected
+execution and mandatory replay to pass or satisfy Known recovery failures,
+and a complete terminal report. Accepted known failures remain distinct from
+genuine passes.
+
+The report is derived execution evidence, never configuration authority.
+A reproduction compares case, build, effective settings, and non-secret
+profile identities before running; missing or changed evidence is reported
+as a changed environment. Repeating a command against an altered server
+must not be described as replaying the original conditions.
+
+The precise command-line flags and structured-result wire schema are
+implementation deliverables in Rollout. Their acceptance tests must prove
+exact selection, stable refusal codes, and complete failure context.
+Bless remains available for an explicit single-engine, fault-free route;
+it is refused for fault, DST, known-failure, and multi-environment executions. A runner must never
+resolve disagreeing environments by rewriting the shared expectation.
+
+
 ### Execution semantics
 
-Per case, in order: create a `tempfile::tempdir()`, then
+The following setup and direct calls describe an explicitly declared
+`omnigraph-engine` / `local-filesystem` environment. Every environment uses
+the lifecycle and operation contract above.
+Per execution, in order: create a `tempfile::tempdir()`, then
 `Omnigraph::init(uri, schema_source)`, then
 `loader::load_jsonl(&db, seed, LoadMode::Overwrite)`, then
 `db.ensure_indices()` (its `Vec<PendingIndex>` return lists deferred
@@ -621,10 +1125,11 @@ process-global state stay Rust tests: the harness refuses a schema using
 `@embed` and a `nearest` over a string argument, both of which resolve an
 embedding provider from process environment variables
 (`EmbeddingClient::from_env`); a `nearest` over an explicit vector
-parameter stays in scope. Failpoint cases stay Rust tests likewise.
-Concurrency between connections (interleaved writers, transaction races)
-stays out: that is DST's domain. This keeps the logic test binary out of
-the serial group entirely.
+parameter stays in scope. Fault cases expressible by Faults at an explicit
+step may use GQT; other failpoint cases stay Rust tests. Interleaved writers
+and transaction races stay in the existing DST suites. Fault-enabled GQT
+executions require the isolation described above; they cannot share a
+process-global hook with unrelated cases.
 
 ### Comparison semantics
 
@@ -743,7 +1248,7 @@ trial under `datatest-stable`) named `case::<file>.gqt`. The runner it
 calls (parser, execution, comparison, bless) is the crate's library,
 `crates/omnigraph-gqt/src/lib.rs`, and the format self-tests are unit
 tests beside it in `crates/omnigraph-gqt/src/tests.rs`; the crate is
-`publish = false` and never built for release. Cases run on one shared
+`publish = false` and never built for release. Direct-engine cases run on one shared
 multi-thread tokio runtime whose worker stacks are 16 MiB (the engine's
 query futures overflow the 2 MiB default; the value equals the CI jobs'
 `RUST_MIN_STACK`, so the harness target does not depend on that
@@ -754,14 +1259,24 @@ once is set by libtest's `--test-threads=<n>` flag, which
 `datatest-stable` honors, independently of corpus size; that flag is a
 runner knob, not format contract.
 The per-PR corpus is the ***fast tier***: a case is expected to finish
-in well under a second. The runner's per-case budget defaults to 10
-seconds, generous against that expectation so a slow CI runner never
-trips it; `OMNIGRAPH_GQ_CASE_TIMEOUT_SECS` overrides the default, and the
-timeout failure message prints the budget in force. The elapsed time on each
-ok/FAIL line, not the timeout, is the drift signal a reviewer reads. A
-case that trips the budget belongs to the heavy-repro tier, defined below
-in the Enforcement ladder, so slowness fails the PR introducing it
-instead of accumulating in the required job. Each case's
+in well under a second. Every file owns its explicit `timeout_ms` budget;
+there is no default and `OMNIGRAPH_GQ_CASE_TIMEOUT_SECS` is refused as an
+ambient override. The timeout failure message prints the budget in force. The
+elapsed time on each ok/FAIL line is the drift signal a reviewer reads.
+
+The GQT corpus admission check must reject a declared file budget above
+10000 milliseconds before case setup, independent of selected environments
+or seeds. The required job must run this check over every corpus file
+before execution. It must not clamp an explicit budget to make a case
+admissible. A case that exceeds
+its admitted budget fails the required job. Larger budgets remain valid
+only for explicit file execution outside the per-PR corpus; the GQT
+command-line runner owns that local reproduction route. It is not
+automatically enrolled in CI. The existing heavy-repro tier, defined below
+in the Enforcement ladder, continues
+to discover Rust repro targets; it does not discover these external GQT
+files. A slow GQT reproduction must be reduced for corpus enrollment or
+converted to that tier's Rust route. Each case's
 outcome, a panic included, is caught and reported as that case's own
 failure, which lets the target run every case before
 failing. A corpus directory holding no case file makes the target panic
@@ -853,8 +1368,8 @@ Rust-test status quo already carries.
 
 ## Invariants
 
-No architectural invariant is touched; the change is test-and-CI only. Every
-engine surface the harness calls is public and chokepoint-registered in the
+No architectural invariant is weakened; the change is test-and-CI only. The
+existing engine surfaces are public and chokepoint-registered in the
 `forbidden_apis.rs` const registries: `query`, `query_with_head`, and
 `run_query_at` read-only, `load_jsonl` / `load_jsonl_file` under `LOAD_V9`,
 the `mutate` family under `MUTATION_V9`, and `open` / `open_with_storage`
@@ -862,11 +1377,14 @@ under the `RecoveryExecutor` write protocol. That `forbidden_apis.rs`
 walk covers `crates/omnigraph/src/**` only, so the `omnigraph-gqt` crate
 adds no registry entries; no deny-list item is affected, and no new
 public API is added.
-The target adds no shared state to the test suite (Execution semantics).
+The proposed fault extension must preserve per-case isolation. It cannot
+weaken graph publication, recovery, policy, or storage admission rules.
+Future HTTP execution needs a separately qualified test-control boundary;
+this amendment does not authorize production fault-control APIs.
 
 ## Compatibility and reversibility
 
-No storage or wire surface changes; the RFC is purely additive to tests,
+No production storage format or wire surface changes; the RFC extends tests,
 CI, and contributor docs. Reverting means deleting the `omnigraph-gqt`
 crate and its `members` entry in the workspace `Cargo.toml` (which drops
 `datatest-stable` and its lockfile closure), the two workflow files with
@@ -877,11 +1395,30 @@ header keys, and missing required headers are refusals, never silent
 skips, so an older harness refuses a newer logic test rather than
 mis-running it.
 
+The explicit runner section is mandatory for all cases. It has no version
+field; parser and corpus changes land together.
+Omitting the section or any required field is `invalid_case`, including for
+previously accepted engine/local-filesystem cases. Migration adds that
+environment explicitly to every existing case; no provider, execution target,
+seed or timeout is discovered from the host or supplied as a format default.
+
+The prototype's `mode: normal` / `mode: dst` runner shape is not an alias
+for this contract. The earlier draft's `runtime` field and `omnigraph-dst`
+value are not aliases either; use `target: omnigraph-engine-dst` for direct
+engine simulation. Migration rewrites every configuration explicitly. In
+particular, the prototype's
+fault occurrence count starts during initialization; the proposed count
+starts at the selected operation. Migration must identify that operation
+and re-establish the failure, never copy occurrence numbers mechanically.
+Old parsers reject the new sections. Rollback requires retaining the newer
+harness or migrating those files back, not silently dropping directives.
+
 Named compatible extensions, deferred until a real case demands each,
 with maintainers deciding each one when the first case that needs it
 forces the question:
 
-- `require <capability>` guards for optional engine features.
+- Additional feature requirements not already derivable from the
+  environment and step contract.
 - Loop nesting.
 - A per-case float-precision override; scale 12 for every number is the
   contract until a case a fixed scale cannot express appears.
@@ -901,10 +1438,29 @@ forces the question:
   execution model; until then the modes-are-equivalent contract keeps its
   existing owner, `tests/proptest_equivalence.rs`.
 
-Multi-connection interleaving stays out
-permanently rather than deferred (DST's domain, per Execution semantics).
+Whole-case execution across declared environments is distinct from the
+per-query second-plan verification deferred above. Multi-connection
+interleaving remains outside GQT and retains its existing DST owner.
 
 ## Alternatives
+
+| Environment/fault alternative | Decision and concrete cost |
+|---|---|
+| Keep only the current local runner and Rust fault tests | Smallest change, but each merge-failure case duplicates setup and assertions in Rust. |
+| Select environments entirely through CLI or CI | Short files, but copying a regression loses its required storage and fault conditions. Exact selection may narrow a file, not redefine it. |
+| Inline every endpoint and credential | Self-contained connection data, but secrets and machine-specific addresses prevent portable cases. Profiles own connection data; resolved evidence exposes drift. |
+| Reopen case/profile paths in every worker | Avoids handing workers resolved input, but an edit after preflight can make two workers agree on a different experiment. Preserve validated input and check worker identities. |
+| Arm faults once at file startup | Simpler lifecycle, but setup can consume the occurrence intended for a later merge. Step scope gives the occurrence an explicit owner. |
+| Add a separate capability list or expected file per target | Duplicates facts already present in operations and assertions, creating disagreement paths. Derive requirements and share expectations. |
+
+The nearest in-repo owners are the GQT parser/comparator, DST environment,
+`StorageAdapter`, and server test support. Extend those boundaries rather
+than add a second assertion engine or cluster lifecycle implementation.
+The [sqllogictest Runner](https://docs.rs/sqllogictest/latest/i686-pc-windows-msvc/sqllogictest/runner/struct.Runner.html)
+separates database execution from validation. [RisingWave's 2023 account](https://risingwave.com/blog/applying-deterministic-simulation-the-risingwave-story-part-2-of-2/)
+describes reusing scripts between real and simulated clusters. These
+support the separation; neither establishes this proposed GQT syntax.
+
 
 - **Regression-only scope first, wider role later** (this RFC's own prior
   draft): rejected because every deferred feature is already proven
@@ -955,6 +1511,44 @@ permanently rather than deferred (DST's domain, per Execution semantics).
   `-- --nocapture` is accepted as before (inert for this target).
 
 ## Evidence and tests
+
+The amendment requires the following evidence before a target/storage
+combination is advertised as supported:
+
+| Owner | Required evidence |
+|---|---|
+| GQT parser self-tests | Missing runner sections on existing and new cases, required fields, distinct environment parameters, all field bounds, invalid positions, unsupported combinations, old `runtime`/`mode` spellings, and migration refusals. |
+| GQT execution/dispatch tests | Every declared environment runs fresh; exact subset selection is visible; deadlines include preflight/setup/replays/cleanup; no-match selections fail. |
+| GQT input identity tests | Editing the original case/profile after preflight cannot change worker input; replacing a worker build is refused before setup; unequal identities cannot count as replay. |
+| GQT scheduling tests | A completed assertion-failing first seed still replays and later seeds run; mismatch, worker failure, deadline, and uncontained cleanup follow the specified continuation rules and account for every not-run attempt. |
+| GQT diagnostic tests | Malformed YAML, unresolved profiles, setup failures, replay mismatch, and cleanup failure have applicable context; missing/incomplete/unwritable reports fail, preserving the original failure. |
+| GQT CI/admission tests | A workflow-equivalent mixed engine/engine-DST corpus with explicit configuration executes every declared attempt; an over-10000-ms corpus file fails admission even under subset selection; explicit out-of-corpus execution preserves its declared budget. |
+| GQT comparison tests | Rows, executed types, counts, and error checks remain active through each executor; transport conversion preserves the existing contract. |
+| Fault isolation tests | Setup cannot consume a fault; another case cannot trigger it; occurrence counting includes production retries; spoofed or missing delivery fails. |
+| Fault cleanup tests | Expected errors, unexpected success, panic, cancellation, and timeout cannot leave a hook armed for another operation. |
+| DST replay tests | Successful and completed failing seeds repeat in fresh processes; changed actual counts, executed types, error payloads, rows, operation sequence, or main snapshot IDs fail comparison even with the same failure classification. |
+| Known recovery failure tests | Exact typed recovery reason and step qualify only with all earlier assertions and fault deliveries; changed reasons, other failures, missing faults, stale markers, and forged replay status fail. Raw reports still compare in full. |
+| Server test support | Backend verification, exclusive fresh graphs, authentication, actual graph reopen, and typed fault correlation before advertising each capability. |
+
+The existing merge-refusal cases retain successful-write expectations
+after the injected failure. An explicitly marked exact recovery defect can
+qualify only under Known recovery failures; its accepted status remains
+distinct from a genuine pass. Unmarked or mismatching failures remain
+regression failures. Neither blessing nor target selection can hide them.
+
+Lance's [object-store configuration](https://lance.org/guide/object_store/)
+documents backend options outside the query text. GQT must record the
+effective settings used by the tested build; current upstream defaults
+are not evidence of the pinned dependency's defaults. The initial engine/DST
+runner records its Rayon and Lance thread counts, deterministic-backoff setting,
+entropy seed when applicable, and Tokio runtime kind with explicit direct-engine
+worker count and stack size. These recorded values configure the worker and are
+verified against both this build's settings and the process environment before
+setup. Replay validates every recorded settings object before dispatching any
+worker. Lance's memory pool is recorded as `dependency_default`, with
+`LANCE_MEM_POOL_SIZE` absent; this identifies the pinned dependency's default
+selection, not a measured or independently verified pool capacity.
+
 
 The harness proves itself on two fronts: the logic-test-expressible #563
 regressions as the first corpus entries, each with a red state recorded
@@ -1030,12 +1624,63 @@ the docs indexes honest, so no new orphan doc file).
    tier member on `main`) is met. `implementation` advances to
    `complete`.
 
+### Environment extension rollout
+
+1. Deliver the first complete engine/DST integration: mandatory configuration
+   and corpus migration, immutable invocation inputs, exact selection, corpus
+   admission, structured diagnostics, preserved lifetime, scoped faults with
+   delivery evidence, shared assertions, and observation replay. Admit only
+   fault-free `omnigraph-engine` / `local-filesystem` and
+   `omnigraph-engine-dst` / `in-memory-object-store`. The GQT maintainer
+   decides the CLI/result schema before enabling this phase, including
+   explicit file execution outside the corpus and acceptance tests for
+   result applicability and failed report publication. The maintainer owns
+   the required workflow's seeded build, its `omnigraph-gqt` worker binary,
+   and the workspace test
+   invocation described in User and operational behavior. Before enrolling
+   DST cases, a workflow-equivalent mixed corpus must prove full declared
+   execution and admission enforcement. The DST package workflow alone is
+   insufficient. Migrate prototype faults by their intended operation.
+   Keep parser capability refusals for every unqualified combination. An
+   explicitly marked recovery defect must meet Known recovery failures,
+   with its raw failure evidence retained; other known-red cases fail.
+2. Qualify direct-engine in-memory storage and, independently, fault controls
+   for ordinary engine execution. These extend the first integration rather
+   than delay its engine-DST path. Preserve the same isolation, attribution,
+   result and reproduction evidence requirements.
+3. Qualify configured S3 and Azure engine execution with provider-specific
+   evidence and existing admission rules. CI must supply declared profiles;
+   missing configured services fail their selected cases.
+4. Add HTTP execution through the existing server lifecycle owner. Enable
+   `omnigraph-server` cases first; enable reopen and faults only when their
+   separate capability tests pass. Qualify `omnigraph-server-dst` independently,
+   including controlled server tasks and the embedded engine. Neither server
+   target is a prerequisite for the first engine/DST integration.
+
+The RFC's `implementation` remains `partial` while this extension has
+unqualified targets. No stage changes engine recovery behavior or claims
+determinism for real external services.
+
 ## Unresolved questions
 
-None before acceptance. The deferred extensions and their decider are
-listed in Compatibility and reversibility.
+The proposed format and failure semantics above are the acceptance
+decisions. Two implementation proposals remain, with explicit owners:
+
+| Proposal | Decision owner | Required event |
+|---|---|---|
+| CLI and diagnostic wire schema | GQT maintainer | Accept the proposal and pass phase 1's selection, applicability, coverage, and report-failure tests before enabling the interface. |
+| HTTP profile and test-control protocol | Server lifecycle maintainer, with GQT maintainer acceptance of the execution contract | Accept the proposal and qualify backend identity, exclusive graphs, result typing, and each requested control before enabling phase 4 capabilities. |
+
+These roles own the decisions, not an assertion that a particular maintainer
+has already approved them. Neither proposal may weaken the specified
+isolation, selection, typing, or evidence requirements.
 
 ## Decision log
+
+The entries below record earlier decisions. The current environment amendment
+supersedes their implicit execution and ambient-budget rules and assigns the
+complete corpus to the separate configured `GQ Logic Tests` context. Their
+historical command and configuration descriptions are not migration aliases.
 
 - 2026-09-02, from review of the RFC PR: the fix-PR gate is a diff check
   whose execution guarantee differs by shape (a corpus match ran green in

--- a/scripts/check-fix-regression.py
+++ b/scripts/check-fix-regression.py
@@ -411,6 +411,12 @@ def failure_message(n: str, code_paths: list[str], hints: list[str]) -> str:
         "    # red_on: <date>, pre-fix build: <what the old build returned>",
         "    # notes: <one line on what the case pins>",
         "",
+        "    --- runner",
+        "    timeout_ms: 10000",
+        "    environments:",
+        "      - target: omnigraph-engine",
+        "        storage: local-filesystem",
+        "",
         "    --- schema",
         "    node Person {",
         "        name: String @key",
@@ -1072,6 +1078,8 @@ def self_test() -> int:
     message = failure_message("563", ["crates/omnigraph/src/lib.rs"], ["hint one"])
     assert message.startswith("FAIL: the body closes #563") and "near miss: hint one" in message
     assert "issue_563_<short_name>.gqt" in message and "# issue: 563" in message
+    assert "    --- runner\n    timeout_ms: 10000\n    environments:" in message
+    assert "      - target: omnigraph-engine\n        storage: local-filesystem" in message
 
     print("self-test ok")
     return 0


### PR DESCRIPTION
## What & why

This PR adds GQT directives that trigger existing engine failpoints under DST, so failure scenarios and their expectations can live in GQT files.

- Declare execution target, storage, timeout and seeds explicitly.
- Inject an error at a named hook during the next operation and require evidence that it fired.
- Compare results and fault evidence across fresh-process replays.
- Share DST execution setup between Rust and GQT scenarios.

## Backing issue / RFC

- [x] Amends [RFC 0045: GQ logic tests](docs/rfcs/0045-gq-logic-tests.md), currently draft, with execution environments, fault injection and replay contracts.

## Checklist

- [x] Change is focused (GQT fault injection and DST execution).
- [x] Tests added/updated (parser, dispatch, fault evidence, replay and recovery reproductions).
- [x] Docs updated (GQT README, testing/CI documentation and RFC 0045).
- [x] Reviewed against docs/dev/invariants.md (engine recovery behavior remains unchanged).

## Local verification

From `crates/omnigraph-gqt`:

- `cargo test -p omnigraph-gqt --locked -j4`: 142 unit tests, 19 integration tests and 73 corpus cases accepted.
- `cargo clippy -p omnigraph-gqt -p omnigraph-dst --all-targets --locked -j4 --message-format=short -- -D warnings -W clippy::dbg_macro`: passed.

From the repository root:

- `cargo test -p omnigraph-gqt --locked --lib --test runner_dispatch --test review_regressions --test result_evidence --test effective_settings --test replay_coverage -j4`: 141 unit tests and nine integration tests passed.
- `cargo check --workspace --locked -j4`: passed.

## Notes for reviewers

- Every case now requires explicit runner configuration. Supported combinations are engine/local-filesystem and engine-DST/in-memory-object-store.
- The corpus contains 70 healthy cases and three strict `known_failure` reproductions. Their healthy write expectations remain unchanged; different failures and unexpected passes fail. The engine bugs remain unfixed.
- Known-failure acceptance proves the recorded symptom; steps after the failed assertion remain unexecuted.
- Worker execution is bounded. Synchronous host-file I/O prevents a hard bound on total command wall time.
- Remote CI and the complete workspace test suite have not run.