### PR TITLE
fix(merge): recover failed branch merges without reopening the graph

### DIFF
--- a/crates/omnigraph-gqt/cases/issue_694_unconfirmed_merge_keeps_writing.gqt
+++ b/crates/omnigraph-gqt/cases/issue_694_unconfirmed_merge_keeps_writing.gqt
@@ -2,6 +2,7 @@
 # red_on: ed3ea500 (2026-09-09): step 6 rejects the unrelated write with pending BranchMerge
 # notes: The runner section injects one merge failure under DST.
 # notes: Reads and the next unrelated write use the same Omnigraph without reopening.
+# notes: The failed merge compensates its own unconfirmed effects before returning, so step 6 succeeds and the merge retry lands.
 
 --- runner
 timeout_ms: 10000
@@ -9,12 +10,6 @@ environments:
   - target: omnigraph-engine-dst
     storage: in-memory-object-store
     seeds: [0, 42]
-
---- known_failure
-step: 6
-match:
-  error: RecoveryRequired
-  reason: "pending BranchMerge recovery operation on branch 'main' blocks the synchronous write/control recovery barrier (datasets dataset for node type 'Person'); reopen the graph read-write before retrying"
 
 --- schema
 node Person {
@@ -114,6 +109,25 @@ query source_unchanged() {
 --- expect unordered
 {"p.name": "alice"}
 {"p.name": "bob"}
+
+--- expect shape
+p.name: String
+
+--- mutate
+branch merge source into main
+
+--- expect ok
+
+--- query branch: main
+query main_after_retry() {
+    match { $p: Person }
+    return { $p.name }
+}
+
+--- expect unordered
+{"p.name": "alice"}
+{"p.name": "bob"}
+{"p.name": "carol"}
 
 --- expect shape
 p.name: String

--- a/crates/omnigraph-gqt/cases/issue_694_unconfirmed_named_target_keeps_writing.gqt
+++ b/crates/omnigraph-gqt/cases/issue_694_unconfirmed_named_target_keeps_writing.gqt
@@ -1,9 +1,9 @@
 # issue: 694
-# red_on: d205f7f3 (2026-09-11): step 8 rejects the unrelated write with pending BranchMerge
+# red_on: fb6ed452 (2026-09-12), cleanup disabled: step 8 rejects the unrelated write with pending BranchMerge on branch 'target'
 # notes: Source and donor diverge; target inherits donor without owning a table fork.
-# notes: The fault fires after merge recovery is armed and before target first-touch.
+# notes: The fault fires after every merge table effect, including the created first-touch fork, and before confirmation.
 # notes: Reads and the next unrelated write use the same Omnigraph without reopening.
-# notes: The failed merge retires its own effect-free sidecar before returning, so step 8 succeeds and the merge retry lands.
+# notes: The failed merge compensates its own unconfirmed effects on a named target before returning, so step 8 succeeds and the merge retry lands.
 
 --- runner
 timeout_ms: 10000
@@ -55,7 +55,7 @@ query add_source_row() {
 --- expect affected: nodes=1 edges=0
 
 --- fault
-at: branch_merge.post_sidecar_pre_fork
+at: branch_merge.post_effects_pre_confirm
 occurrence: 1
 action: return_error
 scope: next_step
@@ -63,7 +63,7 @@ scope: next_step
 --- mutate
 branch merge source into target
 
---- expect error: injected failpoint triggered: branch_merge.post_sidecar_pre_fork
+--- expect error: injected failpoint triggered: branch_merge.post_effects_pre_confirm
 
 --- query branch: target
 query read_after_failure() {

--- a/crates/omnigraph/src/db/manifest.rs
+++ b/crates/omnigraph/src/db/manifest.rs
@@ -73,8 +73,8 @@ pub(crate) use recovery::{
     confirm_schema_apply_sidecar_v9, delete_sidecar, ensure_read_only_schema_coherent,
     finalize_effect_free_occ_sidecar, heal_pending_sidecars_roll_forward, list_sidecars,
     new_branch_merge_sidecar_v9, new_ensure_indices_sidecar_v9, new_occ_sidecar_v9,
-    new_optimize_sidecar_v9, new_schema_apply_sidecar_v9, recover_manifest_drift,
-    schema_apply_serial_queue_key, write_sidecar,
+    new_optimize_sidecar_v9, new_schema_apply_sidecar_v9, recover_failed_branch_merge_under_gates,
+    recover_manifest_drift, schema_apply_serial_queue_key, write_sidecar,
 };
 pub use state::DatasetEntry;
 #[cfg(test)]

--- a/crates/omnigraph/src/db/manifest/recovery.rs
+++ b/crates/omnigraph/src/db/manifest/recovery.rs
@@ -5424,6 +5424,41 @@ async fn roll_back_schema_apply_v7(
     Ok(())
 }
 
+/// Resolve only the failed merge whose schema, branch and table gates remain held.
+/// The caller must have awaited its effect phase to completion; cancelled writers
+/// are left to the ordinary recovery entry points.
+pub(crate) async fn recover_failed_branch_merge_under_gates(
+    root_uri: &str,
+    storage: &std::sync::Arc<dyn StorageAdapter>,
+    failed: &RecoverySidecar,
+) -> Result<bool> {
+    assert_eq!(failed.writer_kind, SidecarKind::BranchMerge);
+    crate::failpoints::maybe_fail(crate::failpoints::names::BRANCH_MERGE_PRE_ERROR_RECOVERY)?;
+    let Some(sidecar) = reread_sidecar_under_gates(root_uri, storage.as_ref(), failed).await?
+    else {
+        return Ok(true);
+    };
+    if !sidecar
+        .protocol_v4
+        .as_ref()
+        .is_some_and(|protocol| protocol.effect_phase == RecoveryEffectPhase::Armed)
+    {
+        return Ok(false);
+    }
+    let coordinator = match sidecar.branch.as_deref() {
+        Some(branch) => GraphCoordinator::open_branch(root_uri, branch, storage.clone()).await?,
+        None => GraphCoordinator::open(root_uri, storage.clone()).await?,
+    };
+    process_branch_merge_sidecar_v4(
+        root_uri,
+        storage,
+        &coordinator.snapshot(),
+        &sidecar,
+        RecoveryMode::Full,
+    )
+    .await
+}
+
 async fn process_branch_merge_sidecar_v4(
     root_uri: &str,
     storage: &std::sync::Arc<dyn StorageAdapter>,

--- a/crates/omnigraph/src/db/omnigraph.rs
+++ b/crates/omnigraph/src/db/omnigraph.rs
@@ -2264,6 +2264,20 @@ impl Omnigraph {
         Ok(())
     }
 
+    pub(crate) async fn recover_failed_branch_merge_under_gates(
+        &self,
+        sidecar: &crate::db::manifest::RecoverySidecar,
+    ) -> Result<bool> {
+        let recovered = crate::db::manifest::recover_failed_branch_merge_under_gates(
+            self.uri(),
+            &self.storage,
+            sidecar,
+        )
+        .await;
+        self.refresh_coordinator_only().await?;
+        recovered
+    }
+
     /// Refresh coordinator state and invalidate the runtime cache WITHOUT
     /// running the recovery sweep. Engine-internal callers that hold an
     /// in-flight sidecar (e.g. `schema_apply::apply_schema_with_lock`'s

--- a/crates/omnigraph/src/exec/merge.rs
+++ b/crates/omnigraph/src/exec/merge.rs
@@ -6396,6 +6396,20 @@ impl Omnigraph {
         let (_updates, changed_edge_tables) = match post_arm_result {
             Ok(result) => result,
             Err(error) => {
+                if let Some((sidecar, _)) = &recovery {
+                    let recovered = self.recover_failed_branch_merge_under_gates(sidecar).await;
+                    match recovered {
+                        Ok(true) => return Err(error),
+                        Ok(false) => {}
+                        Err(recovery_error) => {
+                            tracing::warn!(
+                                operation_id = sidecar.operation_id.as_str(),
+                                error = %recovery_error,
+                                "failed merge recovery did not complete"
+                            );
+                        }
+                    }
+                }
                 return match recovery_operation_id {
                     Some(operation_id) => Err(OmniError::recovery_required(
                         operation_id,

--- a/crates/omnigraph/src/failpoints.rs
+++ b/crates/omnigraph/src/failpoints.rs
@@ -181,6 +181,7 @@ pub mod names {
     /// Every merge table effect is complete, but the sidecar is still in its
     /// pre-confirmation shape.
     pub const BRANCH_MERGE_POST_EFFECTS_PRE_CONFIRM: &str = "branch_merge.post_effects_pre_confirm";
+    pub const BRANCH_MERGE_PRE_ERROR_RECOVERY: &str = "branch_merge.pre_error_recovery";
     pub const BRANCH_MERGE_REWRITE_AFTER_DELETE_PRE_CONFIRM: &str =
         "branch_merge.rewrite_after_delete_pre_confirm";
     pub const BRANCH_MERGE_REWRITE_AFTER_MERGE_PRE_DELETE: &str =

--- a/crates/omnigraph/tests/failpoints.rs
+++ b/crates/omnigraph/tests/failpoints.rs
@@ -22,7 +22,8 @@ use serial_test::serial;
 
 use helpers::recovery::{
     FollowUpMutation, RecoveryExpectation, TableExpectation, assert_post_recovery_invariants,
-    branch_head_commit_id, recovery_audit_kinds, single_sidecar_operation_id,
+    branch_head_commit_id, recovery_audit_kinds, sidecar_operation_ids,
+    single_sidecar_operation_id,
 };
 use helpers::{
     MUTATION_QUERIES, TEST_QUERIES, collect_column_strings, count_rows, mixed_params, mutate_main,
@@ -10551,6 +10552,8 @@ async fn branch_merge_multichunk_insert_armed_prefix_rolls_back() {
     let db = Omnigraph::open(&uri).await.unwrap();
 
     let operation_id = {
+        let _error_recovery_failure =
+            ScopedFailPoint::new(names::BRANCH_MERGE_PRE_ERROR_RECOVERY, "return");
         let _failpoint =
             ScopedFailPoint::new(names::BRANCH_MERGE_ADOPT_BETWEEN_INSERT_CHUNKS, "return");
         match db.branch_merge("feature", "main").await.unwrap_err() {
@@ -10609,6 +10612,140 @@ async fn branch_merge_multichunk_insert_armed_prefix_rolls_back() {
     assert_eq!(count_rows(&recovered, "node:Person").await, 8194);
     let names = collect_column_strings(&read_table(&recovered, "node:Person").await, "name");
     assert!(names.iter().any(|name| name == "merge-row-8192"));
+}
+
+/// The same prefix failure with error cleanup enabled: the merge compensates
+/// its own durable first chunk before returning, and the same handle keeps
+/// writing and can retry without reopening (issue 694).
+#[tokio::test]
+#[serial]
+#[serial(branch_merge_phase_b)]
+async fn issue_694_multichunk_insert_prefix_cleans_up_live() {
+    let _scenario = FailScenario::setup();
+    let dir = tempfile::tempdir().unwrap();
+    let (uri, person_uri, expected_version) = setup_branch_merge_multichunk_adopt(&dir).await;
+    let db = Omnigraph::open(&uri).await.unwrap();
+
+    {
+        let _failpoint =
+            ScopedFailPoint::new(names::BRANCH_MERGE_ADOPT_BETWEEN_INSERT_CHUNKS, "return");
+        let error = db.branch_merge("feature", "main").await.unwrap_err();
+        assert!(
+            !matches!(error, OmniError::RecoveryRequired { .. })
+                && error
+                    .to_string()
+                    .contains(names::BRANCH_MERGE_ADOPT_BETWEEN_INSERT_CHUNKS),
+            "live cleanup must return the original merge error: {error}"
+        );
+    }
+    assert!(
+        sidecar_operation_ids(dir.path()).is_empty(),
+        "the armed partial-prefix sidecar must be retired before the merge returns"
+    );
+    assert!(
+        Dataset::open(&person_uri).await.unwrap().version().version > expected_version + 1,
+        "compensation must restore over the durable first chunk"
+    );
+    assert_eq!(count_rows(&db, "node:Person").await, 1);
+    assert_eq!(
+        recovery_audit_kinds(dir.path())
+            .await
+            .into_iter()
+            .filter(|kind| kind == "RolledBack")
+            .count(),
+        1
+    );
+
+    db.load(
+        "main",
+        r#"{"type":"Person","data":{"name":"live-after-failure","score":2}}"#,
+        LoadMode::Append,
+    )
+    .await
+    .expect("the same handle must accept an unrelated write without reopening");
+    assert_eq!(count_rows(&db, "node:Person").await, 2);
+    db.branch_merge("feature", "main")
+        .await
+        .expect("the complete multi-chunk insert remains retryable after live cleanup");
+    assert_eq!(count_rows(&db, "node:Person").await, 8195);
+    let names = collect_column_strings(&read_table(&db, "node:Person").await, "name");
+    assert!(names.iter().any(|name| name == "merge-row-8192"));
+}
+
+/// Live cleanup interrupted after the table restore but before its publish
+/// keeps the sidecar and returns `RecoveryRequired`; the next open finishes the
+/// compensation from the owned restore (issue 694).
+#[tokio::test]
+#[serial]
+#[serial(branch_merge_phase_b)]
+async fn issue_694_live_cleanup_interrupted_after_restore_retains_recovery() {
+    let _scenario = FailScenario::setup();
+    let dir = tempfile::tempdir().unwrap();
+    let (uri, person_uri, expected_version) = setup_branch_merge_multichunk_adopt(&dir).await;
+    let db = Omnigraph::open(&uri).await.unwrap();
+
+    let operation_id = {
+        let _restore_interrupt =
+            ScopedFailPoint::new(names::RECOVERY_POST_TABLE_RESTORE_PRE_PUBLISH, "return");
+        let _failpoint =
+            ScopedFailPoint::new(names::BRANCH_MERGE_ADOPT_BETWEEN_INSERT_CHUNKS, "return");
+        match db.branch_merge("feature", "main").await.unwrap_err() {
+            OmniError::RecoveryRequired { operation_id, .. } => operation_id,
+            other => panic!("interrupted live cleanup must retain recovery ownership: {other}"),
+        }
+    };
+    let sidecar_path = dir
+        .path()
+        .join("__recovery")
+        .join(format!("{operation_id}.json"));
+    assert!(sidecar_path.exists());
+    assert!(
+        recovery_audit_kinds(dir.path()).await.is_empty(),
+        "an interrupted live rollback must not claim a completed audit outcome"
+    );
+    let person_after_interrupted_restore =
+        Dataset::open(&person_uri).await.unwrap().version().version;
+    assert!(
+        person_after_interrupted_restore > expected_version + 1,
+        "the restore must be durable before the interrupted publish"
+    );
+    assert!(
+        matches!(
+            db.load(
+                "main",
+                r#"{"type":"Person","data":{"name":"live-after-failure","score":2}}"#,
+                LoadMode::Append,
+            )
+            .await,
+            Err(OmniError::RecoveryRequired { .. })
+        ),
+        "a retained sidecar must keep protecting writes on the same handle"
+    );
+    drop(db);
+
+    let recovered = Omnigraph::open(&uri)
+        .await
+        .expect("the next open must finish the interrupted compensation");
+    assert!(!sidecar_path.exists());
+    assert_eq!(
+        Dataset::open(&person_uri).await.unwrap().version().version,
+        person_after_interrupted_restore,
+        "restartable rollback must reuse the owned restore instead of restoring again"
+    );
+    assert_eq!(count_rows(&recovered, "node:Person").await, 1);
+    assert_eq!(
+        recovery_audit_kinds(dir.path())
+            .await
+            .into_iter()
+            .filter(|kind| kind == "RolledBack")
+            .count(),
+        1
+    );
+    recovered
+        .branch_merge("feature", "main")
+        .await
+        .expect("the complete multi-chunk insert remains retryable after recovery");
+    assert_eq!(count_rows(&recovered, "node:Person").await, 8194);
 }
 
 /// Once both exact pure-insert transactions are durably confirmed, a
@@ -10748,6 +10885,8 @@ async fn branch_merge_multichunk_delete_armed_prefix_rolls_back() {
     let db = Omnigraph::open(&uri).await.unwrap();
 
     let operation_id = {
+        let _error_recovery_failure =
+            ScopedFailPoint::new(names::BRANCH_MERGE_PRE_ERROR_RECOVERY, "return");
         let _failpoint = ScopedFailPoint::new(names::BRANCH_MERGE_BETWEEN_DELETE_CHUNKS, "return");
         match db.branch_merge("feature", "main").await.unwrap_err() {
             OmniError::RecoveryRequired { operation_id, .. } => operation_id,
@@ -10953,6 +11092,8 @@ async fn assert_partial_merge_rolls_back(
     // Crash mid-Phase-B at the injected window.
     {
         let db = Omnigraph::open(&uri).await.unwrap();
+        let _error_recovery_failure =
+            ScopedFailPoint::new(names::BRANCH_MERGE_PRE_ERROR_RECOVERY, "return");
         let _fp = ScopedFailPoint::new(failpoint, "return");
         let err = db.branch_merge("feature", "main").await.unwrap_err();
         assert!(
@@ -13746,6 +13887,8 @@ async fn assert_branch_merge_first_touch_ref_is_recovered(
     assert!(inherited_entry.native_dataset_branch.is_some());
 
     let error = {
+        let _error_recovery_failure =
+            ScopedFailPoint::new(names::BRANCH_MERGE_PRE_ERROR_RECOVERY, "return");
         let _failpoint = ScopedFailPoint::new(failpoint, "return");
         db.branch_merge("source", "target").await.unwrap_err()
     };
@@ -14146,6 +14289,8 @@ async fn branch_merge_dropping_a_net_zero_table_confirms_and_recovers() {
     // Crash between the durable effects and the sidecar confirmation.
     {
         let db = Omnigraph::open(&uri).await.unwrap();
+        let _error_recovery_failure =
+            ScopedFailPoint::new(names::BRANCH_MERGE_PRE_ERROR_RECOVERY, "return");
         let _failpoint =
             ScopedFailPoint::new(names::BRANCH_MERGE_POST_EFFECTS_PRE_CONFIRM, "return");
         let err = db.branch_merge("feature", "main").await.unwrap_err();

--- a/docs/dev/recovery.md
+++ b/docs/dev/recovery.md
@@ -83,8 +83,19 @@ the graph quiescent, Full recovery may:
 - promote or discard owned schema staging;
 - refuse an invariant violation or ambiguous effect.
 
-Lance Restore can defeat a concurrent writer, so this destructive mode must not
-run as an in-process heal while writers may be active.
+Lance Restore can defeat a concurrent writer, so ordinary in-process healing
+must not run a destructive Full sweep.
+
+A merge that returns an error before durable effect confirmation resolves only
+its own BranchMerge sidecar while retaining its schema, branch and table gates.
+It re-reads the durable record and reuses the exact Full classifier to retire
+an effect-free attempt or compensate owned unconfirmed effects. The original
+merge error is returned after cleanup; failed or deferred cleanup retains
+`RecoveryRequired`. Confirmed effects remain on the ordinary roll-forward path.
+This scoped error cleanup does not handle a cancelled future and does not add
+cross-process fencing or prove the completion of an already-transmitted remote
+write after an ambiguous I/O failure; the existing recovery support boundary
+still applies.
 
 ### RollForwardOnly
 

--- a/docs/releases/v0.11.0.md
+++ b/docs/releases/v0.11.0.md
@@ -4,6 +4,14 @@ Notes accumulate here until the release is cut.
 
 ## Highlights
 
+- **Failed branch merges can leave the graph writable without reopening.**
+  When a merge returns an error before confirming its effects, it cleans up
+  its own provably effect-free or owned unconfirmed work under the existing
+  write gates. The merge still reports its error. If cleanup cannot prove a
+  safe result, writes remain protected by `RecoveryRequired`. Cancelled merges
+  retain the existing recovery behavior. See
+  [graph recovery](../dev/recovery.md#full).
+
 - **Graph storage moves to internal manifest schema v8, with explicit offline
   upgrades for qualified v6 and v7 graphs.** Every `__manifest` registration row
   is now keyed by the manifest version that wrote it, and a branch's view of a table is the


### PR DESCRIPTION
## What & why

A branch merge that fails after arming its BranchMerge sidecar returned `RecoveryRequired` and left the sidecar in place, so every later write on the target branch was refused until the graph was reopened. The merge now resolves its own durable record under the gates it still holds: an effect-free attempt retires the sidecar, owned unconfirmed effects are compensated, and the original merge error is returned. Confirmed effects keep the existing roll-forward path.

## Backing issue / RFC

- [x] Fixes an **accepted** issue: Closes https://github.com/ModernRelay/omnigraph/issues/694
      (`issue_694_effect_free_merge_keeps_writing.gqt` and `issue_694_unconfirmed_merge_keeps_writing.gqt` lose their `known_failure` sections and gain a merge retry that must land; new `issue_694_unconfirmed_named_target_keeps_writing.gqt` covers unconfirmed effects with a created first-touch fork on a named target; two new `issue_694_*` failpoint tests cover live cleanup after a multi-chunk prefix failure and a cleanup interrupted after the table restore)

## Checklist

- [x] Change is focused (one logical change): returned-error cleanup for the current merge attempt, no new record, protocol or recovery mode
- [x] Tests added/updated for behavior changes: the two issue cases are strengthened (next write succeeds in-process, then the merge retry succeeds and the source row is visible) and a third covers a named target with created first-touch effects; `issue_694_multichunk_insert_prefix_cleans_up_live` pins the rollback path under the new caller (durable first chunk compensated, `RolledBack` audit, same handle writes and retries); `issue_694_live_cleanup_interrupted_after_restore_retains_recovery` pins the failure of cleanup itself (`RecoveryRequired` kept, sidecar retained, next open reuses the owned restore); five existing crash/reopen failpoint tests inject `branch_merge.pre_error_recovery` so their surviving-sidecar setup and reopen assertions are unchanged. All five owners were run red with the cleanup call neutralised and green with it restored
- [x] Public docs updated: `docs/dev/recovery.md` (scoped error cleanup and its boundary), `docs/releases/v0.11.0.md`
- [x] Reviewed against [docs/dev/invariants.md](../blob/main/docs/dev/invariants.md): cleanup runs only for the current Armed attempt under its held schema, branch and table gates; it never runs a Full sweep, never reacquires gates, and never deletes a record it cannot prove effect-free or owned

## Local verification

Base `fb6ed452`, macOS, local `file://` and in-memory object-store backends.

- `cd crates/omnigraph-gqt && cargo test --test gq_logic_tests issue_694` with the cleanup call neutralised — all three cases fail at the next write with pending BranchMerge (seeds 0 and 42); with the fix — 3 passed including the retries, 4.77 s
- `cargo test -p omnigraph-engine --features failpoints --test failpoints issue_694` with the cleanup call neutralised — both new tests fail at their first cleanup assertion; with the fix — 2 passed
- `python3 scripts/check-fix-regression.py --body-file <this body> --range upstream/main --repo ModernRelay/omnigraph` — ok, issue 694 has a matching regression addition
- `cd crates/omnigraph-gqt && cargo test --lib --test gq_logic_tests -j 1 -- --test-threads=2` (the DST target needs the crate's `tokio_unstable` cfg) — 142 runner tests and 75 corpus cases pass, 49.26 s; both issue cases and both merge controls (`merge_pre_arm_failure_keeps_writing`, `merge_confirmed_failure_keeps_writing`) pass on seeds 0 and 42 with replay
- `cargo test -p omnigraph-engine --features failpoints --test failpoints -j 4 -- --test-threads=2` — 156 passed, 1 ignored (subprocess helper), 91.46 s
- `cargo test -p omnigraph-engine --features failpoints --test lance_surface_guards --test recovery --test branching --test merge_fast_forward --test merge_truth_table --test failpoint_names_guard --test forbidden_apis --no-fail-fast -j 4 -- --test-threads=2` — all seven pass: branching 48, failpoint_names_guard 1, forbidden_apis 22, lance_surface_guards 37, merge_fast_forward 20, merge_truth_table 2, recovery 20
- `cargo clippy -p omnigraph-engine -p omnigraph-gqt --all-targets --features omnigraph-engine/failpoints -- -D warnings -W clippy::dbg_macro` — pass, no diagnostics
- `cargo check --workspace`, `cargo fmt --all --check`, `python3 scripts/check-docs.py` (138 files), `bash scripts/check-agents-md.sh`, `git diff --check` — pass
- Successful-merge cost, `cargo bench --bench scenarios -- --scenario general-merge-updates` on unmodified main and on this branch, same binary profile, data, seed and machine — operation wall medians within 5% (fixed/baseline 0.97 for 20k update, 0.97 for 20k insert, 1.05 for 100k update interleaved, n=5 each), identical manifest/data I/O counts, peak RSS within 1%; the success path executes no new code
- Failure-path cost, same failed merge with and without the cleanup in one release failpoints binary, local `file://`, n=5 — cleanup adds 3.2 ms to the effect-free window's error return (8.3 to 11.5 ms) and 9.6 ms to the unconfirmed window's (8.5 to 18.0 ms); the target accepts its next write in-process 7.3 ms and 2.8 ms sooner than the previous reopen-then-write path
- Not run: live S3 or Azure backends; the optional backend tests return without a service

## Notes for reviewers

- The cleanup handles a returned error only. A cancelled merge future never reaches the handler and keeps today's reopen recovery. Cross-process writers and an already-transmitted late remote write stay behind the existing recovery boundary.
- If cleanup itself fails or defers, the merge still returns `RecoveryRequired`, with a `failed merge recovery did not complete` warning. A refresh failure after a successful cleanup can report `RecoveryRequired` for an already-removed sidecar; the next successful refresh clears it.
- Eager cleanup of `EffectsConfirmed` records was tried and rejected: it changed the confirmed control's immediate read result. Those records stay on the next-write roll-forward path.
- Future direction: [RFC 0065: Isolated branch merge publication](https://github.com/ModernRelay/omnigraph/blob/main/docs/rfcs/0065-isolated-branch-merge-publication.md) prepares merges on private native branches so a failed attempt leaves nothing to compensate. This fix is independent of it and stays useful under it for the publication step.