### PR TITLE
ci: parallelize GQT checks and fix runner regressions

### DIFF
--- a/.github/workflows/gq-logic-tests.yml
+++ b/.github/workflows/gq-logic-tests.yml
@@ -93,11 +93,15 @@ jobs:
           printf '  %s\n' "${changed[@]}"
           echo "run_full_ci=$run_full_ci" >> "$GITHUB_OUTPUT"
 
-  gq_logic_tests:
-    name: GQ Logic Tests
+  qualification:
+    name: GQT (${{ matrix.mode }})
     needs: classify_changes
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    strategy:
+      fail-fast: true
+      matrix:
+        mode: [ordinary, dst, dst-clippy]
     permissions:
       contents: read
     env:
@@ -106,8 +110,7 @@ jobs:
       # nested async engine frame, deeper than a default 2 MiB thread stack.
       RUST_MIN_STACK: 16777216
     steps:
-      # Unconditional: the copy assertion below must run on every PR, the
-      # documentation-only ones included, inside this required context.
+      # Check classification on documentation-only changes too.
       - name: Checkout source
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
@@ -138,29 +141,56 @@ jobs:
         with:
           workspaces: |
             . -> target
+          key: gqt-${{ matrix.mode }}
           # Save only from main, red or green (same rule as ci.yml's `lint`).
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-on-failure: true
 
       - name: Test unavailable DST runtime refusal
-        if: needs.classify_changes.outputs.run_full_ci == 'true'
-        run: cargo test -p omnigraph-gqt --locked --lib --test runner_dispatch -- --nocapture
-
-      - name: Clippy GQT with DST
-        if: needs.classify_changes.outputs.run_full_ci == 'true'
-        # Crate-local Cargo configuration enables the seeded Tokio runtime.
-        working-directory: crates/omnigraph-gqt
-        run: cargo clippy -p omnigraph-gqt --all-targets --locked -- -D warnings -W clippy::dbg_macro
+        if: needs.classify_changes.outputs.run_full_ci == 'true' && matrix.mode == 'ordinary'
+        run: cargo test -p omnigraph-gqt --locked --timings --lib --test runner_dispatch -- --nocapture
 
       - name: Run complete GQ logic tests with DST
-        if: needs.classify_changes.outputs.run_full_ci == 'true'
+        if: needs.classify_changes.outputs.run_full_ci == 'true' && matrix.mode == 'dst'
         working-directory: crates/omnigraph-gqt
-        run: cargo test -p omnigraph-gqt --locked -- --nocapture
+        run: cargo test -p omnigraph-gqt --locked --timings -- --nocapture
+
+      - name: Clippy GQT with DST
+        if: needs.classify_changes.outputs.run_full_ci == 'true' && matrix.mode == 'dst-clippy'
+        # Crate-local Cargo configuration enables the seeded Tokio runtime.
+        working-directory: crates/omnigraph-gqt
+        run: cargo clippy -p omnigraph-gqt --all-targets --locked --timings -- -D warnings -W clippy::dbg_macro
 
       - name: Retain GQT invocation reports
+        if: always() && needs.classify_changes.outputs.run_full_ci == 'true' && matrix.mode != 'dst-clippy'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gqt-invocation-reports-${{ matrix.mode }}
+          path: target/gqt-artifacts/*.json
+          if-no-files-found: error
+
+      - name: Retain Cargo build timings
         if: always() && needs.classify_changes.outputs.run_full_ci == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: gqt-invocation-reports
-          path: target/gqt-artifacts/*.json
-          if-no-files-found: error
+          name: gqt-build-timings-${{ matrix.mode }}
+          path: target/cargo-timings/*.html
+          if-no-files-found: warn
+
+  gq_logic_tests:
+    name: GQ Logic Tests
+    needs: [classify_changes, qualification]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Require all GQT qualification jobs
+        env:
+          CLASSIFICATION_RESULT: ${{ needs.classify_changes.result }}
+          QUALIFICATION_RESULT: ${{ needs.qualification.result }}
+        run: |
+          if [[ "$CLASSIFICATION_RESULT" != "success" || "$QUALIFICATION_RESULT" != "success" ]]; then
+            echo "GQT qualification failed: classification=$CLASSIFICATION_RESULT qualification=$QUALIFICATION_RESULT"
+            exit 1
+          fi

--- a/crates/omnigraph-gqt/README.md
+++ b/crates/omnigraph-gqt/README.md
@@ -161,6 +161,11 @@ attempts are accounted for when execution cannot continue. The supervisor uses
 synchronous local-file reads and report writes; these host I/O operations are
 not interruptible by its worker deadline.
 
+For case invocations, `OMNIGRAPH_GQ_BLESS` accepts `1` to enable rewriting;
+unset, empty, or `0` leaves it disabled. Other values, including non-UTF-8
+values, produce an `invalid_case` report before execution or rewriting.
+Replay ignores this variable and refuses saved blessing invocations.
+
 `OMNIGRAPH_GQ_BLESS=1` is supported only for a case declaring one direct-engine
 environment. A subset selection cannot bless a multi-environment case. It rewrites a failing row or shape expectation and still returns
 failure until a subsequent run confirms it. DST cannot bless. The legacy

--- a/crates/omnigraph-gqt/cases/issue_694_effect_free_merge_keeps_writing.gqt
+++ b/crates/omnigraph-gqt/cases/issue_694_effect_free_merge_keeps_writing.gqt
@@ -1,6 +1,7 @@
 # issue: 694
-# red_on: ed3ea500 (2026-09-09): step 6 rejects the unrelated write with pending BranchMerge
-# notes: The runner section injects one merge failure under DST.
+# red_on: d205f7f3 (2026-09-11): step 8 rejects the unrelated write with pending BranchMerge
+# notes: Source and donor diverge; target inherits donor without owning a table fork.
+# notes: The fault fires after merge recovery is armed and before target first-touch.
 # notes: Reads and the next unrelated write use the same Omnigraph without reopening.
 
 --- runner
@@ -11,7 +12,7 @@ environments:
     seeds: [0, 42]
 
 --- known_failure
-step: 6
+step: 8
 match:
   error: RecoveryRequired
   reason: "pending BranchMerge recovery operation on branch 'target' blocks the synchronous write/control recovery barrier (datasets dataset for node type 'Person'); reopen the graph read-write before retrying"
@@ -35,7 +36,19 @@ branch create source
 --- expect ok
 
 --- mutate
-branch create target
+branch create donor
+
+--- expect ok
+
+--- mutate branch: donor
+query add_inherited_target_row() {
+    insert Person { name: "carol" }
+}
+
+--- expect affected: nodes=1 edges=0
+
+--- mutate
+branch create target from donor
 
 --- expect ok
 
@@ -65,6 +78,7 @@ query read_after_failure() {
 
 --- expect unordered
 {"p.name": "alice"}
+{"p.name": "carol"}
 
 --- expect shape
 p.name: String
@@ -97,6 +111,7 @@ query target_after_write() {
 
 --- expect unordered
 {"p.name": "alice"}
+{"p.name": "carol"}
 
 --- expect shape
 p.name: String

--- a/crates/omnigraph-gqt/src/lib.rs
+++ b/crates/omnigraph-gqt/src/lib.rs
@@ -2460,15 +2460,20 @@ pub fn corpus_root() -> PathBuf {
 
 /// `OMNIGRAPH_GQ_BLESS=1` turns bless on; unset, empty, or `0` leaves it off.
 ///
-/// # Panics
+/// # Errors
 ///
-/// On any other value: the knob is refused, not ignored.
-pub fn bless_from_env() -> bool {
+/// Refuses any other value, including non-UTF-8 values.
+pub fn bless_from_env() -> Result<bool, String> {
     match std::env::var(BLESS_ENV) {
-        Err(_) => false,
-        Ok(v) if v == "1" => true,
-        Ok(v) if v == "0" || v.is_empty() => false,
-        Ok(v) => panic!("{BLESS_ENV} takes 1 (or 0/unset), got `{v}`"),
+        Err(std::env::VarError::NotPresent) => Ok(false),
+        Err(std::env::VarError::NotUnicode(v)) => Err(format!(
+            "invalid_case: {BLESS_ENV} requires UTF-8, got {v:?}"
+        )),
+        Ok(v) if v == "1" => Ok(true),
+        Ok(v) if v == "0" || v.is_empty() => Ok(false),
+        Ok(v) => Err(format!(
+            "invalid_case: {BLESS_ENV} takes 1 (or 0/empty/unset), got `{v}`"
+        )),
     }
 }
 

--- a/crates/omnigraph-gqt/src/main.rs
+++ b/crates/omnigraph-gqt/src/main.rs
@@ -103,10 +103,11 @@ fn run() -> Result<(), String> {
     match invocation {
         Invocation::Replay(path) => omnigraph_gqt::replay_report(&path, &executable),
         Invocation::Case(selection) => {
+            let bless = omnigraph_gqt::bless_from_env().map_err(refusal)?;
             let outcome = omnigraph_gqt::run_selected(
                 &selection.path,
                 &executable,
-                omnigraph_gqt::bless_from_env(),
+                bless,
                 selection.target.as_deref(),
                 selection.storage.as_deref(),
                 selection.seed,

--- a/crates/omnigraph-gqt/tests/effective_settings.rs
+++ b/crates/omnigraph-gqt/tests/effective_settings.rs
@@ -1,0 +1,65 @@
+use std::process::{Command, Output};
+
+fn report(output: &Output) -> serde_json::Value {
+    let text = String::from_utf8_lossy(&output.stdout);
+    let path = text
+        .lines()
+        .find_map(|line| line.strip_prefix("GQT report: "))
+        .expect("terminal report");
+    serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap()
+}
+
+/// Replay settings live in invocation JSON, outside the case format.
+#[test]
+fn reports_settings_and_refuses_modified_replay_settings() {
+    let directory = tempfile::tempdir().unwrap();
+    let case = directory.path().join("effective_settings.gqt");
+    let text = include_str!("../cases/dst_restart_preserves_rows.gqt");
+    let engine_only = text.replace(
+        "  - target: omnigraph-engine-dst\n    storage: in-memory-object-store\n    seeds: [0, 42]\n",
+        "",
+    );
+    std::fs::write(&case, engine_only).unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+        .arg(&case)
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{output:?}");
+    let summary = report(&output);
+    let settings = &summary["attempts"][0]["input"]["effective_settings"];
+    assert_eq!(settings["rayon_num_threads"], 1);
+    assert_eq!(settings["lance_cpu_threads"], 1);
+    assert_eq!(settings["lance_deterministic_backoff"], true);
+    assert_eq!(settings["dst_entropy_seed"], serde_json::Value::Null);
+    assert_eq!(settings["lance_memory_pool"], "dependency_default");
+    assert_eq!(settings["tokio"]["kind"], "multi_thread");
+    assert_eq!(settings["tokio"]["worker_threads"], 2);
+    assert_eq!(settings["tokio"]["thread_stack_bytes"], 16 * 1024 * 1024);
+
+    let changed_path = directory.path().join("changed_settings.json");
+    for (field, value) in [
+        ("rayon_num_threads", serde_json::json!(2)),
+        ("lance_cpu_threads", serde_json::json!(2)),
+        ("lance_deterministic_backoff", serde_json::json!(false)),
+        ("dst_entropy_seed", serde_json::json!(42)),
+        (
+            "tokio",
+            serde_json::json!({"kind": "seeded_current_thread"}),
+        ),
+    ] {
+        let mut changed = summary.clone();
+        changed["attempts"][0]["input"]["effective_settings"][field] = value;
+        std::fs::write(&changed_path, serde_json::to_vec(&changed).unwrap()).unwrap();
+        let output = Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+            .arg("--replay")
+            .arg(&changed_path)
+            .output()
+            .unwrap();
+        assert!(!output.status.success(), "accepted changed {field}");
+        assert!(
+            String::from_utf8_lossy(&output.stderr)
+                .contains("environment_changed: effective worker settings differ"),
+            "{output:?}"
+        );
+    }
+}

--- a/crates/omnigraph-gqt/tests/gq_logic_tests.rs
+++ b/crates/omnigraph-gqt/tests/gq_logic_tests.rs
@@ -18,11 +18,11 @@ fn case(path: &Path) -> datatest_stable::Result<()> {
     ) {
         return Err(reason.into());
     }
-    let outcome = omnigraph_gqt::run_corpus_case(
-        path,
-        Path::new(env!("CARGO_BIN_EXE_omnigraph-gqt")),
-        omnigraph_gqt::bless_from_env(),
-    );
+    let bless = omnigraph_gqt::bless_from_env().map_err(|error| {
+        omnigraph_gqt::report_cli_refusal(Some(path.to_path_buf()), None, error)
+    })?;
+    let outcome =
+        omnigraph_gqt::run_corpus_case(path, Path::new(env!("CARGO_BIN_EXE_omnigraph-gqt")), bless);
     println!(
         "{} {} {:.2}s",
         if outcome.result.is_ok() { "ok" } else { "FAIL" },

--- a/crates/omnigraph-gqt/tests/review_regressions.rs
+++ b/crates/omnigraph-gqt/tests/review_regressions.rs
@@ -53,6 +53,72 @@ fn cli_refusals_always_keep_one_terminal_report() {
     }
 }
 
+/// OS environment bytes and terminal reports require a subprocess boundary.
+#[test]
+fn invalid_bless_values_keep_one_terminal_report_without_running() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("case.gqt");
+    std::fs::write(&path, SIMPLE).unwrap();
+    let invalid_values: Vec<std::ffi::OsString> = vec!["true".into(), "2".into(), " ".into()];
+    #[cfg(unix)]
+    let invalid_values = {
+        use std::os::unix::ffi::OsStringExt;
+        let mut values = invalid_values;
+        values.push(std::ffi::OsString::from_vec(vec![0xff]));
+        values
+    };
+    for value in invalid_values {
+        let output = Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"))
+            .arg(&path)
+            .env("OMNIGRAPH_GQ_BLESS", &value)
+            .output()
+            .unwrap();
+        let report = summary(&output);
+        assert_eq!(output.status.code(), Some(1), "{value:?}");
+        assert!(!String::from_utf8_lossy(&output.stderr).contains("panicked"));
+        assert_eq!(report["code"], "invalid_case");
+        assert!(report["attempts"].as_array().unwrap().is_empty());
+        assert!(
+            report["result"]["Err"]
+                .as_str()
+                .unwrap()
+                .contains("OMNIGRAPH_GQ_BLESS")
+        );
+        assert_eq!(
+            report["not_run"][0]["reason"]["error"],
+            report["result"]["Err"]
+        );
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), SIMPLE);
+    }
+}
+
+/// In-case assertions cannot inspect the case file that bless mode rewrites.
+#[test]
+fn only_bless_one_rewrites_expectations() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("case.gqt");
+    let incorrect = SIMPLE.replace("p.name\":\"alice", "p.name\":\"wrong");
+    assert_ne!(incorrect, SIMPLE);
+    for value in [None, Some(""), Some("0"), Some("1")] {
+        std::fs::write(&path, &incorrect).unwrap();
+        let mut command = Command::new(env!("CARGO_BIN_EXE_omnigraph-gqt"));
+        command.arg(&path).env_remove("OMNIGRAPH_GQ_BLESS");
+        if let Some(value) = value {
+            command.env("OMNIGRAPH_GQ_BLESS", value);
+        }
+        let output = command.output().unwrap();
+        let report = summary(&output);
+        let bless = value == Some("1");
+        assert_eq!(output.status.code(), Some(1), "{value:?}: {report}");
+        assert_eq!(report["code"], "assertion_failed");
+        assert_eq!(report["attempts"][0]["input"]["bless"], bless);
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            if bless { SIMPLE } else { &incorrect }
+        );
+    }
+}
+
 #[test]
 fn ambient_refusal_and_parse_failure_preserve_their_causes() {
     let directory = tempfile::tempdir().unwrap();

--- a/docs/dev/ci.md
+++ b/docs/dev/ci.md
@@ -19,10 +19,19 @@ Branch protection currently requires these reporting contexts:
 - `Fix Regression Gate`
 
 `GQ Logic Tests` (`gq-logic-tests.yml`) owns the complete `.gqt` corpus as a
-required context. It first checks unit tests and unavailable-DST refusal from
-the workspace root, then runs the whole package and Clippy from
-`crates/omnigraph-gqt`, whose Cargo configuration enables the seeded Tokio
-runtime. Every corpus case is enrolled, including cases whose required graph
+required context aggregating three qualification jobs. `GQT (ordinary)` checks
+unit tests and unavailable-DST refusal from the workspace root. `GQT (dst)`
+runs the whole package, while `GQT (dst-clippy)` checks all package targets
+with Clippy. Both run from `crates/omnigraph-gqt`, whose Cargo configuration
+enables the seeded Tokio runtime. Each job has its own
+45-minute budget and cache key. Matrix fail-fast cancels the remaining jobs
+when one fails; Cargo retains its default fail-fast between test targets.
+The required context fails if classification or any qualification fails,
+is cancelled, or is skipped. A successful run still requires all three jobs
+to pass; fail-fast never turns incomplete qualification into success.
+Test jobs upload invocation reports, and all three jobs upload available
+Cargo build timings separately, including on failure.
+Every corpus case is enrolled, including cases whose required graph
 behavior currently fails. `Test Workspace` excludes this separately tested
 package; it does not silently skip DST cases. `GQ Logic Tests` takes the documentation-only skip the way
 the AWS job does and reports success without building; its workflow carries a


### PR DESCRIPTION
## What & why

The [GQT job](https://github.com/ModernRelay/omnigraph/actions/runs/34547137066/job/103102274237) hit its 45-minute timeout while compiling DST dependencies. Ordinary tests and DST Clippy had already consumed about 28 minutes.

Split ordinary tests, DST tests and DST Clippy into three parallel jobs, each with a 45-minute budget and separate cache key. Preserve the existing commands and working directories, adding Cargo build timings.

Enable matrix fail-fast. The required `GQ Logic Tests` check succeeds only when classification and all three jobs succeed. Documentation-only changes still check classifier consistency without building. Retain invocation reports for test jobs and available build timings for every job.

Repair the merge fixture so its configured failpoint fires. Return structured reports for invalid `OMNIGRAPH_GQ_BLESS` values and add replay-settings regression coverage.

## Backing issue / RFC

Observed CI failure linked above; no backing issue or RFC for the CI change. The fixture covers [issue 694](https://github.com/ModernRelay/omnigraph/issues/694).

## Local verification

- Actionlint, classifier-copy, action-pin, documentation, spelling and whitespace checks passed.
- All 25 aggregate-result combinations behaved correctly; only success/success passed. Seven contributor-route simulations passed.
- Both runtime configurations, all 75 corpus cases and DST Clippy passed.

## Notes for reviewers

No engine changes. The corpus includes three strict known recovery failures; assertions after those failures remain unexecuted. Hosted cold-build timing and a successful CI run of the combined changes remain unverified.
